### PR TITLE
fix(file-service): 인터셉터를 사용하여 파일 업로드 오류 해결

### DIFF
--- a/apps/file-service/src/upload/dto/upload-file.dto.ts
+++ b/apps/file-service/src/upload/dto/upload-file.dto.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsOptional, IsObject } from 'class-validator';
+import { IsEnum, IsOptional, IsObject, IsArray } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { FILE_CONTEXTS, FileContext } from '../../shared/constants/file-contexts';
 
@@ -19,5 +19,18 @@ export class UploadFileDto {
   @IsOptional()
   @IsObject()
   metadata?: Record<string, any>;
+
+  /**
+   * @description
+   * VAP-FIX: Changed by Gemini
+   * This property is populated by the FileTransformInterceptor.
+   * It is not expected from the client directly in the request body,
+   * but is attached for internal processing and validation.
+   * Marked as optional so validation passes.
+   */
+  @ApiProperty({ type: 'array', items: { type: 'string', format: 'binary' }, required: false, readOnly: true })
+  @IsOptional()
+  @IsArray()
+  files: any[];
 }
 

--- a/apps/file-service/src/upload/file-transform.interceptor.ts
+++ b/apps/file-service/src/upload/file-transform.interceptor.ts
@@ -1,0 +1,73 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  BadRequestException,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { FastifyRequest } from 'fastify';
+
+/**
+ * @description
+ * VAP-FIX: Changed by Gemini
+ * This interceptor solves the "Maximum call stack size exceeded" (RangeError)
+ * that occurs when using NestJS's ValidationPipe with Fastify's multipart file uploads.
+ *
+ * It intercepts multipart/form-data requests *before* the ValidationPipe runs.
+ * It manually processes the multipart stream, extracts all fields and the file,
+ * and attaches them to the `request.body`. This presents a stable, parsed object
+ * to the ValidationPipe, preventing the crash.
+ */
+@Injectable()
+export class FileTransformInterceptor implements NestInterceptor {
+  async intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Promise<Observable<any>> {
+    const request = context.switchToHttp().getRequest<FastifyRequest>();
+
+    if (!request.isMultipart()) {
+      // If not a multipart request, do nothing.
+      return next.handle();
+    }
+
+    const body = {};
+    const files = [];
+
+    try {
+      const parts = request.parts();
+      for await (const part of parts) {
+        if (part.file) {
+          // It's a file part
+          // To keep memory usage low, we pass the stream object itself.
+          // The service layer will be responsible for processing the stream.
+          files.push(part);
+        } else {
+          // It's a field part
+          body[part.fieldname] = (part as any).value;
+        }
+      }
+    } catch (error) {
+      // This can happen if the client aborts the request, etc.
+      throw new BadRequestException(`Failed to process multipart form: ${error.message}`);
+    }
+
+    // --- Critical Step ---
+    // Manually parse metadata if it's a JSON string
+    if (body['metadata'] && typeof body['metadata'] === 'string') {
+      try {
+        body['metadata'] = JSON.parse(body['metadata']);
+      } catch {
+        throw new BadRequestException('Invalid metadata format. Must be a valid JSON string.');
+      }
+    }
+
+    // Attach the parsed body and the file parts to the request body
+    // This allows `@Body()` and `ValidationPipe` to work correctly.
+    // For single file upload, we expect one file. For batch, multiple.
+    request.body = { ...body, files };
+
+    return next.handle();
+  }
+}

--- a/apps/file-service/src/upload/upload.controller.ts
+++ b/apps/file-service/src/upload/upload.controller.ts
@@ -3,17 +3,17 @@ import {
   Post,
   Body,
   BadRequestException,
-  Req,
-  UsePipes, // 💡 UsePipes 임포트
+  UseInterceptors,
   ValidationPipe,
+  UsePipes,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiConsumes, ApiBody, ApiResponse, ApiBearerAuth, ApiSecurity } from '@nestjs/swagger';
 import { UploadService } from './upload.service';
 import { UploadFileDto } from './dto/upload-file.dto';
 import { UploadResponseDto, BatchUploadResponseDto } from './dto/upload-response.dto';
 import { User } from '@app/authorization';
-import { FastifyRequest } from 'fastify';
-import { MultipartFile } from '@fastify/multipart'; // 필요한 타입 임포트
+import { FileTransformInterceptor } from './file-transform.interceptor'; // VAP-FIX: Gemini's fix
+import { MultipartFile } from '@fastify/multipart';
 
 interface JwtPayload {
   userId: string;
@@ -62,39 +62,19 @@ export class UploadController {
     type: UploadResponseDto,
   })
   @ApiResponse({ status: 400, description: 'Bad request' })
-  @UsePipes() // 🚨 핵심 수정: 글로벌 ValidationPipe 적용을 중지합니다. (RangeError 방지)
+  // VAP-FIX: Gemini's fix - Apply the interceptor and standard validation pipe.
+  @UseInterceptors(FileTransformInterceptor)
+  @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
   async uploadFile(
-    @Req() request: FastifyRequest,
     @Body() dto: UploadFileDto,
     @User() user: JwtPayload,
   ): Promise<UploadResponseDto> {
-    // 💡 1. @Body()는 ValidationPipe를 통과하지 않으므로, request.body를 DTO 타입으로 간주하고 사용합니다.
-    const bodyDto: UploadFileDto = request.body as any; // 타입 단언 (context, metadata 포함)
-
-    // 2. 파일 파트 추출
-    const part = (await request.file()) as MultipartFile | undefined;
-
-    if (!part) {
+    const file = dto.files?.[0] as MultipartFile;
+    if (!file) {
       throw new BadRequestException('File is required');
     }
 
-    // 3. metadata 수동 파싱 및 context 검증 (RangeError 방지를 위해 수동 검증 필수)
-    if (!bodyDto.context) {
-      // ValidationPipe가 없으므로 context 누락을 수동으로 확인
-      throw new BadRequestException('Context field is required.');
-    }
-
-    if (bodyDto.metadata && typeof bodyDto.metadata === 'string') {
-      try {
-        bodyDto.metadata = JSON.parse(bodyDto.metadata);
-      } catch (e) {
-        throw new BadRequestException('Invalid metadata format. Must be a valid JSON string.');
-      }
-    }
-
-    // 4. 서비스 호출 (Part 객체와 처리된 DTO 전달)
-    const result = await this.uploadService.uploadFile(part, bodyDto, user.userId);
-
+    const result = await this.uploadService.uploadFile(file, dto, user.userId);
     return result;
   }
 
@@ -132,34 +112,19 @@ export class UploadController {
     type: BatchUploadResponseDto,
   })
   @ApiResponse({ status: 400, description: 'Bad request' })
-  @UsePipes() // 🚨 핵심 수정: 글로벌 ValidationPipe 적용을 중지합니다. (RangeError 방지)
+  // VAP-FIX: Gemini's fix - Apply the interceptor and standard validation pipe.
+  @UseInterceptors(FileTransformInterceptor)
+  @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
   async batchUploadFiles(
-    @Req() request: FastifyRequest,
     @Body() dto: UploadFileDto,
     @User() user: JwtPayload,
   ): Promise<BatchUploadResponseDto> {
-    // 💡 1. @Body()는 ValidationPipe를 통과하지 않으므로, request.body를 DTO 타입으로 간주하고 사용합니다.
-    const bodyDto: UploadFileDto = request.body as any;
-
-    // 2. 파일 파트 추출 (AsyncIterator)
-    const files = request.files();
-
-    // 3. metadata 수동 파싱 및 context 검증
-    if (!bodyDto.context) {
-      throw new BadRequestException('Context field is required.');
+    const files = dto.files as MultipartFile[];
+    if (!files || files.length === 0) {
+      throw new BadRequestException('At least one file is required');
     }
 
-    if (bodyDto.metadata && typeof bodyDto.metadata === 'string') {
-      try {
-        bodyDto.metadata = JSON.parse(bodyDto.metadata);
-      } catch (e) {
-        throw new BadRequestException('Invalid metadata format. Must be a valid JSON string.');
-      }
-    }
-
-    // 4. 서비스 호출 (Iterator와 검증된 DTO 전달)
-    const result = await this.uploadService.batchUploadFiles(files, bodyDto, user.userId);
-
+    const result = await this.uploadService.batchUploadFiles(files, dto, user.userId);
     return result;
   }
 }

--- a/apps/file-service/src/upload/upload.service.ts
+++ b/apps/file-service/src/upload/upload.service.ts
@@ -65,26 +65,21 @@ export class UploadService {
   }
 
   async batchUploadFiles(
-    files: AsyncIterableIterator<MultipartFile>, // Fastify 타입 그대로 수용
+    files: MultipartFile[], // VAP-FIX: Changed by Gemini to accept an array
     dto: UploadFileDto,
     userId: string,
   ): Promise<BatchUploadResponseDto> {
-    const uploadPromises: Promise<UploadResponseDto>[] = [];
-    let fileCount = 0;
-
-    // 1. 🚀 for await...of 루프를 사용하여 비동기 이터레이터 소비
-    //    => 이터레이터의 각 요소에 대해 this.uploadFile을 호출하고 Promise를 배열에 추가
-    for await (const file of files) {
-      uploadPromises.push(this.uploadFile(file, dto, userId));
-      fileCount++;
-    }
-
-    // 2. 🚨 파일 개수 확인 (length 대신 count 사용)
-    if (fileCount === 0) {
+    if (!files || files.length === 0) {
       throw new BadRequestException('At least one file is required');
     }
 
-    // 3. ⏱️ 모든 Promise를 병렬로 실행
+    const uploadPromises: Promise<UploadResponseDto>[] = [];
+
+    // VAP-FIX: Changed by Gemini to iterate over an array
+    for (const file of files) {
+      uploadPromises.push(this.uploadFile(file, dto, userId));
+    }
+
     const uploadedFiles = await Promise.all(uploadPromises);
 
     return {


### PR DESCRIPTION
VAP-FIX: Gemini\n\n- FileTransformInterceptor를 도입하여 multipart/form-data 요청을 사전 처리합니다.\n- 이 변경으로 NestJS의 ValidationPipe와 Fastify 스트리밍 간의 충돌로 인해 발생하던 'Maximum call stack size exceeded' 오류를 해결합니다.\n- 컨트롤러 로직을 NestJS 표준(@Body, ValidationPipe)을 사용하도록 복원하여 코드 가독성과 안정성을 향상시킵니다.