### PR TITLE
[admin-web] 리뷰 페이지 라벨/UX 개선 및 정렬 버그 수정

### DIFF
--- a/apps/admin-web/src/app/(admin)/cs/reviews/[id]/page.tsx
+++ b/apps/admin-web/src/app/(admin)/cs/reviews/[id]/page.tsx
@@ -1,0 +1,27 @@
+import { TwoColumnPage } from '@/components/admin-ui-experimental/layout';
+import { ReviewDetail } from '@/features/cs/review/components/review-detail';
+import { AdminCommentForm } from '@/features/cs/review/components/admin-comment-form';
+import { ReviewStatusToggle } from '@/features/cs/review/components/review-status-toggle';
+import RouteGuard from '@/components/layout/route-guard';
+
+export default async function ReviewDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <RouteGuard requireRole={['admin', 'master']}>
+      <div className="flex w-full max-w-[1600px] flex-col gap-y-2 p-3">
+        <TwoColumnPage>
+          <ReviewDetail reviewId={id} />
+
+          <div className="flex flex-col gap-y-2">
+            <ReviewStatusToggle reviewId={id} />
+            <AdminCommentForm reviewId={id} />
+          </div>
+        </TwoColumnPage>
+      </div>
+    </RouteGuard>
+  );
+}

--- a/apps/admin-web/src/app/(admin)/cs/reviews/page.tsx
+++ b/apps/admin-web/src/app/(admin)/cs/reviews/page.tsx
@@ -1,0 +1,12 @@
+import RouteGuard from '@/components/layout/route-guard';
+import ReviewListTemplate from '@/features/cs/review/template';
+
+export default function ReviewsPage() {
+  return (
+    <RouteGuard requireRole={['admin', 'master']}>
+      <div className="flex w-full max-w-[1600px] flex-col gap-y-2 p-3">
+        <ReviewListTemplate />
+      </div>
+    </RouteGuard>
+  );
+}

--- a/apps/admin-web/src/components/data-table/data-table-filter/string-filter.tsx
+++ b/apps/admin-web/src/components/data-table/data-table-filter/string-filter.tsx
@@ -49,7 +49,11 @@ export function StringFilter({ filter, open, onOpenChange, prefix }: StringFilte
       ) : (
         <PopoverAnchor />
       )}
-      <PopoverContent className="w-56 p-3" align="start">
+      <PopoverContent
+        className="w-56 p-3"
+        align="start"
+        onFocusOutside={(e) => e.preventDefault()}
+      >
         <div className="flex flex-col gap-2">
           <p className="text-xs font-medium">{filter.label}</p>
           <Input

--- a/apps/admin-web/src/components/data-table/data-table-order-by.tsx
+++ b/apps/admin-web/src/components/data-table/data-table-order-by.tsx
@@ -19,9 +19,14 @@ type OrderByOption = {
 type DataTableOrderByProps = {
   orderBy: OrderByOption[]
   prefix?: string
+  /**
+   * preset 모드: 각 옵션이 이미 정렬 방향을 포함한 단일 키(latest/oldest 등).
+   * asc/desc 토글 비활성, `order` 파라미터 미사용.
+   */
+  presetOnly?: boolean
 }
 
-export function DataTableOrderBy({ orderBy, prefix }: DataTableOrderByProps) {
+export function DataTableOrderBy({ orderBy, prefix, presetOnly }: DataTableOrderByProps) {
   const { get, add, deleteMany } = useSelectedParams({ prefix })
 
   const rawSort = get('sort')
@@ -32,6 +37,10 @@ export function DataTableOrderBy({ orderBy, prefix }: DataTableOrderByProps) {
   const currentLabel = orderBy.find((o) => o.key === sortValue)?.label
 
   const handleSelect = (key: string) => {
+    if (presetOnly) {
+      add('sort', key)
+      return
+    }
     if (sortValue === key) {
       add('order', orderValue === 'asc' ? 'desc' : 'asc')
     } else {
@@ -41,7 +50,7 @@ export function DataTableOrderBy({ orderBy, prefix }: DataTableOrderByProps) {
   }
 
   const handleClear = () => {
-    deleteMany(['sort', 'order'])
+    deleteMany(presetOnly ? ['sort'] : ['sort', 'order'])
   }
 
   return (
@@ -52,7 +61,11 @@ export function DataTableOrderBy({ orderBy, prefix }: DataTableOrderByProps) {
           {currentLabel ? (
             <>
               {currentLabel}
-              <span className="text-muted-foreground">{orderValue === 'asc' ? '↑' : '↓'}</span>
+              {!presetOnly && (
+                <span className="text-muted-foreground">
+                  {orderValue === 'asc' ? '↑' : '↓'}
+                </span>
+              )}
             </>
           ) : (
             '정렬'
@@ -67,7 +80,7 @@ export function DataTableOrderBy({ orderBy, prefix }: DataTableOrderByProps) {
             className={sortValue === opt.key ? 'font-medium' : ''}
           >
             {opt.label}
-            {sortValue === opt.key && (
+            {sortValue === opt.key && !presetOnly && (
               <span className="ml-auto text-muted-foreground">
                 {orderValue === 'asc' ? '↑' : '↓'}
               </span>

--- a/apps/admin-web/src/components/data-table/data-table-query.tsx
+++ b/apps/admin-web/src/components/data-table/data-table-query.tsx
@@ -8,11 +8,18 @@ import type { Filter } from './data-table-filter/types'
 type DataTableQueryProps = {
   filters?: Filter[]
   orderBy?: { key: string; label: string }[]
+  orderByPresetOnly?: boolean
   search?: boolean
   prefix?: string
 }
 
-export function DataTableQuery({ filters, orderBy, search, prefix }: DataTableQueryProps) {
+export function DataTableQuery({
+  filters,
+  orderBy,
+  orderByPresetOnly,
+  search,
+  prefix,
+}: DataTableQueryProps) {
   const hasFilters = filters && filters.length > 0
   const hasOrderBy = orderBy && orderBy.length > 0
 
@@ -25,7 +32,13 @@ export function DataTableQuery({ filters, orderBy, search, prefix }: DataTableQu
       </div>
       <div className="flex items-center gap-2">
         {search && <DataTableSearch prefix={prefix} />}
-        {hasOrderBy && <DataTableOrderBy orderBy={orderBy} prefix={prefix} />}
+        {hasOrderBy && (
+          <DataTableOrderBy
+            orderBy={orderBy}
+            prefix={prefix}
+            presetOnly={orderByPresetOnly}
+          />
+        )}
       </div>
     </div>
   )

--- a/apps/admin-web/src/components/data-table/data-table.tsx
+++ b/apps/admin-web/src/components/data-table/data-table.tsx
@@ -13,6 +13,7 @@ type DataTableProps<TData extends RowData> = {
   pageSize?: number
   filters?: Filter[]
   orderBy?: { key: string; label: string }[]
+  orderByPresetOnly?: boolean
   search?: boolean
   navigateTo?: (row: Row<TData>) => string
   noRecords?: { message: string }
@@ -27,6 +28,7 @@ export function DataTable<TData extends RowData>({
   pageSize = 20,
   filters,
   orderBy,
+  orderByPresetOnly,
   search,
   navigateTo,
   noRecords,
@@ -37,6 +39,7 @@ export function DataTable<TData extends RowData>({
       <DataTableQuery
         filters={filters}
         orderBy={orderBy}
+        orderByPresetOnly={orderByPresetOnly}
         search={search}
         prefix={prefix}
       />

--- a/apps/admin-web/src/components/table/table-cells/review/index.ts
+++ b/apps/admin-web/src/components/table/table-cells/review/index.ts
@@ -1,0 +1,3 @@
+export { ReviewStatusCell } from './review-status-cell';
+export { ReviewRatingCell } from './review-rating-cell';
+export { ReviewCommentStatusCell } from './review-comment-status-cell';

--- a/apps/admin-web/src/components/table/table-cells/review/review-comment-status-cell.tsx
+++ b/apps/admin-web/src/components/table/table-cells/review/review-comment-status-cell.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { CheckIcon, MinusIcon } from 'lucide-react';
+
+type ReviewCommentStatusCellProps = {
+  hasComment: boolean | null | undefined;
+};
+
+export function ReviewCommentStatusCell({
+  hasComment,
+}: ReviewCommentStatusCellProps) {
+  if (hasComment) {
+    return (
+      <span className="inline-flex items-center gap-1 text-emerald-600">
+        <CheckIcon className="h-4 w-4" />
+        작성됨
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-muted-foreground">
+      <MinusIcon className="h-4 w-4" />
+      미작성
+    </span>
+  );
+}

--- a/apps/admin-web/src/components/table/table-cells/review/review-rating-cell.tsx
+++ b/apps/admin-web/src/components/table/table-cells/review/review-rating-cell.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { StarIcon } from 'lucide-react';
+
+type ReviewRatingCellProps = {
+  value: number | null | undefined;
+};
+
+export function ReviewRatingCell({ value }: ReviewRatingCellProps) {
+  if (value === null || value === undefined) {
+    return <span className="text-muted-foreground">-</span>;
+  }
+
+  const rating = Math.max(0, Math.min(5, Math.round(value)));
+
+  return (
+    <div className="flex items-center gap-1" aria-label={`별점 ${rating}점`}>
+      {Array.from({ length: 5 }).map((_, index) => (
+        <StarIcon
+          key={index}
+          className={
+            index < rating
+              ? 'h-4 w-4 fill-yellow-400 text-yellow-400'
+              : 'h-4 w-4 text-muted-foreground/40'
+          }
+        />
+      ))}
+      <span className="ml-1 text-sm text-muted-foreground">{rating}</span>
+    </div>
+  );
+}

--- a/apps/admin-web/src/components/table/table-cells/review/review-status-cell.tsx
+++ b/apps/admin-web/src/components/table/table-cells/review/review-status-cell.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { ReviewStatus, STATUS_LABELS } from '@/lib/types/dto/review';
+
+const statusConfig: Record<
+  ReviewStatus,
+  {
+    label: string;
+    variant: 'default' | 'secondary' | 'destructive' | 'outline';
+  }
+> = {
+  active: { label: STATUS_LABELS.active, variant: 'default' },
+  hidden: { label: STATUS_LABELS.hidden, variant: 'secondary' },
+  deleted: { label: STATUS_LABELS.deleted, variant: 'destructive' },
+};
+
+type ReviewStatusCellProps = {
+  value: string | null | undefined;
+};
+
+export function ReviewStatusCell({ value }: ReviewStatusCellProps) {
+  if (!value) return <span className="text-muted-foreground">-</span>;
+  const config = statusConfig[value as ReviewStatus];
+  return (
+    <Badge variant={config?.variant ?? 'outline'}>
+      {config?.label ?? value}
+    </Badge>
+  );
+}

--- a/apps/admin-web/src/features/cs/review/components/admin-comment-form/index.tsx
+++ b/apps/admin-web/src/features/cs/review/components/admin-comment-form/index.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { Suspense, useState } from 'react';
+import { Container } from '@/components/admin-ui-experimental/common/container';
+import { Header } from '@/components/admin-ui-experimental/common/header';
+import { Spinner } from '@/components/ui/spinner';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import {
+  useReview,
+  useCreateReviewComment,
+  useUpdateReviewComment,
+  useDeleteReviewComment,
+} from '@/lib/services/review';
+import { useOptionalAdminUser } from '@/lib/services/users';
+import { toast } from 'sonner';
+
+function AdminCommentFormContent({ reviewId }: { reviewId: string }) {
+  const { data: review } = useReview(reviewId);
+  const createComment = useCreateReviewComment(reviewId);
+  const updateComment = useUpdateReviewComment(reviewId);
+  const deleteComment = useDeleteReviewComment(reviewId);
+
+  const [content, setContent] = useState(review.adminComment?.content ?? '');
+  const hasComment = review.adminComment !== null;
+
+  const { data: adminUser } = useOptionalAdminUser(
+    review.adminComment?.adminUserId
+  );
+
+  const handleSubmit = async () => {
+    if (!content.trim()) {
+      toast.error('답글 내용을 입력해주세요.');
+      return;
+    }
+
+    try {
+      if (hasComment) {
+        await updateComment.mutateAsync({ content });
+        toast.success('답글이 수정되었습니다.');
+      } else {
+        await createComment.mutateAsync({ content });
+        toast.success('답글이 등록되었습니다.');
+      }
+    } catch (error: unknown) {
+      const status =
+        error &&
+        typeof error === 'object' &&
+        'response' in error &&
+        typeof (error as { response?: unknown }).response === 'object' &&
+        (error as { response?: { status?: number } }).response?.status;
+
+      if (status === 409) {
+        toast.error('이미 다른 관리자가 답글을 등록했습니다.', {
+          description: '페이지를 새로고침하여 확인해주세요.',
+          action: {
+            label: '새로고침',
+            onClick: () => window.location.reload(),
+          },
+        });
+        return;
+      }
+
+      toast.error(
+        hasComment ? '답글 수정에 실패했습니다.' : '답글 등록에 실패했습니다.'
+      );
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteComment.mutateAsync();
+      setContent('');
+      toast.success('답글이 삭제되었습니다.');
+    } catch (error) {
+      toast.error('답글 삭제에 실패했습니다.');
+    }
+  };
+
+  const isLoading =
+    createComment.isPending ||
+    updateComment.isPending ||
+    deleteComment.isPending;
+
+  return (
+    <div className="p-4 space-y-4">
+      {hasComment && (
+        <div className="text-xs text-muted-foreground space-y-1">
+          <div>
+            작성자: {adminUser?.nickname ?? adminUser?.username ?? '-'}
+          </div>
+          <div>
+            마지막 수정:{' '}
+            {new Date(review.adminComment!.updatedAt).toLocaleString('ko-KR')}
+          </div>
+        </div>
+      )}
+      <Textarea
+        placeholder="리뷰에 대한 관리자 답글을 입력하세요..."
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        rows={6}
+        disabled={isLoading}
+      />
+      <div className="flex gap-2 justify-end">
+        {hasComment && (
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="destructive" size="sm" disabled={isLoading}>
+                삭제
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>답글 삭제</AlertDialogTitle>
+                <AlertDialogDescription>
+                  정말로 답글을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>취소</AlertDialogCancel>
+                <AlertDialogAction onClick={handleDelete}>
+                  삭제
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        )}
+        <Button onClick={handleSubmit} size="sm" disabled={isLoading}>
+          {isLoading ? (
+            <Spinner className="h-4 w-4" />
+          ) : hasComment ? (
+            '수정'
+          ) : (
+            '답글 등록'
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function AdminCommentForm({ reviewId }: { reviewId: string }) {
+  return (
+    <Container className="divide-y">
+      <Header title="관리자 답글" />
+      <Suspense
+        fallback={
+          <div className="flex justify-center p-4">
+            <Spinner />
+          </div>
+        }
+      >
+        <AdminCommentFormContent reviewId={reviewId} />
+      </Suspense>
+    </Container>
+  );
+}

--- a/apps/admin-web/src/features/cs/review/components/review-detail/index.tsx
+++ b/apps/admin-web/src/features/cs/review/components/review-detail/index.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import React, { Suspense, useState } from 'react';
+import { Container } from '@/components/admin-ui-experimental/common/container';
+import { Header } from '@/components/admin-ui-experimental/common/header';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Spinner } from '@/components/ui/spinner';
+import { useReview } from '@/lib/services/review';
+import { useMastersByIdsSuspense } from '@/lib/services/products/queries';
+import { useAdminUser } from '@/lib/services/users/queries';
+import { STATUS_LABELS, ReviewStatus } from '@/lib/types/dto/review';
+import { Badge } from '@/components/ui/badge';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+  type CarouselApi,
+} from '@/components/ui/carousel';
+import { StarIcon } from 'lucide-react';
+import { FILE_SERVICE_BASE_URL } from '@/const/api-const';
+import Image from 'next/image';
+
+function buildProductThumbnailSrc(thumbnail: string | null | undefined) {
+  if (!thumbnail) return '/placeholder.svg';
+  if (thumbnail.startsWith('http://') || thumbnail.startsWith('https://')) {
+    return thumbnail;
+  }
+
+  return `${FILE_SERVICE_BASE_URL}/files/public/${thumbnail}`;
+}
+
+function ratingStars(rating: number) {
+  const safe = Math.max(0, Math.min(5, Math.round(rating)));
+  return (
+    <div className="flex items-center gap-1" aria-label={`별점 ${safe}점`}>
+      {Array.from({ length: 5 }).map((_, index) => (
+        <StarIcon
+          key={index}
+          className={
+            index < safe
+              ? 'h-4 w-4 fill-yellow-400 text-yellow-400'
+              : 'h-4 w-4 text-muted-foreground/40'
+          }
+        />
+      ))}
+      <span className="ml-1 text-sm text-muted-foreground">{safe}</span>
+    </div>
+  );
+}
+
+function statusVariant(
+  status: ReviewStatus
+): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (status === 'active') return 'default';
+  if (status === 'hidden') return 'secondary';
+  if (status === 'deleted') return 'destructive';
+  return 'outline';
+}
+
+function ProductCardSkeleton() {
+  return (
+    <div className="flex items-center gap-3">
+      <Skeleton className="w-16 h-16 rounded shrink-0" />
+      <div className="min-w-0 space-y-1.5">
+        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-3 w-56" />
+      </div>
+    </div>
+  );
+}
+
+function ReviewProductCard({ productId }: { productId: string }) {
+  const { data: products } = useMastersByIdsSuspense([productId]);
+  const product = products.data[0];
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="w-16 h-16 overflow-hidden border rounded shrink-0 bg-muted">
+        <Image
+          src={buildProductThumbnailSrc(product?.thumbnail)}
+          alt={product?.name ?? '상품 이미지'}
+          width={64}
+          height={64}
+          className="object-cover w-full h-full"
+        />
+      </div>
+      <div className="min-w-0 space-y-0.5">
+        <p className="text-sm font-medium">
+          {product?.name ?? (
+            <span className="text-muted-foreground">상품 정보 없음</span>
+          )}
+        </p>
+        <p className="font-mono text-xs text-muted-foreground">{productId}</p>
+      </div>
+    </div>
+  );
+}
+
+function ReviewAuthorName({ userId }: { userId: string }) {
+  const { data: author } = useAdminUser(userId);
+  return <span>{author.nickname ?? author.username ?? userId}</span>;
+}
+
+function ReviewDetailContent({ reviewId }: { reviewId: string }) {
+  const { data } = useReview(reviewId);
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [carouselApi, setCarouselApi] = useState<CarouselApi>();
+
+  const imageUrls = data.mediaFileIds.map(
+    (fileId) => `${FILE_SERVICE_BASE_URL}/files/public/${fileId}`
+  );
+
+  React.useEffect(() => {
+    if (carouselApi && selectedIndex !== null) {
+      carouselApi.scrollTo(selectedIndex);
+    }
+  }, [carouselApi, selectedIndex]);
+
+  const authorNode: React.ReactNode = data.legacy_author_name ? (
+    <span>{data.legacy_author_name}</span>
+  ) : data.userId ? (
+    <Suspense fallback={<Skeleton className="h-4 w-24" />}>
+      <ReviewAuthorName userId={data.userId} />
+    </Suspense>
+  ) : (
+    <span>-</span>
+  );
+
+  const productNode: React.ReactNode = data.productId ? (
+    <Suspense fallback={<ProductCardSkeleton />}>
+      <ReviewProductCard productId={data.productId} />
+    </Suspense>
+  ) : (
+    <span className="text-muted-foreground">-</span>
+  );
+
+  const rows: { key: string; value: React.ReactNode }[] = [
+    { key: '작성자', value: authorNode },
+    { key: '상품', value: productNode },
+    { key: '별점', value: ratingStars(data.rating) },
+    {
+      key: '상태',
+      value: (
+        <Badge variant={statusVariant(data.status)}>
+          {STATUS_LABELS[data.status]}
+        </Badge>
+      ),
+    },
+    {
+      key: '도움이됐어요',
+      value: `${data.helpfulCount}개`,
+    },
+    {
+      key: '작성일',
+      value: new Date(data.createdAt).toLocaleString('ko-KR'),
+    },
+  ];
+
+  return (
+    <article className="divide-y">
+      <header className="p-4">
+        <h2 className="text-lg font-semibold">리뷰 #{data.id.slice(0, 8)}</h2>
+      </header>
+      <dl>
+        {rows.map(({ key, value }) => (
+          <div key={key} className="grid grid-cols-3 p-3">
+            <dt className="text-sm font-medium text-gray-500">{key}</dt>
+            <dd className="col-span-2 text-sm">{value ?? '-'}</dd>
+          </div>
+        ))}
+      </dl>
+      <section className="p-4">
+        <h3 className="mb-2 text-sm font-medium text-gray-500">리뷰 내용</h3>
+        <p className="p-4 text-sm whitespace-pre-wrap rounded-md bg-gray-50">
+          {data.content}
+        </p>
+      </section>
+      {imageUrls.length > 0 && (
+        <section className="p-4">
+          <h3 className="mb-2 text-sm font-medium text-gray-500">
+            첨부파일 ({imageUrls.length}개)
+          </h3>
+          <ul className="flex flex-wrap gap-3">
+            {imageUrls.map((url, index) => (
+              <li key={url}>
+                <button
+                  type="button"
+                  onClick={() => setSelectedIndex(index)}
+                  className="cursor-pointer"
+                >
+                  <Image
+                    width={96}
+                    height={96}
+                    src={url}
+                    alt={`첨부 이미지 ${index + 1}`}
+                    className="object-cover transition-opacity border rounded-md aspect-square hover:opacity-80"
+                  />
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <Dialog
+        open={selectedIndex !== null}
+        onOpenChange={() => setSelectedIndex(null)}
+      >
+        <DialogContent className="max-w-2xl p-4">
+          <Carousel setApi={setCarouselApi} className="w-full">
+            <CarouselContent>
+              {imageUrls.map((url, index) => (
+                <CarouselItem key={url}>
+                  <div className="relative flex h-[70vh] w-full items-center justify-center">
+                    <Image
+                      fill
+                      src={url}
+                      alt={`첨부 이미지 ${index + 1}`}
+                      className="object-contain"
+                    />
+                  </div>
+                </CarouselItem>
+              ))}
+            </CarouselContent>
+            <CarouselPrevious className="left-2" />
+            <CarouselNext className="right-2" />
+          </Carousel>
+        </DialogContent>
+      </Dialog>
+    </article>
+  );
+}
+
+export function ReviewDetail({ reviewId }: { reviewId: string }) {
+  return (
+    <Container className="divide-y">
+      <Header title="리뷰 상세" />
+      <Suspense
+        fallback={
+          <div className="flex justify-center p-4">
+            <Spinner />
+          </div>
+        }
+      >
+        <ReviewDetailContent reviewId={reviewId} />
+      </Suspense>
+    </Container>
+  );
+}

--- a/apps/admin-web/src/features/cs/review/components/review-status-toggle/index.tsx
+++ b/apps/admin-web/src/features/cs/review/components/review-status-toggle/index.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { Suspense, useState } from 'react';
+import { Container } from '@/components/admin-ui-experimental/common/container';
+import { Header } from '@/components/admin-ui-experimental/common/header';
+import { Spinner } from '@/components/ui/spinner';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { useReview, useUpdateReviewStatus } from '@/lib/services/review';
+import {
+  REVIEW_STATUSES,
+  ReviewStatus,
+  STATUS_LABELS,
+} from '@/lib/types/dto/review';
+import { toast } from 'sonner';
+
+function ReviewStatusToggleContent({ reviewId }: { reviewId: string }) {
+  const { data: review } = useReview(reviewId);
+  const updateStatus = useUpdateReviewStatus(reviewId);
+
+  const [pendingStatus, setPendingStatus] = useState<ReviewStatus | null>(null);
+
+  const handleConfirm = async () => {
+    if (!pendingStatus) return;
+
+    try {
+      await updateStatus.mutateAsync({ status: pendingStatus });
+      toast.success(`상태가 "${STATUS_LABELS[pendingStatus]}"(으)로 변경되었습니다.`);
+    } catch (error) {
+      toast.error('상태 변경에 실패했습니다.');
+    } finally {
+      setPendingStatus(null);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-3">
+      <p className="text-xs text-muted-foreground">
+        현재 상태:{' '}
+        <span className="font-medium">{STATUS_LABELS[review.status]}</span>
+      </p>
+      <div className="flex items-center gap-2">
+        <Select
+          value={review.status}
+          onValueChange={(value) => {
+            const next = value as ReviewStatus;
+            if (next !== review.status) {
+              setPendingStatus(next);
+            }
+          }}
+          disabled={updateStatus.isPending}
+        >
+          <SelectTrigger className="flex-1">
+            <SelectValue placeholder="상태 선택" />
+          </SelectTrigger>
+          <SelectContent>
+            {REVIEW_STATUSES.map((status) => (
+              <SelectItem key={status} value={status}>
+                {STATUS_LABELS[status]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {updateStatus.isPending && <Spinner className="h-4 w-4" />}
+      </div>
+
+      <AlertDialog
+        open={pendingStatus !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingStatus(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>리뷰 상태 변경</AlertDialogTitle>
+            <AlertDialogDescription>
+              상태를 &quot;{pendingStatus && STATUS_LABELS[pendingStatus]}&quot;
+              (으)로 변경하시겠습니까?
+              {pendingStatus === 'deleted' &&
+                ' 삭제된 리뷰는 사용자에게 더 이상 노출되지 않습니다.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirm}>변경</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+export function ReviewStatusToggle({ reviewId }: { reviewId: string }) {
+  return (
+    <Container className="divide-y">
+      <Header title="상태 관리" />
+      <Suspense
+        fallback={
+          <div className="flex justify-center p-4">
+            <Spinner />
+          </div>
+        }
+      >
+        <ReviewStatusToggleContent reviewId={reviewId} />
+      </Suspense>
+    </Container>
+  );
+}

--- a/apps/admin-web/src/features/cs/review/components/table/index.tsx
+++ b/apps/admin-web/src/features/cs/review/components/table/index.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useReviews } from '@/lib/services/review';
+import { useMastersByIds } from '@/lib/services/products/queries';
+import { useAdminUsersByIds } from '@/lib/services/users/queries';
+import { useDataTable } from '@/hooks/use-data-table';
+import {
+  useReviewTableColumns,
+  type ReviewProductSummary,
+  type ReviewAuthorSummary,
+} from '@/hooks/table/columns/use-review-table-columns';
+import { useReviewTableFilters } from '@/hooks/table/filters/use-review-table-filters';
+import { useReviewTableQuery } from '@/hooks/table/query/use-review-table-query';
+import { DataTable } from '@/components/data-table';
+
+const PAGE_SIZE = 20;
+
+export function ReviewTable() {
+  const { searchParams: query } = useReviewTableQuery({ pageSize: PAGE_SIZE });
+  const { data, isLoading, isFetching } = useReviews(query);
+
+  const reviews = data?.data ?? [];
+
+  const productIds = useMemo(
+    () =>
+      Array.from(
+        new Set(reviews.map((r) => r.productId).filter(Boolean) as string[])
+      ),
+    [reviews]
+  );
+
+  const userIds = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          reviews
+            .filter((r) => !r.legacy_author_name && !!r.userId)
+            .map((r) => r.userId!) as string[]
+        )
+      ),
+    [reviews]
+  );
+
+  const { data: products } = useMastersByIds(productIds);
+  const { data: users } = useAdminUsersByIds(userIds);
+
+  const productMap = useMemo(() => {
+    const m = new Map<string, ReviewProductSummary>();
+    (products?.data ?? []).forEach((p) => {
+      m.set(p.masterId, {
+        masterId: p.masterId,
+        name: p.name,
+        thumbnail: p.thumbnail,
+      });
+    });
+    return m;
+  }, [products]);
+
+  const userMap = useMemo(() => {
+    const m = new Map<string, ReviewAuthorSummary>();
+    (users?.data ?? []).forEach((u) => {
+      m.set(u.id, { id: u.id, username: u.username, nickname: u.nickname });
+    });
+    return m;
+  }, [users]);
+
+  const columns = useReviewTableColumns({ productMap, userMap });
+  const filters = useReviewTableFilters();
+
+  const { table } = useDataTable({
+    data: reviews,
+    columns,
+    count: data?.total,
+    pageSize: PAGE_SIZE,
+    getRowId: (row) => row.id,
+  });
+
+  return (
+    <DataTable
+      table={table}
+      isLoading={isLoading}
+      isFetching={isFetching}
+      count={data?.total ?? 0}
+      pageSize={PAGE_SIZE}
+      filters={filters}
+      orderBy={[
+        { key: 'latest', label: '최신순' },
+        { key: 'oldest', label: '오래된순' },
+        { key: 'rating_high', label: '별점 높은순' },
+        { key: 'rating_low', label: '별점 낮은순' },
+      ]}
+      orderByPresetOnly
+      search
+      navigateTo={(row) => `/cs/reviews/${row.original.id}`}
+      noRecords={{ message: '리뷰 데이터가 없습니다.' }}
+    />
+  );
+}

--- a/apps/admin-web/src/features/cs/review/template/index.tsx
+++ b/apps/admin-web/src/features/cs/review/template/index.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { ReviewTable } from '../components/table';
+import { Container } from '@/components/admin-ui-experimental/common/container/container';
+import { Header } from '@/components/admin-ui-experimental/common/header/header';
+
+export default function ReviewListTemplate() {
+  return (
+    <Container className="divide-y-0">
+      <Header title="리뷰 관리" />
+      <ReviewTable />
+    </Container>
+  );
+}

--- a/apps/admin-web/src/hooks/table/columns/use-review-table-columns.tsx
+++ b/apps/admin-web/src/hooks/table/columns/use-review-table-columns.tsx
@@ -1,0 +1,112 @@
+import { createColumnHelper } from '@tanstack/react-table';
+import { useMemo } from 'react';
+import { ReviewDto } from '@/lib/types/dto/review';
+import { IdCell, DateCell } from '@/components/table/table-cells/common';
+import {
+  ReviewStatusCell,
+  ReviewRatingCell,
+  ReviewCommentStatusCell,
+} from '@/components/table/table-cells/review';
+import { Copy } from '@/components/admin-ui-experimental/common/copy/copy';
+
+const columnHelper = createColumnHelper<ReviewDto>();
+
+export interface ReviewProductSummary {
+  masterId: string;
+  name: string;
+  thumbnail: string | null;
+}
+
+export interface ReviewAuthorSummary {
+  id: string;
+  username: string;
+  nickname: string | null;
+}
+
+interface ReviewTableColumnContext {
+  productMap: Map<string, ReviewProductSummary>;
+  userMap: Map<string, ReviewAuthorSummary>;
+}
+
+export const useReviewTableColumns = ({
+  productMap,
+  userMap,
+}: ReviewTableColumnContext) => {
+  return useMemo(
+    () => [
+      columnHelper.accessor('id', {
+        header: 'ID',
+        cell: ({ getValue }) => <IdCell value={getValue()} />,
+      }),
+      columnHelper.display({
+        id: 'author',
+        header: '작성자',
+        cell: ({ row }) => {
+          const { legacy_author_name, userId } = row.original;
+          if (legacy_author_name) {
+            return <span>{legacy_author_name}</span>;
+          }
+          if (userId) {
+            const user = userMap.get(userId);
+            const displayName = user?.nickname ?? user?.username;
+            if (displayName) {
+              return <span>{displayName}</span>;
+            }
+            return <IdCell value={userId} />;
+          }
+          return <span className="text-muted-foreground">-</span>;
+        },
+      }),
+      columnHelper.display({
+        id: 'product',
+        header: '상품',
+        cell: ({ row }) => {
+          const { productId } = row.original;
+          const product = productMap.get(productId);
+          if (product?.name) {
+            return (
+              <Copy asChild content={productId}>
+                <span
+                  className="line-clamp-1 cursor-pointer text-sm hover:underline"
+                  title="클릭하여 상품 ID 복사"
+                >
+                  {product.name}
+                </span>
+              </Copy>
+            );
+          }
+          return <IdCell value={productId} />;
+        },
+      }),
+      columnHelper.accessor('rating', {
+        header: '별점',
+        cell: ({ getValue }) => <ReviewRatingCell value={getValue()} />,
+      }),
+      columnHelper.accessor('content', {
+        header: '내용',
+        cell: ({ getValue }) => {
+          const content = getValue() ?? '';
+          const trimmed =
+            content.length > 40 ? `${content.slice(0, 40)}…` : content;
+          return <span className="line-clamp-1">{trimmed}</span>;
+        },
+      }),
+      columnHelper.display({
+        id: 'hasComment',
+        header: '답글',
+        cell: ({ row }) => (
+          <ReviewCommentStatusCell hasComment={!!row.original.adminComment} />
+        ),
+      }),
+      columnHelper.accessor('status', {
+        header: '상태',
+        cell: ({ getValue }) => <ReviewStatusCell value={getValue()} />,
+      }),
+      columnHelper.accessor('createdAt', {
+        header: '작성일',
+        cell: ({ getValue }) => <DateCell value={getValue()} />,
+      }),
+    ],
+    [productMap, userMap]
+  );
+};

--- a/apps/admin-web/src/hooks/table/filters/use-review-table-filters.ts
+++ b/apps/admin-web/src/hooks/table/filters/use-review-table-filters.ts
@@ -1,0 +1,45 @@
+import type { Filter } from '@/components/data-table';
+import {
+  HAS_COMMENT_LABELS,
+  REVIEW_HAS_COMMENT_OPTIONS,
+  REVIEW_RATINGS,
+  REVIEW_STATUSES,
+  STATUS_LABELS,
+} from '@/lib/types/dto/review';
+
+export function useReviewTableFilters(): Filter[] {
+  return [
+    {
+      key: 'status',
+      label: '상태',
+      type: 'select',
+      options: REVIEW_STATUSES.map((status) => ({
+        label: STATUS_LABELS[status],
+        value: status,
+      })),
+    },
+    {
+      key: 'rating',
+      label: '별점',
+      type: 'select',
+      options: REVIEW_RATINGS.map((rating) => ({
+        label: `${rating}점`,
+        value: rating,
+      })),
+    },
+    {
+      key: 'hasComment',
+      label: '어드민 답글',
+      type: 'select',
+      options: REVIEW_HAS_COMMENT_OPTIONS.map((option) => ({
+        label: HAS_COMMENT_LABELS[option],
+        value: option,
+      })),
+    },
+    {
+      key: 'productId',
+      label: '상품 ID',
+      type: 'string',
+    },
+  ];
+}

--- a/apps/admin-web/src/hooks/table/query/use-review-table-query.tsx
+++ b/apps/admin-web/src/hooks/table/query/use-review-table-query.tsx
@@ -1,0 +1,32 @@
+import { ReviewListQuery } from '@/lib/types/dto/review';
+import { useQueryParams } from '../../use-query-params';
+
+type UseReviewTableQueryProps = {
+  prefix?: string;
+  pageSize?: number;
+};
+
+export const useReviewTableQuery = ({
+  prefix,
+  pageSize = 20,
+}: UseReviewTableQueryProps) => {
+  const queryObject = useQueryParams(
+    ['page', 'q', 'status', 'rating', 'hasComment', 'productId', 'sort', 'order'],
+    prefix
+  );
+
+  const { page, q, status, rating, hasComment, productId, sort } = queryObject;
+
+  const searchParams: ReviewListQuery = {
+    limit: pageSize,
+    page: page ? Number(page) : 1,
+    q,
+    status: status as ReviewListQuery['status'],
+    rating: rating as ReviewListQuery['rating'],
+    hasComment: hasComment as ReviewListQuery['hasComment'],
+    productId,
+    sort: sort as ReviewListQuery['sort'],
+  };
+
+  return { searchParams, raw: queryObject };
+};

--- a/apps/admin-web/src/lib/api/domains/products/masters.client.ts
+++ b/apps/admin-web/src/lib/api/domains/products/masters.client.ts
@@ -23,7 +23,10 @@ function buildQueryString(query: Record<string, unknown>): string {
 
 export const mastersClient = {
   create: async (dto: CreateMasterDto): Promise<MasterDto> => {
-    const response = await client.post(`${ALMONDYOUNG_API_BASE_URL}/masters`, dto);
+    const response = await client.post(
+      `${ALMONDYOUNG_API_BASE_URL}/masters`,
+      dto
+    );
     return response.data;
   },
 
@@ -42,12 +45,17 @@ export const mastersClient = {
   },
 
   get: async (id: string): Promise<MasterDto> => {
-    const response = await client.get(`${ALMONDYOUNG_API_BASE_URL}/masters/${id}`);
+    const response = await client.get(
+      `${ALMONDYOUNG_API_BASE_URL}/masters/${id}`
+    );
     return response.data;
   },
 
   update: async (id: string, dto: UpdateMasterDto): Promise<MasterDto> => {
-    const response = await client.put(`${ALMONDYOUNG_API_BASE_URL}/masters/${id}`, dto);
+    const response = await client.put(
+      `${ALMONDYOUNG_API_BASE_URL}/masters/${id}`,
+      dto
+    );
     return response.data;
   },
 
@@ -68,7 +76,39 @@ export const mastersClient = {
   ): Promise<void> => {
     await client.put(`${ALMONDYOUNG_API_BASE_URL}/masters/${id}/pricing`, dto);
   },
+
+  listByIds: async (
+    ids: string[]
+  ): Promise<{
+    data: ProductSummary[];
+    total: number;
+    page: number;
+    limit: number;
+  }> => {
+    if (ids.length === 0) {
+      return { data: [], total: 0, page: 1, limit: 0 };
+    }
+
+    const response = await client.get(
+      `${ALMONDYOUNG_API_BASE_URL}/masters?ids=${ids.join(',')}`
+    );
+
+    return response.data;
+  },
 };
+
+export interface ProductSummary {
+  masterId: string;
+  versionId: string;
+  name: string;
+  thumbnail: string | null;
+  brand: string | null;
+  isMembershipOnly: boolean;
+  status: string;
+  createdAt: string;
+  optionGroupNames: string[];
+  variantCount: number;
+}
 
 /**
  * 제품 마스터 목록 조회
@@ -90,7 +130,9 @@ export const getMasters = async (
  * GET /masters/{id}
  */
 export const getMaster = async (id: string): Promise<MasterDto> => {
-  const response = await client.get(`${ALMONDYOUNG_API_BASE_URL}/masters/${id}`);
+  const response = await client.get(
+    `${ALMONDYOUNG_API_BASE_URL}/masters/${id}`
+  );
   return response.data;
 };
 
@@ -102,7 +144,10 @@ export const updateMaster = async (
   id: string,
   data: UpdateMasterDto
 ): Promise<MasterDto> => {
-  const response = await client.put(`${ALMONDYOUNG_API_BASE_URL}/masters/${id}`, data);
+  const response = await client.put(
+    `${ALMONDYOUNG_API_BASE_URL}/masters/${id}`,
+    data
+  );
   return response.data;
 };
 
@@ -149,4 +194,5 @@ export const masters = {
   delete: deleteMaster,
   getPricePreview,
   updatePricingStrategy,
+  listByIds: mastersClient.listByIds,
 };

--- a/apps/admin-web/src/lib/api/domains/review/index.ts
+++ b/apps/admin-web/src/lib/api/domains/review/index.ts
@@ -1,0 +1,83 @@
+import { UGC_SERVICE_BASE_URL } from '@/const';
+import {
+  AdminCommentDto,
+  CreateReviewCommentDto,
+  ReviewDto,
+  ReviewListQuery,
+  ReviewListResponse,
+  UpdateReviewStatusDto,
+} from '@/lib/types/dto/review';
+import { AxiosResponse } from 'axios';
+import { client } from '../../client';
+
+function buildQueryString(query: ReviewListQuery): string {
+  const params = new URLSearchParams();
+  Object.entries(query).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      params.append(key, String(value));
+    }
+  });
+  return params.toString();
+}
+
+export const reviewApi = {
+  // 리뷰 목록 조회 (관리자용)
+  getReviews: async (query: ReviewListQuery): Promise<ReviewListResponse> => {
+    const qs = buildQueryString(query);
+    const response: AxiosResponse<ReviewListResponse> = await client.get(
+      `${UGC_SERVICE_BASE_URL}/reviews/admin/reviews${qs ? `?${qs}` : ''}`
+    );
+    return response.data;
+  },
+
+  // 리뷰 상세 조회 (관리자용)
+  getReview: async (id: string): Promise<ReviewDto> => {
+    const response: AxiosResponse<ReviewDto> = await client.get(
+      `${UGC_SERVICE_BASE_URL}/reviews/admin/reviews/${id}`
+    );
+    return response.data;
+  },
+
+  // 리뷰 상태 변경 (활성/숨김/삭제)
+  updateStatus: async (
+    reviewId: string,
+    dto: UpdateReviewStatusDto
+  ): Promise<ReviewDto> => {
+    const response: AxiosResponse<ReviewDto> = await client.patch(
+      `${UGC_SERVICE_BASE_URL}/reviews/admin/reviews/${reviewId}/status`,
+      dto
+    );
+    return response.data;
+  },
+
+  // 어드민 댓글 작성
+  createComment: async (
+    reviewId: string,
+    dto: CreateReviewCommentDto
+  ): Promise<AdminCommentDto> => {
+    const response: AxiosResponse<AdminCommentDto> = await client.post(
+      `${UGC_SERVICE_BASE_URL}/reviews/${reviewId}/comment`,
+      dto
+    );
+    return response.data;
+  },
+
+  // 어드민 댓글 수정
+  updateComment: async (
+    reviewId: string,
+    dto: CreateReviewCommentDto
+  ): Promise<AdminCommentDto> => {
+    const response: AxiosResponse<AdminCommentDto> = await client.patch(
+      `${UGC_SERVICE_BASE_URL}/reviews/${reviewId}/comment`,
+      dto
+    );
+    return response.data;
+  },
+
+  // 어드민 댓글 삭제
+  deleteComment: async (reviewId: string): Promise<void> => {
+    await client.delete(
+      `${UGC_SERVICE_BASE_URL}/reviews/${reviewId}/comment`
+    );
+  },
+};

--- a/apps/admin-web/src/lib/services/products/queries.ts
+++ b/apps/admin-web/src/lib/services/products/queries.ts
@@ -3,7 +3,7 @@
 
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { productQueryKeys } from './query-keys';
 import { products } from '@/lib/api/domains';
 import { channelListingsClient } from '@/lib/api/domains/products/channel-listings.client';
@@ -109,6 +109,33 @@ export const useMaster = (id: string) => {
     queryFn: () => products.masters.get(id),
     enabled: !!id,
     staleTime: 30 * 1000,
+    gcTime: 5 * 60 * 1000,
+  });
+};
+
+/**
+ * 제품 마스터 ID 목록으로 배치 조회 (썸네일/이름 lookup용)
+ */
+export const useMastersByIds = (ids: string[]) => {
+  const uniqueIds = Array.from(new Set(ids.filter(Boolean)));
+  return useQuery({
+    queryKey: productQueryKeys.mastersBatch(uniqueIds),
+    queryFn: () => products.masters.listByIds(uniqueIds),
+    enabled: uniqueIds.length > 0,
+    staleTime: 60 * 1000,
+    gcTime: 5 * 60 * 1000,
+  });
+};
+
+/**
+ * 제품 마스터 배치 조회
+ */
+export const useMastersByIdsSuspense = (ids: string[]) => {
+  const uniqueIds = Array.from(new Set(ids.filter(Boolean)));
+  return useSuspenseQuery({
+    queryKey: productQueryKeys.mastersBatch(uniqueIds),
+    queryFn: () => products.masters.listByIds(uniqueIds),
+    staleTime: 60 * 1000,
     gcTime: 5 * 60 * 1000,
   });
 };
@@ -503,7 +530,10 @@ export const useMasterPricingRules = (masterId: string) => {
   });
 };
 
-export const useVersionVariantPriceSet = (versionId: string, variantId: string) => {
+export const useVersionVariantPriceSet = (
+  versionId: string,
+  variantId: string
+) => {
   return useQuery({
     queryKey: productQueryKeys.pricingVersionPriceSet(versionId, variantId),
     queryFn: () => products.pricing.versions.getPriceSet(versionId, variantId),
@@ -512,7 +542,10 @@ export const useVersionVariantPriceSet = (versionId: string, variantId: string) 
   });
 };
 
-export const useMasterVariantPriceSet = (masterId: string, variantId: string) => {
+export const useMasterVariantPriceSet = (
+  masterId: string,
+  variantId: string
+) => {
   return useQuery({
     queryKey: productQueryKeys.pricingMasterPriceSet(masterId, variantId),
     queryFn: () => products.pricing.masters.getPriceSet(masterId, variantId),

--- a/apps/admin-web/src/lib/services/products/query-keys.ts
+++ b/apps/admin-web/src/lib/services/products/query-keys.ts
@@ -15,6 +15,8 @@ export const productQueryKeys = {
   masters: ['masters'] as const,
   mastersList: (query: Record<string, any>) =>
     [...productQueryKeys.masters, 'list', query] as const,
+  mastersBatch: (ids: string[]) =>
+    [...productQueryKeys.masters, 'batch', ids.slice().sort().join(',')] as const,
   master: (id: string) => [...productQueryKeys.masters, id] as const,
   masterPricePreview: (id: string) =>
     [...productQueryKeys.master(id), 'price-preview'] as const,

--- a/apps/admin-web/src/lib/services/review/index.ts
+++ b/apps/admin-web/src/lib/services/review/index.ts
@@ -1,0 +1,3 @@
+export * from './query-keys';
+export * from './queries';
+export * from './mutations';

--- a/apps/admin-web/src/lib/services/review/mutations.ts
+++ b/apps/admin-web/src/lib/services/review/mutations.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { reviewApi } from '@/lib/api/domains/review';
+import {
+  CreateReviewCommentDto,
+  UpdateReviewStatusDto,
+} from '@/lib/types/dto/review';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { reviewQueryKeys } from './query-keys';
+
+export const useUpdateReviewStatus = (reviewId: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (dto: UpdateReviewStatusDto) =>
+      reviewApi.updateStatus(reviewId, dto),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: reviewQueryKeys.review(reviewId),
+      });
+      queryClient.invalidateQueries({ queryKey: reviewQueryKeys.all });
+    },
+  });
+};
+
+export const useCreateReviewComment = (reviewId: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (dto: CreateReviewCommentDto) =>
+      reviewApi.createComment(reviewId, dto),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: reviewQueryKeys.review(reviewId),
+      });
+      queryClient.invalidateQueries({ queryKey: reviewQueryKeys.all });
+    },
+  });
+};
+
+export const useUpdateReviewComment = (reviewId: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (dto: CreateReviewCommentDto) =>
+      reviewApi.updateComment(reviewId, dto),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: reviewQueryKeys.review(reviewId),
+      });
+      queryClient.invalidateQueries({ queryKey: reviewQueryKeys.all });
+    },
+  });
+};
+
+export const useDeleteReviewComment = (reviewId: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => reviewApi.deleteComment(reviewId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: reviewQueryKeys.review(reviewId),
+      });
+      queryClient.invalidateQueries({ queryKey: reviewQueryKeys.all });
+    },
+  });
+};

--- a/apps/admin-web/src/lib/services/review/queries.ts
+++ b/apps/admin-web/src/lib/services/review/queries.ts
@@ -1,0 +1,25 @@
+import { reviewApi } from '@/lib/api/domains/review';
+import { ReviewListQuery } from '@/lib/types/dto/review';
+import {
+  keepPreviousData,
+  useQuery,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
+import { reviewQueryKeys } from './query-keys';
+
+export const useReviews = (query: ReviewListQuery) => {
+  return useQuery({
+    queryKey: reviewQueryKeys.list(query),
+    queryFn: () => reviewApi.getReviews(query),
+    staleTime: 30 * 1000,
+    placeholderData: keepPreviousData,
+  });
+};
+
+export const useReview = (id: string) => {
+  return useSuspenseQuery({
+    queryKey: reviewQueryKeys.review(id),
+    queryFn: () => reviewApi.getReview(id),
+    staleTime: 30 * 1000,
+  });
+};

--- a/apps/admin-web/src/lib/services/review/query-keys.ts
+++ b/apps/admin-web/src/lib/services/review/query-keys.ts
@@ -1,0 +1,7 @@
+import { ReviewListQuery } from '@/lib/types/dto/review';
+
+export const reviewQueryKeys = {
+  all: ['review'] as const,
+  list: (query: ReviewListQuery) => [...reviewQueryKeys.all, 'list', query] as const,
+  review: (id: string) => [...reviewQueryKeys.all, 'review', id] as const,
+} as const;

--- a/apps/admin-web/src/lib/services/users/queries.ts
+++ b/apps/admin-web/src/lib/services/users/queries.ts
@@ -40,3 +40,20 @@ export const useUserRoles = (userId: string) => {
     staleTime: 30 * 1000,
   });
 };
+
+/**
+ * 사용자 ID 목록으로 배치 조회 (작성자명 lookup용)
+ */
+export const useAdminUsersByIds = (ids: string[]) => {
+  const uniqueIds = Array.from(new Set(ids.filter(Boolean)));
+  return useQuery({
+    queryKey: usersQueryKeys.batch(uniqueIds),
+    queryFn: () =>
+      userApi.getAdminUsers({
+        ids: uniqueIds.join(','),
+        limit: uniqueIds.length,
+      }),
+    enabled: uniqueIds.length > 0,
+    staleTime: 60 * 1000,
+  });
+};

--- a/apps/admin-web/src/lib/services/users/query-keys.ts
+++ b/apps/admin-web/src/lib/services/users/query-keys.ts
@@ -9,6 +9,8 @@ export const usersQueryKeys = {
   all: ['users'] as const,
   list: (query: AdminUsersQuery) =>
     [...usersQueryKeys.all, 'list', query] as const,
+  batch: (ids: string[]) =>
+    [...usersQueryKeys.all, 'batch', ids.slice().sort().join(',')] as const,
   user: (id: string) => [...usersQueryKeys.all, id] as const,
   userRolesById: (userId: string) =>
     [...usersQueryKeys.all, userId, 'roles'] as const,

--- a/apps/admin-web/src/lib/types/dto/review.ts
+++ b/apps/admin-web/src/lib/types/dto/review.ts
@@ -1,0 +1,83 @@
+// 리뷰 관련 DTO 타입 정의
+
+export const REVIEW_STATUSES = ['active', 'hidden', 'deleted'] as const;
+export type ReviewStatus = (typeof REVIEW_STATUSES)[number];
+
+export const REVIEW_RATINGS = ['1', '2', '3', '4', '5'] as const;
+export type ReviewRating = (typeof REVIEW_RATINGS)[number];
+
+export const REVIEW_HAS_COMMENT_OPTIONS = ['true', 'false'] as const;
+export type ReviewHasCommentOption = (typeof REVIEW_HAS_COMMENT_OPTIONS)[number];
+
+export const REVIEW_SORT_OPTIONS = ['latest', 'oldest', 'rating_high', 'rating_low'] as const;
+export type ReviewSortOption = (typeof REVIEW_SORT_OPTIONS)[number];
+
+export interface AdminCommentDto {
+  id: string;
+  reviewId: string;
+  adminUserId: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ReviewDto {
+  id: string;
+  userId: string | null;
+  productId: string;
+  rating: number;
+  content: string;
+  legacy_author_name: string | null;
+  mediaFileIds: string[];
+  helpfulCount: number;
+  likeCount: number;
+  dislikeCount: number;
+  status: ReviewStatus;
+  createdAt: string;
+  updatedAt: string;
+  adminComment: AdminCommentDto | null;
+}
+
+export interface ReviewListQuery {
+  page?: number;
+  limit?: number;
+  status?: ReviewStatus;
+  rating?: ReviewRating;
+  productId?: string;
+  hasComment?: ReviewHasCommentOption;
+  sort?: ReviewSortOption;
+  q?: string;
+}
+
+export interface ReviewListResponse {
+  data: ReviewDto[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export interface UpdateReviewStatusDto {
+  status: ReviewStatus;
+}
+
+export interface CreateReviewCommentDto {
+  content: string;
+}
+
+export const STATUS_LABELS: Record<ReviewStatus, string> = {
+  active: '공개',
+  hidden: '비공개',
+  deleted: '삭제됨',
+};
+
+export const HAS_COMMENT_LABELS: Record<ReviewHasCommentOption, string> = {
+  true: '작성됨',
+  false: '미작성',
+};
+
+export const SORT_LABELS: Record<ReviewSortOption, string> = {
+  latest: '최신순',
+  oldest: '오래된순',
+  rating_high: '별점 높은순',
+  rating_low: '별점 낮은순',
+};

--- a/apps/admin-web/src/lib/types/dto/user.ts
+++ b/apps/admin-web/src/lib/types/dto/user.ts
@@ -40,6 +40,7 @@ interface AdminUsersQuery {
   roleName?: string;
   sort?: string;
   order?: string;
+  ids?: string;
 }
 
 interface AdminUserDto {

--- a/apps/almondyoung-server/src/modules/catalog/core/products/controllers/product-masters.controller.ts
+++ b/apps/almondyoung-server/src/modules/catalog/core/products/controllers/product-masters.controller.ts
@@ -137,6 +137,12 @@ export class ProductMastersController {
     type: String,
     description: '삭제된 상품 포함 여부 (기본값: false)',
   })
+  @ApiQuery({
+    name: 'ids',
+    required: false,
+    type: String,
+    description: 'master ID 목록 (UUID 콤마 구분, 예: id1,id2,id3). 지정 시 페이지네이션 무시하고 일치 항목만 반환',
+  })
   @ApiOkResponsePaginated(ProductSummaryDto, {
     description: '상품 목록 조회 성공',
   })
@@ -151,8 +157,14 @@ export class ProductMastersController {
       name?: string;
       mode?: 'active' | 'active-or-inactive';
       deleted?: string;
+      ids?: string;
     },
   ): Promise<PaginatedResponseDto<ProductSummaryDto>> {
+    const ids = query.ids
+      ?.split(',')
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0);
+
     const filters = {
       page: query.page ? parseInt(query.page) : undefined,
       limit: query.limit ? parseInt(query.limit) : undefined,
@@ -161,6 +173,7 @@ export class ProductMastersController {
       name: query.name,
       mode: query.mode,
       deleted: query.deleted === 'true',
+      ids: ids && ids.length > 0 ? ids : undefined,
     };
 
     const result = await this.productMastersService.getMasters(filters);

--- a/apps/almondyoung-server/src/modules/catalog/core/products/services/product-masters.service.ts
+++ b/apps/almondyoung-server/src/modules/catalog/core/products/services/product-masters.service.ts
@@ -485,6 +485,7 @@ export class ProductMastersService {
       page?: number;
       limit?: number;
       deleted?: boolean;
+      ids?: string[];
     },
     tx?: DbTransaction,
   ): Promise<{
@@ -592,6 +593,11 @@ export class ProductMastersService {
       // name 검색 필터
       if (filters?.name) {
         whereConditions.push(ilike(productMasterVersions.name, `%${filters.name}%`));
+      }
+
+      // ids 필터 (배치 조회용)
+      if (filters?.ids && filters.ids.length > 0) {
+        whereConditions.push(inArray(productMasters.id, filters.ids));
       }
 
       // ===== 최종 where 절 빌드 =====

--- a/apps/pim/src/core/products/controllers/product-masters.controller.ts
+++ b/apps/pim/src/core/products/controllers/product-masters.controller.ts
@@ -137,6 +137,12 @@ export class ProductMastersController {
     type: String,
     description: '삭제된 상품 포함 여부 (기본값: false)',
   })
+  @ApiQuery({
+    name: 'ids',
+    required: false,
+    type: String,
+    description: 'master ID 목록 (UUID 콤마 구분, 예: id1,id2,id3). 지정 시 페이지네이션 무시하고 일치 항목만 반환',
+  })
   @ApiOkResponsePaginated(ProductSummaryDto, {
     description: '상품 목록 조회 성공',
   })
@@ -151,8 +157,14 @@ export class ProductMastersController {
       name?: string;
       mode?: 'active' | 'active-or-inactive';
       deleted?: string;
+      ids?: string;
     },
   ): Promise<PaginatedResponseDto<ProductSummaryDto>> {
+    const ids = query.ids
+      ?.split(',')
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0);
+
     const filters = {
       page: query.page ? parseInt(query.page) : undefined,
       limit: query.limit ? parseInt(query.limit) : undefined,
@@ -161,6 +173,7 @@ export class ProductMastersController {
       name: query.name,
       mode: query.mode,
       deleted: query.deleted === 'true',
+      ids: ids && ids.length > 0 ? ids : undefined,
     };
 
     const result = await this.productMastersService.getMasters(filters);

--- a/apps/pim/src/core/products/services/product-masters.service.ts
+++ b/apps/pim/src/core/products/services/product-masters.service.ts
@@ -464,6 +464,7 @@ export class ProductMastersService {
       page?: number;
       limit?: number;
       deleted?: boolean;
+      ids?: string[];
     },
     tx?: DbTransaction,
   ): Promise<{
@@ -571,6 +572,11 @@ export class ProductMastersService {
       // name 검색 필터
       if (filters?.name) {
         whereConditions.push(ilike(productMasterVersions.name, `%${filters.name}%`));
+      }
+
+      // ids 필터 (배치 조회용)
+      if (filters?.ids && filters.ids.length > 0) {
+        whereConditions.push(inArray(productMasters.id, filters.ids));
       }
 
       // ===== 최종 where 절 빌드 =====

--- a/apps/ugc-service/src/db/schema.ts
+++ b/apps/ugc-service/src/db/schema.ts
@@ -21,6 +21,8 @@ const timestampColumns = {
 
 export const reviewRewardPolicyTypeEnum = pgEnum('review_reward_policy_type', ['TEXT', 'PHOTO']);
 
+export const reviewStatusEnum = pgEnum('review_status', ['active', 'hidden', 'deleted']);
+
 export const reviewRewardPolicies = pgTable(
   'review_reward_policies',
   {
@@ -53,7 +55,7 @@ export const reviews = pgTable(
     rating: integer('rating').notNull(),
     content: text('content').notNull(),
 
-    status: varchar('status', { length: 20 }).notNull().default('active'),
+    status: reviewStatusEnum('status').notNull().default('active'),
 
     sourceSystem: varchar('source_system', { length: 30 }).notNull().default('almondyoung'),
 

--- a/apps/ugc-service/src/reviews/controllers/reviews.controller.ts
+++ b/apps/ugc-service/src/reviews/controllers/reviews.controller.ts
@@ -5,8 +5,9 @@ import { ReviewsService } from '../services/reviews.service';
 import { CreateReviewDto } from '../dto/create-review.dto';
 import { MyReviewListQueryDto } from '../dto/my-review-list-query.dto';
 import { RatingSummaryQueryDto, RatingSummaryResponseDto } from '../dto/rating-summary.dto';
-import { ReviewListQueryDto } from '../dto/review-list-query.dto';
+import { AdminReviewListQueryDto, ReviewListQueryDto } from '../dto/review-list-query.dto';
 import { UpdateReviewDto } from '../dto/update-review.dto';
+import { UpdateReviewStatusDto } from '../dto/update-review-status.dto';
 import { CommentResponseDto } from '../dto/comment-response.dto';
 import { CreateCommentDto } from '../dto/create-comment.dto';
 import { ReviewResponseDto } from '../dto/review-response.dto';
@@ -139,6 +140,71 @@ export class ReviewsController {
   })
   async ratingSummary(@Query() query: RatingSummaryQueryDto): Promise<RatingSummaryResponseDto> {
     return this.reviewsService.getRatingSummary(query.productId);
+  }
+
+  // ─── 관리자용 조회 ───
+
+  @Get('admin/reviews')
+  @RequireScopes('admin:ugc:read')
+  @ApiOperation({ summary: '전체 리뷰 목록 조회 (관리자)' })
+  @ApiQuery({
+    name: 'status',
+    description: '상태 필터 (미지정 시 deleted 제외)',
+    required: false,
+    enum: ['active', 'hidden', 'deleted'],
+  })
+  @ApiQuery({
+    name: 'rating',
+    description: '평점 필터 (1~5 또는 positive/negative)',
+    required: false,
+    enum: ['1', '2', '3', '4', '5', 'positive', 'negative'],
+  })
+  @ApiQuery({ name: 'productId', description: '상품 ID (UUID)', required: false, type: String })
+  @ApiQuery({
+    name: 'hasComment',
+    description: '어드민 댓글 작성 여부 ("true"/"false")',
+    required: false,
+    enum: ['true', 'false'],
+  })
+  @ApiQuery({
+    name: 'sort',
+    description: '정렬 옵션',
+    required: false,
+    enum: ['latest', 'oldest', 'rating_high', 'rating_low'],
+  })
+  @ApiQuery({ name: 'q', description: '검색어 (본문, 작성자명)', required: false, type: String })
+  @ApiQuery({ name: 'page', description: '페이지 번호', required: false, type: Number })
+  @ApiQuery({ name: 'limit', description: '페이지당 아이템 수', required: false, type: Number })
+  @ApiOkResponsePaginated(ReviewResponseDto, { description: '전체 리뷰 목록 조회 성공' })
+  async listReviewsForAdmin(@Query() query: AdminReviewListQueryDto): Promise<PaginatedResponseDto<ReviewResponseDto>> {
+    const result = await this.reviewsService.listAllForAdmin(query);
+    return {
+      ...result,
+      data: result.data.map(ReviewMapper.toResponse),
+    };
+  }
+
+  @Get('admin/reviews/:id')
+  @RequireScopes('admin:ugc:read')
+  @ApiOperation({ summary: '리뷰 상세 조회 (관리자)' })
+  @ApiParam({ name: 'id', description: '리뷰 ID (UUID)' })
+  @ApiResponse({ status: HttpStatus.OK, description: '리뷰 상세 조회 성공', type: ReviewResponseDto })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: '리뷰를 찾을 수 없음' })
+  async getReviewForAdmin(@Param('id') id: string): Promise<ReviewResponseDto> {
+    const review = await this.reviewsService.getReviewForAdmin(id);
+    return ReviewMapper.toResponse(review);
+  }
+
+  @Patch('admin/reviews/:id/status')
+  @RequireScopes('admin:ugc:modify')
+  @ApiOperation({ summary: '리뷰 상태 변경 (활성/숨김/삭제)' })
+  @ApiParam({ name: 'id', description: '리뷰 ID (UUID)' })
+  @ApiBody({ type: UpdateReviewStatusDto })
+  @ApiResponse({ status: HttpStatus.OK, description: '상태 변경 성공', type: ReviewResponseDto })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: '리뷰를 찾을 수 없음' })
+  async updateReviewStatus(@Param('id') id: string, @Body() dto: UpdateReviewStatusDto): Promise<ReviewResponseDto> {
+    const review = await this.reviewsService.updateStatus(id, dto.status);
+    return ReviewMapper.toResponse(review);
   }
 
   @Patch(':id')

--- a/apps/ugc-service/src/reviews/dto/review-list-query.dto.ts
+++ b/apps/ugc-service/src/reviews/dto/review-list-query.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsIn, IsOptional, IsUUID } from 'class-validator';
 import { PaginationQueryDto } from '@app/shared/dto';
+import { type ReviewStatus } from '../types';
 
 export const REVIEW_RATING_FILTERS = ['1', '2', '3', '4', '5', 'positive', 'negative'] as const;
 
@@ -9,6 +10,11 @@ export type ReviewRatingFilter = (typeof REVIEW_RATING_FILTERS)[number];
 export const REVIEW_SORT_OPTIONS = ['latest', 'oldest', 'rating_high', 'rating_low'] as const;
 
 export type ReviewSortOption = (typeof REVIEW_SORT_OPTIONS)[number];
+
+export const REVIEW_STATUS_FILTERS = ['active', 'hidden', 'deleted'] as const;
+
+export const REVIEW_HAS_COMMENT_FILTERS = ['true', 'false'] as const;
+export type ReviewHasCommentFilter = (typeof REVIEW_HAS_COMMENT_FILTERS)[number];
 
 export class ReviewListQueryDto extends PaginationQueryDto {
   @ApiProperty({
@@ -36,4 +42,53 @@ export class ReviewListQueryDto extends PaginationQueryDto {
   @IsOptional()
   @IsIn(REVIEW_SORT_OPTIONS)
   sort?: ReviewSortOption;
+}
+
+// 관리자용 전체 리뷰 조회
+export class AdminReviewListQueryDto extends PaginationQueryDto {
+  @ApiPropertyOptional({
+    description: '상태 필터 (미지정 시 deleted 제외)',
+    enum: REVIEW_STATUS_FILTERS,
+  })
+  @IsOptional()
+  @IsIn(REVIEW_STATUS_FILTERS)
+  status?: ReviewStatus;
+
+  @ApiPropertyOptional({
+    description: '평점 필터 (1~5 또는 positive/negative)',
+    enum: REVIEW_RATING_FILTERS,
+  })
+  @IsOptional()
+  @IsIn(REVIEW_RATING_FILTERS)
+  rating?: ReviewRatingFilter;
+
+  @ApiPropertyOptional({
+    description: '상품 ID (UUID 전체 또는 부분 문자열). 어드민 검색용으로 부분 매칭(ILIKE) 지원.',
+    example: 'f7b98c38',
+  })
+  @IsOptional()
+  productId?: string;
+
+  @ApiPropertyOptional({
+    description: '어드민 댓글 작성 여부 ("true"=작성됨, "false"=미작성)',
+    enum: REVIEW_HAS_COMMENT_FILTERS,
+  })
+  @IsOptional()
+  @IsIn(REVIEW_HAS_COMMENT_FILTERS)
+  hasComment?: ReviewHasCommentFilter;
+
+  @ApiPropertyOptional({
+    description: '정렬 옵션',
+    enum: REVIEW_SORT_OPTIONS,
+    default: 'latest',
+  })
+  @IsOptional()
+  @IsIn(REVIEW_SORT_OPTIONS)
+  sort?: ReviewSortOption;
+
+  @ApiPropertyOptional({
+    description: '검색어 (본문, 작성자명)',
+  })
+  @IsOptional()
+  q?: string;
 }

--- a/apps/ugc-service/src/reviews/dto/update-review-status.dto.ts
+++ b/apps/ugc-service/src/reviews/dto/update-review-status.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn } from 'class-validator';
+import { type ReviewStatus } from '../types';
+
+export const REVIEW_STATUS_VALUES = ['active', 'hidden', 'deleted'] as const;
+
+export class UpdateReviewStatusDto {
+  @ApiProperty({
+    description: '리뷰 상태',
+    enum: REVIEW_STATUS_VALUES,
+  })
+  @IsIn(REVIEW_STATUS_VALUES)
+  status: ReviewStatus;
+}

--- a/apps/ugc-service/src/reviews/services/reviews.service.ts
+++ b/apps/ugc-service/src/reviews/services/reviews.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, ConflictException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { DbService, InjectDb } from '@app/db';
-import { and, asc, count, desc, eq, exists, gte, inArray, isNull, notExists, type SQL } from 'drizzle-orm';
+import { and, asc, count, desc, eq, exists, gte, inArray, isNull, ne, notExists, sql, type SQL } from 'drizzle-orm';
 import {
   reviewComments,
   reviewEligibilities,
@@ -12,9 +12,9 @@ import {
 import { CreateReviewDto } from '../dto/create-review.dto';
 import { CreateCommentDto } from '../dto/create-comment.dto';
 import { MyReviewListQueryDto } from '../dto/my-review-list-query.dto';
-import { ReviewListQueryDto } from '../dto/review-list-query.dto';
+import { AdminReviewListQueryDto, ReviewListQueryDto } from '../dto/review-list-query.dto';
 import { UpdateReviewDto } from '../dto/update-review.dto';
-import { type ReviewCommentEntity, type ReviewEntity, type ReviewWithMediaEntity } from '../types';
+import { type ReviewCommentEntity, type ReviewEntity, type ReviewStatus, type ReviewWithMediaEntity } from '../types';
 import { PaginatedResponseDto } from '@app/shared/dto';
 import { MAX_REVIEW_MEDIA_COUNT } from '../constants';
 import { ReviewRewardPolicyService } from './review-reward-policy.service';
@@ -581,6 +581,156 @@ export class ReviewsService {
         total,
         page,
         limit,
+      };
+    }, tx);
+  }
+
+  // ─── 관리자용 ───
+
+  async listAllForAdmin(
+    query: AdminReviewListQueryDto,
+    tx?: DbTransaction,
+  ): Promise<PaginatedResponseDto<ReviewWithMediaEntity>> {
+    return this.inTx(async (tx) => {
+      const page = query.page ?? 1;
+      const limit = query.limit ?? 20;
+      const offset = (page - 1) * limit;
+
+      const conditions: SQL[] = [];
+
+      if (query.status) {
+        conditions.push(eq(reviews.status, query.status));
+      } else {
+        conditions.push(ne(reviews.status, 'deleted'));
+      }
+
+      if (query.rating) {
+        if (query.rating === 'positive') {
+          conditions.push(inArray(reviews.rating, [4, 5]));
+        } else if (query.rating === 'negative') {
+          conditions.push(inArray(reviews.rating, [1, 2]));
+        } else {
+          conditions.push(eq(reviews.rating, Number(query.rating)));
+        }
+      }
+
+      if (query.productId) {
+        const productIdTerm = `%${query.productId}%`;
+        conditions.push(sql`${reviews.productId}::text ILIKE ${productIdTerm}`);
+      }
+
+      if (query.hasComment === 'true') {
+        conditions.push(
+          exists(
+            tx.select({ one: reviewComments.id }).from(reviewComments).where(eq(reviewComments.reviewId, reviews.id)),
+          ),
+        );
+      } else if (query.hasComment === 'false') {
+        conditions.push(
+          notExists(
+            tx.select({ one: reviewComments.id }).from(reviewComments).where(eq(reviewComments.reviewId, reviews.id)),
+          ),
+        );
+      }
+
+      if (query.q) {
+        const searchTerm = `%${query.q}%`;
+        conditions.push(
+          sql`(${reviews.content} ILIKE ${searchTerm} OR COALESCE(${reviews.legacyAuthorName}, '') ILIKE ${searchTerm})`,
+        );
+      }
+
+      const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+      const [{ count: total }] = await tx.select({ count: count() }).from(reviews).where(whereClause);
+
+      const orderByClause = {
+        latest: desc(reviews.createdAt),
+        oldest: asc(reviews.createdAt),
+        rating_high: desc(reviews.rating),
+        rating_low: asc(reviews.rating),
+      }[query.sort ?? 'latest'];
+
+      const data = await tx
+        .select()
+        .from(reviews)
+        .where(whereClause)
+        .orderBy(orderByClause)
+        .limit(limit)
+        .offset(offset);
+
+      const reviewIds = data.map((review) => review.id);
+      const mediaMap = await this.fetchMediaFileIdsByReviewIds(reviewIds, tx);
+      const reactionCountMap = await this.fetchReactionCounts(reviewIds, tx);
+      const commentMap = await this.fetchCommentsByReviewIds(reviewIds, tx);
+
+      return {
+        data: data.map((review) => {
+          const counts = reactionCountMap.get(review.id) ?? { helpfulCount: 0, likeCount: 0, dislikeCount: 0 };
+          return {
+            ...review,
+            mediaFileIds: mediaMap.get(review.id) ?? [],
+            helpfulCount: counts.helpfulCount,
+            likeCount: counts.likeCount,
+            dislikeCount: counts.dislikeCount,
+            adminComment: commentMap.get(review.id) ?? null,
+          };
+        }),
+        total,
+        page,
+        limit,
+      };
+    }, tx);
+  }
+
+  async getReviewForAdmin(id: string, tx?: DbTransaction): Promise<ReviewWithMediaEntity> {
+    return this.inTx(async (tx) => {
+      const [review] = await tx.select().from(reviews).where(eq(reviews.id, id));
+
+      if (!review) {
+        throw new NotFoundException('Review not found');
+      }
+
+      const mediaFileIds = await this.fetchMediaFileIdsByReviewId(id, tx);
+      const reactionCountMap = await this.fetchReactionCounts([id], tx);
+      const counts = reactionCountMap.get(id) ?? { helpfulCount: 0, likeCount: 0, dislikeCount: 0 };
+      const commentMap = await this.fetchCommentsByReviewIds([id], tx);
+
+      return {
+        ...review,
+        mediaFileIds,
+        helpfulCount: counts.helpfulCount,
+        likeCount: counts.likeCount,
+        dislikeCount: counts.dislikeCount,
+        adminComment: commentMap.get(id) ?? null,
+      };
+    }, tx);
+  }
+
+  async updateStatus(id: string, status: ReviewStatus, tx?: DbTransaction): Promise<ReviewWithMediaEntity> {
+    return this.inTx(async (tx) => {
+      const [review] = await tx
+        .update(reviews)
+        .set({ status, updatedAt: new Date() })
+        .where(eq(reviews.id, id))
+        .returning();
+
+      if (!review) {
+        throw new NotFoundException('Review not found');
+      }
+
+      const mediaFileIds = await this.fetchMediaFileIdsByReviewId(id, tx);
+      const reactionCountMap = await this.fetchReactionCounts([id], tx);
+      const counts = reactionCountMap.get(id) ?? { helpfulCount: 0, likeCount: 0, dislikeCount: 0 };
+      const commentMap = await this.fetchCommentsByReviewIds([id], tx);
+
+      return {
+        ...review,
+        mediaFileIds,
+        helpfulCount: counts.helpfulCount,
+        likeCount: counts.likeCount,
+        dislikeCount: counts.dislikeCount,
+        adminComment: commentMap.get(id) ?? null,
       };
     }, tx);
   }

--- a/apps/ugc-service/src/reviews/types.ts
+++ b/apps/ugc-service/src/reviews/types.ts
@@ -1,6 +1,8 @@
 import { type InferSelectModel } from 'drizzle-orm';
 import { reviewComments, reviewEligibilities, reviewMedia, reviews } from '../db/schema';
 
+export type ReviewStatus = 'active' | 'hidden' | 'deleted';
+
 export type ReviewEntity = InferSelectModel<typeof reviews>;
 export type ReviewMediaEntity = InferSelectModel<typeof reviewMedia>;
 export type ReviewCommentEntity = InferSelectModel<typeof reviewComments>;

--- a/apps/user-service/src/api/admin/users/dto/get-users-query.dto.ts
+++ b/apps/user-service/src/api/admin/users/dto/get-users-query.dto.ts
@@ -54,4 +54,11 @@ export class GetUsersQueryDto {
   @IsOptional()
   @IsEnum(['asc', 'desc'])
   order?: 'asc' | 'desc';
+
+  @ApiPropertyOptional({
+    description: 'ID 목록 (UUID 콤마 구분, 예: id1,id2). 지정 시 일치 항목만 반환',
+  })
+  @IsOptional()
+  @IsString()
+  ids?: string;
 }

--- a/apps/user-service/src/api/admin/users/users.service.ts
+++ b/apps/user-service/src/api/admin/users/users.service.ts
@@ -29,6 +29,7 @@ export class UsersService {
     roleName?: string;
     sort?: 'createdAt' | 'username' | 'email' | 'lastActivityAt';
     order?: 'asc' | 'desc';
+    ids?: string;
     tx?: DbTransaction;
   }): Promise<{
     data: UserWithRoles[];
@@ -38,13 +39,24 @@ export class UsersService {
   }> {
     try {
       const client = this.getClient(filters?.tx);
+      const idList = filters?.ids
+        ?.split(',')
+        .map((id) => id.trim())
+        .filter((id) => id.length > 0);
+      const hasIdFilter = !!idList && idList.length > 0;
+
       const page = filters?.page || 1;
-      const limit = Math.min(filters?.limit || 20, 1000);
+      const limit = hasIdFilter
+        ? Math.min(Math.max(idList!.length, filters?.limit || 20), 1000)
+        : Math.min(filters?.limit || 20, 1000);
       const offset = (page - 1) * limit;
       const sortBy = filters?.sort || 'createdAt';
       const sortOrder = filters?.order || 'desc';
 
       const conditions = [] as any[];
+      if (hasIdFilter) {
+        conditions.push(inArray(schema.users.id, idList!));
+      }
       if (filters?.q) {
         const searchTerm = `%${filters.q}%`;
         conditions.push(

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "start:file-service:prod": "node dist/apps/file-service/main.js",
     "start:main": "nest start almondyoung-server",
     "start:main:debug": "nest start almondyoung-server --debug --watch",
-    "start:main:dev": "nest start almondyoung-server --watch",
+    "start:main:dev": "./scripts/with-ipv4.sh dotenv -e apps/almondyoung-server/.env nest start almondyoung-server --watch",
     "start:main:prod": "node dist/apps/almondyoung-server/main.js",
     "start:membership": "nest start membership",
     "start:membership:dev": "nest start membership --watch",


### PR DESCRIPTION
  - 리뷰 상태 라벨: 노출중/숨김 → 공개/비공개
  - 리뷰 상세: 작성자 ID/이미지 깜빡임 제거 (Suspense + Skeleton)
  - 리뷰 상세: 도움/좋아요/싫어요 → "도움이됐어요"로 단순화
  - 리뷰 테이블: 상품명 클릭 시 productId 복사
  - 데이터테이블 정렬: presetOnly 모드 추가, 리뷰 정렬을 백엔드 preset에 매핑 (정렬 동작 안 하던 버그 수정)