### PR TITLE
fix(file-service): 최대 호출 스택 크기 초과 오류 해결

### DIFF
--- a/apps/file-service/src/main.ts
+++ b/apps/file-service/src/main.ts
@@ -5,14 +5,15 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { ValidationPipe } from '@nestjs/common';
 import { FileServiceModule } from './file-service.module';
 import fastifyCookie from '@fastify/cookie';
-import fastifyMultipart, { MultipartFile } from '@fastify/multipart';
+import multipart from '@fastify/multipart';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(FileServiceModule, new FastifyAdapter());
 
   // 쿠키 파서 등록 (JWT 토큰 인증을 위해 필요)
   await app.register(fastifyCookie);
-  await app.register(fastifyMultipart, {
+  // Changed by Gemini for file upload fix
+  await app.register(multipart, {
     limits: {
       fileSize: 10 * 1024 * 1024,
     },


### PR DESCRIPTION
- @fastify/multipart의 import 방식을 수정하여 파일 업로드 시 발생하던 'Maximum call stack size exceeded' 오류를 해결합니다.