### PR TITLE
[wallet-web] 결제 confirm 401 시 토큰 갱신·재시도 (결제창 안 넘어감 수정)

### DIFF
--- a/apps/wallet-web/app/api/payment-intents/[intentId]/proxy.spec.ts
+++ b/apps/wallet-web/app/api/payment-intents/[intentId]/proxy.spec.ts
@@ -1,4 +1,20 @@
+jest.mock('../../../../lib/auth/oidc-client', () => ({
+  refreshTokens: jest.fn(),
+}));
+jest.mock('../../../../lib/auth/session-cookies', () => ({
+  SESSION_COOKIE_NAMES: {
+    ACCESS_TOKEN: 'wallet_at',
+    REFRESH_TOKEN: 'wallet_rt',
+    ID_TOKEN: 'wallet_it',
+    STATE_COOKIE: 'wallet_oidc_state',
+  },
+  backendAuthCookieFromToken: (token: string | null | undefined) => (token ? `accessToken=${token}` : ''),
+  writeSessionCookies: jest.fn(),
+}));
+
 import { proxyPaymentIntentAction } from './proxy';
+import { refreshTokens } from '../../../../lib/auth/oidc-client';
+import { writeSessionCookies } from '../../../../lib/auth/session-cookies';
 
 describe('payment intent proxy', () => {
   const originalFetch = global.fetch;
@@ -9,6 +25,7 @@ describe('payment intent proxy', () => {
     global.fetch = originalFetch;
     process.env.WALLET_API_URL = originalWalletApiUrl;
     process.env.NEXT_PUBLIC_WALLET_API_URL = originalPublicWalletApiUrl;
+    jest.clearAllMocks();
     jest.restoreAllMocks();
   });
 
@@ -45,6 +62,7 @@ describe('payment intent proxy', () => {
         }),
       }),
     );
+    expect(refreshTokens).not.toHaveBeenCalled();
   });
 
   it('forwards cancel requests without requiring a body', async () => {
@@ -73,5 +91,67 @@ describe('payment intent proxy', () => {
       }),
     );
     expect(init.body).toBeUndefined();
+  });
+
+  it('refreshes the wallet-web session and retries when the wallet API returns 401', async () => {
+    process.env.WALLET_API_URL = 'https://wallet-api.example.com';
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }))
+      .mockResolvedValueOnce(Response.json({ id: 'pi_123', status: 'AWAITING_DEPOSIT' }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+    (refreshTokens as jest.Mock).mockResolvedValue({
+      accessToken: 'new_at',
+      refreshToken: 'new_rt',
+      idToken: 'new_it',
+      expiresIn: 900,
+    });
+
+    const body = JSON.stringify({ paymentMethodId: 'pm_1' });
+    const request = new Request('https://wallet-web.example.com/api/payment-intents/pi_123/confirm', {
+      method: 'POST',
+      headers: {
+        Cookie: 'wallet_at=expired; wallet_rt=valid_refresh',
+        'Content-Type': 'application/json',
+        'Idempotency-Key': 'idem_abc',
+      },
+      body,
+    });
+
+    const response = await proxyPaymentIntentAction(request, 'pi_123', 'confirm');
+
+    expect(response.status).toBe(200);
+    expect(refreshTokens).toHaveBeenCalledWith('valid_refresh');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Retried with the refreshed access token and the SAME idempotency key.
+    const retryInit = fetchMock.mock.calls[1][1] as RequestInit;
+    const retryHeaders = retryInit.headers as Record<string, string>;
+    expect(retryHeaders.Cookie).toBe('accessToken=new_at');
+    expect(retryHeaders['Idempotency-Key']).toBe('idem_abc');
+
+    // Rotated session persisted back to the browser.
+    expect(writeSessionCookies).toHaveBeenCalledTimes(1);
+    expect((writeSessionCookies as jest.Mock).mock.calls[0][1]).toEqual(
+      expect.objectContaining({ accessToken: 'new_at', refreshToken: 'new_rt' }),
+    );
+  });
+
+  it('returns the original 401 when there is no refresh token to bounce with', async () => {
+    process.env.WALLET_API_URL = 'https://wallet-api.example.com';
+    const fetchMock = jest.fn().mockResolvedValue(new Response('Unauthorized', { status: 401 }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const request = new Request('https://wallet-web.example.com/api/payment-intents/pi_123/confirm', {
+      method: 'POST',
+      headers: { Cookie: 'wallet_at=expired', 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+
+    const response = await proxyPaymentIntentAction(request, 'pi_123', 'confirm');
+
+    expect(response.status).toBe(401);
+    expect(refreshTokens).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(writeSessionCookies).not.toHaveBeenCalled();
   });
 });

--- a/apps/wallet-web/app/api/payment-intents/[intentId]/proxy.spec.ts
+++ b/apps/wallet-web/app/api/payment-intents/[intentId]/proxy.spec.ts
@@ -137,6 +137,41 @@ describe('payment intent proxy', () => {
     );
   });
 
+  it('persists rotated session cookies even when the retried wallet API call fails', async () => {
+    process.env.WALLET_API_URL = 'https://wallet-api.example.com';
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }))
+      .mockResolvedValueOnce(Response.json({ message: 'intent expired' }, { status: 409 }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+    (refreshTokens as jest.Mock).mockResolvedValue({
+      accessToken: 'new_at',
+      refreshToken: 'new_rt',
+      idToken: 'new_it',
+      expiresIn: 900,
+    });
+
+    const request = new Request('https://wallet-web.example.com/api/payment-intents/pi_123/confirm', {
+      method: 'POST',
+      headers: {
+        Cookie: 'wallet_at=expired; wallet_rt=valid_refresh',
+        'Content-Type': 'application/json',
+        'Idempotency-Key': 'idem_abc',
+      },
+      body: '{}',
+    });
+
+    const response = await proxyPaymentIntentAction(request, 'pi_123', 'confirm');
+
+    expect(response.status).toBe(409);
+    expect(refreshTokens).toHaveBeenCalledWith('valid_refresh');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(writeSessionCookies).toHaveBeenCalledTimes(1);
+    expect((writeSessionCookies as jest.Mock).mock.calls[0][1]).toEqual(
+      expect.objectContaining({ accessToken: 'new_at', refreshToken: 'new_rt' }),
+    );
+  });
+
   it('returns the original 401 when there is no refresh token to bounce with', async () => {
     process.env.WALLET_API_URL = 'https://wallet-api.example.com';
     const fetchMock = jest.fn().mockResolvedValue(new Response('Unauthorized', { status: 401 }));

--- a/apps/wallet-web/app/api/payment-intents/[intentId]/proxy.ts
+++ b/apps/wallet-web/app/api/payment-intents/[intentId]/proxy.ts
@@ -1,21 +1,55 @@
+import { refreshTokens, type TokenSet } from '../../../../lib/auth/oidc-client';
+import {
+  SESSION_COOKIE_NAMES,
+  backendAuthCookieFromToken,
+  writeSessionCookies,
+} from '../../../../lib/auth/session-cookies';
+
 type PaymentIntentAction = 'confirm' | 'cancel' | 'abandon';
 
 function getWalletApiUrl(): string {
   return process.env.WALLET_API_URL ?? process.env.NEXT_PUBLIC_WALLET_API_URL ?? 'http://localhost:3100';
 }
 
-function buildHeaders(request: Request, includeBody: boolean): Record<string, string> {
-  const headers: Record<string, string> = {
-    'Idempotency-Key': request.headers.get('Idempotency-Key') ?? crypto.randomUUID(),
+function readCookie(cookieHeader: string | null, name: string): string | null {
+  if (!cookieHeader) return null;
+  for (const part of cookieHeader.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === name) return part.slice(eq + 1).trim();
+  }
+  return null;
+}
+
+/**
+ * Adapter exposing the `set(name, value, options)` shape that {@link writeSessionCookies}
+ * expects, backed by a plain {@link Headers}. Lets us reuse the single source of truth for
+ * session cookie attributes (httpOnly/secure/sameSite/maxAge) without depending on NextResponse.
+ */
+function cookieJar(headers: Headers) {
+  return {
+    set(
+      name: string,
+      value: string,
+      options: {
+        httpOnly?: boolean;
+        secure?: boolean;
+        sameSite?: 'lax' | 'strict' | 'none';
+        path?: string;
+        maxAge?: number;
+      } = {},
+    ): void {
+      let cookie = `${name}=${value}`;
+      if (options.maxAge !== undefined) cookie += `; Max-Age=${options.maxAge}`;
+      cookie += `; Path=${options.path ?? '/'}`;
+      if (options.httpOnly) cookie += '; HttpOnly';
+      if (options.secure) cookie += '; Secure';
+      if (options.sameSite) {
+        cookie += `; SameSite=${options.sameSite[0].toUpperCase()}${options.sameSite.slice(1)}`;
+      }
+      headers.append('Set-Cookie', cookie);
+    },
   };
-  const cookie = request.headers.get('Cookie');
-  if (cookie) {
-    headers.Cookie = cookie;
-  }
-  if (includeBody) {
-    headers['Content-Type'] = request.headers.get('Content-Type') ?? 'application/json';
-  }
-  return headers;
 }
 
 export async function proxyPaymentIntentAction(
@@ -25,18 +59,69 @@ export async function proxyPaymentIntentAction(
 ): Promise<Response> {
   const includeBody = action === 'confirm';
   const body = includeBody ? await request.text() : undefined;
-  const upstream = await fetch(`${getWalletApiUrl()}/v1/payment-intents/${encodeURIComponent(intentId)}/${action}`, {
-    method: 'POST',
-    headers: buildHeaders(request, includeBody),
-    body,
-    cache: 'no-store',
-  });
+  const url = `${getWalletApiUrl()}/v1/payment-intents/${encodeURIComponent(intentId)}/${action}`;
+
+  // The same Idempotency-Key MUST be reused across the refresh-retry so the wallet never
+  // double-processes a confirm.
+  const idempotencyKey = request.headers.get('Idempotency-Key') ?? crypto.randomUUID();
+  const contentType = request.headers.get('Content-Type') ?? 'application/json';
+  const rawCookie = request.headers.get('Cookie');
+
+  const callUpstream = (cookie: string | null): Promise<Response> => {
+    const headers: Record<string, string> = { 'Idempotency-Key': idempotencyKey };
+    if (cookie) headers.Cookie = cookie;
+    if (includeBody) headers['Content-Type'] = contentType;
+    return fetch(url, { method: 'POST', headers, body, cache: 'no-store' });
+  };
+
+  // 1st attempt: forward the browser cookies as-is (unchanged behaviour).
+  let upstream = await callUpstream(rawCookie);
+  let refreshed: TokenSet | null = null;
+
+  // On auth failure, do a one-shot refresh with wallet-web's refresh token and retry.
+  // This rescues sessions whose short-lived access token expired while the customer lingered
+  // on the payment screen — the dominant "결제창이 안 넘어가요" / 401 "No auth token" failure.
+  // (In-app browsers that drop cookies entirely have no refresh token here and still 401;
+  // those need the same-origin / token-handoff fix.)
+  if (upstream.status === 401) {
+    const refreshToken = readCookie(rawCookie, SESSION_COOKIE_NAMES.REFRESH_TOKEN);
+    if (refreshToken) {
+      try {
+        refreshed = await refreshTokens(refreshToken);
+        upstream = await callUpstream(backendAuthCookieFromToken(refreshed.accessToken));
+      } catch {
+        // Refresh token is dead too — fall through with the original 401 so the client can
+        // bounce to /auth/ensure on the next navigation.
+        refreshed = null;
+      }
+    }
+    // Observability: identify which browsers/sessions still fail at payment confirm so we can
+    // confirm the in-app-browser (no cookies → no refresh token) cohort without edge access logs.
+    // No tokens are logged — only the User-Agent and the refresh outcome.
+    console.warn(
+      JSON.stringify({
+        tag: 'pay-confirm-auth-401',
+        action,
+        intentId,
+        userAgent: request.headers.get('User-Agent') ?? null,
+        hadRefreshToken: Boolean(refreshToken),
+        refreshAttempted: Boolean(refreshToken),
+        rescued: Boolean(refreshed && upstream.status < 400),
+        finalStatus: upstream.status,
+      }),
+    );
+  }
+
   const responseBody = await upstream.text();
   const headers = new Headers();
-  const contentType = upstream.headers.get('Content-Type');
+  const upstreamContentType = upstream.headers.get('Content-Type');
+  if (upstreamContentType) {
+    headers.set('Content-Type', upstreamContentType);
+  }
 
-  if (contentType) {
-    headers.set('Content-Type', contentType);
+  // Persist the rotated session so the browser keeps the refreshed token for later calls.
+  if (refreshed && upstream.status < 400) {
+    writeSessionCookies(cookieJar(headers), refreshed);
   }
 
   return new Response(responseBody || null, {

--- a/apps/wallet-web/app/api/payment-intents/[intentId]/proxy.ts
+++ b/apps/wallet-web/app/api/payment-intents/[intentId]/proxy.ts
@@ -120,7 +120,7 @@ export async function proxyPaymentIntentAction(
   }
 
   // Persist the rotated session so the browser keeps the refreshed token for later calls.
-  if (refreshed && upstream.status < 400) {
+  if (refreshed) {
     writeSessionCookies(cookieJar(headers), refreshed);
   }
 

--- a/docs/adr/0023-payment-screen-auth-token-handoff.md
+++ b/docs/adr/0023-payment-screen-auth-token-handoff.md
@@ -1,0 +1,44 @@
+# 결제창 인증 — 서브도메인 쿠키 의존 제거 (토큰 핸드오프)
+
+결제창은 별도 서브도메인 `wallet-web` 에서 뜨고, 거기서 고객 로그인 세션을 **스스로 다시 확보**한 뒤 wallet-api 의 인증 엔드포인트(`/v1/payment-intents/:id/confirm` 등)를 호출한다. 세션 재확보는 (1) 부모 도메인 `.almondyoung-next.com` 에 박힌 쿠키를 wallet-web 서브도메인이 읽거나, (2) `/auth/ensure` 가 `wallet_rt`(14일 refresh) 로 토큰을 갱신하거나, 실패 시 (3) `/login` OIDC silent-SSO 왕복으로 이뤄진다.
+
+이 구조는 **인앱브라우저(카카오톡·인스타·네이버)·iOS Safari(WebKit/ITP)** 에서 깨진다. 이들 환경은 서브도메인 간 쿠키 전송을 차단/격리하거나 다단계 redirect 중 IdP 세션 쿠키를 잃어버려, wallet-web 이 유효한 access token 을 끝내 확보하지 못한다. 그 결과:
+
+- confirm 호출이 인증 없이 wallet-api 에 도달 → `JwtAuthGuard: "No auth token"` → **401**, 결제창이 다음 단계로 넘어가지 않음("결제창이 안 넘어가요").
+- 같은 인증 경로를 쓰는 **배송지 저장(`POST /store/customers/me/addresses`)도 401** 로 함께 실패.
+- intent 가 사용자에게 claim 되지 못해 `payment_intents.user_id` 가 NULL 로 남는다(읽기는 되고 쓰기만 막히는 특징).
+
+라이브 로그상 confirm 401 이 한 고객에게서 28분간 반복됐고(새로고침/재진입에도 동일), 같은 유형의 미claim intent 가 누적되고 있었다. CloudFront·ALB 접속로그가 꺼져 있어 정확한 브라우저(User-Agent)는 사후 추출이 불가능했다.
+
+## Decision
+
+### 1. (적용) confirm/cancel/abandon 프록시에 refresh-on-401 + 관찰 로그
+
+`apps/wallet-web/app/api/payment-intents/[intentId]/proxy.ts`:
+
+- 1차 시도는 기존 동작(브라우저 쿠키 그대로 forwarding) 유지 — 현재 성공 경로에 영향 없음.
+- **401 일 때만** `wallet_rt` 로 `refreshTokens()` 갱신 → **동일 `Idempotency-Key` 로 재시도** → 성공 시 회전된 세션 쿠키를 응답에 기록. 결제 페이지 체류 중 15분 access token 이 만료된 "시간초과형" 실패를 구제한다.
+- 401 시 **User-Agent + refresh 성공여부**를 구조화 로그(`tag: pay-confirm-auth-401`)로 남겨, edge 로그 없이도 인앱브라우저 코호트를 식별한다(토큰은 로깅하지 않음).
+
+한계: 쿠키 자체가 차단된 인앱브라우저는 여기서도 `wallet_rt` 가 없어 401 그대로다 — 아래 2번이 그 케이스를 해결한다.
+
+### 2. (계획) 토큰 핸드오프로 서브도메인 쿠키 의존 제거
+
+결제창이 세션을 "스스로 재확보"하는 의존을 없앤다. 스토어프론트는 결제 intent 를 만드는 시점에 이미 인증돼 있으므로, **거기서 단기·1회용 서명 핸드오프 토큰을 발급**해 URL 로 넘기고 wallet-web 이 서버에서 교환한다.
+
+- **user-service(IdP)**: 인증 사용자에 대해 `aud=wallet-web`, **TTL ~120초, 1회용**(jti 소비) 핸드오프 토큰 발급 + 교환 엔드포인트(토큰셋 반환).
+- **스토어프론트**: 결제 리다이렉트 시 핸드오프 토큰을 받아 `…/pay/{intentId}?h=<code>` 로 이동.
+- **wallet-web `/pay`**: 유효 세션이 없고 `?h=` 가 있으면 **서버에서 교환 → 자기 host-only 세션쿠키 발급 → 파라미터 제거 후 진행**. 없으면 기존 `/auth/ensure` 폴백.
+
+인앱브라우저에서도 동작하는 이유: 토큰이 **first-party 네비게이션(URL)** 으로 전달되고 wallet-web 이 **자기 도메인 쿠키를 직접** 심는다. 인앱브라우저/ITP 가 막는 것은 "남의 출처 쿠키 읽기"이지 first-party 쿠키 발급이 아니다. 1회용·단기·intent 바인딩이라 URL 노출은 안전하다.
+
+### 3. (장기) 결제 흐름을 스토어프론트와 동일 출처로 통합
+
+`www.almondyoung-next.com/pay/...` 경로에서 처리(CloudFront rewrite 또는 storefront 내 렌더)하면 서브도메인 교차 쿠키·silent SSO 가 원천 제거된다. 가장 견고하나 라우팅/CSP 변경 범위가 커서 2번 이후로 둔다.
+
+## Consequences
+
+- 1번만으로 "시간초과형"(다수)이 즉시 개선되고, 401 로그로 잔여 코호트를 계량할 수 있다.
+- 2번 적용 후 인앱브라우저 고객까지 결제·배송지 저장이 정상화된다. IdP 에 핸드오프 엔드포인트가 추가되며, 토큰은 단기·1회용·intent 바인딩을 강제해야 한다.
+- 운영 임시 대응(고객을 외부 브라우저로 유도, 입금완료 건 수동 복구)은 2번 배포 전까지 유지한다.
+- 재발 진단을 위해 CloudFront 접속로그(또는 1번의 앱 레벨 UA 로그)를 상시 확보한다.


### PR DESCRIPTION
## 배경
일부 고객이 결제 버튼을 눌러도 다음 단계로 넘어가지 않는 현상(+배송지 등록 실패). 라이브 로그 분석 결과 동일 원인이었음:

- 결제창(wallet-web)에서 호출하는 `POST /v1/payment-intents/:id/confirm` 이 wallet-api에 **인증 토큰 없이 도달 → 401 `No auth token`** (한 고객에게 28분간 반복).
- access token TTL이 15분인데, confirm 프록시(`proxyPaymentIntentAction`)는 쿠키를 **그대로 forwarding만 하고 401 시 갱신을 안 함** → 결제 페이지에 머무는 동안 만료되면 그대로 실패.
- 같은 인증 경로라 **배송지 저장(POST /store/customers/me/addresses)도 401** 로 동반 실패하고, intent가 claim되지 못해 `user_id`가 NULL로 남음.

## 변경 (1차 완화)
`apps/wallet-web/.../payment-intents/[intentId]/proxy.ts`
- 1차 시도는 **기존 동작 유지**(raw 쿠키 forwarding) → 현재 성공 경로 영향 없음(순수 가산).
- **401일 때만** `wallet_rt`로 `refreshTokens()` → **동일 Idempotency-Key로 재시도** → 성공 시 세션쿠키 회전.
- 401 시 **User-Agent + refresh 결과**를 구조화 로그(`tag: pay-confirm-auth-401`)로 기록 → edge 접속로그 없이 인앱브라우저 코호트 식별(토큰 미로깅).


운영 임시대응: 고객 외부 브라우저 유도, 입금완료 건 수동 복구.