### PR TITLE
fix(core): 유실된 purchase-constraints 마이그레이션을 drizzle journal에 복원

### DIFF
--- a/apps/core/drizzle/meta/_journal.json
+++ b/apps/core/drizzle/meta/_journal.json
@@ -110,12 +110,19 @@
     {
       "idx": 15,
       "version": "7",
+      "when": 1780943232258,
+      "tag": "20260608182712_typical_speedball",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
       "when": 1780974262229,
       "tag": "20260609030422_add-inspection-tables",
       "breakpoints": true
     },
     {
-      "idx": 16,
+      "idx": 17,
       "version": "7",
       "when": 1780986649103,
       "tag": "20260609063049_add-shipments-fo-unique-idx",


### PR DESCRIPTION
20260608182712_typical_speedball (product_purchase_constraints / product_master_purchase_constraints 생성)의 .sql/스냅샷 파일은 남아있으나, squash 머지(12c3b929) 때 평행 브랜치 충돌로 _journal.json 항목만 유실됨.

drizzle-kit migrate는 journal에 등록된 것만 적용하므로 이 테이블이 어느 환경에도 생성되지 않았고, 버전 상세 조회(_fetchPurchaseConstraint)가 매번 존재하지 않는 테이블을 조회해 500을 유발함.

원본 항목(idx 15, when=1780943232258)을 git에서 복원하고 뒤 두
마이그레이션을 16/17로 재번호. 신규 DB는 이걸로 정상화됨. 기존 DB(dev/prod)는 시간순 비교 특성상 migrate가 건너뛰므로 SQL 1회 수동 적용 필요.