### PR TITLE
feat(wallet): 리전 기반 결제수단 관리 기능 구현

### DIFF
--- a/apps/admin-web/src/app/(admin)/mall/regions/page.tsx
+++ b/apps/admin-web/src/app/(admin)/mall/regions/page.tsx
@@ -1,0 +1,12 @@
+import RouteGuard from '@/components/layout/route-guard';
+import StoreRegionsTemplate from '@/features/store-regions/store-regions-template';
+
+export default function MallRegionsPage() {
+  return (
+    <RouteGuard requireRole={['admin', 'master']}>
+      <div className="flex w-full max-w-[1600px] flex-col gap-y-2 p-3">
+        <StoreRegionsTemplate />
+      </div>
+    </RouteGuard>
+  );
+}

--- a/apps/admin-web/src/app/(admin)/payments/methods/page.tsx
+++ b/apps/admin-web/src/app/(admin)/payments/methods/page.tsx
@@ -1,0 +1,12 @@
+import RouteGuard from '@/components/layout/route-guard';
+import PaymentMethodCatalogTemplate from '@/features/payment-config/catalog-template';
+
+export default function PaymentMethodsPage() {
+  return (
+    <RouteGuard requireRole={['admin', 'master']}>
+      <div className="flex w-full max-w-[1600px] flex-col gap-y-2 p-3">
+        <PaymentMethodCatalogTemplate />
+      </div>
+    </RouteGuard>
+  );
+}

--- a/apps/admin-web/src/app/(admin)/payments/regions/page.tsx
+++ b/apps/admin-web/src/app/(admin)/payments/regions/page.tsx
@@ -1,0 +1,12 @@
+import RouteGuard from '@/components/layout/route-guard';
+import RegionsTemplate from '@/features/payment-config/regions-template';
+
+export default function RegionsPage() {
+  return (
+    <RouteGuard requireRole={['admin', 'master']}>
+      <div className="flex w-full max-w-[1600px] flex-col gap-y-2 p-3">
+        <RegionsTemplate />
+      </div>
+    </RouteGuard>
+  );
+}

--- a/apps/admin-web/src/features/payment-config/catalog-template.tsx
+++ b/apps/admin-web/src/features/payment-config/catalog-template.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { Container } from '@/components/admin-ui-experimental/common/container/container';
+import { Header } from '@/components/admin-ui-experimental/common/header/header';
+import { Badge } from '@/components/ui/badge';
+import { Switch } from '@/components/ui/switch';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  usePaymentMethodCatalog,
+  useUpdatePaymentMethodCatalog,
+} from '@/lib/services/wallet';
+import { useMemo } from 'react';
+import { toast } from 'sonner';
+
+export default function PaymentMethodCatalogTemplate() {
+  const { data, isLoading } = usePaymentMethodCatalog();
+  const catalog = useMemo(() => data ?? [], [data]);
+  const updateMutation = useUpdatePaymentMethodCatalog();
+
+  const handleToggle = async (code: string, next: boolean) => {
+    try {
+      await updateMutation.mutateAsync({ code, payload: { isEnabled: next } });
+      toast.success(
+        `${code} 결제수단을 ${next ? '활성화' : '비활성화'}했어요.`
+      );
+    } catch {
+      toast.error('변경에 실패했어요.');
+    }
+  };
+
+  return (
+    <Container className="divide-y-0">
+      <Header
+        title="결제수단 관리"
+        subtitle="시스템 전체에서 사용할 결제수단을 켜고 끕니다. 끄면 모든 리전에서 숨겨집니다. 리전별 노출은 '리전·결제수단 관리'에서 설정합니다."
+      />
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>코드</TableHead>
+            <TableHead>이름</TableHead>
+            <TableHead>설명</TableHead>
+            <TableHead>상태</TableHead>
+            <TableHead className="w-[100px] text-right">
+              글로벌 활성화
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {isLoading && (
+            <TableRow>
+              <TableCell
+                colSpan={5}
+                className="py-8 text-center text-muted-foreground"
+              >
+                불러오는 중...
+              </TableCell>
+            </TableRow>
+          )}
+          {!isLoading && catalog.length === 0 && (
+            <TableRow>
+              <TableCell
+                colSpan={5}
+                className="py-8 text-center text-muted-foreground"
+              >
+                등록된 결제수단이 없습니다.
+              </TableCell>
+            </TableRow>
+          )}
+          {catalog.map((c) => (
+            <TableRow key={c.id}>
+              <TableCell className="font-mono text-sm">{c.code}</TableCell>
+              <TableCell>{c.displayName}</TableCell>
+              <TableCell className="text-muted-foreground">
+                {c.description ?? '-'}
+              </TableCell>
+              <TableCell>
+                <Badge variant={c.isEnabled ? 'default' : 'secondary'}>
+                  {c.isEnabled ? '활성' : '비활성'}
+                </Badge>
+              </TableCell>
+              <TableCell className="text-right">
+                <Switch
+                  checked={c.isEnabled}
+                  onCheckedChange={(v) => handleToggle(c.code, v)}
+                  disabled={updateMutation.isPending}
+                  aria-label={`${c.displayName} 글로벌 활성화`}
+                />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Container>
+  );
+}

--- a/apps/admin-web/src/features/payment-config/components/create-region-dialog.tsx
+++ b/apps/admin-web/src/features/payment-config/components/create-region-dialog.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useCreateRegion } from '@/lib/services/wallet';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+export function CreateRegionDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [code, setCode] = useState('');
+  const [name, setName] = useState('');
+  const createMutation = useCreateRegion();
+
+  const reset = () => {
+    setCode('');
+    setName('');
+  };
+
+  const handleSubmit = async () => {
+    const normalized = code.trim().toLowerCase();
+    if (!/^[a-z]{2}$/.test(normalized)) {
+      toast.error('국가코드는 소문자 alpha-2 형식이어야 해요 (예: kr, us).');
+      return;
+    }
+    if (!name.trim()) {
+      toast.error('리전 이름을 입력해 주세요.');
+      return;
+    }
+    try {
+      await createMutation.mutateAsync({ code: normalized, name: name.trim() });
+      toast.success(`리전 "${normalized}" 을 추가했어요.`);
+      reset();
+      onOpenChange(false);
+    } catch {
+      toast.error('리전 추가에 실패했어요. (이미 존재하는 코드일 수 있어요)');
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) reset();
+        onOpenChange(o);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>리전 추가</DialogTitle>
+          <DialogDescription>
+            소문자 ISO 3166-1 alpha-2 국가코드로 리전을 만듭니다 (예: kr, us,
+            jp).
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-4 py-2">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="region-code">국가코드 (alpha-2)</Label>
+            <Input
+              id="region-code"
+              placeholder="kr"
+              maxLength={2}
+              value={code}
+              onChange={(e) => setCode(e.target.value.toLowerCase())}
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="region-name">리전 이름</Label>
+            <Input
+              id="region-name"
+              placeholder="대한민국"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={createMutation.isPending}
+          >
+            취소
+          </Button>
+          <Button onClick={handleSubmit} disabled={createMutation.isPending}>
+            {createMutation.isPending ? '추가 중...' : '추가'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin-web/src/features/payment-config/regions-template.tsx
+++ b/apps/admin-web/src/features/payment-config/regions-template.tsx
@@ -1,0 +1,287 @@
+'use client';
+
+import { Container } from '@/components/admin-ui-experimental/common/container/container';
+import { Header } from '@/components/admin-ui-experimental/common/header/header';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  useRegions,
+  useRegionPaymentMethods,
+  useUpdateRegion,
+  usePutRegionPaymentMethods,
+} from '@/lib/services/wallet';
+import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { CreateRegionDialog } from './components/create-region-dialog';
+
+export default function RegionsTemplate() {
+  const { data: regionsData, isLoading: regionsLoading } = useRegions();
+  const regions = useMemo(() => regionsData ?? [], [regionsData]);
+
+  const [selectedCode, setSelectedCode] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  // 리전 활성화 로컬 편집: region code -> 변경된 isActive
+  const [regionActiveEdits, setRegionActiveEdits] = useState<
+    Record<string, boolean>
+  >({});
+  // 매트릭스 로컬 편집: code -> 변경된 isEnabled
+  const [methodEdits, setMethodEdits] = useState<Record<string, boolean>>({});
+
+  const updateRegion = useUpdateRegion();
+  const putMethods = usePutRegionPaymentMethods();
+  const { data: matrix, isLoading: matrixLoading } =
+    useRegionPaymentMethods(selectedCode);
+
+  // 첫 리전 자동 선택
+  useEffect(() => {
+    if (!selectedCode && regions.length > 0) setSelectedCode(regions[0].code);
+  }, [regions, selectedCode]);
+
+  // 리전 전환 시 해당 리전의 결제수단 편집만 초기화
+  useEffect(() => {
+    setMethodEdits({});
+  }, [selectedCode]);
+
+  const effectiveRegionActive = (code: string, isActive: boolean) =>
+    regionActiveEdits[code] ?? isActive;
+  const effectiveMethodEnabled = (code: string, regionEnabled: boolean) =>
+    methodEdits[code] ?? regionEnabled;
+  const hasRegionChanges = Object.keys(regionActiveEdits).length > 0;
+  const hasMethodChanges = Object.keys(methodEdits).length > 0;
+  const hasChanges = hasRegionChanges || hasMethodChanges;
+
+  const handleRegionActiveToggle = (
+    code: string,
+    original: boolean,
+    next: boolean
+  ) => {
+    setRegionActiveEdits((prev) => {
+      const draft = { ...prev };
+      if (next === original) delete draft[code];
+      else draft[code] = next;
+      return draft;
+    });
+  };
+
+  const handleMethodToggle = (
+    code: string,
+    regionEnabled: boolean,
+    next: boolean
+  ) => {
+    setMethodEdits((prev) => {
+      const draft = { ...prev };
+      // 원래 값과 같아지면 편집 목록에서 제거
+      if (next === regionEnabled) delete draft[code];
+      else draft[code] = next;
+      return draft;
+    });
+  };
+
+  const handleSave = async () => {
+    if (!selectedCode || (hasMethodChanges && !matrix)) return;
+
+    setIsSaving(true);
+    try {
+      for (const [code, isActive] of Object.entries(regionActiveEdits)) {
+        await updateRegion.mutateAsync({
+          code,
+          payload: { isActive },
+        });
+      }
+
+      if (hasMethodChanges && matrix) {
+        const items = matrix.items.map((it) => ({
+          code: it.code,
+          isEnabled: effectiveMethodEnabled(it.code, it.regionEnabled),
+          sortOrder: it.sortOrder,
+        }));
+        await putMethods.mutateAsync({ code: selectedCode, items });
+      }
+
+      toast.success('변경사항을 저장했어요.');
+      setRegionActiveEdits({});
+      setMethodEdits({});
+    } catch {
+      toast.error('저장에 실패했어요.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Container className="divide-y-0">
+      <Header
+        title="리전·결제수단 관리"
+        subtitle="리전(국가)별로 노출할 결제수단을 설정합니다. 실제 노출은 결제수단의 글로벌 활성화와 리전 활성화가 모두 켜진 경우입니다."
+        right={<Button onClick={() => setCreateOpen(true)}>리전 추가</Button>}
+      />
+
+      <div className="flex gap-4 px-6 pb-6">
+        {/* 리전 목록 */}
+        <div className="border rounded-md w-72 shrink-0">
+          <div className="px-3 py-2 text-sm font-semibold border-b">리전</div>
+          {regionsLoading && (
+            <div className="px-3 py-4 text-sm text-muted-foreground">
+              불러오는 중...
+            </div>
+          )}
+          {!regionsLoading && regions.length === 0 && (
+            <div className="px-3 py-4 text-sm text-muted-foreground">
+              등록된 리전이 없습니다.
+            </div>
+          )}
+          {regions.map((r) => {
+            const isActive = effectiveRegionActive(r.code, r.isActive);
+            return (
+              <div
+                key={r.id}
+                className={`flex items-center justify-between gap-2 border-b px-3 py-2 ${
+                  selectedCode === r.code ? 'bg-muted' : ''
+                }`}
+              >
+                <button
+                  type="button"
+                  className="flex items-center flex-1 gap-2 text-left"
+                  onClick={() => setSelectedCode(r.code)}
+                >
+                  <span className="font-mono text-sm uppercase">{r.code}</span>
+                  <span className="text-sm">{r.name}</span>
+                  {!isActive && <Badge variant="secondary">비활성</Badge>}
+                </button>
+                <Switch
+                  checked={isActive}
+                  onCheckedChange={(v) =>
+                    handleRegionActiveToggle(r.code, r.isActive, v)
+                  }
+                  disabled={isSaving}
+                  aria-label={`리전 ${r.code} 활성화`}
+                />
+              </div>
+            );
+          })}
+        </div>
+
+        {/* 선택 리전의 결제수단 매트릭스 */}
+        <div className="flex-1">
+          {!selectedCode && (
+            <div className="py-8 text-sm text-center text-muted-foreground">
+              리전을 선택하세요.
+            </div>
+          )}
+          {selectedCode && (
+            <>
+              <div className="flex items-center justify-between mb-2">
+                <div className="text-sm text-muted-foreground">
+                  {matrix
+                    ? `${matrix.region.name} (${matrix.region.code}) 결제수단`
+                    : '불러오는 중...'}
+                </div>
+                <Button
+                  onClick={handleSave}
+                  disabled={
+                    !hasChanges || isSaving || (hasMethodChanges && !matrix)
+                  }
+                  size="sm"
+                  className={[
+                    'bg-slate-900 text-white hover:bg-slate-800',
+                    'disabled:bg-slate-200 disabled:text-slate-500 disabled:opacity-100',
+                  ].join(' ')}
+                >
+                  {isSaving ? '저장 중...' : '변경사항 저장'}
+                </Button>
+              </div>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>결제수단</TableHead>
+                    <TableHead>글로벌</TableHead>
+                    <TableHead>실제 노출</TableHead>
+                    <TableHead className="w-[120px] text-right">
+                      리전 활성화
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {matrixLoading && (
+                    <TableRow>
+                      <TableCell
+                        colSpan={4}
+                        className="py-8 text-center text-muted-foreground"
+                      >
+                        불러오는 중...
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  {matrix?.items.map((it) => {
+                    const regionEnabled = effectiveMethodEnabled(
+                      it.code,
+                      it.regionEnabled
+                    );
+                    const regionActive = effectiveRegionActive(
+                      matrix.region.code,
+                      matrix.region.isActive
+                    );
+                    const available =
+                      regionActive && it.globalEnabled && regionEnabled;
+                    return (
+                      <TableRow key={it.code}>
+                        <TableCell>
+                          <div className="flex items-center gap-2">
+                            <span className="font-mono text-sm">{it.code}</span>
+                            <span className="text-sm text-muted-foreground">
+                              {it.displayName}
+                            </span>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge
+                            variant={it.globalEnabled ? 'default' : 'secondary'}
+                          >
+                            {it.globalEnabled ? '활성' : '비활성'}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant={available ? 'default' : 'outline'}>
+                            {available ? '노출' : '숨김'}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <Switch
+                            checked={regionEnabled}
+                            onCheckedChange={(v) =>
+                              handleMethodToggle(it.code, it.regionEnabled, v)
+                            }
+                            disabled={isSaving}
+                            aria-label={`${it.displayName} ${matrix.region.code} 활성화`}
+                          />
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+              {matrix?.items.some((it) => !it.globalEnabled) && (
+                <p className="mt-2 text-xs text-muted-foreground">
+                  * 글로벌이 비활성인 결제수단은 리전에서 켜도 실제로는
+                  숨겨집니다. ‘결제수단 관리’에서 글로벌을 먼저 켜세요.
+                </p>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      <CreateRegionDialog open={createOpen} onOpenChange={setCreateOpen} />
+    </Container>
+  );
+}

--- a/apps/admin-web/src/features/store-regions/components/region-form-dialog.tsx
+++ b/apps/admin-web/src/features/store-regions/components/region-form-dialog.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import type { MedusaRegion } from '@/lib/api/domains/medusa/regions';
+import {
+  useCreateMedusaRegion,
+  useUpdateMedusaRegion,
+} from '@/lib/services/medusa-regions';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** null 이면 생성, 값이 있으면 수정 */
+  region: MedusaRegion | null;
+}
+
+export function RegionFormDialog({ open, onOpenChange, region }: Props) {
+  const isEdit = !!region;
+  const createMutation = useCreateMedusaRegion();
+  const updateMutation = useUpdateMedusaRegion();
+  const pending = createMutation.isPending || updateMutation.isPending;
+
+  const [name, setName] = useState('');
+  const [currency, setCurrency] = useState('');
+  const [countries, setCountries] = useState('');
+  const [automaticTaxes, setAutomaticTaxes] = useState(true);
+  const [taxInclusive, setTaxInclusive] = useState(false);
+
+  // dialog 가 열리거나 대상 region 이 바뀌면 폼 초기화
+  useEffect(() => {
+    if (!open) return;
+    setName(region?.name ?? '');
+    setCurrency(region?.currency_code ?? '');
+    setCountries((region?.countries ?? []).map((c) => c.iso_2).join(', '));
+    setAutomaticTaxes(region?.automatic_taxes ?? true);
+    setTaxInclusive(region?.is_tax_inclusive ?? false);
+  }, [open, region]);
+
+  const parseCountries = (raw: string): string[] =>
+    raw
+      .split(',')
+      .map((c) => c.trim().toLowerCase())
+      .filter(Boolean);
+
+  const handleSubmit = async () => {
+    const countryList = parseCountries(countries);
+    const currencyCode = currency.trim().toLowerCase();
+
+    if (!name.trim()) return toast.error('리전 이름을 입력해 주세요.');
+    if (!/^[a-z]{3}$/.test(currencyCode))
+      return toast.error('통화 코드는 소문자 3자입니다 (예: krw, usd).');
+    if (countryList.length === 0)
+      return toast.error('국가코드를 1개 이상 입력해 주세요 (예: kr, us).');
+    if (countryList.some((c) => !/^[a-z]{2}$/.test(c)))
+      return toast.error(
+        '국가코드는 소문자 alpha-2 형식이어야 해요 (예: kr, us).'
+      );
+
+    try {
+      if (isEdit && region) {
+        await updateMutation.mutateAsync({
+          id: region.id,
+          payload: {
+            name: name.trim(),
+            currency_code: currencyCode,
+            countries: countryList,
+            automatic_taxes: automaticTaxes,
+            is_tax_inclusive: taxInclusive,
+          },
+        });
+        toast.success('리전을 수정했어요.');
+      } else {
+        await createMutation.mutateAsync({
+          name: name.trim(),
+          currency_code: currencyCode,
+          countries: countryList,
+          automatic_taxes: automaticTaxes,
+          is_tax_inclusive: taxInclusive,
+        });
+        toast.success('리전을 생성했어요.');
+      }
+      onOpenChange(false);
+    } catch {
+      toast.error(
+        isEdit
+          ? '리전 수정에 실패했어요.'
+          : '리전 생성에 실패했어요. (국가/통화 중복일 수 있어요)'
+      );
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{isEdit ? '리전 수정' : '리전 추가'}</DialogTitle>
+          <DialogDescription>
+            Medusa 리전의 통화·국가·세금 설정입니다. 국가코드는 소문자
+            alpha-2(kr, us)를 사용하며, 결제수단 관리(리전·결제수단)와 동일한
+            코드를 쓰면 정합합니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-2">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="region-name">이름</Label>
+            <Input
+              id="region-name"
+              placeholder="Korea"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="region-currency">통화 코드 (소문자 3자)</Label>
+            <Input
+              id="region-currency"
+              placeholder="krw"
+              maxLength={3}
+              value={currency}
+              onChange={(e) => setCurrency(e.target.value.toLowerCase())}
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="region-countries">
+              국가코드 (alpha-2, 쉼표로 구분)
+            </Label>
+            <Input
+              id="region-countries"
+              placeholder="kr, us"
+              value={countries}
+              onChange={(e) => setCountries(e.target.value)}
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="flex flex-col">
+              <Label>자동 세금 계산</Label>
+              <span className="text-xs text-muted-foreground">
+                체크아웃 시 세금을 자동 계산합니다.
+              </span>
+            </div>
+            <Switch
+              checked={automaticTaxes}
+              onCheckedChange={setAutomaticTaxes}
+              className="data-[state=unchecked]:border-slate-400 data-[state=unchecked]:bg-slate-200"
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="flex flex-col">
+              <Label>세금 포함 가격</Label>
+              <span className="text-xs text-muted-foreground">
+                이 통화의 가격이 세금을 포함하는지 여부입니다.
+              </span>
+            </div>
+            <Switch
+              checked={taxInclusive}
+              onCheckedChange={setTaxInclusive}
+              className="data-[state=unchecked]:border-slate-400 data-[state=unchecked]:bg-slate-200"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={pending}
+          >
+            취소
+          </Button>
+          <Button onClick={handleSubmit} disabled={pending}>
+            {pending ? '처리 중...' : isEdit ? '저장' : '추가'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin-web/src/features/store-regions/store-regions-template.tsx
+++ b/apps/admin-web/src/features/store-regions/store-regions-template.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { Container } from '@/components/admin-ui-experimental/common/container/container';
+import { Header } from '@/components/admin-ui-experimental/common/header/header';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type { MedusaRegion } from '@/lib/api/domains/medusa/regions';
+import { useMedusaRegions } from '@/lib/services/medusa-regions';
+import { useMemo, useState } from 'react';
+import { RegionFormDialog } from './components/region-form-dialog';
+
+export default function StoreRegionsTemplate() {
+  const { data, isLoading } = useMedusaRegions({ limit: 100 });
+  const regions = useMemo(() => data?.regions ?? [], [data]);
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<MedusaRegion | null>(null);
+
+  const openCreate = () => {
+    setEditTarget(null);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (region: MedusaRegion) => {
+    setEditTarget(region);
+    setDialogOpen(true);
+  };
+
+  return (
+    <Container className="divide-y-0">
+      <Header
+        title="리전 설정 (Medusa)"
+        subtitle="스토어의 통화·국가·세금 설정입니다. 결제수단 가용성은 '리전·결제수단 관리'에서 별도로 설정합니다."
+        right={<Button onClick={openCreate}>리전 추가</Button>}
+      />
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>이름</TableHead>
+            <TableHead>통화</TableHead>
+            <TableHead>국가</TableHead>
+            <TableHead>자동 세금</TableHead>
+            <TableHead>세금 포함</TableHead>
+            <TableHead className="w-[80px] text-right" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {isLoading && (
+            <TableRow>
+              <TableCell
+                colSpan={6}
+                className="py-8 text-center text-muted-foreground"
+              >
+                불러오는 중...
+              </TableCell>
+            </TableRow>
+          )}
+          {!isLoading && regions.length === 0 && (
+            <TableRow>
+              <TableCell
+                colSpan={6}
+                className="py-8 text-center text-muted-foreground"
+              >
+                등록된 리전이 없습니다.
+              </TableCell>
+            </TableRow>
+          )}
+          {regions.map((r) => (
+            <TableRow key={r.id}>
+              <TableCell className="font-medium">{r.name}</TableCell>
+              <TableCell className="font-mono text-sm uppercase">
+                {r.currency_code}
+              </TableCell>
+              <TableCell>
+                <div className="flex flex-wrap gap-1">
+                  {(r.countries ?? []).map((c) => (
+                    <Badge
+                      key={c.iso_2}
+                      variant="secondary"
+                      className="font-mono uppercase"
+                    >
+                      {c.iso_2}
+                    </Badge>
+                  ))}
+                </div>
+              </TableCell>
+              <TableCell>
+                <Badge variant={r.automatic_taxes ? 'default' : 'outline'}>
+                  {r.automatic_taxes ? 'ON' : 'OFF'}
+                </Badge>
+              </TableCell>
+              <TableCell>
+                {r.is_tax_inclusive === undefined ? (
+                  <span className="text-muted-foreground">—</span>
+                ) : (
+                  <Badge variant={r.is_tax_inclusive ? 'default' : 'outline'}>
+                    {r.is_tax_inclusive ? '포함' : '별도'}
+                  </Badge>
+                )}
+              </TableCell>
+              <TableCell className="text-right">
+                <Button variant="ghost" size="sm" onClick={() => openEdit(r)}>
+                  수정
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      <RegionFormDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        region={editTarget}
+      />
+    </Container>
+  );
+}

--- a/apps/admin-web/src/features/users/components/table/index.tsx
+++ b/apps/admin-web/src/features/users/components/table/index.tsx
@@ -40,7 +40,7 @@ export function UserTable() {
   return (
     <div>
       {selectedUserIds.length > 0 && (
-        <div className="flex items-center gap-2 p-3 bg-muted/50 border-b">
+        <div className="flex items-center gap-2 p-3 border-b bg-muted/50">
           <span className="text-sm text-muted-foreground">
             {selectedUserIds.length}명 선택됨
           </span>

--- a/apps/admin-web/src/lib/api/domains/medusa/price-preferences.ts
+++ b/apps/admin-web/src/lib/api/domains/medusa/price-preferences.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { MEDUSA_BASE_URL } from '@/const';
+import { client } from '../../client';
+import {
+  CURRENCY_TAX_INCLUSIVE_ATTRIBUTE,
+  findCurrencyTaxInclusivePreference,
+} from './region-tax-inclusive';
+
+/**
+ * Medusa 의 세금 포함 가격(tax-inclusive) SoT.
+ * attribute 가 'currency_code' 또는 'region_id' 이며 value 가 해당 코드/ID.
+ */
+export interface PricePreference {
+  id: string;
+  attribute: string;
+  value: string;
+  is_tax_inclusive: boolean;
+}
+
+export interface PricePreferenceListResponse {
+  price_preferences: PricePreference[];
+  count: number;
+  offset: number;
+  limit: number;
+}
+
+export const medusaPricePreferencesApi = {
+  list: async () => {
+    const res = await client.get<PricePreferenceListResponse>(
+      `${MEDUSA_BASE_URL}/admin/price-preferences?limit=1000`,
+    );
+    return res.data;
+  },
+
+  // Medusa Admin API 는 update 도 POST 를 사용한다.
+  update: async (id: string, isTaxInclusive: boolean) => {
+    const res = await client.post<{ price_preference: PricePreference }>(
+      `${MEDUSA_BASE_URL}/admin/price-preferences/${id}`,
+      { is_tax_inclusive: isTaxInclusive },
+    );
+    return res.data.price_preference;
+  },
+
+  create: async (payload: { attribute: string; value: string; is_tax_inclusive: boolean }) => {
+    const res = await client.post<{ price_preference: PricePreference }>(
+      `${MEDUSA_BASE_URL}/admin/price-preferences`,
+      payload,
+    );
+    return res.data.price_preference;
+  },
+
+  upsertCurrencyTaxInclusive: async (currencyCode: string, isTaxInclusive: boolean) => {
+    const normalizedCurrencyCode = currencyCode.trim().toLowerCase();
+    const { price_preferences: pricePreferences } = await medusaPricePreferencesApi.list();
+    const existing = findCurrencyTaxInclusivePreference(pricePreferences, normalizedCurrencyCode);
+
+    if (existing) {
+      return medusaPricePreferencesApi.update(existing.id, isTaxInclusive);
+    }
+
+    return medusaPricePreferencesApi.create({
+      attribute: CURRENCY_TAX_INCLUSIVE_ATTRIBUTE,
+      value: normalizedCurrencyCode,
+      is_tax_inclusive: isTaxInclusive,
+    });
+  },
+};

--- a/apps/admin-web/src/lib/api/domains/medusa/region-tax-inclusive.spec.ts
+++ b/apps/admin-web/src/lib/api/domains/medusa/region-tax-inclusive.spec.ts
@@ -1,0 +1,57 @@
+import { applyCurrencyTaxInclusivePreferences } from './region-tax-inclusive';
+
+describe('applyCurrencyTaxInclusivePreferences', () => {
+  it('fills region tax-inclusive state from currency-level price preferences', () => {
+    const regions = [
+      { id: 'reg_kr', currency_code: 'krw' },
+      { id: 'reg_us', currency_code: 'usd' },
+    ];
+
+    const result = applyCurrencyTaxInclusivePreferences(regions, [
+      {
+        attribute: 'currency_code',
+        value: 'krw',
+        is_tax_inclusive: true,
+      },
+      {
+        attribute: 'currency_code',
+        value: 'usd',
+        is_tax_inclusive: false,
+      },
+    ]);
+
+    expect(result).toEqual([
+      { id: 'reg_kr', currency_code: 'krw', is_tax_inclusive: true },
+      { id: 'reg_us', currency_code: 'usd', is_tax_inclusive: false },
+    ]);
+  });
+
+  it('matches currency codes case-insensitively and ignores region-level preferences', () => {
+    const result = applyCurrencyTaxInclusivePreferences(
+      [{ id: 'reg_kr', currency_code: 'KRW' }],
+      [
+        {
+          attribute: 'region_id',
+          value: 'reg_kr',
+          is_tax_inclusive: false,
+        },
+        {
+          attribute: 'currency_code',
+          value: 'krw',
+          is_tax_inclusive: true,
+        },
+      ],
+    );
+
+    expect(result[0].is_tax_inclusive).toBe(true);
+  });
+
+  it('defaults tax-inclusive state to false when there is no currency preference', () => {
+    const result = applyCurrencyTaxInclusivePreferences(
+      [{ id: 'reg_jp', currency_code: 'jpy' }],
+      [],
+    );
+
+    expect(result[0].is_tax_inclusive).toBe(false);
+  });
+});

--- a/apps/admin-web/src/lib/api/domains/medusa/region-tax-inclusive.ts
+++ b/apps/admin-web/src/lib/api/domains/medusa/region-tax-inclusive.ts
@@ -1,0 +1,41 @@
+export interface RegionTaxInclusiveSource {
+  currency_code: string;
+  is_tax_inclusive?: boolean;
+}
+
+export interface TaxInclusivePricePreference {
+  attribute: string;
+  value: string;
+  is_tax_inclusive: boolean;
+}
+
+export const CURRENCY_TAX_INCLUSIVE_ATTRIBUTE = 'currency_code';
+
+const normalizePreferenceValue = (value: string) => value.trim().toLowerCase();
+
+export function findCurrencyTaxInclusivePreference<T extends TaxInclusivePricePreference>(
+  pricePreferences: T[],
+  currencyCode: string,
+): T | undefined {
+  const normalizedCurrencyCode = normalizePreferenceValue(currencyCode);
+
+  return pricePreferences.find(
+    (preference) =>
+      preference.attribute === CURRENCY_TAX_INCLUSIVE_ATTRIBUTE &&
+      normalizePreferenceValue(preference.value) === normalizedCurrencyCode,
+  );
+}
+
+export function applyCurrencyTaxInclusivePreferences<T extends RegionTaxInclusiveSource>(
+  regions: T[],
+  pricePreferences: TaxInclusivePricePreference[],
+): Array<T & { is_tax_inclusive: boolean }> {
+  return regions.map((region) => {
+    const preference = findCurrencyTaxInclusivePreference(pricePreferences, region.currency_code);
+
+    return {
+      ...region,
+      is_tax_inclusive: preference?.is_tax_inclusive ?? false,
+    };
+  });
+}

--- a/apps/admin-web/src/lib/api/domains/medusa/regions.spec.ts
+++ b/apps/admin-web/src/lib/api/domains/medusa/regions.spec.ts
@@ -1,0 +1,108 @@
+jest.mock('@/const', () => ({ MEDUSA_BASE_URL: '/medusa' }), {
+  virtual: true,
+});
+
+jest.mock('../../client', () => ({
+  client: {
+    get: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+jest.mock('./price-preferences', () => ({
+  medusaPricePreferencesApi: {
+    list: jest.fn(),
+    upsertCurrencyTaxInclusive: jest.fn(),
+  },
+}));
+
+import { client } from '../../client';
+import { medusaPricePreferencesApi } from './price-preferences';
+import { medusaRegionsApi, type MedusaRegion } from './regions';
+
+const mockedClient = client as unknown as {
+  get: jest.Mock;
+  post: jest.Mock;
+};
+
+const mockedPricePreferencesApi = medusaPricePreferencesApi as unknown as {
+  list: jest.Mock;
+  upsertCurrencyTaxInclusive: jest.Mock;
+};
+
+const region: MedusaRegion = {
+  id: 'reg_kr',
+  name: 'Korea',
+  currency_code: 'krw',
+  automatic_taxes: true,
+  countries: [{ iso_2: 'kr', display_name: 'Korea' }],
+  created_at: '2026-06-08T00:00:00.000Z',
+  updated_at: '2026-06-08T00:00:00.000Z',
+};
+
+describe('medusaRegionsApi tax-inclusive price preferences', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fills listed regions from currency-level price preferences', async () => {
+    mockedClient.get
+      .mockResolvedValueOnce({
+        data: {
+          regions: [{ id: 'reg_kr' }],
+          count: 1,
+          offset: 0,
+          limit: 100,
+        },
+      })
+      .mockResolvedValueOnce({ data: { region } });
+    mockedPricePreferencesApi.list.mockResolvedValue({
+      price_preferences: [
+        {
+          id: 'pref_krw',
+          attribute: 'currency_code',
+          value: 'krw',
+          is_tax_inclusive: true,
+        },
+      ],
+      count: 1,
+      offset: 0,
+      limit: 1000,
+    });
+
+    const result = await medusaRegionsApi.list({ limit: 100 });
+
+    expect(result.regions[0].is_tax_inclusive).toBe(true);
+  });
+
+  it('stores tax-inclusive state as a currency-level price preference when creating a region', async () => {
+    mockedClient.post.mockResolvedValueOnce({ data: { region } });
+    mockedPricePreferencesApi.upsertCurrencyTaxInclusive.mockResolvedValue({
+      id: 'pref_krw',
+      attribute: 'currency_code',
+      value: 'krw',
+      is_tax_inclusive: true,
+    });
+
+    const result = await medusaRegionsApi.create({
+      name: 'Korea',
+      currency_code: 'krw',
+      countries: ['kr'],
+      automatic_taxes: true,
+      is_tax_inclusive: true,
+    });
+
+    expect(mockedClient.post).toHaveBeenCalledWith('/medusa/admin/regions', {
+      name: 'Korea',
+      currency_code: 'krw',
+      countries: ['kr'],
+      automatic_taxes: true,
+    });
+    expect(mockedPricePreferencesApi.upsertCurrencyTaxInclusive).toHaveBeenCalledWith(
+      'krw',
+      true,
+    );
+    expect(result.is_tax_inclusive).toBe(true);
+  });
+});

--- a/apps/admin-web/src/lib/api/domains/medusa/regions.ts
+++ b/apps/admin-web/src/lib/api/domains/medusa/regions.ts
@@ -1,0 +1,124 @@
+'use client';
+
+import { MEDUSA_BASE_URL } from '@/const';
+import { client } from '../../client';
+import { medusaPricePreferencesApi } from './price-preferences';
+import { applyCurrencyTaxInclusivePreferences } from './region-tax-inclusive';
+
+export interface MedusaRegionCountry {
+  iso_2: string;
+  display_name: string;
+}
+
+export interface MedusaRegion {
+  id: string;
+  name: string;
+  currency_code: string;
+  automatic_taxes: boolean;
+  // Medusa 2.13 의 region 응답에는 is_tax_inclusive 가 노출되지 않는다(입력 payload 로만 받음). optional.
+  is_tax_inclusive?: boolean;
+  // list 엔드포인트는 countries 를 주지 않아 detail 로 보강한다. optional.
+  countries?: MedusaRegionCountry[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MedusaRegionListResponse {
+  regions: MedusaRegion[];
+  count: number;
+  offset: number;
+  limit: number;
+}
+
+export interface CreateMedusaRegionPayload {
+  name: string;
+  currency_code: string;
+  // 소문자 ISO 3166-1 alpha-2 (예: ['kr','us'])
+  countries: string[];
+  automatic_taxes?: boolean;
+  is_tax_inclusive?: boolean;
+}
+
+export interface UpdateMedusaRegionPayload {
+  name?: string;
+  currency_code?: string;
+  countries?: string[];
+  automatic_taxes?: boolean;
+  is_tax_inclusive?: boolean;
+}
+
+const getMedusaRegion = async (id: string) => {
+  const res = await client.get<{ region: MedusaRegion }>(
+    `${MEDUSA_BASE_URL}/admin/regions/${id}`
+  );
+  return res.data.region;
+};
+
+export const medusaRegionsApi = {
+  // list 엔드포인트는 countries 같은 relation 을 주지 않으므로, 각 region 을 detail 로 보강한다.
+  list: async (params: { limit?: number; offset?: number } = {}) => {
+    const p = new URLSearchParams();
+    if (params.limit !== undefined) p.append('limit', String(params.limit));
+    if (params.offset !== undefined) p.append('offset', String(params.offset));
+    const res = await client.get<MedusaRegionListResponse>(
+      `${MEDUSA_BASE_URL}/admin/regions?${p.toString()}`
+    );
+    const [detailed, pricePreferences] = await Promise.all([
+      Promise.all(res.data.regions.map((r) => getMedusaRegion(r.id))),
+      medusaPricePreferencesApi.list(),
+    ]);
+
+    return {
+      ...res.data,
+      regions: applyCurrencyTaxInclusivePreferences(
+        detailed,
+        pricePreferences.price_preferences
+      ),
+    };
+  },
+
+  // detail 엔드포인트는 countries 를 기본 포함한다.
+  get: async (id: string) => {
+    const [region, pricePreferences] = await Promise.all([
+      getMedusaRegion(id),
+      medusaPricePreferencesApi.list(),
+    ]);
+    return applyCurrencyTaxInclusivePreferences(
+      [region],
+      pricePreferences.price_preferences
+    )[0];
+  },
+
+  create: async ({ is_tax_inclusive, ...payload }: CreateMedusaRegionPayload) => {
+    const res = await client.post<{ region: MedusaRegion }>(
+      `${MEDUSA_BASE_URL}/admin/regions`,
+      payload
+    );
+    if (is_tax_inclusive === undefined) return res.data.region;
+
+    const preference = await medusaPricePreferencesApi.upsertCurrencyTaxInclusive(
+      res.data.region.currency_code,
+      is_tax_inclusive
+    );
+    return { ...res.data.region, is_tax_inclusive: preference.is_tax_inclusive };
+  },
+
+  // Medusa Admin API 는 update 도 POST 를 사용한다.
+  update: async (id: string, { is_tax_inclusive, ...payload }: UpdateMedusaRegionPayload) => {
+    const res = await client.post<{ region: MedusaRegion }>(
+      `${MEDUSA_BASE_URL}/admin/regions/${id}`,
+      payload
+    );
+    if (is_tax_inclusive === undefined) return res.data.region;
+
+    const preference = await medusaPricePreferencesApi.upsertCurrencyTaxInclusive(
+      res.data.region.currency_code,
+      is_tax_inclusive
+    );
+    return { ...res.data.region, is_tax_inclusive: preference.is_tax_inclusive };
+  },
+
+  delete: async (id: string) => {
+    await client.delete(`${MEDUSA_BASE_URL}/admin/regions/${id}`);
+  },
+};

--- a/apps/admin-web/src/lib/api/domains/wallet/index.spec.ts
+++ b/apps/admin-web/src/lib/api/domains/wallet/index.spec.ts
@@ -1,0 +1,82 @@
+jest.mock('@/const', () => ({ WALLET_SERVICE_BASE_URL: '/wallet' }), {
+  virtual: true,
+});
+
+jest.mock('../../client', () => ({
+  client: {
+    get: jest.fn(),
+    post: jest.fn(),
+    patch: jest.fn(),
+    put: jest.fn(),
+  },
+}));
+
+import { client } from '../../client';
+import { walletApi } from './index';
+
+const IDEMPOTENCY_KEY = '00000000-0000-4000-8000-000000000000';
+const idempotencyConfig = {
+  headers: { 'Idempotency-Key': IDEMPOTENCY_KEY },
+};
+
+const mockedClient = client as unknown as {
+  post: jest.Mock;
+  patch: jest.Mock;
+  put: jest.Mock;
+};
+
+describe('walletApi payment config writes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(crypto, 'randomUUID').mockReturnValue(IDEMPOTENCY_KEY);
+    mockedClient.post.mockResolvedValue({ data: {} });
+    mockedClient.patch.mockResolvedValue({ data: {} });
+    mockedClient.put.mockResolvedValue({ data: {} });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('sends an Idempotency-Key when updating the payment method catalog', async () => {
+    await walletApi.updatePaymentMethodCatalog('TOSS', { isEnabled: false });
+
+    expect(mockedClient.patch).toHaveBeenCalledWith(
+      '/wallet/v1/admin/payment-methods/TOSS',
+      { isEnabled: false },
+      idempotencyConfig
+    );
+  });
+
+  it('sends an Idempotency-Key when creating a region', async () => {
+    await walletApi.createRegion({ code: 'kr', name: 'Korea' });
+
+    expect(mockedClient.post).toHaveBeenCalledWith(
+      '/wallet/v1/admin/regions',
+      { code: 'kr', name: 'Korea' },
+      idempotencyConfig
+    );
+  });
+
+  it('sends an Idempotency-Key when toggling a region', async () => {
+    await walletApi.updateRegion('kr', { isActive: false });
+
+    expect(mockedClient.patch).toHaveBeenCalledWith(
+      '/wallet/v1/admin/regions/kr',
+      { isActive: false },
+      idempotencyConfig
+    );
+  });
+
+  it('sends an Idempotency-Key when saving region payment methods', async () => {
+    const items = [{ code: 'TOSS', isEnabled: false, sortOrder: 10 }];
+
+    await walletApi.putRegionPaymentMethods('kr', items);
+
+    expect(mockedClient.put).toHaveBeenCalledWith(
+      '/wallet/v1/admin/regions/kr/payment-methods',
+      { items },
+      idempotencyConfig
+    );
+  });
+});

--- a/apps/admin-web/src/lib/api/domains/wallet/index.ts
+++ b/apps/admin-web/src/lib/api/domains/wallet/index.ts
@@ -18,6 +18,13 @@ import {
   AdminRecurringBillingOverview,
   AdminRecurringBillingRow,
   AdminRecurringBillingListQuery,
+  PaymentMethodCatalogDto,
+  UpdateCatalogPayload,
+  RegionDto,
+  CreateRegionPayload,
+  UpdateRegionPayload,
+  RegionMethodMatrixResponse,
+  PutRegionMethodItem,
 } from '@/lib/types/dto/wallet';
 import { client } from '../../client';
 
@@ -31,6 +38,12 @@ function buildQueryString(query: Record<string, unknown>): string {
     }
   });
   return params.toString();
+}
+
+function idempotencyConfig() {
+  return {
+    headers: { 'Idempotency-Key': crypto.randomUUID() },
+  };
 }
 
 export const walletApi = {
@@ -59,15 +72,23 @@ export const walletApi = {
   },
 
   captureIntent: async (id: string): Promise<void> => {
-    await client.post(`${BASE}/v1/admin/payment-intents/${id}/capture`, undefined, {
-      headers: { 'Idempotency-Key': crypto.randomUUID() },
-    });
+    await client.post(
+      `${BASE}/v1/admin/payment-intents/${id}/capture`,
+      undefined,
+      {
+        headers: { 'Idempotency-Key': crypto.randomUUID() },
+      }
+    );
   },
 
   cancelIntent: async (id: string): Promise<void> => {
-    await client.post(`${BASE}/v1/admin/payment-intents/${id}/cancel`, undefined, {
-      headers: { 'Idempotency-Key': crypto.randomUUID() },
-    });
+    await client.post(
+      `${BASE}/v1/admin/payment-intents/${id}/cancel`,
+      undefined,
+      {
+        headers: { 'Idempotency-Key': crypto.randomUUID() },
+      }
+    );
   },
 
   refundIntent: async (
@@ -79,9 +100,13 @@ export const walletApi = {
       reasonMessage?: string;
     }
   ): Promise<RefundDto> => {
-    const res = await client.post(`${BASE}/v1/admin/payment-intents/${id}/refund`, dto, {
-      headers: { 'Idempotency-Key': crypto.randomUUID() },
-    });
+    const res = await client.post(
+      `${BASE}/v1/admin/payment-intents/${id}/refund`,
+      dto,
+      {
+        headers: { 'Idempotency-Key': crypto.randomUUID() },
+      }
+    );
     return res.data;
   },
 
@@ -91,7 +116,7 @@ export const walletApi = {
     const res = await client.post(
       `${BASE}/v1/admin/refunds/${encodeURIComponent(id)}/confirm`,
       undefined,
-      { headers: { 'Idempotency-Key': crypto.randomUUID() } },
+      { headers: { 'Idempotency-Key': crypto.randomUUID() } }
     );
     return res.data;
   },
@@ -126,13 +151,16 @@ export const walletApi = {
     await client.post(
       `${BASE}/v1/admin/payment-intents/${id}/bank-transfer-confirm`,
       { depositorNote },
-      { headers: { 'Idempotency-Key': crypto.randomUUID() } },
+      { headers: { 'Idempotency-Key': crypto.randomUUID() } }
     );
   },
 
   // ── Points ───────────────────────────────────────────────────────────────
 
-  getPointsStats: async (params?: { dateFrom?: string; dateTo?: string }): Promise<PointsStatsDto> => {
+  getPointsStats: async (params?: {
+    dateFrom?: string;
+    dateTo?: string;
+  }): Promise<PointsStatsDto> => {
     const res = await client.get(`${BASE}/v1/admin/points/stats`, { params });
     return res.data;
   },
@@ -145,7 +173,9 @@ export const walletApi = {
     dateFrom?: string;
     dateTo?: string;
   }): Promise<PaginatedResponse<PointsEventDto>> => {
-    const res = await client.get(`${BASE}/v1/admin/points/events/all`, { params });
+    const res = await client.get(`${BASE}/v1/admin/points/events/all`, {
+      params,
+    });
     return res.data;
   },
 
@@ -155,18 +185,27 @@ export const walletApi = {
     reasonCode?: string,
     expiresAt?: string
   ): Promise<BatchEarnResultDto> => {
-    const res = await client.post(`${BASE}/v1/admin/points/earn/batch`, { userIds, amount, reasonCode, expiresAt }, {
-      headers: { 'Idempotency-Key': crypto.randomUUID() },
-    });
+    const res = await client.post(
+      `${BASE}/v1/admin/points/earn/batch`,
+      { userIds, amount, reasonCode, expiresAt },
+      {
+        headers: { 'Idempotency-Key': crypto.randomUUID() },
+      }
+    );
     return res.data;
   },
 
   getTopPointUsers: async (limit?: number): Promise<TopPointUserDto[]> => {
-    const res = await client.get(`${BASE}/v1/admin/points/users/top`, { params: { limit } });
+    const res = await client.get(`${BASE}/v1/admin/points/users/top`, {
+      params: { limit },
+    });
     return res.data;
   },
 
-  processExpiredPoints: async (): Promise<{ processed: number; cancelled: number }> => {
+  processExpiredPoints: async (): Promise<{
+    processed: number;
+    cancelled: number;
+  }> => {
     const res = await client.post(`${BASE}/v1/admin/points/expire`, undefined, {
       headers: { 'Idempotency-Key': crypto.randomUUID() },
     });
@@ -174,7 +213,9 @@ export const walletApi = {
   },
 
   getPointsBalance: async (userId: string): Promise<PointsBalanceDto> => {
-    const res = await client.get(`${BASE}/v1/admin/points/balance`, { params: { user_id: userId } });
+    const res = await client.get(`${BASE}/v1/admin/points/balance`, {
+      params: { user_id: userId },
+    });
     return res.data;
   },
 
@@ -196,9 +237,13 @@ export const walletApi = {
     reasonCode?: string,
     expiresAt?: string
   ): Promise<void> => {
-    await client.post(`${BASE}/v1/admin/points/earn`, { userId, amount, reasonCode, expiresAt }, {
-      headers: { 'Idempotency-Key': crypto.randomUUID() },
-    });
+    await client.post(
+      `${BASE}/v1/admin/points/earn`,
+      { userId, amount, reasonCode, expiresAt },
+      {
+        headers: { 'Idempotency-Key': crypto.randomUUID() },
+      }
+    );
   },
 
   deductPoints: async (
@@ -206,9 +251,13 @@ export const walletApi = {
     amount: number,
     reasonCode?: string
   ): Promise<void> => {
-    await client.post(`${BASE}/v1/admin/points/deduct`, { userId, amount, reasonCode }, {
-      headers: { 'Idempotency-Key': crypto.randomUUID() },
-    });
+    await client.post(
+      `${BASE}/v1/admin/points/deduct`,
+      { userId, amount, reasonCode },
+      {
+        headers: { 'Idempotency-Key': crypto.randomUUID() },
+      }
+    );
   },
 
   cancelEarnPoints: async (
@@ -217,48 +266,146 @@ export const walletApi = {
     amount?: number,
     reasonCode?: string
   ): Promise<void> => {
-    await client.post(`${BASE}/v1/admin/points/earn-cancel`, {
-      userId,
-      earnEventId,
-      ...(amount !== undefined && { amount }),
-      ...(reasonCode && { reasonCode }),
-    }, {
-      headers: { 'Idempotency-Key': crypto.randomUUID() },
-    });
+    await client.post(
+      `${BASE}/v1/admin/points/earn-cancel`,
+      {
+        userId,
+        earnEventId,
+        ...(amount !== undefined && { amount }),
+        ...(reasonCode && { reasonCode }),
+      },
+      {
+        headers: { 'Idempotency-Key': crypto.randomUUID() },
+      }
+    );
   },
 
   // ── Recurring Billing Admin ──────────────────────────────────────────────────
 
-  getRecurringBillingOverview: async (): Promise<AdminRecurringBillingOverview> => {
-    const res = await client.get(`${BASE}/v1/admin/recurring-billing/overview`);
-    return res.data;
-  },
+  getRecurringBillingOverview:
+    async (): Promise<AdminRecurringBillingOverview> => {
+      const res = await client.get(
+        `${BASE}/v1/admin/recurring-billing/overview`
+      );
+      return res.data;
+    },
 
-  listRecurringBillingItems: async (query: AdminRecurringBillingListQuery): Promise<PaginatedResponse<AdminRecurringBillingRow>> => {
+  listRecurringBillingItems: async (
+    query: AdminRecurringBillingListQuery
+  ): Promise<PaginatedResponse<AdminRecurringBillingRow>> => {
     const qs = buildQueryString(query as Record<string, unknown>);
-    const res = await client.get(`${BASE}/v1/admin/recurring-billing/items${qs ? `?${qs}` : ''}`);
+    const res = await client.get(
+      `${BASE}/v1/admin/recurring-billing/items${qs ? `?${qs}` : ''}`
+    );
     return res.data;
   },
 
   pollCmsMember: async (id: string): Promise<AdminRecurringBillingRow> => {
-    const res = await client.post(`${BASE}/v1/admin/recurring-billing/providers/cms/members/${id}/poll`, undefined, {
-      headers: { 'Idempotency-Key': crypto.randomUUID() },
-    });
+    const res = await client.post(
+      `${BASE}/v1/admin/recurring-billing/providers/cms/members/${id}/poll`,
+      undefined,
+      {
+        headers: { 'Idempotency-Key': crypto.randomUUID() },
+      }
+    );
     return res.data;
   },
 
   pollCmsWithdrawal: async (id: string): Promise<AdminRecurringBillingRow> => {
-    const res = await client.post(`${BASE}/v1/admin/recurring-billing/providers/cms/withdrawals/${id}/poll`, undefined, {
-      headers: { 'Idempotency-Key': crypto.randomUUID() },
-    });
+    const res = await client.post(
+      `${BASE}/v1/admin/recurring-billing/providers/cms/withdrawals/${id}/poll`,
+      undefined,
+      {
+        headers: { 'Idempotency-Key': crypto.randomUUID() },
+      }
+    );
     return res.data;
   },
 
-  getAgreementStateByRefs: async (refs: string[]): Promise<Record<string, import('@/lib/types/dto/membership').AgreementStateEntry | null>> => {
+  getAgreementStateByRefs: async (
+    refs: string[]
+  ): Promise<
+    Record<
+      string,
+      import('@/lib/types/dto/membership').AgreementStateEntry | null
+    >
+  > => {
     if (!refs.length) return {};
     const params = new URLSearchParams();
     refs.forEach((r) => params.append('refs', r));
-    const res = await client.get(`${BASE}/v1/admin/recurring-billing/agreement-state-by-refs?${params.toString()}`);
+    const res = await client.get(
+      `${BASE}/v1/admin/recurring-billing/agreement-state-by-refs?${params.toString()}`
+    );
+    return res.data;
+  },
+
+  // ── Payment method catalog (글로벌) ──────────────────────────────────────────
+
+  listPaymentMethodCatalog: async (): Promise<PaymentMethodCatalogDto[]> => {
+    const res = await client.get(`${BASE}/v1/admin/payment-methods`);
+    return res.data;
+  },
+
+  updatePaymentMethodCatalog: async (
+    code: string,
+    payload: UpdateCatalogPayload
+  ): Promise<PaymentMethodCatalogDto> => {
+    const res = await client.patch(
+      `${BASE}/v1/admin/payment-methods/${encodeURIComponent(code)}`,
+      payload,
+      idempotencyConfig()
+    );
+    return res.data;
+  },
+
+  // ── Regions ──────────────────────────────────────────────────────────────────
+
+  listRegions: async (): Promise<RegionDto[]> => {
+    const res = await client.get(`${BASE}/v1/admin/regions`);
+    return res.data;
+  },
+
+  createRegion: async (payload: CreateRegionPayload): Promise<RegionDto> => {
+    const res = await client.post(
+      `${BASE}/v1/admin/regions`,
+      payload,
+      idempotencyConfig()
+    );
+    return res.data;
+  },
+
+  updateRegion: async (
+    code: string,
+    payload: UpdateRegionPayload
+  ): Promise<RegionDto> => {
+    const res = await client.patch(
+      `${BASE}/v1/admin/regions/${encodeURIComponent(code)}`,
+      payload,
+      idempotencyConfig()
+    );
+    return res.data;
+  },
+
+  // ── Region ↔ 결제수단 매핑 ───────────────────────────────────────────────────
+
+  getRegionPaymentMethods: async (
+    code: string
+  ): Promise<RegionMethodMatrixResponse> => {
+    const res = await client.get(
+      `${BASE}/v1/admin/regions/${encodeURIComponent(code)}/payment-methods`
+    );
+    return res.data;
+  },
+
+  putRegionPaymentMethods: async (
+    code: string,
+    items: PutRegionMethodItem[]
+  ): Promise<RegionMethodMatrixResponse> => {
+    const res = await client.put(
+      `${BASE}/v1/admin/regions/${encodeURIComponent(code)}/payment-methods`,
+      { items },
+      idempotencyConfig()
+    );
     return res.data;
   },
 };

--- a/apps/admin-web/src/lib/services/medusa-regions.ts
+++ b/apps/admin-web/src/lib/services/medusa-regions.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  medusaRegionsApi,
+  type CreateMedusaRegionPayload,
+  type UpdateMedusaRegionPayload,
+} from '@/lib/api/domains/medusa/regions';
+
+const medusaRegionKeys = {
+  all: ['medusa-regions'] as const,
+  list: (params: object) => [...medusaRegionKeys.all, 'list', params] as const,
+  detail: (id: string) => [...medusaRegionKeys.all, id] as const,
+};
+
+export const useMedusaRegions = (
+  params: { limit?: number; offset?: number } = {}
+) =>
+  useQuery({
+    queryKey: medusaRegionKeys.list(params),
+    queryFn: () => medusaRegionsApi.list(params),
+    staleTime: 30_000,
+  });
+
+export const useCreateMedusaRegion = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: CreateMedusaRegionPayload) =>
+      medusaRegionsApi.create(payload),
+    onSuccess: () => qc.invalidateQueries({ queryKey: medusaRegionKeys.all }),
+  });
+};
+
+export const useUpdateMedusaRegion = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      payload,
+    }: {
+      id: string;
+      payload: UpdateMedusaRegionPayload;
+    }) => medusaRegionsApi.update(id, payload),
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: medusaRegionKeys.all });
+      qc.invalidateQueries({ queryKey: medusaRegionKeys.detail(variables.id) });
+    },
+  });
+};
+
+export const useDeleteMedusaRegion = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => medusaRegionsApi.delete(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: medusaRegionKeys.all }),
+  });
+};

--- a/apps/admin-web/src/lib/services/wallet/mutations.ts
+++ b/apps/admin-web/src/lib/services/wallet/mutations.ts
@@ -3,6 +3,12 @@
 import { walletApi } from '@/lib/api/domains/wallet';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { walletQueryKeys } from './query-keys';
+import type {
+  CreateRegionPayload,
+  PutRegionMethodItem,
+  UpdateCatalogPayload,
+  UpdateRegionPayload,
+} from '@/lib/types/dto/wallet';
 
 export const useCaptureIntent = (intentId: string) => {
   const queryClient = useQueryClient();
@@ -170,6 +176,75 @@ export const useCancelEarnPoints = () => {
         queryKey: walletQueryKeys.pointsBalance(variables.userId),
       });
       queryClient.invalidateQueries({ queryKey: walletQueryKeys.points() });
+    },
+  });
+};
+
+// ── Payment method catalog & regions ─────────────────────────────────────────
+
+export const useUpdatePaymentMethodCatalog = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      code,
+      payload,
+    }: {
+      code: string;
+      payload: UpdateCatalogPayload;
+    }) => walletApi.updatePaymentMethodCatalog(code, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: walletQueryKeys.catalog() });
+      // 글로벌 토글은 모든 리전 매트릭스의 available 에 영향
+      queryClient.invalidateQueries({ queryKey: walletQueryKeys.regions() });
+    },
+  });
+};
+
+export const useCreateRegion = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: CreateRegionPayload) =>
+      walletApi.createRegion(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: walletQueryKeys.regions() });
+    },
+  });
+};
+
+export const useUpdateRegion = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      code,
+      payload,
+    }: {
+      code: string;
+      payload: UpdateRegionPayload;
+    }) => walletApi.updateRegion(code, payload),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: walletQueryKeys.regions() });
+      queryClient.invalidateQueries({
+        queryKey: walletQueryKeys.regionMethods(variables.code),
+      });
+    },
+  });
+};
+
+export const usePutRegionPaymentMethods = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      code,
+      items,
+    }: {
+      code: string;
+      items: PutRegionMethodItem[];
+    }) => walletApi.putRegionPaymentMethods(code, items),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: walletQueryKeys.regionMethods(variables.code),
+      });
+      queryClient.invalidateQueries({ queryKey: walletQueryKeys.regions() });
     },
   });
 };

--- a/apps/admin-web/src/lib/services/wallet/queries.ts
+++ b/apps/admin-web/src/lib/services/wallet/queries.ts
@@ -86,7 +86,10 @@ export const usePointsEvents = (
   });
 };
 
-export const usePointsStats = (params?: { dateFrom?: string; dateTo?: string }) => {
+export const usePointsStats = (params?: {
+  dateFrom?: string;
+  dateTo?: string;
+}) => {
   return useQuery({
     queryKey: walletQueryKeys.pointsStats(params),
     queryFn: () => walletApi.getPointsStats(params),
@@ -115,5 +118,32 @@ export const useTopPointUsers = (limit?: number) => {
     queryKey: walletQueryKeys.topUsers(limit),
     queryFn: () => walletApi.getTopPointUsers(limit),
     staleTime: 60 * 1000,
+  });
+};
+
+// ── Payment method catalog & regions ─────────────────────────────────────────
+
+export const usePaymentMethodCatalog = () => {
+  return useQuery({
+    queryKey: walletQueryKeys.catalog(),
+    queryFn: () => walletApi.listPaymentMethodCatalog(),
+    staleTime: 30 * 1000,
+  });
+};
+
+export const useRegions = () => {
+  return useQuery({
+    queryKey: walletQueryKeys.regions(),
+    queryFn: () => walletApi.listRegions(),
+    staleTime: 30 * 1000,
+  });
+};
+
+export const useRegionPaymentMethods = (code: string | null) => {
+  return useQuery({
+    queryKey: walletQueryKeys.regionMethods(code ?? ''),
+    queryFn: () => walletApi.getRegionPaymentMethods(code as string),
+    staleTime: 30 * 1000,
+    enabled: !!code,
   });
 };

--- a/apps/admin-web/src/lib/services/wallet/query-keys.ts
+++ b/apps/admin-web/src/lib/services/wallet/query-keys.ts
@@ -36,4 +36,12 @@ export const walletQueryKeys = {
     [...walletQueryKeys.points(), 'events', 'all', params] as const,
   topUsers: (limit?: number) =>
     [...walletQueryKeys.points(), 'users', 'top', { limit }] as const,
+
+  // Payment method catalog
+  catalog: () => [...walletQueryKeys.all, 'catalog'] as const,
+
+  // Regions
+  regions: () => [...walletQueryKeys.all, 'regions'] as const,
+  regionMethods: (code: string) =>
+    [...walletQueryKeys.regions(), code, 'payment-methods'] as const,
 } as const;

--- a/apps/admin-web/src/lib/types/dto/wallet.ts
+++ b/apps/admin-web/src/lib/types/dto/wallet.ts
@@ -201,7 +201,12 @@ export interface PaginatedResponse<T> {
 
 // ── Recurring Billing Admin ──────────────────────────────────────────────────
 
-export type AdminRecurringBillingIssueType = 'PROVIDER_METHOD' | 'PROVIDER_MANDATE' | 'PROVIDER_CHARGE' | 'PAYMENT_INTENT' | 'CONTRACT';
+export type AdminRecurringBillingIssueType =
+  | 'PROVIDER_METHOD'
+  | 'PROVIDER_MANDATE'
+  | 'PROVIDER_CHARGE'
+  | 'PAYMENT_INTENT'
+  | 'CONTRACT';
 
 export interface AdminRecurringBillingRow {
   issueType: AdminRecurringBillingIssueType;
@@ -226,7 +231,12 @@ export interface AdminRecurringBillingRow {
     agreementStatus?: string | null;
     withdrawalId?: string;
     transactionId?: string;
-    withdrawalStatus?: 'REQUESTED' | 'PROCESSING' | 'SUCCEEDED' | 'FAILED' | 'DELETED';
+    withdrawalStatus?:
+      | 'REQUESTED'
+      | 'PROCESSING'
+      | 'SUCCEEDED'
+      | 'FAILED'
+      | 'DELETED';
     paymentDate?: string;
     resultCode?: string | null;
     resultMessage?: string | null;
@@ -234,6 +244,65 @@ export interface AdminRecurringBillingRow {
   };
   createdAt: string;
   updatedAt: string;
+}
+
+// ── Payment method catalog & regions ────────────────────────────────────────
+
+export interface PaymentMethodCatalogDto {
+  id: string;
+  code: string;
+  displayName: string;
+  description: string | null;
+  isEnabled: boolean;
+  sortOrder: number;
+}
+
+export interface UpdateCatalogPayload {
+  isEnabled?: boolean;
+  displayName?: string;
+  sortOrder?: number;
+}
+
+export interface RegionDto {
+  id: string;
+  code: string;
+  name: string;
+  isActive: boolean;
+  sortOrder: number;
+}
+
+export interface CreateRegionPayload {
+  code: string;
+  name: string;
+  isActive?: boolean;
+  sortOrder?: number;
+}
+
+export interface UpdateRegionPayload {
+  name?: string;
+  isActive?: boolean;
+  sortOrder?: number;
+}
+
+export interface RegionMethodMatrixItem {
+  code: string;
+  displayName: string;
+  description: string | null;
+  globalEnabled: boolean;
+  regionEnabled: boolean;
+  available: boolean;
+  sortOrder: number;
+}
+
+export interface RegionMethodMatrixResponse {
+  region: RegionDto;
+  items: RegionMethodMatrixItem[];
+}
+
+export interface PutRegionMethodItem {
+  code: string;
+  isEnabled: boolean;
+  sortOrder?: number;
 }
 
 export interface AdminRecurringBillingOverview {
@@ -253,7 +322,12 @@ export interface AdminRecurringBillingListQuery {
   dateFrom?: string;
   dateTo?: string;
   cmsMemberStatus?: 'PENDING' | 'REGISTERED' | 'FAILED' | 'DELETED';
-  withdrawalStatus?: 'REQUESTED' | 'PROCESSING' | 'SUCCEEDED' | 'FAILED' | 'DELETED';
+  withdrawalStatus?:
+    | 'REQUESTED'
+    | 'PROCESSING'
+    | 'SUCCEEDED'
+    | 'FAILED'
+    | 'DELETED';
   userId?: string;
   contractId?: string;
   cmsMemberId?: string;

--- a/apps/admin-web/src/lib/utils/menu.ts
+++ b/apps/admin-web/src/lib/utils/menu.ts
@@ -478,6 +478,11 @@ export const mainMenus: MainMenu[] = [
         isComingSoon: true,
       },
       {
+        id: 'store-regions',
+        title: '리전 설정 (통화/세금)',
+        path: '/mall/regions',
+      },
+      {
         id: 'settings',
         title: '설정',
         path: '/mall/settings',
@@ -509,6 +514,16 @@ export const mainMenus: MainMenu[] = [
         id: 'points-management',
         title: '적립금 관리',
         path: '/payments/points',
+      },
+      {
+        id: 'payment-methods-management',
+        title: '결제수단 관리',
+        path: '/payments/methods',
+      },
+      {
+        id: 'region-management',
+        title: '리전·결제수단 관리',
+        path: '/payments/regions',
       },
     ],
   },

--- a/apps/wallet-web/app/pay/[intentId]/page.tsx
+++ b/apps/wallet-web/app/pay/[intentId]/page.tsx
@@ -1,6 +1,12 @@
 import { cookies } from 'next/headers';
 import { notFound, redirect } from 'next/navigation';
-import { getPaymentIntent, getPaymentMethods, getPointsBalance, getBillingMethods } from '@/lib/wallet-api';
+import {
+  getPaymentIntent,
+  getPaymentMethods,
+  getPointsBalance,
+  getBillingMethods,
+  getAvailablePaymentMethods,
+} from '@/lib/wallet-api';
 import { buildReturnUrl } from '@/lib/return-url';
 import { PayForm } from './pay-form';
 import { Card, CardContent } from '@/components/ui/card';
@@ -10,10 +16,12 @@ import { CheckCircle2, XCircle } from 'lucide-react';
 
 interface Props {
   params: Promise<{ intentId: string }>;
+  searchParams: Promise<{ region?: string }>;
 }
 
-export default async function PayPage({ params }: Props) {
+export default async function PayPage({ params, searchParams }: Props) {
   const { intentId } = await params;
+  const { region } = await searchParams;
 
   // 서버 컴포넌트에서 브라우저 쿠키를 wallet API로 직접 포워딩
   const cookieStore = await cookies();
@@ -28,9 +36,14 @@ export default async function PayPage({ params }: Props) {
 
   const isRecurring = intent.metadata?.billingMode === 'recurring';
 
-  const [methods, billingMethods] = await Promise.all([
+  const [methods, billingMethods, availableMethods] = await Promise.all([
     getPaymentMethods(cookieHeader).catch(() => []),
     isRecurring ? getBillingMethods(cookieHeader) : Promise.resolve([]),
+    // region 미지정 → null (필터 미적용, 하위호환).
+    // region 명시 → 가용 결제수단 목록. 조회 실패해도 [] 로 막아, 설정 안 된 리전에 다른 리전(KR) 수단이 새지 않게 한다.
+    region
+      ? getAvailablePaymentMethods(region, cookieHeader).catch(() => [])
+      : Promise.resolve(null),
   ]);
 
   if (['AUTHORIZED', 'CAPTURED', 'SUCCEEDED'].includes(intent.status)) {
@@ -92,5 +105,14 @@ export default async function PayPage({ params }: Props) {
     );
   }
 
-  return <PayForm intent={intent} methods={methods} pointsBalance={pointsBalance} billingMethodsExist={billingMethodsExist} />;
+  return (
+    <PayForm
+      intent={intent}
+      methods={methods}
+      pointsBalance={pointsBalance}
+      billingMethodsExist={billingMethodsExist}
+      availableMethods={availableMethods}
+      region={region ?? null}
+    />
+  );
 }

--- a/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
+++ b/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
@@ -60,6 +60,23 @@ function getMethodIcon(type: string): ReactNode {
   }
 }
 
+// region(countryCode)별 사람이 읽는 이름. 미정의 코드는 코드 그대로(대문자) 표시한다.
+const REGION_LABELS: Record<string, string> = {
+  kr: '대한민국',
+  jp: '일본',
+  us: '미국',
+};
+
+// 빈 결제수단 안내에서 "어느 지역으로 들어왔는지"를 명확히 보여주기 위한 라벨.
+// 예: jp → "일본(JP)", fr → "FR". region 이 없으면 null.
+function getRegionLabel(region?: string | null): string | null {
+  const code = region?.trim();
+  if (!code) return null;
+  const upper = code.toUpperCase();
+  const name = REGION_LABELS[code.toLowerCase()];
+  return name ? `${name}(${upper})` : upper;
+}
+
 function formatAmount(amount: number, currency: string): string {
   if (currency === 'KRW') {
     return `${amount.toLocaleString('ko-KR')}원`;
@@ -88,6 +105,7 @@ export function PayForm({ intent, methods, pointsBalance, billingMethodsExist, a
     ? new Map(availableMethods.map((method) => [method.code, method]))
     : null;
   const isAvailableInRegion = (type: string) => !availableMethodMap || availableMethodMap.has(type);
+  const regionLabel = getRegionLabel(region);
 
   const externalMethods = methods
     .filter((m) => m.type !== 'POINTS' && isAvailableInRegion(m.type))
@@ -411,7 +429,9 @@ export function PayForm({ intent, methods, pointsBalance, billingMethodsExist, a
                       <CreditCard className="w-8 h-8 text-muted-foreground/50" />
                       <p className="text-sm text-muted-foreground">
                         {Array.isArray(availableMethods)
-                          ? '이 지역에서 사용 가능한 결제수단이 없습니다. 관리자 설정이 필요합니다.'
+                          ? regionLabel
+                            ? `${regionLabel} 지역에서 사용 가능한 결제수단이 없습니다. 관리자에게 문의해주세요.`
+                            : '이 지역에서 사용 가능한 결제수단이 없습니다. 관리자에게 문의해주세요.'
                           : '사용 가능한 결제 수단이 없습니다.'}
                       </p>
                     </div>

--- a/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
+++ b/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
@@ -4,7 +4,7 @@ import { useState, type ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
 import { confirmPaymentIntent, cancelPaymentIntent } from '@/lib/wallet-api';
 import { buildReturnUrl } from '@/lib/return-url';
-import type { PaymentIntent, PaymentMethod, PointsBalance } from '@/lib/wallet-api';
+import type { AvailablePaymentMethod, PaymentIntent, PaymentMethod, PointsBalance } from '@/lib/wallet-api';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
@@ -20,6 +20,7 @@ import {
   ChevronRight,
   Coins,
   RefreshCw,
+  Landmark,
 } from 'lucide-react';
 
 interface Props {
@@ -27,18 +28,35 @@ interface Props {
   methods: PaymentMethod[];
   pointsBalance: PointsBalance;
   billingMethodsExist: boolean;
+  /**
+   * 리전에서 사용 가능한 결제수단 목록. storefront 가 region 을 전달했을 때만 채워진다.
+   * null 이면 리전 필터를 적용하지 않는다.
+   */
+  availableMethods?: AvailablePaymentMethod[] | null;
+  region?: string | null;
+}
+
+interface BankTransferPendingAction {
+  type: 'BANK_TRANSFER_PENDING';
+  bankName?: string;
+  accountNumber?: string;
+  accountHolder?: string;
+  amount?: number;
+  currency?: string;
 }
 
 function getMethodIcon(type: string): ReactNode {
   switch (type) {
     case 'TOSS':
-      return <Smartphone className="h-5 w-5" />;
+      return <Smartphone className="w-5 h-5" />;
     case 'CARD':
-      return <CreditCard className="h-5 w-5" />;
+      return <CreditCard className="w-5 h-5" />;
     case 'BALANCE':
-      return <Wallet className="h-5 w-5" />;
+      return <Wallet className="w-5 h-5" />;
+    case 'BANK_TRANSFER':
+      return <Landmark className="w-5 h-5" />;
     default:
-      return <CreditCard className="h-5 w-5" />;
+      return <CreditCard className="w-5 h-5" />;
   }
 }
 
@@ -49,16 +67,47 @@ function formatAmount(amount: number, currency: string): string {
   return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(amount);
 }
 
-export function PayForm({ intent, methods, pointsBalance, billingMethodsExist }: Props) {
+function buildPayPath(intentId: string, region?: string | null, extra?: Record<string, string>) {
+  const params = new URLSearchParams(extra);
+  if (region) params.set('region', region);
+  const query = params.toString();
+  return `/pay/${intentId}${query ? `?${query}` : ''}`;
+}
+
+function isBankTransferPendingAction(value: unknown): value is BankTransferPendingAction {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { type?: unknown }).type === 'BANK_TRANSFER_PENDING'
+  );
+}
+
+export function PayForm({ intent, methods, pointsBalance, billingMethodsExist, availableMethods, region }: Props) {
   const router = useRouter();
-  const externalMethods = methods.filter((m) => m.type !== 'POINTS' && m.type !== 'BANK_TRANSFER');
-  const availablePoints = pointsBalance.available;
+  const availableMethodMap = availableMethods
+    ? new Map(availableMethods.map((method) => [method.code, method]))
+    : null;
+  const isAvailableInRegion = (type: string) => !availableMethodMap || availableMethodMap.has(type);
+
+  const externalMethods = methods
+    .filter((m) => m.type !== 'POINTS' && isAvailableInRegion(m.type))
+    .sort((a, b) => {
+      const aOrder = availableMethodMap?.get(a.type)?.sortOrder ?? 0;
+      const bOrder = availableMethodMap?.get(b.type)?.sortOrder ?? 0;
+      if (aOrder !== bOrder) return aOrder - bOrder;
+      return a.type.localeCompare(b.type);
+    });
+
+  // 포인트는 리전이 POINTS 를 허용할 때만 사용 가능.
+  const pointsAllowedInRegion = isAvailableInRegion('POINTS');
+  const availablePoints = pointsAllowedInRegion ? pointsBalance.available : 0;
 
   const [selectedMethodId, setSelectedMethodId] = useState<string>(externalMethods[0]?.id ?? '');
   const [usePoints, setUsePoints] = useState(false);
   const [pointsAmount, setPointsAmount] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [bankTransferPending, setBankTransferPending] = useState<BankTransferPendingAction | null>(null);
 
   const isRecurring = intent.metadata?.billingMode === 'recurring';
   const maxPoints = Math.min(availablePoints, intent.payableAmount);
@@ -103,18 +152,29 @@ export function PayForm({ intent, methods, pointsBalance, billingMethodsExist }:
         const { loadTossPayments } = await import('@tosspayments/tosspayments-sdk');
         const tossPayments = await loadTossPayments(na.clientKey as string);
         const payment = tossPayments.payment({ customerKey: `user-${intent.userId}` });
+        const tossCompletePath = buildPayPath(`${intent.id}/toss-complete`, region);
         await payment.requestPayment({
           method: 'CARD',
           orderId: na.orderId as string,
           orderName: na.orderName as string,
           amount: { currency: 'KRW', value: na.amount as number },
-          successUrl: `${window.location.origin}/pay/${intent.id}/toss-complete`,
-          failUrl: `${window.location.origin}/pay/${intent.id}?toss_fail=1`,
+          successUrl: `${window.location.origin}${tossCompletePath}`,
+          failUrl: `${window.location.origin}${buildPayPath(intent.id, region, { toss_fail: '1' })}`,
           ...(na.customerName ? { customerName: na.customerName as string } : {}),
           ...(na.customerEmail ? { customerEmail: na.customerEmail as string } : {}),
           ...(na.customerMobilePhone ? { customerMobilePhone: na.customerMobilePhone as string } : {}),
         });
         return; // requestPayment redirects
+      }
+
+      if (result.status === 'REQUIRES_ACTION' && isBankTransferPendingAction(result.nextAction)) {
+        setBankTransferPending(result.nextAction);
+        return;
+      }
+
+      if (result.status === 'REQUIRES_ACTION') {
+        setError('추가 인증이 필요한 결제수단이지만 wallet-web에서 아직 지원하지 않습니다.');
+        return;
       }
 
       if (result.returnUrl) {
@@ -129,7 +189,7 @@ export function PayForm({ intent, methods, pointsBalance, billingMethodsExist }:
           router.replace(successUrl);
         }
       } else {
-        router.replace(`/pay/${intent.id}`);
+        router.replace(buildPayPath(intent.id, region));
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : '결제에 실패했어요.');
@@ -151,7 +211,7 @@ export function PayForm({ intent, methods, pointsBalance, billingMethodsExist }:
           }),
         );
       } else {
-        router.replace(`/pay/${intent.id}`);
+        router.replace(buildPayPath(intent.id, region));
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : '취소에 실패했어요.');
@@ -161,6 +221,70 @@ export function PayForm({ intent, methods, pointsBalance, billingMethodsExist }:
   }
 
   const canConfirm = remainingAmount === 0 || !!selectedMethodId;
+
+  if (bankTransferPending) {
+    return (
+      <div className="min-h-screen bg-muted/40">
+        <div className="border-b bg-card">
+          <div className="flex items-center justify-center gap-1.5 py-2.5">
+            <Lock className="h-3.5 w-3.5 text-muted-foreground" />
+          </div>
+        </div>
+
+        <div className="mx-auto flex min-h-[calc(100vh-41px)] max-w-md items-center px-4 py-8">
+          <Card className="w-full border shadow-sm border-border/60">
+            <CardContent className="p-6 space-y-5">
+              <div className="flex items-start gap-3">
+                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+                  <Landmark className="h-5 w-5" />
+                </div>
+                <div className="space-y-1">
+                  <h1 className="text-lg font-semibold">입금 확인 대기 중입니다</h1>
+                  <p className="text-sm text-muted-foreground">
+                    아래 계좌로 입금하면 관리자가 확인한 뒤 결제가 완료됩니다.
+                  </p>
+                </div>
+              </div>
+
+              <Separator />
+
+              <dl className="space-y-3 text-sm">
+                <div className="flex justify-between gap-4">
+                  <dt className="text-muted-foreground">입금 금액</dt>
+                  <dd className="font-semibold">
+                    {formatAmount(bankTransferPending.amount ?? remainingAmount, bankTransferPending.currency ?? intent.currency)}
+                  </dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-muted-foreground">은행</dt>
+                  <dd className="font-medium text-right">{bankTransferPending.bankName || '-'}</dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-muted-foreground">계좌번호</dt>
+                  <dd className="font-mono font-medium text-right">{bankTransferPending.accountNumber || '-'}</dd>
+                </div>
+                <div className="flex justify-between gap-4">
+                  <dt className="text-muted-foreground">예금주</dt>
+                  <dd className="font-medium text-right">{bankTransferPending.accountHolder || '-'}</dd>
+                </div>
+              </dl>
+
+              <Alert>
+                <AlertCircle className="w-4 h-4" />
+                <AlertDescription>
+                  입금 전에는 주문이 최종 확정되지 않습니다. 입금 확인은 관리자 승인 후 처리됩니다.
+                </AlertDescription>
+              </Alert>
+
+              <Button variant="outline" className="w-full" onClick={() => router.refresh()}>
+                결제 상태 새로고침
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-muted/40">
@@ -172,35 +296,29 @@ export function PayForm({ intent, methods, pointsBalance, billingMethodsExist }:
       </div>
 
       {/* 메인 콘텐츠 */}
-      <div className="max-w-4xl mx-auto px-4 py-8 md:py-16">
-        <div className="flex flex-col md:flex-row gap-6 md:gap-8 md:items-start">
+      <div className="max-w-4xl px-4 py-8 mx-auto md:py-16">
+        <div className="flex flex-col gap-6 md:flex-row md:gap-8 md:items-start">
           {/* 좌측 패널: 주문 요약 */}
           <div className="w-full md:w-[380px] md:shrink-0">
-            <Card className="shadow-sm border border-border/60">
+            <Card className="border shadow-sm border-border/60">
               <CardContent className="p-6 space-y-4">
                 <div className="flex items-center gap-2">
-                  <ShoppingBag className="h-4 w-4 text-muted-foreground" />
-                  <span className="text-sm text-muted-foreground font-mono">
-                    #{intent.id.slice(-8).toUpperCase()}
-                  </span>
+                  <ShoppingBag className="w-4 h-4 text-muted-foreground" />
+                  <span className="font-mono text-sm text-muted-foreground">#{intent.id.slice(-8).toUpperCase()}</span>
                 </div>
                 {typeof intent.metadata?.orderName === 'string' && (
-                  <p className="text-sm font-medium">
-                    {intent.metadata.orderName}
-                  </p>
+                  <p className="text-sm font-medium">{intent.metadata.orderName}</p>
                 )}
                 {isRecurring && (
                   <div className="flex items-center gap-1.5 rounded-md bg-amber-50 px-2.5 py-1.5 text-xs font-medium text-amber-700">
-                    <RefreshCw className="h-3 w-3" />
+                    <RefreshCw className="w-3 h-3" />
                     정기결제 · 매월 자동갱신
                   </div>
                 )}
                 <Separator />
                 <div>
-                  <p className="text-xs text-muted-foreground mb-1">결제 금액</p>
-                  <p className="text-3xl font-bold">
-                    {formatAmount(intent.payableAmount, intent.currency)}
-                  </p>
+                  <p className="mb-1 text-xs text-muted-foreground">결제 금액</p>
+                  <p className="text-3xl font-bold">{formatAmount(intent.payableAmount, intent.currency)}</p>
                 </div>
                 {intent.expiresAt && (
                   <p className="text-xs text-muted-foreground">
@@ -208,7 +326,7 @@ export function PayForm({ intent, methods, pointsBalance, billingMethodsExist }:
                   </p>
                 )}
                 <div className="flex items-center gap-1.5 pt-1">
-                  <Lock className="h-3 w-3 text-muted-foreground" />
+                  <Lock className="w-3 h-3 text-muted-foreground" />
                   <span className="text-xs text-muted-foreground">SSL 암호화로 보호됩니다</span>
                 </div>
               </CardContent>
@@ -218,11 +336,11 @@ export function PayForm({ intent, methods, pointsBalance, billingMethodsExist }:
           {/* 우측 패널: 포인트 + 결제수단 + CTA */}
           <div className="flex-1 space-y-4">
             {/* 포인트 사용 카드 */}
-            <Card className="shadow-sm border border-border/60">
+            <Card className="border shadow-sm border-border/60">
               <CardContent className="p-6">
                 <div className="flex items-center justify-between mb-4">
                   <div className="flex items-center gap-2">
-                    <Coins className="h-4 w-4 text-muted-foreground" />
+                    <Coins className="w-4 h-4 text-muted-foreground" />
                     <span className="text-sm font-semibold">포인트 사용</span>
                   </div>
                   <span className="text-sm text-muted-foreground">
@@ -239,7 +357,7 @@ export function PayForm({ intent, methods, pointsBalance, billingMethodsExist }:
                         type="checkbox"
                         checked={usePoints}
                         onChange={(e) => handleTogglePoints(e.target.checked)}
-                        className="h-4 w-4 rounded border-border"
+                        className="w-4 h-4 rounded border-border"
                       />
                       <span className="text-sm">포인트 사용하기</span>
                     </label>
@@ -269,9 +387,7 @@ export function PayForm({ intent, methods, pointsBalance, billingMethodsExist }:
                             {formatAmount(remainingAmount, intent.currency)} 추가 결제
                           </p>
                         ) : (
-                          <p className="text-xs text-emerald-600 font-medium">
-                            포인트로 전액 결제됩니다
-                          </p>
+                          <p className="text-xs font-medium text-emerald-600">포인트로 전액 결제됩니다</p>
                         )}
                       </div>
                     )}
@@ -282,7 +398,7 @@ export function PayForm({ intent, methods, pointsBalance, billingMethodsExist }:
 
             {/* 결제수단 선택 카드 (잔액이 있을 때만 표시) */}
             {remainingAmount > 0 && (
-              <Card className="shadow-sm border border-border/60">
+              <Card className="border shadow-sm border-border/60">
                 <CardContent className="p-6">
                   <div className="flex items-center justify-between mb-4">
                     <span className="text-sm font-semibold">결제 수단 선택</span>
@@ -292,9 +408,11 @@ export function PayForm({ intent, methods, pointsBalance, billingMethodsExist }:
                   </div>
                   {externalMethods.length === 0 ? (
                     <div className="flex flex-col items-center gap-2 py-8 text-center">
-                      <CreditCard className="h-8 w-8 text-muted-foreground/50" />
+                      <CreditCard className="w-8 h-8 text-muted-foreground/50" />
                       <p className="text-sm text-muted-foreground">
-                        사용 가능한 결제 수단이 없습니다.
+                        {Array.isArray(availableMethods)
+                          ? '이 지역에서 사용 가능한 결제수단이 없습니다. 관리자 설정이 필요합니다.'
+                          : '사용 가능한 결제 수단이 없습니다.'}
                       </p>
                     </div>
                   ) : (
@@ -319,20 +437,24 @@ export function PayForm({ intent, methods, pointsBalance, billingMethodsExist }:
                                 isSelected ? 'border-primary' : 'border-muted-foreground/40',
                               ].join(' ')}
                             >
-                              {isSelected && (
-                                <div className="h-1.5 w-1.5 rounded-full bg-primary" />
-                              )}
+                              {isSelected && <div className="h-1.5 w-1.5 rounded-full bg-primary" />}
                             </div>
                             {/* 아이콘 박스 */}
-                            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                            <div className="flex items-center justify-center rounded-md h-9 w-9 shrink-0 bg-muted text-muted-foreground">
                               {getMethodIcon(m.type)}
                             </div>
-                            {/* 이름 */}
-                            <span className="flex-1 text-sm font-medium">
-                              {m.displayName || m.type}
+                            <span className="flex-1">
+                              <span className="block text-sm font-medium">
+                                {availableMethodMap?.get(m.type)?.displayName || m.displayName || m.type}
+                              </span>
+                              {availableMethodMap?.get(m.type)?.description && (
+                                <span className="mt-0.5 block text-xs text-muted-foreground">
+                                  {availableMethodMap.get(m.type)?.description}
+                                </span>
+                              )}
                             </span>
                             {/* 선택 시 chevron */}
-                            {isSelected && <ChevronRight className="h-4 w-4 text-primary" />}
+                            {isSelected && <ChevronRight className="w-4 h-4 text-primary" />}
                           </button>
                         );
                       })}
@@ -345,7 +467,7 @@ export function PayForm({ intent, methods, pointsBalance, billingMethodsExist }:
             {/* 에러 */}
             {error && (
               <Alert variant="destructive">
-                <AlertCircle className="h-4 w-4" />
+                <AlertCircle className="w-4 h-4" />
                 <AlertDescription>{error}</AlertDescription>
               </Alert>
             )}
@@ -359,12 +481,12 @@ export function PayForm({ intent, methods, pointsBalance, billingMethodsExist }:
               >
                 {loading ? (
                   <>
-                    <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                    <span className="w-4 h-4 border-2 border-current rounded-full animate-spin border-t-transparent" />
                     처리 중...
                   </>
                 ) : (
                   <>
-                    <Lock className="h-4 w-4" />
+                    <Lock className="w-4 h-4" />
                     {formatAmount(intent.payableAmount, intent.currency)} 결제하기
                   </>
                 )}
@@ -373,7 +495,7 @@ export function PayForm({ intent, methods, pointsBalance, billingMethodsExist }:
                 <button
                   onClick={handleCancel}
                   disabled={loading}
-                  className="text-sm text-muted-foreground hover:text-foreground underline-offset-4 hover:underline transition-colors disabled:opacity-50"
+                  className="text-sm transition-colors text-muted-foreground hover:text-foreground underline-offset-4 hover:underline disabled:opacity-50"
                 >
                   취소하기
                 </button>

--- a/apps/wallet-web/app/pay/[intentId]/toss-complete/page.tsx
+++ b/apps/wallet-web/app/pay/[intentId]/toss-complete/page.tsx
@@ -6,18 +6,25 @@ import { buildReturnUrl } from '@/lib/return-url';
 
 interface Props {
   params: Promise<{ intentId: string }>;
-  searchParams: Promise<{ paymentKey?: string; orderId?: string; amount?: string }>;
+  searchParams: Promise<{ paymentKey?: string; orderId?: string; amount?: string; region?: string }>;
+}
+
+function buildPayPath(intentId: string, region?: string, extra?: Record<string, string>) {
+  const params = new URLSearchParams(extra);
+  if (region) params.set('region', region);
+  const query = params.toString();
+  return `/pay/${intentId}${query ? `?${query}` : ''}`;
 }
 
 export default async function TossCompletePage({ params, searchParams }: Props) {
   const { intentId } = await params;
-  const { paymentKey, orderId, amount } = await searchParams;
+  const { paymentKey, orderId, amount, region } = await searchParams;
 
   console.log('[toss-complete] params:', { intentId, paymentKey, orderId, amount });
 
   if (!paymentKey || !orderId || !amount) {
     console.log('[toss-complete] missing searchParams, redirecting to fail');
-    redirect(`/pay/${intentId}?toss_fail=1`);
+    redirect(buildPayPath(intentId, region, { toss_fail: '1' }));
   }
 
   try {
@@ -38,10 +45,10 @@ export default async function TossCompletePage({ params, searchParams }: Props) 
       }
       redirect(successUrl);
     }
-    redirect(`/pay/${intentId}`);
+    redirect(buildPayPath(intentId, region));
   } catch (e) {
     if (isRedirectError(e)) throw e;
     console.error('[toss-complete] approveToss failed:', e);
-    redirect(`/pay/${intentId}?toss_fail=1`);
+    redirect(buildPayPath(intentId, region, { toss_fail: '1' }));
   }
 }

--- a/apps/wallet-web/lib/wallet-api.ts
+++ b/apps/wallet-web/lib/wallet-api.ts
@@ -20,6 +20,13 @@ export interface PaymentMethod {
   isReusable: boolean;
 }
 
+export interface AvailablePaymentMethod {
+  code: string;
+  displayName: string;
+  description: string | null;
+  sortOrder: number;
+}
+
 export interface ConfirmResult {
   id: string;
   status: string;
@@ -90,6 +97,32 @@ export async function getPaymentMethods(cookieHeader?: string): Promise<PaymentM
   return res.json();
 }
 
+/**
+ * 리전(소문자 alpha-2)에서 사용 가능한 결제수단 카탈로그를 조회한다.
+ * storefront 가 전달한 region 으로 어떤 결제수단을 제시할지 결정하는 데 쓴다.
+ */
+export async function getAvailablePaymentMethods(
+  region: string,
+  cookieHeader?: string,
+): Promise<AvailablePaymentMethod[]> {
+  const code = region.trim().toLowerCase();
+  if (!/^[a-z]{2}$/.test(code)) return [];
+
+  const headers: Record<string, string> = {};
+  if (cookieHeader) headers['Cookie'] = cookieHeader;
+
+  const res = await fetch(`${BASE_URL}/v1/regions/${code}/payment-methods`, {
+    headers,
+    credentials: cookieHeader ? undefined : 'include',
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.message ?? `Failed to load available payment methods (${res.status})`);
+  }
+  return res.json();
+}
+
 export async function getPointsBalance(cookieHeader?: string): Promise<PointsBalance> {
   const headers: Record<string, string> = {};
   if (cookieHeader) headers['Cookie'] = cookieHeader;
@@ -156,10 +189,7 @@ export interface CmsBankAccountPayload {
   paymentNumber: string;
 }
 
-export async function registerCmsBankAccount(
-  dto: CmsBankAccountPayload,
-  cookieHeader: string,
-): Promise<BillingMethod> {
+export async function registerCmsBankAccount(dto: CmsBankAccountPayload, cookieHeader: string): Promise<BillingMethod> {
   const res = await fetch(`${BASE_URL}/v1/billing-methods/cms/register`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Cookie: cookieHeader, 'Idempotency-Key': crypto.randomUUID() },

--- a/apps/wallet/docs/payment-flow.html
+++ b/apps/wallet/docs/payment-flow.html
@@ -1,0 +1,988 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Wallet 결제 흐름</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --page: #f5f7fa;
+        --ink: #182230;
+        --body: #475467;
+        --muted: #667085;
+        --line: #d8dee8;
+        --panel: #ffffff;
+        --soft: #f8fafc;
+        --blue: #1f5eff;
+        --blue-soft: #eaf1ff;
+        --green: #0f7a55;
+        --green-soft: #e7f6ee;
+        --orange: #b45f06;
+        --orange-soft: #fff1dc;
+        --red: #b42318;
+        --red-soft: #ffe7e3;
+        --purple: #6941c6;
+        --purple-soft: #f0ebff;
+        --teal: #087983;
+        --teal-soft: #e3f7f8;
+        --shadow: 0 16px 38px rgba(16, 24, 40, 0.08);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html {
+        scroll-behavior: smooth;
+      }
+
+      body {
+        margin: 0;
+        background: var(--page);
+        color: var(--ink);
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.55;
+      }
+
+      main {
+        width: min(1180px, calc(100% - 36px));
+        margin: 0 auto;
+        padding: 34px 0 56px;
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        margin: 0;
+      }
+
+      h1 {
+        font-size: clamp(30px, 4vw, 46px);
+        line-height: 1.08;
+        letter-spacing: 0;
+      }
+
+      h2 {
+        font-size: 22px;
+        line-height: 1.25;
+        letter-spacing: 0;
+      }
+
+      h3 {
+        font-size: 16px;
+        line-height: 1.35;
+        letter-spacing: 0;
+      }
+
+      code {
+        border-radius: 5px;
+        background: #edf2f7;
+        color: #111827;
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+        font-size: 0.9em;
+        padding: 1px 5px;
+      }
+
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) 330px;
+        gap: 22px;
+        align-items: stretch;
+        margin-bottom: 18px;
+      }
+
+      .hero-copy,
+      .hero-card,
+      .section {
+        border: 1px solid #e3e8ef;
+        border-radius: 8px;
+        background: var(--panel);
+        box-shadow: var(--shadow);
+      }
+
+      .hero-copy {
+        padding: 28px;
+      }
+
+      .eyebrow {
+        display: inline-flex;
+        width: fit-content;
+        align-items: center;
+        min-height: 28px;
+        border-radius: 999px;
+        background: var(--blue-soft);
+        color: var(--blue);
+        font-size: 12px;
+        font-weight: 800;
+        padding: 4px 10px;
+        margin-bottom: 14px;
+      }
+
+      .hero-copy p {
+        max-width: 760px;
+        color: var(--body);
+        margin-top: 12px;
+        font-size: 16px;
+      }
+
+      .hero-card {
+        padding: 22px;
+        display: grid;
+        align-content: center;
+        gap: 12px;
+      }
+
+      .big-summary {
+        border-radius: 8px;
+        background: #111827;
+        color: #ffffff;
+        padding: 18px;
+      }
+
+      .big-summary strong {
+        display: block;
+        font-size: 20px;
+        line-height: 1.25;
+        margin-bottom: 8px;
+      }
+
+      .big-summary span {
+        color: #d1d5db;
+        font-size: 14px;
+      }
+
+      .quick-links {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .quick-links a {
+        display: inline-flex;
+        align-items: center;
+        min-height: 34px;
+        border: 1px solid var(--line);
+        border-radius: 7px;
+        color: var(--ink);
+        background: var(--soft);
+        font-size: 13px;
+        font-weight: 700;
+        padding: 6px 10px;
+        text-decoration: none;
+      }
+
+      .section {
+        margin-top: 18px;
+        padding: 22px;
+      }
+
+      .section-head {
+        display: flex;
+        justify-content: space-between;
+        gap: 16px;
+        align-items: end;
+        margin-bottom: 16px;
+      }
+
+      .section-head p {
+        max-width: 680px;
+        color: var(--body);
+        font-size: 14px;
+        margin-top: 6px;
+      }
+
+      .grid-3 {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 14px;
+      }
+
+      .grid-2 {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 14px;
+      }
+
+      .term-card,
+      .choice-card,
+      .note-card,
+      .state-card {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--soft);
+        padding: 16px;
+      }
+
+      .term-card {
+        min-height: 184px;
+      }
+
+      .term-top {
+        display: flex;
+        justify-content: space-between;
+        gap: 10px;
+        align-items: start;
+        margin-bottom: 10px;
+      }
+
+      .term-word {
+        color: var(--blue);
+        font-size: 13px;
+        font-weight: 900;
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        min-height: 24px;
+        border-radius: 999px;
+        font-size: 11px;
+        font-weight: 900;
+        padding: 3px 8px;
+        white-space: nowrap;
+      }
+
+      .badge.intent {
+        color: var(--blue);
+        background: var(--blue-soft);
+      }
+
+      .badge.charge {
+        color: var(--teal);
+        background: var(--teal-soft);
+      }
+
+      .badge.provider {
+        color: var(--purple);
+        background: var(--purple-soft);
+      }
+
+      .badge.ok {
+        color: var(--green);
+        background: var(--green-soft);
+      }
+
+      .badge.wait {
+        color: var(--orange);
+        background: var(--orange-soft);
+      }
+
+      .badge.bad {
+        color: var(--red);
+        background: var(--red-soft);
+      }
+
+      .term-card p,
+      .choice-card p,
+      .note-card p,
+      .state-card p {
+        color: var(--body);
+        font-size: 14px;
+        margin-top: 8px;
+      }
+
+      .example {
+        border-radius: 7px;
+        background: #ffffff;
+        border: 1px dashed #c7d0dc;
+        color: var(--muted);
+        font-size: 13px;
+        padding: 10px;
+        margin-top: 12px;
+      }
+
+      .story {
+        display: grid;
+        grid-template-columns: repeat(6, minmax(128px, 1fr));
+        gap: 12px;
+      }
+
+      .story-step {
+        position: relative;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--soft);
+        padding: 14px;
+        min-height: 214px;
+      }
+
+      .story-step:not(:last-child)::after {
+        content: "";
+        position: absolute;
+        top: 44px;
+        right: -11px;
+        width: 20px;
+        height: 2px;
+        background: var(--line);
+      }
+
+      .story-step:not(:last-child)::before {
+        content: "";
+        position: absolute;
+        top: 39px;
+        right: -13px;
+        border-left: 8px solid var(--line);
+        border-top: 6px solid transparent;
+        border-bottom: 6px solid transparent;
+      }
+
+      .number {
+        display: grid;
+        place-items: center;
+        width: 30px;
+        height: 30px;
+        border-radius: 50%;
+        background: var(--blue);
+        color: #ffffff;
+        font-size: 13px;
+        font-weight: 900;
+        margin-bottom: 12px;
+      }
+
+      .story-step ul,
+      .simple-list {
+        margin: 10px 0 0;
+        padding-left: 18px;
+      }
+
+      .story-step li,
+      .simple-list li {
+        color: var(--body);
+        font-size: 13px;
+        margin: 5px 0;
+      }
+
+      .money-map {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 14px;
+        align-items: stretch;
+      }
+
+      .map-card {
+        position: relative;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: #ffffff;
+        padding: 16px;
+      }
+
+      .map-card h3 {
+        margin-bottom: 10px;
+      }
+
+      .flow-line {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        align-items: center;
+        margin-top: 10px;
+      }
+
+      .node {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 34px;
+        border: 1px solid var(--line);
+        border-radius: 7px;
+        background: #ffffff;
+        color: var(--ink);
+        font-size: 12px;
+        font-weight: 850;
+        padding: 6px 10px;
+        white-space: nowrap;
+      }
+
+      .node.blue {
+        border-color: #adc6ff;
+        background: var(--blue-soft);
+        color: var(--blue);
+      }
+
+      .node.green {
+        border-color: #a8dbc3;
+        background: var(--green-soft);
+        color: var(--green);
+      }
+
+      .node.orange {
+        border-color: #f2c98d;
+        background: var(--orange-soft);
+        color: var(--orange);
+      }
+
+      .arrow {
+        color: var(--muted);
+        font-weight: 900;
+      }
+
+      .lane {
+        display: grid;
+        grid-template-columns: 160px 1fr;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        overflow: hidden;
+        background: #ffffff;
+        margin-top: 10px;
+      }
+
+      .lane-title {
+        background: #eef2f7;
+        color: var(--ink);
+        border-right: 1px solid var(--line);
+        font-weight: 850;
+        padding: 12px;
+      }
+
+      .lane-body {
+        color: var(--body);
+        padding: 12px;
+      }
+
+      .state-grid {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .state-card {
+        background: #ffffff;
+      }
+
+      .state-card strong {
+        display: block;
+        margin-top: 8px;
+      }
+
+      .warning {
+        border-left: 4px solid var(--orange);
+        border-radius: 7px;
+        background: var(--orange-soft);
+        color: #713f12;
+        padding: 13px 14px;
+        margin-top: 14px;
+      }
+
+      .file-note {
+        color: var(--muted);
+        font-size: 13px;
+      }
+
+      @media (max-width: 1040px) {
+        .hero,
+        .grid-2,
+        .grid-3,
+        .money-map,
+        .state-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .story {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+
+        .story-step:not(:last-child)::before,
+        .story-step:not(:last-child)::after {
+          display: none;
+        }
+      }
+
+      @media (max-width: 640px) {
+        main {
+          width: min(100% - 24px, 1180px);
+          padding-top: 22px;
+        }
+
+        .hero-copy,
+        .hero-card,
+        .section {
+          padding: 16px;
+        }
+
+        .section-head {
+          display: block;
+        }
+
+        .story {
+          grid-template-columns: 1fr;
+        }
+
+        .story-step {
+          min-height: auto;
+        }
+
+        .lane {
+          grid-template-columns: 1fr;
+        }
+
+        .lane-title {
+          border-right: 0;
+          border-bottom: 1px solid var(--line);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header class="hero">
+        <div class="hero-copy">
+          <span class="eyebrow">초등학생도 이해하는 결제 흐름</span>
+          <h1>결제는 “돈을 바로 빼는 일”이 아니라, 약속표를 만들고 확인한 뒤 확정하는 일입니다.</h1>
+          <p>
+            이 페이지는 wallet 서비스의 결제 흐름을 쉬운 말로 풀어쓴 그림입니다. 어려운 단어는 먼저
+            생활 속 비유로 설명하고, 그 아래에 실제 코드 이름을 붙였습니다.
+          </p>
+        </div>
+        <aside class="hero-card">
+          <div class="big-summary">
+            <strong>한 줄 요약</strong>
+            <span>Intent는 “결제 예약표”, Charge는 “실제 돈을 움직여 본 기록”, Provider는 “결제 담당자”입니다.</span>
+          </div>
+          <nav class="quick-links" aria-label="quick links">
+            <a href="#words">단어 뜻</a>
+            <a href="#main-flow">전체 흐름</a>
+            <a href="#providers">결제수단별 차이</a>
+            <a href="#states">상태 뜻</a>
+          </nav>
+        </aside>
+      </header>
+
+      <section id="words" class="section">
+        <div class="section-head">
+          <div>
+            <h2>먼저 단어부터 쉽게 보기</h2>
+            <p>코드에 나오는 어려운 이름을 “학교 매점에서 물건 사는 상황”처럼 생각하면 됩니다.</p>
+          </div>
+          <span class="file-note">관련 코드: <code>apps/wallet/src/payment-intents</code></span>
+        </div>
+
+        <div class="grid-3">
+          <article class="term-card">
+            <div class="term-top">
+              <div>
+                <div class="term-word">Payment Intent</div>
+                <h3>결제 예약표</h3>
+              </div>
+              <span class="badge intent">intent</span>
+            </div>
+            <p>
+              “누가, 얼마를, 어떤 주문 때문에 결제하려고 하는지” 적어 둔 표입니다. 아직 돈이 빠져나간 것은
+              아닙니다.
+            </p>
+            <div class="example">
+              예: “민수가 12,000원짜리 주문을 결제하려고 한다”라고 적힌 예약표
+            </div>
+          </article>
+
+          <article class="term-card">
+            <div class="term-top">
+              <div>
+                <div class="term-word">Charge</div>
+                <h3>결제 시도 기록</h3>
+              </div>
+              <span class="badge charge">charge</span>
+            </div>
+            <p>
+              실제로 포인트를 잡아두거나, 카드사/은행에 결제를 부탁한 기록입니다. 포인트+카드 복합결제면
+              charge가 2개 생길 수 있습니다.
+            </p>
+            <div class="example">예: “포인트 2,000원 잡아둠”, “토스 카드 10,000원 결제 요청함”</div>
+          </article>
+
+          <article class="term-card">
+            <div class="term-top">
+              <div>
+                <div class="term-word">Provider</div>
+                <h3>결제 담당자</h3>
+              </div>
+              <span class="badge provider">provider</span>
+            </div>
+            <p>
+              결제 수단마다 실제 일을 해 주는 담당자입니다. 포인트 담당자, 토스 담당자, 무통장입금 담당자처럼
+              나뉩니다.
+            </p>
+            <div class="example">코드에서는 <code>PaymentProvider</code> 인터페이스를 구현합니다.</div>
+          </article>
+        </div>
+
+        <div class="grid-3" style="margin-top: 14px">
+          <article class="term-card">
+            <div class="term-top">
+              <div>
+                <div class="term-word">Authorize</div>
+                <h3>돈을 잠깐 잡아두기</h3>
+              </div>
+              <span class="badge wait">hold</span>
+            </div>
+            <p>
+              “이 돈으로 결제할 수 있나?” 확인하는 단계입니다. 포인트는 예약해두고, 카드 결제는 카드사 확인을
+              받습니다.
+            </p>
+            <div class="example">아직 최종 확정 전입니다. 실패하면 다시 풀 수 있습니다.</div>
+          </article>
+
+          <article class="term-card">
+            <div class="term-top">
+              <div>
+                <div class="term-word">Capture</div>
+                <h3>결제를 확정하기</h3>
+              </div>
+              <span class="badge ok">confirm</span>
+            </div>
+            <p>
+              잡아둔 돈을 진짜 결제로 확정하는 단계입니다. 이 코드에서는 대부분 자동으로 capture까지
+              이어집니다.
+            </p>
+            <div class="example">포인트는 실제 차감되고, 외부 결제는 결제 완료로 기록됩니다.</div>
+          </article>
+
+          <article class="term-card">
+            <div class="term-top">
+              <div>
+                <div class="term-word">Kind</div>
+                <h3>provider 종류</h3>
+              </div>
+              <span class="badge provider">kind</span>
+            </div>
+            <p>
+              여기서 kind는 “친절한”이 아니라 “종류”라는 뜻입니다. 내부 장부인지, 외부 결제망인지 구분합니다.
+            </p>
+            <div class="example"><code>ledger</code> = 포인트, <code>gateway</code> = 토스/은행/CMS</div>
+          </article>
+        </div>
+      </section>
+
+      <section id="main-flow" class="section">
+        <div class="section-head">
+          <div>
+            <h2>전체 결제 흐름</h2>
+            <p>가장 흔한 흐름은 “예약표 만들기 → 결제수단 확인 → 돈 잡아두기 → 결제 확정”입니다.</p>
+          </div>
+        </div>
+
+        <div class="story">
+          <article class="story-step">
+            <div class="number">1</div>
+            <h3>쇼핑몰이 예약표를 만듭니다</h3>
+            <ul>
+              <li><code>POST /v1/payment-intents</code></li>
+              <li>주문 금액을 계산합니다.</li>
+              <li>Intent 상태는 <code>CREATED</code>입니다.</li>
+            </ul>
+          </article>
+
+          <article class="story-step">
+            <div class="number">2</div>
+            <h3>사용자가 결제 버튼을 누릅니다</h3>
+            <ul>
+              <li><code>POST /:id/confirm</code></li>
+              <li>포인트를 쓸지 확인합니다.</li>
+              <li>카드/은행 결제가 필요한지 봅니다.</li>
+            </ul>
+          </article>
+
+          <article class="story-step">
+            <div class="number">3</div>
+            <h3>Wallet이 결제 계획을 세웁니다</h3>
+            <ul>
+              <li>포인트 단독인지 봅니다.</li>
+              <li>외부 결제 단독인지 봅니다.</li>
+              <li>포인트+외부 복합결제인지 봅니다.</li>
+              <li>Intent 상태는 <code>PROCESSING</code>입니다.</li>
+            </ul>
+          </article>
+
+          <article class="story-step">
+            <div class="number">4</div>
+            <h3>담당 provider에게 일을 맡깁니다</h3>
+            <ul>
+              <li><code>ProviderRegistry</code>가 담당자를 찾습니다.</li>
+              <li>포인트면 포인트 원장을 봅니다.</li>
+              <li>토스면 Toss checkout을 준비합니다.</li>
+            </ul>
+          </article>
+
+          <article class="story-step">
+            <div class="number">5</div>
+            <h3>돈을 잡아두거나 대기합니다</h3>
+            <ul>
+              <li>성공하면 <code>AUTHORIZED</code>입니다.</li>
+              <li>사용자 행동이 필요하면 <code>REQUIRES_ACTION</code>입니다.</li>
+              <li>배치 결과 대기면 <code>PENDING_SETTLEMENT</code>입니다.</li>
+            </ul>
+          </article>
+
+          <article class="story-step">
+            <div class="number">6</div>
+            <h3>결제를 확정합니다</h3>
+            <ul>
+              <li><code>AutoCaptureService</code>가 자동 확정을 시도합니다.</li>
+              <li>성공하면 <code>CAPTURED</code>입니다.</li>
+              <li>이제 주문 쪽에 “결제됨” 이벤트를 보냅니다.</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-head">
+          <div>
+            <h2>코드가 실제로 하는 일을 더 짧게 보면</h2>
+            <p>위 그림을 실제 서비스 이름과 맞추면 아래처럼 이어집니다.</p>
+          </div>
+        </div>
+
+        <div class="grid-2">
+          <article class="note-card">
+            <h3>confirm은 두 단계입니다</h3>
+            <div class="lane">
+              <div class="lane-title">Phase 1</div>
+              <div class="lane-body">
+                DB 안에서 안전하게 준비합니다. Intent를 잠그고, charge 기록을 만들고, 상태를
+                <code>PROCESSING</code>으로 바꿉니다.
+              </div>
+            </div>
+            <div class="lane">
+              <div class="lane-title">Phase 2</div>
+              <div class="lane-body">
+                DB 밖에서 provider를 호출합니다. 외부 API는 느리거나 실패할 수 있어서 DB 트랜잭션 밖에서
+                실행합니다.
+              </div>
+            </div>
+          </article>
+
+          <article class="note-card">
+            <h3>ProviderRegistry는 안내 데스크입니다</h3>
+            <p>
+              “TOSS로 결제해줘”라는 요청이 오면 실제 <code>TossPaymentProvider</code>를 찾아줍니다.
+              “POINTS로 결제해줘”라면 <code>PointsPaymentProvider</code>를 찾아줍니다.
+            </p>
+            <div class="flow-line">
+              <span class="node blue">method.type</span>
+              <span class="arrow">→</span>
+              <span class="node">대문자로 정리</span>
+              <span class="arrow">→</span>
+              <span class="node green">provider 반환</span>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="providers" class="section">
+        <div class="section-head">
+          <div>
+            <h2>결제수단별로 뭐가 다른가요?</h2>
+            <p>모두 같은 provider 모양을 쓰지만, 실제 동작은 조금씩 다릅니다.</p>
+          </div>
+        </div>
+
+        <div class="money-map">
+          <article class="map-card">
+            <h3>POINTS</h3>
+            <span class="badge intent">kind: ledger</span>
+            <p>내부 포인트 장부를 보고 포인트를 먼저 잡아둡니다.</p>
+            <div class="flow-line">
+              <span class="node blue">authorize</span>
+              <span class="arrow">→</span>
+              <span class="node orange">포인트 홀드</span>
+              <span class="arrow">→</span>
+              <span class="node green">capture 때 차감</span>
+            </div>
+          </article>
+
+          <article class="map-card">
+            <h3>TOSS</h3>
+            <span class="badge provider">kind: gateway</span>
+            <p>사용자가 Toss checkout 화면에서 결제를 끝내야 합니다.</p>
+            <div class="flow-line">
+              <span class="node blue">authorize</span>
+              <span class="arrow">→</span>
+              <span class="node orange">REQUIRES_ACTION</span>
+              <span class="arrow">→</span>
+              <span class="node green">toss-approve</span>
+            </div>
+          </article>
+
+          <article class="map-card">
+            <h3>BANK_TRANSFER</h3>
+            <span class="badge provider">kind: gateway</span>
+            <p>사용자가 계좌로 입금하고, 관리자가 입금 확인을 해줘야 합니다.</p>
+            <div class="flow-line">
+              <span class="node blue">authorize</span>
+              <span class="arrow">→</span>
+              <span class="node orange">입금 대기</span>
+              <span class="arrow">→</span>
+              <span class="node green">관리자 확인</span>
+            </div>
+          </article>
+        </div>
+
+        <div class="money-map" style="margin-top: 14px">
+          <article class="map-card">
+            <h3>CMS_BATCH</h3>
+            <span class="badge provider">kind: gateway</span>
+            <p>은행 출금 신청을 해두고, 나중에 출금 결과를 폴링해서 확인합니다.</p>
+            <div class="flow-line">
+              <span class="node blue">출금 신청</span>
+              <span class="arrow">→</span>
+              <span class="node orange">PENDING_SETTLEMENT</span>
+              <span class="arrow">→</span>
+              <span class="node green">poller 성공</span>
+            </div>
+          </article>
+
+          <article class="map-card">
+            <h3>포인트 + 외부결제</h3>
+            <span class="badge ok">복합결제</span>
+            <p>포인트를 먼저 잡아두고, 그 다음 카드/은행/CMS 결제를 진행합니다.</p>
+            <div class="flow-line">
+              <span class="node blue">POINTS 먼저</span>
+              <span class="arrow">→</span>
+              <span class="node">외부결제</span>
+              <span class="arrow">→</span>
+              <span class="node green">같이 capture</span>
+            </div>
+          </article>
+
+          <article class="map-card">
+            <h3>실패하면?</h3>
+            <span class="badge bad">cleanup</span>
+            <p>외부 결제가 실패하면, 이미 잡아둔 포인트 홀드를 풀려고 시도합니다.</p>
+            <div class="flow-line">
+              <span class="node orange">외부 실패</span>
+              <span class="arrow">→</span>
+              <span class="node">POINTS cancel</span>
+              <span class="arrow">→</span>
+              <span class="node blue">CREATED 복귀</span>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="states" class="section">
+        <div class="section-head">
+          <div>
+            <h2>상태값을 쉬운 말로 번역하면</h2>
+            <p>상태는 “지금 결제가 어디까지 왔는지” 알려주는 이름표입니다.</p>
+          </div>
+        </div>
+
+        <div class="state-grid">
+          <article class="state-card">
+            <span class="badge intent">CREATED</span>
+            <strong>예약표만 있음</strong>
+            <p>아직 결제를 시작하지 않았습니다.</p>
+          </article>
+          <article class="state-card">
+            <span class="badge intent">PROCESSING</span>
+            <strong>결제 준비 중</strong>
+            <p>Wallet이 결제수단을 보고 provider 호출을 준비합니다.</p>
+          </article>
+          <article class="state-card">
+            <span class="badge wait">REQUIRES_ACTION</span>
+            <strong>사람 행동 필요</strong>
+            <p>토스 checkout 완료, 무통장 입금 같은 추가 행동이 필요합니다.</p>
+          </article>
+          <article class="state-card">
+            <span class="badge wait">PENDING_SETTLEMENT</span>
+            <strong>외부 결과 기다림</strong>
+            <p>CMS 배치 출금처럼 결과가 나중에 오는 상태입니다.</p>
+          </article>
+          <article class="state-card">
+            <span class="badge ok">AUTHORIZED</span>
+            <strong>돈을 잡아둠</strong>
+            <p>결제할 수 있다는 확인을 받았습니다. 이제 확정하면 됩니다.</p>
+          </article>
+          <article class="state-card">
+            <span class="badge ok">CAPTURED</span>
+            <strong>결제 확정</strong>
+            <p>실제로 결제가 완료된 상태입니다.</p>
+          </article>
+          <article class="state-card">
+            <span class="badge bad">FAILED</span>
+            <strong>실패</strong>
+            <p>결제를 진행하지 못했습니다.</p>
+          </article>
+          <article class="state-card">
+            <span class="badge bad">CANCELED</span>
+            <strong>취소</strong>
+            <p>사용자나 시스템이 결제를 취소했습니다.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-head">
+          <div>
+            <h2>취소와 환불은 어떻게 달라요?</h2>
+            <p>취소는 “아직 확정 전 일을 멈추기”, 환불은 “이미 확정된 결제를 되돌리기”에 가깝습니다.</p>
+          </div>
+        </div>
+
+        <div class="grid-2">
+          <article class="choice-card">
+            <h3>취소 Cancel</h3>
+            <p>아직 결제가 끝나기 전이면, 잡아둔 포인트나 외부 결제 승인을 풀어줍니다.</p>
+            <div class="flow-line">
+              <span class="node blue">AUTHORIZED</span>
+              <span class="arrow">→</span>
+              <span class="node">provider.cancel()</span>
+              <span class="arrow">→</span>
+              <span class="node orange">CANCELED</span>
+            </div>
+          </article>
+
+          <article class="choice-card">
+            <h3>환불 Refund</h3>
+            <p>이미 결제가 끝난 뒤에는 refund 기록을 만들고 provider에 환불을 요청합니다.</p>
+            <div class="flow-line">
+              <span class="node green">CAPTURED</span>
+              <span class="arrow">→</span>
+              <span class="node">refund PENDING</span>
+              <span class="arrow">→</span>
+              <span class="node blue">SUCCEEDED</span>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-head">
+          <div>
+            <h2>개발자가 코드에서 보면</h2>
+            <p>쉬운 설명을 실제 파일 이름에 대응하면 아래와 같습니다.</p>
+          </div>
+        </div>
+
+        <div class="grid-2">
+          <article class="note-card">
+            <h3>주요 파일</h3>
+            <ul class="simple-list">
+              <li><code>payment-intents.service.ts</code>: create, confirm, capture, cancel 입구</li>
+              <li><code>confirm.service.ts</code>: 결제 계획 만들고 provider authorize 호출</li>
+              <li><code>capture.service.ts</code>: authorize된 charge들을 확정</li>
+              <li><code>provider.registry.ts</code>: provider 찾기와 kind 메타데이터</li>
+              <li><code>state-transition.rules.ts</code>: 상태가 어디로 이동 가능한지 규칙</li>
+            </ul>
+          </article>
+
+          <article class="note-card">
+            <h3>주의해서 볼 점</h3>
+            <p>
+              현재 <code>BankTransferAdminService.confirmDeposit()</code>는 intent를 <code>SUCCEEDED</code>로
+              바꾸려 하지만, 상태 전이 규칙에는 <code>REQUIRES_ACTION → SUCCEEDED</code>가 없습니다.
+            </p>
+            <div class="warning">
+              무통장입금 확인이 실제로 실패한다면, 이 전이 규칙을 <code>AUTHORIZED</code>나
+              <code>CAPTURED</code> 흐름과 맞추는지 확인해야 합니다.
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/apps/wallet/drizzle/20260608013923_add-payment-method-catalog-and-regions.sql
+++ b/apps/wallet/drizzle/20260608013923_add-payment-method-catalog-and-regions.sql
@@ -1,0 +1,40 @@
+CREATE TABLE "payment_method_catalog" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"code" varchar(32) NOT NULL,
+	"display_name" varchar(255) NOT NULL,
+	"description" text,
+	"is_enabled" boolean DEFAULT true NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "region_payment_methods" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"region_id" uuid NOT NULL,
+	"catalog_id" uuid NOT NULL,
+	"is_enabled" boolean DEFAULT true NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "regions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"code" varchar(2) NOT NULL,
+	"name" varchar(128) NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "regions_code_lowercase" CHECK ("regions"."code" = lower("regions"."code"))
+);
+--> statement-breakpoint
+ALTER TABLE "event"."outbox_events" ADD COLUMN "processing_started_at" timestamp;--> statement-breakpoint
+ALTER TABLE "region_payment_methods" ADD CONSTRAINT "region_payment_methods_region_id_regions_id_fk" FOREIGN KEY ("region_id") REFERENCES "public"."regions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "region_payment_methods" ADD CONSTRAINT "region_payment_methods_catalog_id_payment_method_catalog_id_fk" FOREIGN KEY ("catalog_id") REFERENCES "public"."payment_method_catalog"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_payment_method_catalog_code" ON "payment_method_catalog" USING btree ("code");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_region_payment_methods_region_catalog" ON "region_payment_methods" USING btree ("region_id","catalog_id");--> statement-breakpoint
+CREATE INDEX "idx_region_payment_methods_region" ON "region_payment_methods" USING btree ("region_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_regions_code" ON "regions" USING btree ("code");--> statement-breakpoint
+CREATE INDEX "outbox_processing_started_idx" ON "event"."outbox_events" USING btree ("status","processing_started_at");

--- a/apps/wallet/drizzle/meta/20260608013923_snapshot.json
+++ b/apps/wallet/drizzle/meta/20260608013923_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "20260527120000",
-  "prevId": "20260521041943",
+  "id": "3d6f1455-ec81-4f6e-bc36-bee12e66dff3",
+  "prevId": "20260527120000",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1943,16 +1943,16 @@
           "name": "idx_payment_intents_billing_idempotency_key",
           "columns": [
             {
-              "expression": "(metadata->>'idempotencyKey')",
-              "isExpression": true,
+              "expression": "(\"metadata\"->>'idempotencyKey')",
               "asc": true,
+              "isExpression": true,
               "nulls": "last"
             }
           ],
           "isUnique": true,
+          "where": "\"payment_intents\".\"metadata\"->>'idempotencyKey' IS NOT NULL",
           "concurrently": false,
           "method": "btree",
-          "where": "metadata->>'idempotencyKey' IS NOT NULL",
           "with": {}
         }
       },
@@ -1980,6 +1980,88 @@
           "value": "\"payment_intents\".\"payable_amount\" >= 0"
         }
       },
+      "isRLSEnabled": false
+    },
+    "public.payment_method_catalog": {
+      "name": "payment_method_catalog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_payment_method_catalog_code": {
+          "name": "uq_payment_method_catalog_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.payment_methods": {
@@ -3245,6 +3327,211 @@
       },
       "isRLSEnabled": false
     },
+    "public.region_payment_methods": {
+      "name": "region_payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_id": {
+          "name": "catalog_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_region_payment_methods_region_catalog": {
+          "name": "uq_region_payment_methods_region_catalog",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "catalog_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_region_payment_methods_region": {
+          "name": "idx_region_payment_methods_region",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "region_payment_methods_region_id_regions_id_fk": {
+          "name": "region_payment_methods_region_id_regions_id_fk",
+          "tableFrom": "region_payment_methods",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "region_payment_methods_catalog_id_payment_method_catalog_id_fk": {
+          "name": "region_payment_methods_catalog_id_payment_method_catalog_id_fk",
+          "tableFrom": "region_payment_methods",
+          "tableTo": "payment_method_catalog",
+          "columnsFrom": [
+            "catalog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_regions_code": {
+          "name": "uq_regions_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "regions_code_lowercase": {
+          "name": "regions_code_lowercase",
+          "value": "\"regions\".\"code\" = lower(\"regions\".\"code\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
     "event.outbox_events": {
       "name": "outbox_events",
       "schema": "event",
@@ -3299,6 +3586,12 @@
           "notNull": true,
           "default": "now()"
         },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
         "published_at": {
           "name": "published_at",
           "type": "timestamp",
@@ -3337,6 +3630,27 @@
             },
             {
               "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_processing_started_idx": {
+          "name": "outbox_processing_started_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processing_started_at",
               "isExpression": false,
               "asc": true,
               "nulls": "last"

--- a/apps/wallet/drizzle/meta/_journal.json
+++ b/apps/wallet/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1779768000000,
       "tag": "20260527120000_add-billing-idempotency-index",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1780882763488,
+      "tag": "20260608013923_add-payment-method-catalog-and-regions",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wallet/src/payment-config/dto/index.ts
+++ b/apps/wallet/src/payment-config/dto/index.ts
@@ -1,0 +1,156 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsBoolean,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+const toLowerTrim = ({ value }: { value: unknown }) => (typeof value === 'string' ? value.trim().toLowerCase() : value);
+
+// ─── Catalog ───────────────────────────────────────────────────────────────
+
+export class UpdateCatalogDto {
+  @ApiPropertyOptional({ description: '글로벌 활성화 여부' })
+  @IsOptional()
+  @IsBoolean()
+  isEnabled?: boolean;
+
+  @ApiPropertyOptional({ description: '표시 이름' })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  displayName?: string;
+
+  @ApiPropertyOptional({ description: '정렬 순서 (작을수록 먼저)' })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  sortOrder?: number;
+}
+
+export class CatalogResponseDto {
+  @ApiProperty() id!: string;
+  @ApiProperty({ description: 'provider 코드 (TOSS, NICEPAY, ...)' }) code!: string;
+  @ApiProperty() displayName!: string;
+  @ApiProperty({ nullable: true, type: String }) description!: string | null;
+  @ApiProperty() isEnabled!: boolean;
+  @ApiProperty() sortOrder!: number;
+}
+
+// ─── Region ──────────────────────────────────────────────────────────────────
+
+export class CreateRegionDto {
+  @ApiProperty({ description: '소문자 alpha-2 국가코드', example: 'kr' })
+  @Transform(toLowerTrim)
+  @IsString()
+  @Matches(/^[a-z]{2}$/, { message: 'code must be a lowercase ISO 3166-1 alpha-2 code (e.g. kr, us)' })
+  code!: string;
+
+  @ApiProperty({ description: '리전 이름', example: '대한민국' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(128)
+  name!: string;
+
+  @ApiPropertyOptional({ description: '활성 여부 (기본 true)' })
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+
+  @ApiPropertyOptional({ description: '정렬 순서' })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  sortOrder?: number;
+}
+
+export class UpdateRegionDto {
+  @ApiPropertyOptional({ description: '리전 이름' })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(128)
+  name?: string;
+
+  @ApiPropertyOptional({ description: '활성 여부' })
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+
+  @ApiPropertyOptional({ description: '정렬 순서' })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  sortOrder?: number;
+}
+
+export class RegionResponseDto {
+  @ApiProperty() id!: string;
+  @ApiProperty({ example: 'kr' }) code!: string;
+  @ApiProperty() name!: string;
+  @ApiProperty() isActive!: boolean;
+  @ApiProperty() sortOrder!: number;
+}
+
+// ─── Region ↔ Catalog mapping ─────────────────────────────────────────────────
+
+export class RegionMethodItemDto {
+  @ApiProperty({ description: '카탈로그 코드', example: 'TOSS' })
+  @IsString()
+  @IsNotEmpty()
+  code!: string;
+
+  @ApiProperty({ description: '이 리전에서의 활성화 여부' })
+  @IsBoolean()
+  isEnabled!: boolean;
+
+  @ApiPropertyOptional({ description: '정렬 순서' })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  sortOrder?: number;
+}
+
+export class PutRegionMethodsDto {
+  @ApiProperty({ type: [RegionMethodItemDto], description: '리전별 결제수단 설정 일괄' })
+  @IsArray()
+  @ArrayMaxSize(100)
+  @ValidateNested({ each: true })
+  @Type(() => RegionMethodItemDto)
+  items!: RegionMethodItemDto[];
+}
+
+/** 어드민 매트릭스: 카탈로그 전체 + 해당 리전에서의 설정 상태 */
+export class RegionMethodMatrixItemDto {
+  @ApiProperty() code!: string;
+  @ApiProperty() displayName!: string;
+  @ApiProperty({ nullable: true, type: String }) description!: string | null;
+  @ApiProperty({ description: '카탈로그 글로벌 활성화' }) globalEnabled!: boolean;
+  @ApiProperty({ description: '이 리전에서의 활성화 (매핑 없으면 false)' }) regionEnabled!: boolean;
+  @ApiProperty({ description: '글로벌·리전 모두 켜져 실제 노출되는지' }) available!: boolean;
+  @ApiProperty() sortOrder!: number;
+}
+
+export class RegionMethodMatrixResponseDto {
+  @ApiProperty({ type: RegionResponseDto }) region!: RegionResponseDto;
+  @ApiProperty({ type: [RegionMethodMatrixItemDto] }) items!: RegionMethodMatrixItemDto[];
+}
+
+// ─── Public: available payment methods ────────────────────────────────────────
+
+export class AvailablePaymentMethodDto {
+  @ApiProperty({ description: 'provider 코드', example: 'TOSS' }) code!: string;
+  @ApiProperty({ example: '토스페이먼츠' }) displayName!: string;
+  @ApiProperty({ nullable: true, type: String }) description!: string | null;
+  @ApiProperty() sortOrder!: number;
+}

--- a/apps/wallet/src/payment-config/payment-config-admin.controller.ts
+++ b/apps/wallet/src/payment-config/payment-config-admin.controller.ts
@@ -1,0 +1,90 @@
+import { Body, Controller, Get, HttpCode, Param, Patch, Post, Put } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { PaymentConfigService } from './payment-config.service';
+import { WalletAdminAuth } from '../wallet-admin-auth.decorator';
+import { PaymentMethodCatalog, Region } from '../types';
+import {
+  CatalogResponseDto,
+  CreateRegionDto,
+  PutRegionMethodsDto,
+  RegionMethodMatrixResponseDto,
+  RegionResponseDto,
+  UpdateCatalogDto,
+  UpdateRegionDto,
+} from './dto';
+
+function toCatalogResponse(c: PaymentMethodCatalog): CatalogResponseDto {
+  return {
+    id: c.id,
+    code: c.code,
+    displayName: c.displayName,
+    description: c.description,
+    isEnabled: c.isEnabled,
+    sortOrder: c.sortOrder,
+  };
+}
+
+function toRegionResponse(r: Region): RegionResponseDto {
+  return { id: r.id, code: r.code, name: r.name, isActive: r.isActive, sortOrder: r.sortOrder };
+}
+
+@ApiTags('Admin - Payment Config')
+@WalletAdminAuth()
+@Controller('v1/admin')
+export class PaymentConfigAdminController {
+  constructor(private readonly service: PaymentConfigService) {}
+
+  // ── Catalog (글로벌 결제수단) ──────────────────────────────────────────────
+
+  @Get('payment-methods')
+  @ApiOperation({ summary: '결제수단 카탈로그 목록 (글로벌 활성화 상태 포함)' })
+  async listCatalog(): Promise<CatalogResponseDto[]> {
+    const rows = await this.service.listCatalog();
+    return rows.map(toCatalogResponse);
+  }
+
+  @Patch('payment-methods/:code')
+  @ApiOperation({ summary: '결제수단 글로벌 활성화/비활성화 및 표시정보 수정' })
+  async updateCatalog(@Param('code') code: string, @Body() dto: UpdateCatalogDto): Promise<CatalogResponseDto> {
+    return toCatalogResponse(await this.service.updateCatalog(code, dto));
+  }
+
+  // ── Regions ─────────────────────────────────────────────────────────────────
+
+  @Get('regions')
+  @ApiOperation({ summary: '리전 목록' })
+  async listRegions(): Promise<RegionResponseDto[]> {
+    const rows = await this.service.listRegions();
+    return rows.map(toRegionResponse);
+  }
+
+  @Post('regions')
+  @HttpCode(201)
+  @ApiOperation({ summary: '리전 생성 (소문자 alpha-2)' })
+  async createRegion(@Body() dto: CreateRegionDto): Promise<RegionResponseDto> {
+    return toRegionResponse(await this.service.createRegion(dto));
+  }
+
+  @Patch('regions/:code')
+  @ApiOperation({ summary: '리전 수정/활성화' })
+  async updateRegion(@Param('code') code: string, @Body() dto: UpdateRegionDto): Promise<RegionResponseDto> {
+    return toRegionResponse(await this.service.updateRegion(code, dto));
+  }
+
+  // ── Region ↔ 결제수단 매핑 ───────────────────────────────────────────────────
+
+  @Get('regions/:code/payment-methods')
+  @ApiOperation({ summary: '해당 리전의 결제수단 매트릭스 (카탈로그 전체 + 리전별 상태)' })
+  async getRegionMethods(@Param('code') code: string): Promise<RegionMethodMatrixResponseDto> {
+    return this.service.getRegionMethods(code);
+  }
+
+  @Put('regions/:code/payment-methods')
+  @ApiOperation({ summary: '리전별 결제수단 활성화 일괄 저장' })
+  async putRegionMethods(
+    @Param('code') code: string,
+    @Body() dto: PutRegionMethodsDto,
+  ): Promise<RegionMethodMatrixResponseDto> {
+    return this.service.putRegionMethods(code, dto);
+  }
+}

--- a/apps/wallet/src/payment-config/payment-config.controller.ts
+++ b/apps/wallet/src/payment-config/payment-config.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { PaymentConfigService } from './payment-config.service';
+import { WalletJwtAuth } from '../wallet-auth.decorator';
+import { AvailablePaymentMethodDto } from './dto';
+
+/**
+ * storefront/wallet-web facing.
+ * 리전(소문자 alpha-2)에서 실제 노출 가능한 결제수단 종류를 반환한다.
+ */
+@ApiTags('Payment Config')
+@Controller('v1/regions')
+export class PaymentConfigController {
+  constructor(private readonly service: PaymentConfigService) {}
+
+  @Get(':code/payment-methods')
+  @WalletJwtAuth()
+  @ApiOperation({ summary: '해당 리전에서 사용 가능한 결제수단 목록' })
+  async available(@Param('code') code: string): Promise<AvailablePaymentMethodDto[]> {
+    return this.service.getAvailablePaymentMethods(code);
+  }
+}

--- a/apps/wallet/src/payment-config/payment-config.service.spec.ts
+++ b/apps/wallet/src/payment-config/payment-config.service.spec.ts
@@ -1,0 +1,145 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { PaymentConfigService } from './payment-config.service';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeService(db: any): PaymentConfigService {
+  return new PaymentConfigService({ db } as any);
+}
+
+const REGION_KR = { id: 'r-kr', code: 'kr', name: '대한민국', isActive: true, sortOrder: 10 };
+
+describe('PaymentConfigService', () => {
+  // ── 2계층 AND 가용성 (글로벌 AND 리전 AND 리전 active) ──────────────────────
+  describe('getRegionMethods - 매트릭스 available 계산', () => {
+    it('available = region.isActive && globalEnabled && regionEnabled 를 정확히 반영한다', async () => {
+      const matrixRows = [
+        // globalEnabled && regionEnabled → available
+        {
+          code: 'TOSS',
+          displayName: '토스',
+          description: null,
+          globalEnabled: true,
+          catalogSort: 20,
+          mappingEnabled: true,
+          mappingSort: 20,
+        },
+        // global off → not available
+        {
+          code: 'NICEPAY',
+          displayName: '나이스',
+          description: null,
+          globalEnabled: false,
+          catalogSort: 40,
+          mappingEnabled: true,
+          mappingSort: 40,
+        },
+        // region off → not available
+        {
+          code: 'BANK_TRANSFER',
+          displayName: '무통장',
+          description: null,
+          globalEnabled: true,
+          catalogSort: 30,
+          mappingEnabled: false,
+          mappingSort: 30,
+        },
+        // 매핑 없음(null) → regionEnabled false → not available
+        {
+          code: 'POINTS',
+          displayName: '포인트',
+          description: null,
+          globalEnabled: true,
+          catalogSort: 10,
+          mappingEnabled: null,
+          mappingSort: null,
+        },
+      ];
+
+      const select = jest
+        .fn()
+        // 1st call: getRegionOrThrow
+        .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([REGION_KR]) }) }) })
+        // 2nd call: matrix
+        .mockReturnValueOnce({ from: () => ({ leftJoin: () => ({ orderBy: () => Promise.resolve(matrixRows) }) }) });
+
+      const service = makeService({ select });
+      const result = await service.getRegionMethods('kr');
+
+      const byCode = Object.fromEntries(result.items.map((i) => [i.code, i]));
+      expect(byCode.TOSS.available).toBe(true);
+      expect(byCode.NICEPAY.available).toBe(false);
+      expect(byCode.BANK_TRANSFER.available).toBe(false);
+      expect(byCode.POINTS.available).toBe(false);
+      expect(byCode.POINTS.regionEnabled).toBe(false);
+      expect(result.region.code).toBe('kr');
+    });
+
+    it('리전이 비활성(isActive=false)이면 모든 결제수단 available=false', async () => {
+      const inactiveRegion = { ...REGION_KR, isActive: false };
+      const matrixRows = [
+        {
+          code: 'TOSS',
+          displayName: '토스',
+          description: null,
+          globalEnabled: true,
+          catalogSort: 20,
+          mappingEnabled: true,
+          mappingSort: 20,
+        },
+      ];
+      const select = jest
+        .fn()
+        .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([inactiveRegion]) }) }) })
+        .mockReturnValueOnce({ from: () => ({ leftJoin: () => ({ orderBy: () => Promise.resolve(matrixRows) }) }) });
+
+      const service = makeService({ select });
+      const result = await service.getRegionMethods('kr');
+      expect(result.items[0].available).toBe(false);
+    });
+
+    it('존재하지 않는 리전이면 NotFoundException', async () => {
+      const select = jest
+        .fn()
+        .mockReturnValueOnce({ from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) }) });
+      const service = makeService({ select });
+      await expect(service.getRegionMethods('kr')).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  // ── 소문자 alpha-2 검증/정규화 ────────────────────────────────────────────────
+  describe('region code 정규화/검증', () => {
+    it.each(['USA', 'u1', 'k', '12', ''])('잘못된 코드 "%s" 는 BadRequestException', async (bad) => {
+      const service = makeService({});
+      await expect(service.getAvailablePaymentMethods(bad)).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('대문자 입력은 소문자로 정규화되어 저장된다', async () => {
+      let capturedValues: any = null;
+      const db = {
+        select: () => ({ from: () => ({ where: () => ({ limit: () => Promise.resolve([]) }) }) }),
+        insert: () => ({
+          values: (v: any) => {
+            capturedValues = v;
+            return { returning: () => Promise.resolve([{ id: 'r1', ...v }]) };
+          },
+        }),
+      };
+      const service = makeService(db);
+      const region = await service.createRegion({ code: 'KR', name: '대한민국' } as any);
+      expect(capturedValues.code).toBe('kr');
+      expect(region.code).toBe('kr');
+    });
+  });
+
+  // ── 카탈로그 글로벌 토글 ─────────────────────────────────────────────────────
+  describe('updateCatalog', () => {
+    it('존재하지 않는 code 면 NotFoundException', async () => {
+      const db = {
+        update: () => ({ set: () => ({ where: () => ({ returning: () => Promise.resolve([]) }) }) }),
+      };
+      const service = makeService(db);
+      await expect(service.updateCatalog('UNKNOWN', { isEnabled: false })).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+});

--- a/apps/wallet/src/payment-config/payment-config.service.ts
+++ b/apps/wallet/src/payment-config/payment-config.service.ts
@@ -1,0 +1,249 @@
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { DbService } from '@app/db';
+import { and, asc, eq } from 'drizzle-orm';
+import { WalletSchema, paymentMethodCatalog, regionPaymentMethods, regions } from '../schema';
+import { PaymentMethodCatalog, Region } from '../types';
+import {
+  AvailablePaymentMethodDto,
+  CreateRegionDto,
+  PutRegionMethodsDto,
+  RegionMethodMatrixResponseDto,
+  UpdateCatalogDto,
+  UpdateRegionDto,
+} from './dto';
+
+/**
+ * 결제수단 카탈로그(글로벌) + 리전 + 리전별 매핑을 관리한다.
+ * 최종 노출 = 카탈로그 isEnabled(글로벌) AND 리전 isActive AND 매핑 isEnabled.
+ */
+@Injectable()
+export class PaymentConfigService {
+  constructor(private readonly dbService: DbService<WalletSchema>) {}
+
+  private get db() {
+    return this.dbService.db;
+  }
+
+  private normalizeRegionCode(code: string): string {
+    const normalized = code.trim().toLowerCase();
+    if (!/^[a-z]{2}$/.test(normalized)) {
+      throw new BadRequestException({
+        error: 'INVALID_REGION_CODE',
+        message: `Region code must be a lowercase alpha-2 code: ${code}`,
+      });
+    }
+    return normalized;
+  }
+
+  // ─── Catalog ───────────────────────────────────────────────────────────────
+
+  async listCatalog(): Promise<PaymentMethodCatalog[]> {
+    return this.db
+      .select()
+      .from(paymentMethodCatalog)
+      .orderBy(asc(paymentMethodCatalog.sortOrder), asc(paymentMethodCatalog.code));
+  }
+
+  async updateCatalog(code: string, dto: UpdateCatalogDto): Promise<PaymentMethodCatalog> {
+    const normalizedCode = code.trim().toUpperCase();
+    const patch: Partial<typeof paymentMethodCatalog.$inferInsert> = { updatedAt: new Date() };
+    if (dto.isEnabled !== undefined) patch.isEnabled = dto.isEnabled;
+    if (dto.displayName !== undefined) patch.displayName = dto.displayName;
+    if (dto.sortOrder !== undefined) patch.sortOrder = dto.sortOrder;
+
+    const rows = await this.db
+      .update(paymentMethodCatalog)
+      .set(patch)
+      .where(eq(paymentMethodCatalog.code, normalizedCode))
+      .returning();
+
+    const row = rows[0];
+    if (!row) {
+      throw new NotFoundException({
+        error: 'PAYMENT_METHOD_NOT_FOUND',
+        message: `Payment method not found in catalog: ${normalizedCode}`,
+      });
+    }
+    return row;
+  }
+
+  // ─── Region ────────────────────────────────────────────────────────────────
+
+  async listRegions(): Promise<Region[]> {
+    return this.db.select().from(regions).orderBy(asc(regions.sortOrder), asc(regions.code));
+  }
+
+  async createRegion(dto: CreateRegionDto): Promise<Region> {
+    const code = this.normalizeRegionCode(dto.code);
+
+    const existing = await this.db.select({ id: regions.id }).from(regions).where(eq(regions.code, code)).limit(1);
+    if (existing[0]) {
+      throw new ConflictException({ error: 'REGION_ALREADY_EXISTS', message: `Region already exists: ${code}` });
+    }
+
+    const rows = await this.db
+      .insert(regions)
+      .values({
+        code,
+        name: dto.name,
+        isActive: dto.isActive ?? true,
+        sortOrder: dto.sortOrder ?? 0,
+      })
+      .returning();
+
+    const row = rows[0];
+    if (!row) throw new Error('REGION_INSERT_FAILED');
+    return row;
+  }
+
+  async updateRegion(code: string, dto: UpdateRegionDto): Promise<Region> {
+    const normalizedCode = this.normalizeRegionCode(code);
+    const patch: Partial<typeof regions.$inferInsert> = { updatedAt: new Date() };
+    if (dto.name !== undefined) patch.name = dto.name;
+    if (dto.isActive !== undefined) patch.isActive = dto.isActive;
+    if (dto.sortOrder !== undefined) patch.sortOrder = dto.sortOrder;
+
+    const rows = await this.db.update(regions).set(patch).where(eq(regions.code, normalizedCode)).returning();
+
+    const row = rows[0];
+    if (!row) {
+      throw new NotFoundException({ error: 'REGION_NOT_FOUND', message: `Region not found: ${normalizedCode}` });
+    }
+    return row;
+  }
+
+  private async getRegionOrThrow(code: string): Promise<Region> {
+    const normalizedCode = this.normalizeRegionCode(code);
+    const rows = await this.db.select().from(regions).where(eq(regions.code, normalizedCode)).limit(1);
+    const region = rows[0];
+    if (!region) {
+      throw new NotFoundException({ error: 'REGION_NOT_FOUND', message: `Region not found: ${normalizedCode}` });
+    }
+    return region;
+  }
+
+  // ─── Region ↔ Catalog mapping ──────────────────────────────────────────────
+
+  /** 어드민 매트릭스: 카탈로그 전체 + 해당 리전에서의 설정 상태 (매핑 없으면 regionEnabled=false) */
+  async getRegionMethods(code: string): Promise<RegionMethodMatrixResponseDto> {
+    const region = await this.getRegionOrThrow(code);
+
+    const rows = await this.db
+      .select({
+        code: paymentMethodCatalog.code,
+        displayName: paymentMethodCatalog.displayName,
+        description: paymentMethodCatalog.description,
+        globalEnabled: paymentMethodCatalog.isEnabled,
+        catalogSort: paymentMethodCatalog.sortOrder,
+        mappingEnabled: regionPaymentMethods.isEnabled,
+        mappingSort: regionPaymentMethods.sortOrder,
+      })
+      .from(paymentMethodCatalog)
+      .leftJoin(
+        regionPaymentMethods,
+        and(eq(regionPaymentMethods.catalogId, paymentMethodCatalog.id), eq(regionPaymentMethods.regionId, region.id)),
+      )
+      .orderBy(asc(paymentMethodCatalog.sortOrder), asc(paymentMethodCatalog.code));
+
+    const items = rows.map((r) => {
+      const regionEnabled = r.mappingEnabled ?? false;
+      return {
+        code: r.code,
+        displayName: r.displayName,
+        description: r.description,
+        globalEnabled: r.globalEnabled,
+        regionEnabled,
+        available: region.isActive && r.globalEnabled && regionEnabled,
+        sortOrder: r.mappingSort ?? r.catalogSort,
+      };
+    });
+
+    return {
+      region: {
+        id: region.id,
+        code: region.code,
+        name: region.name,
+        isActive: region.isActive,
+        sortOrder: region.sortOrder,
+      },
+      items,
+    };
+  }
+
+  /** 리전별 결제수단 설정 일괄 저장 (upsert). 알 수 없는 code 는 거부. */
+  async putRegionMethods(code: string, dto: PutRegionMethodsDto): Promise<RegionMethodMatrixResponseDto> {
+    const region = await this.getRegionOrThrow(code);
+
+    await this.db.transaction(async (tx) => {
+      const catalog = await tx
+        .select({ id: paymentMethodCatalog.id, code: paymentMethodCatalog.code })
+        .from(paymentMethodCatalog);
+      const codeToId = new Map(catalog.map((c) => [c.code, c.id]));
+
+      for (const item of dto.items) {
+        const itemCode = item.code.trim().toUpperCase();
+        const catalogId = codeToId.get(itemCode);
+        if (!catalogId) {
+          throw new BadRequestException({
+            error: 'PAYMENT_METHOD_NOT_FOUND',
+            message: `Unknown payment method code: ${item.code}`,
+          });
+        }
+
+        await tx
+          .insert(regionPaymentMethods)
+          .values({
+            regionId: region.id,
+            catalogId,
+            isEnabled: item.isEnabled,
+            sortOrder: item.sortOrder ?? 0,
+          })
+          .onConflictDoUpdate({
+            target: [regionPaymentMethods.regionId, regionPaymentMethods.catalogId],
+            set: {
+              isEnabled: item.isEnabled,
+              sortOrder: item.sortOrder ?? 0,
+              updatedAt: new Date(),
+            },
+          });
+      }
+    });
+
+    return this.getRegionMethods(region.code);
+  }
+
+  // ─── Public: available payment methods ───────────────────────────────────────
+
+  /** 해당 리전에서 실제 노출 가능한 결제수단 (글로벌 on AND 리전 active AND 매핑 on) */
+  async getAvailablePaymentMethods(code: string): Promise<AvailablePaymentMethodDto[]> {
+    const normalizedCode = this.normalizeRegionCode(code);
+
+    const rows = await this.db
+      .select({
+        code: paymentMethodCatalog.code,
+        displayName: paymentMethodCatalog.displayName,
+        description: paymentMethodCatalog.description,
+        mappingSort: regionPaymentMethods.sortOrder,
+        catalogSort: paymentMethodCatalog.sortOrder,
+      })
+      .from(regionPaymentMethods)
+      .innerJoin(regions, eq(regions.id, regionPaymentMethods.regionId))
+      .innerJoin(paymentMethodCatalog, eq(paymentMethodCatalog.id, regionPaymentMethods.catalogId))
+      .where(
+        and(
+          eq(regions.code, normalizedCode),
+          eq(regions.isActive, true),
+          eq(regionPaymentMethods.isEnabled, true),
+          eq(paymentMethodCatalog.isEnabled, true),
+        ),
+      )
+      .orderBy(asc(regionPaymentMethods.sortOrder), asc(paymentMethodCatalog.sortOrder));
+
+    return rows.map((r) => ({
+      code: r.code,
+      displayName: r.displayName,
+      description: r.description,
+      sortOrder: r.mappingSort,
+    }));
+  }
+}

--- a/apps/wallet/src/schema.ts
+++ b/apps/wallet/src/schema.ts
@@ -126,6 +126,67 @@ export const paymentMethods = pgTable(
   ],
 );
 
+// ─── Payment method catalog & regions ────────────────────────────────────────
+// 사용자별 결제수단(payment_methods)과 별개로, 시스템이 지원하는 결제수단 "종류"의
+// 카탈로그와 리전(국가)별 가용성을 관리한다. 최종 노출 = 카탈로그 글로벌 on AND 리전 매핑 on.
+
+export const paymentMethodCatalog = pgTable(
+  'payment_method_catalog',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    // provider.registry 의 providerType 과 1:1 (예: 'TOSS','NICEPAY','BANK_TRANSFER','POINTS','CMS_BATCH')
+    code: varchar('code', { length: 32 }).notNull(),
+    displayName: varchar('display_name', { length: 255 }).notNull(),
+    description: text('description'),
+    // 글로벌 활성화 스위치 (2계층 중 1계층). false 이면 모든 리전에서 숨김.
+    isEnabled: boolean('is_enabled').notNull().default(true),
+    sortOrder: integer('sort_order').notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [uniqueIndex('uq_payment_method_catalog_code').on(table.code)],
+);
+
+export const regions = pgTable(
+  'regions',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    // 소문자 ISO 3166-1 alpha-2 (예: 'kr','us'). Medusa region.countries.iso_2 와 정합.
+    code: varchar('code', { length: 2 }).notNull(),
+    name: varchar('name', { length: 128 }).notNull(),
+    isActive: boolean('is_active').notNull().default(true),
+    sortOrder: integer('sort_order').notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex('uq_regions_code').on(table.code),
+    check('regions_code_lowercase', sql`${table.code} = lower(${table.code})`),
+  ],
+);
+
+export const regionPaymentMethods = pgTable(
+  'region_payment_methods',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    regionId: uuid('region_id')
+      .notNull()
+      .references(() => regions.id, { onDelete: 'cascade' }),
+    catalogId: uuid('catalog_id')
+      .notNull()
+      .references(() => paymentMethodCatalog.id, { onDelete: 'cascade' }),
+    // 리전별 활성화 스위치 (2계층 중 2계층).
+    isEnabled: boolean('is_enabled').notNull().default(true),
+    sortOrder: integer('sort_order').notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex('uq_region_payment_methods_region_catalog').on(table.regionId, table.catalogId),
+    index('idx_region_payment_methods_region').on(table.regionId),
+  ],
+);
+
 export const paymentIntents = pgTable(
   'payment_intents',
   {
@@ -675,6 +736,9 @@ export type CmsWithdrawalStatus = (typeof cmsWithdrawalStatusEnum.enumValues)[nu
 
 export const walletSchema = {
   paymentMethods,
+  paymentMethodCatalog,
+  regions,
+  regionPaymentMethods,
   paymentIntents,
   paymentIntentItems,
   paymentIntentItemDiscounts,

--- a/apps/wallet/src/types.ts
+++ b/apps/wallet/src/types.ts
@@ -14,8 +14,11 @@ import {
   paymentIntentItems,
   paymentIntentOrderDiscounts,
   paymentIntents,
+  paymentMethodCatalog,
   paymentMethods,
   paymentStateTransitions,
+  regionPaymentMethods,
+  regions,
   pointEventDetails,
   pointEvents,
   pointHoldDetails,
@@ -31,6 +34,18 @@ export type DbTransaction = DbTx;
 export type PaymentMethod = InferSelectModel<typeof paymentMethods>;
 export type NewPaymentMethod = InferInsertModel<typeof paymentMethods>;
 export type UpdatePaymentMethod = Partial<Omit<NewPaymentMethod, 'id' | 'createdAt' | 'updatedAt'>>;
+
+export type PaymentMethodCatalog = InferSelectModel<typeof paymentMethodCatalog>;
+export type NewPaymentMethodCatalog = InferInsertModel<typeof paymentMethodCatalog>;
+export type UpdatePaymentMethodCatalog = Partial<Omit<NewPaymentMethodCatalog, 'id' | 'createdAt' | 'updatedAt'>>;
+
+export type Region = InferSelectModel<typeof regions>;
+export type NewRegion = InferInsertModel<typeof regions>;
+export type UpdateRegion = Partial<Omit<NewRegion, 'id' | 'createdAt' | 'updatedAt'>>;
+
+export type RegionPaymentMethod = InferSelectModel<typeof regionPaymentMethods>;
+export type NewRegionPaymentMethod = InferInsertModel<typeof regionPaymentMethods>;
+export type UpdateRegionPaymentMethod = Partial<Omit<NewRegionPaymentMethod, 'id' | 'createdAt' | 'updatedAt'>>;
 
 export type PaymentIntent = InferSelectModel<typeof paymentIntents>;
 export type NewPaymentIntent = InferInsertModel<typeof paymentIntents>;

--- a/apps/wallet/src/wallet.module.ts
+++ b/apps/wallet/src/wallet.module.ts
@@ -62,6 +62,11 @@ import { PaymentIntentAdminService } from './admin/payment-intent-admin.service'
 import { PaymentIntentAdminController } from './admin/payment-intent-admin.controller';
 import { RefundAdminController } from './admin/refund-admin.controller';
 
+// Payment config (catalog + regions)
+import { PaymentConfigService } from './payment-config/payment-config.service';
+import { PaymentConfigAdminController } from './payment-config/payment-config-admin.controller';
+import { PaymentConfigController } from './payment-config/payment-config.controller';
+
 // Points (user-facing)
 import { PointsController } from './points/points.controller';
 import { BankTransferAdminService } from './admin/bank-transfer-admin.service';
@@ -366,6 +371,8 @@ async function resolveCanActivate(result: boolean | Promise<boolean> | unknown):
     PointsAdminController,
     PaymentIntentAdminController,
     RefundAdminController,
+    PaymentConfigAdminController,
+    PaymentConfigController,
     PointsController,
     TossWebhookController,
     BillingMethodController,
@@ -434,6 +441,7 @@ async function resolveCanActivate(result: boolean | Promise<boolean> | unknown):
 
     // Methods / Charges
     PaymentMethodsService,
+    PaymentConfigService,
     ChargesService,
 
     // Intents

--- a/docs/adr/0020-region-country-code-lowercase-alpha2.md
+++ b/docs/adr/0020-region-country-code-lowercase-alpha2.md
@@ -1,0 +1,20 @@
+# 리전/국가 식별자는 소문자 ISO 3166-1 alpha-2 로 통일한다
+
+플랫폼이 다국가(리전) 운영으로 확장되면서 "국가/리전"을 식별하는 키가 여러 곳에서 필요해졌다. wallet 의 리전별 결제수단 관리, storefront 의 `[countryCode]` 동적 라우트, Medusa 의 region/country, 알림(Twilio) 의 전화번호 국가 등이 각자 다른 표기(소문자/대문자, region UUID/country code)를 쓰면 경계마다 변환 버그와 매칭 실패가 생긴다.
+
+기존 현황: Medusa 는 `region.countries.iso_2` 와 cart `country_code` 에 **소문자 alpha-2**(`kr`)를 쓰고, storefront `[countryCode]` 라우트도 소문자다. user-service 의 Twilio lookup 만 대문자(`KR`)를 요구한다. wallet 에는 리전 개념이 없었다.
+
+## 결정
+
+- 리전/국가를 식별하는 키는 **소문자 ISO 3166-1 alpha-2 국가코드**(`kr`, `us`)로 통일한다. 이것이 플랫폼 전역의 canonical 표기다.
+- wallet 의 `regions.code` 는 `varchar(2)` 이며 `code = lower(code)` CHECK 제약으로 소문자를 강제한다. 입력 DTO 도 진입 시 `toLowerCase()` 정규화 후 `^[a-z]{2}$` 로 검증한다.
+- storefront → wallet-web → wallet 으로 리전을 전달할 때 이 키(`?region=kr`)를 그대로 쓴다. Medusa `region.countries.iso_2` 와 동일 값이므로 별도 매핑 테이블이 필요 없다.
+- 대문자 alpha-2(예: ISO 표준 표기) 또는 alpha-3 를 요구하는 외부 연동(Twilio 등)은 **경계에서만** 변환한다(`code.toUpperCase()`). 내부 저장/전달 값은 항상 소문자로 유지한다.
+- 새로 국가 식별이 필요한 코드(스토어프론트 라우트, 결제, 배송, 정산 등)는 이 표준을 따른다. region UUID(Medusa 내부 식별자)를 도메인 간 경계로 넘기지 않는다.
+
+## Consequences
+
+- wallet 리전 키와 Medusa/스토어프론트 country code 가 변환 없이 정합한다.
+- Twilio 처럼 대문자를 요구하는 연동은 명시적 변환 한 줄로 처리되며, 그 외 코드는 표기 분기를 갖지 않는다.
+- 향후 country code 가 필요한 이벤트/페이로드(예: 주문 이벤트)에도 소문자 alpha-2 를 싣는 것을 기본으로 한다.
+- 외부 시스템이 대문자/alpha-3 만 제공하는 경우, 수신 어댑터가 소문자 alpha-2 로 정규화한 뒤 내부로 전달할 책임을 진다.

--- a/scripts/seeding/lib/service-registry.ts
+++ b/scripts/seeding/lib/service-registry.ts
@@ -15,7 +15,7 @@ const ROOT_REGISTRY: ServiceConfig[] = [
   { name: 'membership', database: 'membership', drizzleConfig: 'apps/membership/drizzle.config.ts', hasSeedStep: true },
   { name: 'notification', database: 'notification', drizzleConfig: 'apps/notification/database/drizzle/drizzle.config.ts', hasSeedStep: true },
   { name: 'ugc-service', database: 'ugc', drizzleConfig: 'apps/ugc-service/src/db/drizzle.config.ts', hasSeedStep: false },
-  { name: 'wallet', database: 'wallet', drizzleConfig: 'apps/wallet/drizzle.config.ts', hasSeedStep: false },
+  { name: 'wallet', database: 'wallet', drizzleConfig: 'apps/wallet/drizzle.config.ts', hasSeedStep: true },
   { name: 'file-service', database: 'file_service', drizzleConfig: 'apps/file-service/drizzle.config.ts', hasSeedStep: true },
   { name: 'medusa', database: 'medusa', hasSeedStep: false },
 ];
@@ -41,7 +41,7 @@ const LCNINE_SERVICES_REGISTRY: ServiceConfig[] = [
   { name: 'membership', database: 'membership', drizzleConfig: 'apps/membership/drizzle.config.ts', hasSeedStep: true },
   { name: 'notification', database: 'notification', drizzleConfig: 'apps/notification/database/drizzle/drizzle.config.ts', hasSeedStep: true },
   { name: 'ugc-service', database: 'ugc', drizzleConfig: 'apps/ugc-service/src/db/drizzle.config.ts', hasSeedStep: false },
-  { name: 'wallet', database: 'wallet', drizzleConfig: 'apps/wallet/drizzle.config.ts', hasSeedStep: false },
+  { name: 'wallet', database: 'wallet', drizzleConfig: 'apps/wallet/drizzle.config.ts', hasSeedStep: true },
   { name: 'file-service', database: 'file_service', drizzleConfig: 'apps/file-service/drizzle.config.ts', hasSeedStep: true },
   { name: 'medusa', database: 'medusa', hasSeedStep: false },
 ];

--- a/scripts/seeding/phases/03-seed-orchestrator.ts
+++ b/scripts/seeding/phases/03-seed-orchestrator.ts
@@ -10,6 +10,7 @@ import { PimSeedStep } from '../steps/pim.seed-step';
 import { ProductMatchingBackfillSeedStep } from '../steps/product-matching-backfill.seed-step';
 import { UserServiceSeedStep, type OAuthClientSeed } from '../steps/user-service.seed-step';
 import { MembershipSeedStep } from '../steps/membership.seed-step';
+import { WalletSeedStep } from '../steps/wallet.seed-step';
 import { FileServiceSeedStep } from '../steps/file-service.seed-step';
 import { NotificationSeedStep } from '../steps/notification.seed-step';
 import { DemoUserSeedStep } from '../steps/demo-user.seed-step';
@@ -187,6 +188,11 @@ function buildSeedSteps(
   const membershipEntry = registryMap.get('membership');
   if (membershipEntry?.hasSeedStep) {
     steps.push(new MembershipSeedStep(urlFor(membershipEntry.database)));
+  }
+
+  const walletEntry = registryMap.get('wallet');
+  if (walletEntry?.hasSeedStep) {
+    steps.push(new WalletSeedStep(urlFor(walletEntry.database)));
   }
 
   const fileEntry = registryMap.get('file-service');

--- a/scripts/seeding/steps/wallet.seed-step.ts
+++ b/scripts/seeding/steps/wallet.seed-step.ts
@@ -1,0 +1,151 @@
+import { sql } from 'drizzle-orm';
+import { SeedStep } from './base-seed-step';
+import { SeedCheckResult, SeedApplyResult } from '../lib/types';
+
+/**
+ * 결제수단 카탈로그(글로벌) + 리전 + 리전별 매핑의 기준(reference) 시드.
+ * 카탈로그 code 는 provider.registry 의 providerType 과 일치한다.
+ * 최종 노출 = 카탈로그 is_enabled(글로벌) AND 리전 is_active AND 매핑 is_enabled.
+ */
+const CATALOG = [
+  { code: 'POINTS', displayName: '포인트', description: '내부 포인트 결제', isEnabled: true, sortOrder: 10 },
+  {
+    code: 'TOSS',
+    displayName: '토스페이먼츠',
+    description: '카드/간편결제 (토스페이먼츠)',
+    isEnabled: true,
+    sortOrder: 20,
+  },
+  {
+    code: 'BANK_TRANSFER',
+    displayName: '무통장입금',
+    description: '계좌 무통장 입금 (수동 확인)',
+    isEnabled: true,
+    sortOrder: 30,
+  },
+  // NICEPAY 는 provider 코드는 있으나 아직 미운영 → 글로벌 비활성으로 등록 (admin 이 준비되면 켠다)
+  {
+    code: 'NICEPAY',
+    displayName: '나이스페이',
+    description: '카드/간편결제 (나이스페이)',
+    isEnabled: false,
+    sortOrder: 40,
+  },
+] as const;
+
+const REGIONS = [{ code: 'kr', name: '대한민국', isActive: true, sortOrder: 10 }] as const;
+
+// kr 에서 활성화할 결제수단 (글로벌 is_enabled 와 AND 되어 최종 노출).
+// NICEPAY 는 kr 매핑은 켜두되 글로벌이 꺼져 있어 실제로는 숨겨진다.
+const REGION_METHODS = [
+  { regionCode: 'kr', catalogCode: 'POINTS', isEnabled: true, sortOrder: 10 },
+  { regionCode: 'kr', catalogCode: 'TOSS', isEnabled: true, sortOrder: 20 },
+  { regionCode: 'kr', catalogCode: 'BANK_TRANSFER', isEnabled: true, sortOrder: 30 },
+  { regionCode: 'kr', catalogCode: 'NICEPAY', isEnabled: true, sortOrder: 40 },
+] as const;
+
+export class WalletSeedStep extends SeedStep {
+  readonly groups = ['baseline'] as const;
+
+  constructor(databaseUrl: string) {
+    super('Wallet', databaseUrl);
+  }
+
+  async check(): Promise<SeedCheckResult> {
+    const existingCatalog = await this.findExistingKeys(
+      'payment_method_catalog',
+      CATALOG.map((c) => c.code),
+      'code',
+    );
+    const missingCatalog = CATALOG.filter((c) => !existingCatalog.has(c.code));
+
+    const existingRegions = await this.findExistingKeys(
+      'regions',
+      REGIONS.map((r) => r.code),
+      'code',
+    );
+    const missingRegions = REGIONS.filter((r) => !existingRegions.has(r.code));
+
+    const mappingCount = await this.countRows('region_payment_methods');
+    const missingMappings = Math.max(0, REGION_METHODS.length - mappingCount);
+
+    const items = [
+      {
+        entity: 'payment_method_catalog',
+        expected: CATALOG.length,
+        existing: existingCatalog.size,
+        missing: missingCatalog.length,
+        missingDetails: missingCatalog.map((c) => c.code),
+      },
+      {
+        entity: 'regions',
+        expected: REGIONS.length,
+        existing: existingRegions.size,
+        missing: missingRegions.length,
+        missingDetails: missingRegions.map((r) => r.code),
+      },
+      {
+        entity: 'region_payment_methods',
+        expected: REGION_METHODS.length,
+        existing: mappingCount,
+        missing: missingMappings,
+        missingDetails: [],
+      },
+    ];
+
+    const isFullySeeded = items.every((i) => i.missing === 0);
+    const totalMissing = items.reduce((sum, i) => sum + i.missing, 0);
+
+    return {
+      service: 'Wallet',
+      items,
+      isFullySeeded,
+      summary: isFullySeeded ? 'All Wallet seed data present' : `${totalMissing} missing record(s)`,
+    };
+  }
+
+  async apply(): Promise<SeedApplyResult> {
+    const start = Date.now();
+    let itemsApplied = 0;
+
+    try {
+      this.logger.step(1, 3, 'Inserting payment method catalog');
+      for (const c of CATALOG) {
+        await this.db.execute(sql`
+          INSERT INTO payment_method_catalog (code, display_name, description, is_enabled, sort_order)
+          VALUES (${c.code}, ${c.displayName}, ${c.description}, ${c.isEnabled}, ${c.sortOrder})
+          ON CONFLICT (code) DO NOTHING
+        `);
+      }
+      itemsApplied += CATALOG.length;
+
+      this.logger.step(2, 3, 'Inserting regions');
+      for (const r of REGIONS) {
+        await this.db.execute(sql`
+          INSERT INTO regions (code, name, is_active, sort_order)
+          VALUES (${r.code}, ${r.name}, ${r.isActive}, ${r.sortOrder})
+          ON CONFLICT (code) DO NOTHING
+        `);
+      }
+      itemsApplied += REGIONS.length;
+
+      this.logger.step(3, 3, 'Inserting region payment methods');
+      for (const m of REGION_METHODS) {
+        await this.db.execute(sql`
+          INSERT INTO region_payment_methods (region_id, catalog_id, is_enabled, sort_order)
+          SELECT r.id, c.id, ${m.isEnabled}, ${m.sortOrder}
+          FROM regions r, payment_method_catalog c
+          WHERE r.code = ${m.regionCode} AND c.code = ${m.catalogCode}
+          ON CONFLICT (region_id, catalog_id) DO NOTHING
+        `);
+      }
+      itemsApplied += REGION_METHODS.length;
+
+      this.logger.success('Wallet seeding completed');
+      return { service: 'Wallet', success: true, itemsApplied, duration: Date.now() - start };
+    } catch (error: any) {
+      this.logger.error('Wallet seeding failed', error);
+      return { service: 'Wallet', success: false, itemsApplied, duration: Date.now() - start, error: error.message };
+    }
+  }
+}

--- a/web/almondyoung-storefront/src/app/[countryCode]/(mypage)/mypage/membership/subscribe/payment/components.tsx
+++ b/web/almondyoung-storefront/src/app/[countryCode]/(mypage)/mypage/membership/subscribe/payment/components.tsx
@@ -205,7 +205,7 @@ export function MembershipForm({
           const { intentId } = await createMembershipCheckoutIntent(selectedPlanId, returnUrl, "one_time")
           setPendingPaymentMode("membership", { planId: selectedPlanId, billingMode: "one_time" })
           const walletWebUrl = process.env.NEXT_PUBLIC_WALLET_WEB_URL || "http://localhost:3200"
-          window.location.href = `${walletWebUrl}/pay/${intentId}`
+          window.location.href = `${walletWebUrl}/pay/${intentId}?region=${countryCode}`
         }
       }
     } catch (error) {

--- a/web/almondyoung-storefront/src/domains/checkout/templates/checkout-template.tsx
+++ b/web/almondyoung-storefront/src/domains/checkout/templates/checkout-template.tsx
@@ -63,8 +63,15 @@ export default function CheckoutTemplate({
     }, 0)
 
     // cart.discount_total은 cart 전체 기준이므로 부분 선택 시 item 단위 합산 필수.
-    const itemDiscount = selectedItems.reduce((acc, item) => acc + (item.discount_total ?? 0), 0)
-    const shippingDiscount = cart.shipping_methods?.reduce((acc, sm) => acc + (sm.discount_total ?? 0), 0) ?? 0
+    const itemDiscount = selectedItems.reduce(
+      (acc, item) => acc + (item.discount_total ?? 0),
+      0
+    )
+    const shippingDiscount =
+      cart.shipping_methods?.reduce(
+        (acc, sm) => acc + (sm.discount_total ?? 0),
+        0
+      ) ?? 0
     const discount_subtotal = itemDiscount + shippingDiscount
 
     const membershipDiscount =
@@ -190,10 +197,12 @@ export default function CheckoutTemplate({
 
       const walletWebUrl =
         process.env.NEXT_PUBLIC_WALLET_WEB_URL || "http://localhost:3200"
-      window.location.href = `${walletWebUrl}/pay/${intentId}`
+      window.location.href = `${walletWebUrl}/pay/${intentId}?region=${countryCode}`
     } catch (err) {
       console.error("결제 처리 실패:", err)
-      setError(err instanceof Error ? err.message : tProcess("toasts.unknownError"))
+      setError(
+        err instanceof Error ? err.message : tProcess("toasts.unknownError")
+      )
       setLoading(false)
     }
   }

--- a/web/almondyoung-storefront/src/domains/checkout/templates/membership-checkout-template.tsx
+++ b/web/almondyoung-storefront/src/domains/checkout/templates/membership-checkout-template.tsx
@@ -58,7 +58,7 @@ export default function MembershipCheckoutTemplate({
     const { intentId } = await createMembershipCheckoutIntent(planId, returnUrl, "one_time")
     setPendingPaymentMode("membership", { planId, billingMode: "one_time" })
     const walletWebUrl = process.env.NEXT_PUBLIC_WALLET_WEB_URL || "http://localhost:3200"
-    window.location.href = `${walletWebUrl}/pay/${intentId}`
+    window.location.href = `${walletWebUrl}/pay/${intentId}?region=${countryCode}`
   }
 
   const handlePayment = async () => {


### PR DESCRIPTION
## 변경 사항

- Wallet API에 결제수단 활성화/비활성화 기능 추가
- Admin Web에서 결제수단 활성화 상태 관리 가능하도록 연동
- Wallet에 Region 개념 추가
- Region별 사용 가능한 결제수단 관리 API 추가
- Admin Web에서 Region별 결제수단 관리 기능 구현
- Storefront → Wallet 연동 시 국가 코드(ISO Alpha-2)를 전달하도록 지원
- Wallet이 전달받은 Region 기준으로 사용 가능한 결제수단만 반환하도록 구현


## Region 정책

- Region Key는 ISO 3166-1 Alpha-2 국가 코드 사용
  - `kr`
  - `us`
  - `jp`
  - ...

향후 국가 식별이 필요한 기능은 동일한 규격을 사용합니다.
