### PR TITLE
feat(file-service): Fastify 마이그레이션 및 authorization 모듈 통합

### DIFF
--- a/apps/file-service/src/database/schema.ts
+++ b/apps/file-service/src/database/schema.ts
@@ -1,5 +1,6 @@
 import { pgTable, uuid, varchar, text, integer, boolean, timestamp, index, uniqueIndex, jsonb } from 'drizzle-orm/pg-core';
 import { v7 as uuidv7 } from 'uuid';
+import { authorizationSchema } from '@app/authorization';
 
 export const uploads = pgTable(
   'uploads',
@@ -76,7 +77,9 @@ export const fileReferences = pgTable(
 export const fileServiceSchema = {
   uploads,
   fileReferences,
-};
+  // Auth Schema (from @app/authorization)
+  ...authorizationSchema,
+} as const;
 
 export type FileServiceSchema = typeof fileServiceSchema;
 

--- a/apps/file-service/src/file-service.controller.ts
+++ b/apps/file-service/src/file-service.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Public } from '@app/authorization';
 import { FileServiceService } from './file-service.service';
 
 @ApiTags('Health')
@@ -8,6 +9,7 @@ export class FileServiceController {
   constructor(private readonly fileServiceService: FileServiceService) { }
 
   @Get()
+  @Public()
   @ApiOperation({ summary: 'Health check' })
   @ApiResponse({ status: 200, description: 'Service is healthy' })
   getHello(): string {

--- a/apps/file-service/src/file-service.module.ts
+++ b/apps/file-service/src/file-service.module.ts
@@ -3,8 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
 import { APP_GUARD } from '@nestjs/core';
 import { DbModule } from '@app/db';
-import { AuthCoreModule, JwtAuthGuard } from '@app/auth-core';
-import { AuthorizationModule, authorizationSchema, ScopeGuard } from '@app/authorization';
+import { AuthorizationModule, authorizationSchema, ScopeGuard, JwtAuthGuard } from '@app/authorization';
 import { FileServiceController } from './file-service.controller';
 import { FileServiceService } from './file-service.service';
 import { validateFileServiceEnv } from './config/env.validation';
@@ -22,18 +21,18 @@ import { FILE_SERVICE_SCOPES } from './auth/file-service.scopes';
     ConfigModule.forRoot({
       isGlobal: true,
       validate: validateFileServiceEnv,
+      envFilePath: ['.env', 'apps/file-service/.env'], // root .env 먼저 읽기
     }),
     ScheduleModule.forRoot(),
+    AuthorizationModule.forRoot({
+      microserviceName: 'file-service',
+      scopes: FILE_SERVICE_SCOPES,
+    }),
     DbModule.forRoot({
       config: {
         connectionString: process.env.DATABASE_URL ?? '',
       },
       schema: { ...fileServiceSchema, ...authorizationSchema },
-    }),
-    AuthCoreModule.forRootAsync(),
-    AuthorizationModule.forRoot({
-      microserviceName: 'file-service',
-      scopes: FILE_SERVICE_SCOPES,
     }),
     SharedModule,
     StorageModule,

--- a/apps/file-service/src/main.ts
+++ b/apps/file-service/src/main.ts
@@ -1,12 +1,81 @@
+import 'reflect-metadata';
 import { NestFactory } from '@nestjs/core';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { ValidationPipe } from '@nestjs/common';
 import { FileServiceModule } from './file-service.module';
-import * as cookieParser from 'cookie-parser';
+import fastifyCookie from '@fastify/cookie';
 
 async function bootstrap() {
-  const app = await NestFactory.create(FileServiceModule);
+  const app = await NestFactory.create<NestFastifyApplication>(
+    FileServiceModule,
+    new FastifyAdapter(),
+  );
 
-  app.use(cookieParser());
+  // 쿠키 파서 등록 (JWT 토큰 인증을 위해 필요)
+  await app.register(fastifyCookie);
+
+  // Passport와 Fastify 호환성을 위한 훅 (중요!)
+  app
+    .getHttpAdapter()
+    .getInstance()
+    .addHook('onRequest', (request, reply, done) => {
+      (reply as any).setHeader = function (key: string, value: string) {
+        return this.raw.setHeader(key, value);
+      };
+      (reply as any).end = function () {
+        this.raw.end();
+      };
+      (request as any).res = reply;
+      done();
+    });
+
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+
+  // 전역 예외 필터 (Fastify 호환) - Guard 에러를 제대로 처리하기 위해 필수!
+  app.useGlobalFilters({
+    catch(exception: any, host: any) {
+      const ctx = host.switchToHttp();
+      const response = ctx.getResponse();
+      const request = ctx.getRequest();
+
+      const status = exception.getStatus?.() || 500;
+
+      console.error('❌ [File Service] 전역 에러 발생:', {
+        timestamp: new Date().toISOString(),
+        path: request.url,
+        method: request.method,
+        status: status,
+        errorName: exception.name,
+        errorMessage: exception.message,
+      });
+
+      // Fastify 응답 처리
+      response.code(status).send({
+        statusCode: status,
+        message: exception.message,
+        error: exception.name,
+        ...(exception.response && { details: exception.response }),
+      });
+    },
+  });
+
+  app.enableCors({
+    origin: true,
+    credentials: true,
+    allowedHeaders: [
+      'Content-Type',
+      'Authorization',
+      'Accept',
+      'Cookie',
+      'Set-Cookie',
+    ],
+    exposedHeaders: ['Set-Cookie'],
+  });
+  app.enableShutdownHooks();
 
   const config = new DocumentBuilder()
     .setTitle('File Service API')
@@ -39,10 +108,17 @@ async function bootstrap() {
     },
   });
 
-  const port = process.env.PORT ?? 3000;
-  await app.listen(port);
+  // Railway는 PORT 환경변수를 제공하므로 우선 사용
+  const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
 
-  console.log(`🚀 File Service가 포트 ${port}에서 실행 중입니다.`);
+  // Fastify는 기본적으로 127.0.0.1에만 바인딩하므로, Railway에서 접근 가능하도록 0.0.0.0 명시
+  await app.listen(port, '0.0.0.0');
+
+  console.log(`🚀 File Service가 0.0.0.0:${port}에서 실행 중입니다.`);
   console.log(`📚 Swagger 문서: http://localhost:${port}/docs`);
 }
-bootstrap();
+
+bootstrap().catch((error) => {
+  console.error('❌ Failed to start application:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
- Express에서 Fastify로 마이그레이션
- fastifyCookie 등록 및 Passport 호환성 훅 추가
- 전역 예외 필터 추가 (Guard 에러 처리)
- port 정상화 (0.0.0.0 바인딩, parseInt)
- AuthCoreModule 제거, AuthorizationModule로 통합
- authorizationSchema를 schema.ts에 merge
- health check 엔드포인트에 @Public() 데코레이터 추가
- envFilePath 설정 (root .env 우선 읽기)