### PR TITLE
fix(payment): 무통장입금 주문 선생성 + 카트 쿠키 복구 (#439~#442)

### DIFF
--- a/apps/channel-adapter/src/adapters/medusa/medusa.client.ts
+++ b/apps/channel-adapter/src/adapters/medusa/medusa.client.ts
@@ -43,6 +43,8 @@ export interface MedusaOrder {
   created_at?: string;
   updated_at?: string;
   canceled_at?: string;
+  // 주문 레벨 메타데이터. 무통장입금 선생성 주문의 bank_transfer_status('awaiting_deposit'|'confirmed')로 입금 전(미수집) 여부를 판별하는 데 사용
+  metadata?: Record<string, unknown> | null;
   items?: Array<{
     id: string;
     title?: string;
@@ -134,6 +136,7 @@ const ORDER_FIELDS = [
   'created_at',
   'updated_at',
   'canceled_at',
+  'metadata',
   '*items',
   'items.id',
   'items.title',

--- a/apps/channel-adapter/src/consumers/payment-events.consumer.ts
+++ b/apps/channel-adapter/src/consumers/payment-events.consumer.ts
@@ -25,6 +25,7 @@ const MEDUSA_PAYMENT_EVENT_TYPES = [
   'payment.intent.created',
   'payment.intent.authorized',
   'payment.intent.captured',
+  'payment.intent.awaiting_deposit',
   'payment.intent.succeeded',
   'payment.intent.failed',
   'payment.intent.canceled',
@@ -88,6 +89,14 @@ export class PaymentEventsConsumer {
 
   @OnEvent('payments.events.v1', 'payment.intent.captured')
   async handleIntentCaptured(@EventEnvelope() envelope: MessageEnvelope) {
+    await this.forwardToMedusa(envelope);
+  }
+
+  /**
+   * 무통장입금 입금 대기 진입 — Medusa 가 주문을 '입금확인중' 으로 선생성하도록 전달
+   */
+  @OnEvent('payments.events.v1', 'payment.intent.awaiting_deposit')
+  async handleIntentAwaitingDeposit(@EventEnvelope() envelope: MessageEnvelope) {
     await this.forwardToMedusa(envelope);
   }
 

--- a/apps/channel-adapter/src/services/order-collection/medusa-order.provider.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/medusa-order.provider.spec.ts
@@ -63,6 +63,62 @@ describe('MedusaOrderProvider', () => {
     });
   });
 
+  // 무통장입금 선생성 주문은 입금 확인(capture) 전까지 WMS 출고 수집에서 제외
+  const bankTransferOrder = (overrides: Record<string, unknown>) => ({
+    id: 'order_bt_1',
+    customer_id: 'cus_1',
+    currency_code: 'KRW',
+    total: 10000,
+    subtotal: 10000,
+    shipping_total: 0,
+    discount_total: 0,
+    created_at: '2026-06-23T01:00:00.000Z',
+    updated_at: '2026-06-23T01:05:00.000Z',
+    items: [
+      {
+        id: 'item_1',
+        title: 'Product',
+        quantity: 1,
+        unit_price: 10000,
+        variant_id: 'variant_1',
+        variant: {
+          metadata: { pimVariantId: 'pim_variant_1' },
+          product: { metadata: { pimMasterId: 'master_1', pimVersionId: 'version_1' } },
+        },
+      },
+    ],
+    shipping_address: { first_name: 'Jane', last_name: 'Kim', phone: '010-0000-0000', postal_code: '12345', address_1: 'Seoul', address_2: '' },
+    ...overrides,
+  });
+
+  it('무통장 입금대기(awaiting_deposit + authorized) 주문은 수집(OrderCreated)에서 제외한다', async () => {
+    const provider = new MedusaOrderProvider({
+      listOrders: jest.fn().mockResolvedValue([
+        bankTransferOrder({ payment_status: 'authorized', metadata: { bank_transfer_status: 'awaiting_deposit' } }),
+      ]),
+    } as any);
+
+    const result = await provider.fetchOrders(null);
+
+    expect(result.orders).toHaveLength(0);
+    expect(result.failures).toHaveLength(0);
+    expect(result.lifecycleEvents ?? []).toHaveLength(0);
+  });
+
+  it('입금 확인 후(captured)에는 awaiting_deposit metadata 가 남아있어도 수집한다', async () => {
+    const provider = new MedusaOrderProvider({
+      listOrders: jest.fn().mockResolvedValue([
+        // confirmed metadata 갱신이 실패해 awaiting_deposit 가 남았더라도, captured 면 수집
+        bankTransferOrder({ payment_status: 'captured', metadata: { bank_transfer_status: 'awaiting_deposit' } }),
+      ]),
+    } as any);
+
+    const result = await provider.fetchOrders(null);
+
+    expect(result.orders).toHaveLength(1);
+    expect(result.orders[0].externalOrderId).toBe('order_bt_1');
+  });
+
   it('builds an OrderCreated payload that passes stream validation when optional address details are blank', async () => {
     const provider = new MedusaOrderProvider({
       listOrders: jest.fn().mockResolvedValue([

--- a/apps/channel-adapter/src/services/order-collection/medusa-order.provider.ts
+++ b/apps/channel-adapter/src/services/order-collection/medusa-order.provider.ts
@@ -57,7 +57,18 @@ export class MedusaOrderProvider implements ReplayableChannelOrderProvider {
     // attaches cancellation/refund only to already-collected orders, so an uncollected
     // canceled snapshot (even one whose payment is still authorized/captured) is observed
     // for lifecycle but is not eligible for OrderCreated.
-    const eligibleForOrderCreation = PAYMENT_ACCEPTED_STATUSES.has(order.payment_status) && order.status !== 'canceled';
+    // 무통장입금 선생성 주문: 입금 확인 전에는 결제가 authorized(미capture) 상태라
+    // PAYMENT_ACCEPTED_STATUSES 를 통과하지만, 실제 입금이 안 됐으므로 WMS 출고 파이프라인에
+    // 태우면 안 됨. metadata.bank_transfer_status='awaiting_deposit' 면 수집(OrderCreated)에서 제외
+    //
+    // 단, 게이트를 metadata 단독이 아니라 payment_status 와 함께 본다: 관리자 입금확인 후
+    // payment_status='captured' 가 되면, Medusa 의 'confirmed' metadata 갱신이 (네트워크 등으로)
+    // 실패해 awaiting_deposit 가 남아있더라도 수집을 영구히 막지 않도록 한다. 즉 '미입금(authorized) + awaiting_deposit' 일 때만 제외
+    const isAwaitingBankDeposit =
+      (order.metadata as Record<string, unknown> | null | undefined)?.bank_transfer_status === 'awaiting_deposit' &&
+      order.payment_status !== 'captured';
+    const eligibleForOrderCreation =
+      PAYMENT_ACCEPTED_STATUSES.has(order.payment_status) && order.status !== 'canceled' && !isAwaitingBankDeposit;
     const lifecycleStatusSnapshot = this.isLifecycleStatusSnapshot(order);
     const hasLifecycleObservation = lifecycleStatusSnapshot || this.hasLifecycleObservation(order);
     if (!eligibleForOrderCreation && !hasLifecycleObservation) {

--- a/apps/medusa/src/api/hooks/payment-events/__tests__/payment-events.unit.spec.ts
+++ b/apps/medusa/src/api/hooks/payment-events/__tests__/payment-events.unit.spec.ts
@@ -167,7 +167,11 @@ describe('handleCancelProjection', () => {
 
 describe('handleAwaitingDepositProjection', () => {
   it('주문 생성(completeCartWorkflow) 전에 cart 에 awaiting_deposit marker 를 원자적으로 심는다', async () => {
-    const completeRun = jest.fn().mockResolvedValue({ errors: [] });
+    let orderCreated = false;
+    const completeRun = jest.fn().mockImplementation(async () => {
+      orderCreated = true;
+      return { errors: [] };
+    });
     (completeCartWorkflow as unknown as jest.Mock).mockReturnValue({ run: completeRun });
     const deleteRun = jest.fn().mockResolvedValue({ errors: [] });
     (deleteLineItemsWorkflow as unknown as jest.Mock).mockReturnValue({ run: deleteRun });
@@ -183,7 +187,9 @@ describe('handleAwaitingDepositProjection', () => {
           ],
         };
       }
-      if (entity === 'order_cart') return { data: [] };
+      if (entity === 'order_cart') {
+        return { data: orderCreated ? [{ cart_id: 'cart_1', order_id: 'order_1' }] : [] };
+      }
       if (entity === 'cart') {
         const id = (filters as any)?.id;
         if (id === 'cart_1') return { data: [{ id: 'cart_1', metadata: { source_cart_id: 'src_1', source_line_item_ids: ['li_1'] } }] };
@@ -196,6 +202,13 @@ describe('handleAwaitingDepositProjection', () => {
       paymentModule: {
         listPaymentSessions: jest.fn().mockResolvedValue([{ id: 'payses_1', payment_collection_id: 'pc_1' }]),
         listPayments: jest.fn().mockResolvedValue([]),
+      },
+      orderModule: {
+        retrieveOrder: jest.fn().mockResolvedValue({
+          id: 'order_1',
+          payment_status: 'authorized',
+          metadata: { bank_transfer_status: 'awaiting_deposit' },
+        }),
       },
       graph,
     });
@@ -219,7 +232,7 @@ describe('handleAwaitingDepositProjection', () => {
     );
   });
 
-  it('이미 완료된 cart(이벤트 순서 역전: capture 선처리)면 marker 를 심지 않는다', async () => {
+  it('이미 완료된 cart 의 기존 주문이 captured 면 awaiting_deposit marker 를 뒤늦게 심지 않는다', async () => {
     const completeRun = jest.fn().mockResolvedValue({ errors: [] });
     (completeCartWorkflow as unknown as jest.Mock).mockReturnValue({ run: completeRun });
     (deleteLineItemsWorkflow as unknown as jest.Mock).mockReturnValue({ run: jest.fn().mockResolvedValue({ errors: [] }) });
@@ -228,6 +241,7 @@ describe('handleAwaitingDepositProjection', () => {
       if (entity === 'payment_collection') {
         return { data: [{ id: 'pc_1', cart: { id: 'cart_1', completed_at: '2026-06-23T00:00:00Z', metadata: {} } }] };
       }
+      if (entity === 'order_cart') return { data: [{ cart_id: 'cart_1', order_id: 'order_1' }] };
       if (entity === 'cart') {
         const id = (filters as any)?.id;
         if (id === 'cart_1') return { data: [{ id: 'cart_1', metadata: {} }] };
@@ -235,9 +249,13 @@ describe('handleAwaitingDepositProjection', () => {
       return { data: [] };
     };
 
-    const { scope, cartModule } = makeScope({
+    const { scope, cartModule, orderModule } = makeScope({
       paymentModule: {
         listPaymentSessions: jest.fn().mockResolvedValue([{ id: 'payses_1', payment_collection_id: 'pc_1' }]),
+      },
+      orderModule: {
+        retrieveOrder: jest.fn().mockResolvedValue({ id: 'order_1', payment_status: 'captured', metadata: {} }),
+        updateOrders: jest.fn(),
       },
       graph,
     });
@@ -245,7 +263,49 @@ describe('handleAwaitingDepositProjection', () => {
     await handleAwaitingDepositProjection(scope as any, 'intent_bt', 'msg_b', logger as any);
 
     expect(cartModule.updateCarts).not.toHaveBeenCalled();
+    expect(orderModule.updateOrders).not.toHaveBeenCalled();
     expect(completeRun).not.toHaveBeenCalled();
+  });
+
+  it('이미 완료된 cart 의 기존 주문이 uncaptured 면 awaiting_deposit marker 를 보수한다 (P1 회귀)', async () => {
+    const completeRun = jest.fn().mockResolvedValue({ errors: [] });
+    (completeCartWorkflow as unknown as jest.Mock).mockReturnValue({ run: completeRun });
+    (deleteLineItemsWorkflow as unknown as jest.Mock).mockReturnValue({ run: jest.fn().mockResolvedValue({ errors: [] }) });
+
+    const graph: GraphFn = async ({ entity, filters }) => {
+      if (entity === 'payment_collection') {
+        return { data: [{ id: 'pc_1', cart: { id: 'cart_1', completed_at: '2026-06-23T00:00:00Z', metadata: {} } }] };
+      }
+      if (entity === 'order_cart') return { data: [{ cart_id: 'cart_1', order_id: 'order_1' }] };
+      if (entity === 'cart') {
+        const id = (filters as any)?.id;
+        if (id === 'cart_1') return { data: [{ id: 'cart_1', metadata: {} }] };
+      }
+      return { data: [] };
+    };
+    const updateOrders = jest.fn().mockResolvedValue(undefined);
+
+    const { scope, cartModule } = makeScope({
+      paymentModule: {
+        listPaymentSessions: jest.fn().mockResolvedValue([{ id: 'payses_1', payment_collection_id: 'pc_1' }]),
+      },
+      orderModule: {
+        retrieveOrder: jest.fn().mockResolvedValue({ id: 'order_1', payment_status: 'authorized', metadata: {} }),
+        updateOrders,
+      },
+      graph,
+    });
+
+    await handleAwaitingDepositProjection(scope as any, 'intent_bt', 'msg_completed_uncaptured', logger as any);
+
+    expect(cartModule.updateCarts).not.toHaveBeenCalled();
+    expect(completeRun).not.toHaveBeenCalled();
+    expect(updateOrders).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'order_1',
+        metadata: expect.objectContaining({ bank_transfer_status: 'awaiting_deposit' }),
+      }),
+    ]);
   });
 
   it('session 자체가 없으면(비-Medusa intent: 멤버십/빌링 무통장) throw 없이 skip 한다', async () => {

--- a/apps/medusa/src/api/hooks/payment-events/__tests__/payment-events.unit.spec.ts
+++ b/apps/medusa/src/api/hooks/payment-events/__tests__/payment-events.unit.spec.ts
@@ -247,6 +247,23 @@ describe('handleAwaitingDepositProjection', () => {
     expect(cartModule.updateCarts).not.toHaveBeenCalled();
     expect(completeRun).not.toHaveBeenCalled();
   });
+
+  it('session 자체가 없으면(비-Medusa intent: 멤버십/빌링 무통장) throw 없이 skip 한다', async () => {
+    // offline-wait 이벤트는 결제수단(무통장) 기준으로 발행되므로, Medusa 세션이 없는
+    // 멤버십/빌링 무통장 intent 도 이 핸들러에 도달한다. capture/cancel/refund 핸들러처럼
+    // terminal no-op(200) 으로 끝내야 무한 재시도/DLQ 를 피한다.
+    const { scope, cartModule } = makeScope({
+      paymentModule: { listPaymentSessions: jest.fn().mockResolvedValue([]) },
+    });
+
+    await expect(
+      handleAwaitingDepositProjection(scope as any, 'intent_non_medusa', 'msg_no_session', logger as any),
+    ).resolves.toBeUndefined();
+
+    expect(completeCartWorkflow).not.toHaveBeenCalled();
+    expect(cartModule.updateCarts).not.toHaveBeenCalled();
+    expect(deleteLineItemsWorkflow).not.toHaveBeenCalled();
+  });
 });
 
 describe('handleCaptureProjection', () => {

--- a/apps/medusa/src/api/hooks/payment-events/__tests__/payment-events.unit.spec.ts
+++ b/apps/medusa/src/api/hooks/payment-events/__tests__/payment-events.unit.spec.ts
@@ -1,27 +1,65 @@
-import { handleCancelProjection, handleCaptureProjection, handleRefundProjection } from '../route';
+import {
+  handleAwaitingDepositProjection,
+  handleCancelProjection,
+  handleCaptureProjection,
+  handleRefundProjection,
+} from '../route';
 import { capturePaymentWorkflow } from '@medusajs/core-flows';
-import { completeCartWorkflow } from '@medusajs/medusa/core-flows';
+import { completeCartWorkflow, cancelOrderWorkflow, deleteLineItemsWorkflow } from '@medusajs/medusa/core-flows';
 
 // Workflow imports are mocked so importing the route is cheap and we can assert
 // they are NOT invoked on skip paths.
 jest.mock('@medusajs/core-flows', () => ({ capturePaymentWorkflow: jest.fn() }));
-jest.mock('@medusajs/medusa/core-flows', () => ({ completeCartWorkflow: jest.fn() }));
+jest.mock('@medusajs/medusa/core-flows', () => ({
+  completeCartWorkflow: jest.fn(),
+  cancelOrderWorkflow: jest.fn(),
+  deleteLineItemsWorkflow: jest.fn(),
+}));
 
-type PaymentModuleStub = {
-  listPaymentSessions: jest.Mock;
-  listPayments: jest.Mock;
-  updatePayment: jest.Mock;
-};
+type GraphArgs = { entity: string; fields?: string[]; filters?: Record<string, unknown> };
+type GraphFn = (args: GraphArgs) => Promise<{ data: any[] }> | { data: any[] };
 
-function makeScope(paymentModule: Partial<PaymentModuleStub>) {
-  const full: PaymentModuleStub = {
+function makeScope(opts: {
+  paymentModule?: Record<string, unknown>;
+  orderModule?: Record<string, unknown>;
+  cartModule?: Record<string, unknown>;
+  graph?: GraphFn;
+} = {}) {
+  const paymentModule = {
     listPaymentSessions: jest.fn().mockResolvedValue([]),
     listPayments: jest.fn().mockResolvedValue([]),
     updatePayment: jest.fn(),
-    ...paymentModule,
+    ...opts.paymentModule,
   };
-  const scope = { resolve: jest.fn().mockReturnValue(full) };
-  return { scope, paymentModule: full };
+  const orderModule = {
+    retrieveOrder: jest.fn().mockResolvedValue(null),
+    updateOrders: jest.fn(),
+    ...opts.orderModule,
+  };
+  const cartModule = {
+    updateCarts: jest.fn(),
+    ...opts.cartModule,
+  };
+  const query = {
+    graph: jest.fn(opts.graph ?? (async () => ({ data: [] }))),
+  };
+  // Medusa container keys resolve to string tokens: Modules.PAYMENT='payment',
+  // Modules.ORDER='order', Modules.CART='cart', ContainerRegistrationKeys.QUERY='query'.
+  const scope = {
+    resolve: jest.fn((key: string) => {
+      if (key === 'order') return orderModule;
+      if (key === 'cart') return cartModule;
+      if (key === 'query') return query;
+      return paymentModule;
+    }),
+  };
+  return { scope, paymentModule, orderModule, cartModule, query };
+}
+
+function mockCancelOrder(result: { errors?: Array<{ error: unknown }> } = { errors: [] }) {
+  const run = jest.fn().mockResolvedValue(result);
+  (cancelOrderWorkflow as unknown as jest.Mock).mockReturnValue({ run });
+  return run;
 }
 
 const logger = { info: jest.fn(), warn: jest.fn(), debug: jest.fn(), error: jest.fn() };
@@ -31,7 +69,7 @@ beforeEach(() => jest.clearAllMocks());
 describe('handleCancelProjection', () => {
   it('비-Medusa intent(session 없음)는 throw 없이 skip 한다', async () => {
     const { scope, paymentModule } = makeScope({
-      listPaymentSessions: jest.fn().mockResolvedValue([]),
+      paymentModule: { listPaymentSessions: jest.fn().mockResolvedValue([]) },
     });
 
     await expect(
@@ -41,25 +79,180 @@ describe('handleCancelProjection', () => {
     expect(paymentModule.updatePayment).not.toHaveBeenCalled();
   });
 
-  it('실제 Medusa payment가 있으면 canceled_at 으로 표시한다 (회귀 가드)', async () => {
-    const payment = { id: 'pay_1', canceled_at: null, metadata: {} };
+  it('payment 있고 주문이 없으면 canceled_at 으로 표시한다 (회귀 가드)', async () => {
+    const payment = { id: 'pay_1', canceled_at: null, captured_at: null, metadata: {} };
     const { scope, paymentModule } = makeScope({
-      listPaymentSessions: jest.fn().mockResolvedValue([{ id: 'payses_1' }]),
-      listPayments: jest.fn().mockResolvedValue([payment]),
+      paymentModule: {
+        listPaymentSessions: jest.fn().mockResolvedValue([{ id: 'payses_1' }]),
+        listPayments: jest.fn().mockResolvedValue([payment]),
+      },
+      // graph 기본값 {data:[]} → payment_collection 조회 빈 결과 → 주문 없음
     });
 
     await handleCancelProjection(scope as any, 'intent_medusa', 'msg_4', logger as any);
 
+    expect(cancelOrderWorkflow).not.toHaveBeenCalled();
     expect(paymentModule.updatePayment).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'pay_1', canceled_at: expect.any(Date) }),
     );
+  });
+
+  it('미입금(미capture) 선생성 주문이 있으면 주문을 취소하고 payment 를 취소 표시한다', async () => {
+    const payment = { id: 'pay_1', canceled_at: null, captured_at: null, metadata: {} };
+    const runCancel = mockCancelOrder({ errors: [] });
+    const graph: GraphFn = async ({ entity }) => {
+      if (entity === 'payment_collection') return { data: [{ id: 'pc_1', cart: { id: 'cart_1' } }] };
+      if (entity === 'order_cart') return { data: [{ cart_id: 'cart_1', order_id: 'order_1' }] };
+      return { data: [] };
+    };
+    const { scope, paymentModule, orderModule } = makeScope({
+      paymentModule: {
+        listPaymentSessions: jest.fn().mockResolvedValue([{ id: 'payses_1', payment_collection_id: 'pc_1' }]),
+        listPayments: jest.fn().mockResolvedValue([payment]),
+      },
+      orderModule: { retrieveOrder: jest.fn().mockResolvedValue({ id: 'order_1', status: 'pending' }) },
+      graph,
+    });
+
+    await handleCancelProjection(scope as any, 'intent_bt', 'msg_5', logger as any);
+
+    expect(runCancel).toHaveBeenCalledWith(
+      expect.objectContaining({ input: expect.objectContaining({ order_id: 'order_1' }) }),
+    );
+    expect(paymentModule.updatePayment).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'pay_1', canceled_at: expect.any(Date) }),
+    );
+    expect(orderModule.retrieveOrder).toHaveBeenCalled();
+  });
+
+  it('주문 취소가 실패하면 throw 하고(재시도 가능) payment 는 취소 표시하지 않는다', async () => {
+    const payment = { id: 'pay_1', canceled_at: null, captured_at: null, metadata: {} };
+    mockCancelOrder({ errors: [{ error: new Error('boom') }] });
+    const graph: GraphFn = async ({ entity }) => {
+      if (entity === 'payment_collection') return { data: [{ id: 'pc_1', cart: { id: 'cart_1' } }] };
+      if (entity === 'order_cart') return { data: [{ cart_id: 'cart_1', order_id: 'order_1' }] };
+      return { data: [] };
+    };
+    const { scope, paymentModule } = makeScope({
+      paymentModule: {
+        listPaymentSessions: jest.fn().mockResolvedValue([{ id: 'payses_1', payment_collection_id: 'pc_1' }]),
+        listPayments: jest.fn().mockResolvedValue([payment]),
+      },
+      orderModule: { retrieveOrder: jest.fn().mockResolvedValue({ id: 'order_1', status: 'pending' }) },
+      graph,
+    });
+
+    await expect(
+      handleCancelProjection(scope as any, 'intent_bt', 'msg_6', logger as any),
+    ).rejects.toThrow(/cancelOrderWorkflow failed/);
+
+    expect(paymentModule.updatePayment).not.toHaveBeenCalled();
+  });
+
+  it('이미 capture(입금확정)된 주문은 취소하지 않는다', async () => {
+    const payment = { id: 'pay_1', canceled_at: null, captured_at: new Date(), metadata: {} };
+    const runCancel = mockCancelOrder({ errors: [] });
+    const { scope } = makeScope({
+      paymentModule: {
+        listPaymentSessions: jest.fn().mockResolvedValue([{ id: 'payses_1' }]),
+        listPayments: jest.fn().mockResolvedValue([payment]),
+      },
+    });
+
+    await handleCancelProjection(scope as any, 'intent_captured', 'msg_7', logger as any);
+
+    expect(runCancel).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleAwaitingDepositProjection', () => {
+  it('주문 생성(completeCartWorkflow) 전에 cart 에 awaiting_deposit marker 를 원자적으로 심는다', async () => {
+    const completeRun = jest.fn().mockResolvedValue({ errors: [] });
+    (completeCartWorkflow as unknown as jest.Mock).mockReturnValue({ run: completeRun });
+    const deleteRun = jest.fn().mockResolvedValue({ errors: [] });
+    (deleteLineItemsWorkflow as unknown as jest.Mock).mockReturnValue({ run: deleteRun });
+
+    const graph: GraphFn = async ({ entity, filters }) => {
+      if (entity === 'payment_collection') {
+        return {
+          data: [
+            {
+              id: 'pc_1',
+              cart: { id: 'cart_1', completed_at: null, metadata: { source_cart_id: 'src_1', source_line_item_ids: ['li_1'] } },
+            },
+          ],
+        };
+      }
+      if (entity === 'order_cart') return { data: [] };
+      if (entity === 'cart') {
+        const id = (filters as any)?.id;
+        if (id === 'cart_1') return { data: [{ id: 'cart_1', metadata: { source_cart_id: 'src_1', source_line_item_ids: ['li_1'] } }] };
+        if (id === 'src_1') return { data: [{ id: 'src_1', completed_at: null, items: [{ id: 'li_1' }] }] };
+      }
+      return { data: [] };
+    };
+
+    const { scope, cartModule } = makeScope({
+      paymentModule: {
+        listPaymentSessions: jest.fn().mockResolvedValue([{ id: 'payses_1', payment_collection_id: 'pc_1' }]),
+        listPayments: jest.fn().mockResolvedValue([]),
+      },
+      graph,
+    });
+
+    await handleAwaitingDepositProjection(scope as any, 'intent_bt', 'msg_a', logger as any);
+
+    // marker 가 cart.metadata 에 심긴다 (completeCartWorkflow 가 order 로 복사 → 원자적)
+    expect(cartModule.updateCarts).toHaveBeenCalledWith(
+      'cart_1',
+      expect.objectContaining({
+        metadata: expect.objectContaining({ bank_transfer_status: 'awaiting_deposit' }),
+      }),
+    );
+    // 순서 보장: marker(updateCarts) → 주문 생성(completeCartWorkflow). marker 없는 authorized 주문 창 없음.
+    expect((cartModule.updateCarts as jest.Mock).mock.invocationCallOrder[0]).toBeLessThan(
+      completeRun.mock.invocationCallOrder[0],
+    );
+    // 원본 카트 정리도 실행 (구매한 라인 삭제)
+    expect(deleteRun).toHaveBeenCalledWith(
+      expect.objectContaining({ input: { cart_id: 'src_1', ids: ['li_1'] } }),
+    );
+  });
+
+  it('이미 완료된 cart(이벤트 순서 역전: capture 선처리)면 marker 를 심지 않는다', async () => {
+    const completeRun = jest.fn().mockResolvedValue({ errors: [] });
+    (completeCartWorkflow as unknown as jest.Mock).mockReturnValue({ run: completeRun });
+    (deleteLineItemsWorkflow as unknown as jest.Mock).mockReturnValue({ run: jest.fn().mockResolvedValue({ errors: [] }) });
+
+    const graph: GraphFn = async ({ entity, filters }) => {
+      if (entity === 'payment_collection') {
+        return { data: [{ id: 'pc_1', cart: { id: 'cart_1', completed_at: '2026-06-23T00:00:00Z', metadata: {} } }] };
+      }
+      if (entity === 'cart') {
+        const id = (filters as any)?.id;
+        if (id === 'cart_1') return { data: [{ id: 'cart_1', metadata: {} }] };
+      }
+      return { data: [] };
+    };
+
+    const { scope, cartModule } = makeScope({
+      paymentModule: {
+        listPaymentSessions: jest.fn().mockResolvedValue([{ id: 'payses_1', payment_collection_id: 'pc_1' }]),
+      },
+      graph,
+    });
+
+    await handleAwaitingDepositProjection(scope as any, 'intent_bt', 'msg_b', logger as any);
+
+    expect(cartModule.updateCarts).not.toHaveBeenCalled();
+    expect(completeRun).not.toHaveBeenCalled();
   });
 });
 
 describe('handleCaptureProjection', () => {
   it('session 자체가 없으면 무통장 복구를 시도하지 않고 skip 한다', async () => {
     const { scope } = makeScope({
-      listPaymentSessions: jest.fn().mockResolvedValue([]),
+      paymentModule: { listPaymentSessions: jest.fn().mockResolvedValue([]) },
     });
 
     await expect(
@@ -68,13 +261,14 @@ describe('handleCaptureProjection', () => {
 
     expect(completeCartWorkflow).not.toHaveBeenCalled();
     expect(capturePaymentWorkflow).not.toHaveBeenCalled();
+    expect(deleteLineItemsWorkflow).not.toHaveBeenCalled();
   });
 });
 
 describe('handleRefundProjection', () => {
   it('Medusa payment 없으면 throw 없이 skip 한다', async () => {
     const { scope, paymentModule } = makeScope({
-      listPaymentSessions: jest.fn().mockResolvedValue([]),
+      paymentModule: { listPaymentSessions: jest.fn().mockResolvedValue([]) },
     });
 
     await expect(

--- a/apps/medusa/src/api/hooks/payment-events/__tests__/payment-events.unit.spec.ts
+++ b/apps/medusa/src/api/hooks/payment-events/__tests__/payment-events.unit.spec.ts
@@ -263,6 +263,60 @@ describe('handleCaptureProjection', () => {
     expect(capturePaymentWorkflow).not.toHaveBeenCalled();
     expect(deleteLineItemsWorkflow).not.toHaveBeenCalled();
   });
+
+  // 선생성된 무통장 주문의 입금확인 경로. capturePaymentWorkflow 는 order 행의 updated_at 을
+  // 건드리지 않으므로(payment capture + order_transaction insert + order_summary update 뿐),
+  // 'confirmed' metadata 갱신(updateOrders)이 capture 이후 order.updated_at 을 올리는 유일한
+  // 쓰기다. 이 게 best-effort 로 삼켜지면 결제된 주문이 channel-adapter watermark 에 추월당해
+  // 영영 수집되지 않을 수 있다 → 실패는 propagate 되어 hook 이 재시도해야 한다.
+  function makeCaptureScope(updateOrders: jest.Mock) {
+    (capturePaymentWorkflow as unknown as jest.Mock).mockReturnValue({
+      run: jest.fn().mockResolvedValue({}),
+    });
+    const payment = { id: 'pay_1', captured_at: null, data: {} };
+    const graph: GraphFn = async ({ entity, filters }) => {
+      if (entity === 'payment_collection') return { data: [{ id: 'pc_1', cart: { id: 'cart_1' } }] };
+      if (entity === 'order_cart') return { data: [{ cart_id: 'cart_1', order_id: 'order_1' }] };
+      // cleanupSourceCartItems: checkout cart 에 source_cart_id 없음 → no-op
+      if (entity === 'cart') return { data: [{ id: 'cart_1', metadata: {} }] };
+      return { data: [] };
+    };
+    return makeScope({
+      paymentModule: {
+        listPaymentSessions: jest.fn().mockResolvedValue([{ id: 'payses_1', payment_collection_id: 'pc_1' }]),
+        listPayments: jest.fn().mockResolvedValue([payment]),
+        updatePayment: jest.fn(),
+      },
+      orderModule: {
+        retrieveOrder: jest.fn().mockResolvedValue({ id: 'order_1', metadata: { bank_transfer_status: 'awaiting_deposit' } }),
+        updateOrders: updateOrders,
+      },
+      graph,
+    });
+  }
+
+  it("입금확인(capture) 후 awaiting_deposit → confirmed 로 order.updated_at 을 bump 한다", async () => {
+    const updateOrders = jest.fn().mockResolvedValue(undefined);
+    const { scope } = makeCaptureScope(updateOrders);
+
+    await handleCaptureProjection(scope as any, 'intent_bt', 'msg_cap', logger as any);
+
+    expect(updateOrders).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'order_1',
+        metadata: expect.objectContaining({ bank_transfer_status: 'confirmed' }),
+      }),
+    ]);
+  });
+
+  it('confirmed metadata 갱신(updateOrders) 실패 시 throw 하여 hook 이 재시도하게 한다 (P2 회귀)', async () => {
+    const updateOrders = jest.fn().mockRejectedValue(new Error('order metadata write failed'));
+    const { scope } = makeCaptureScope(updateOrders);
+
+    await expect(
+      handleCaptureProjection(scope as any, 'intent_bt', 'msg_cap_fail', logger as any),
+    ).rejects.toThrow(/order metadata write failed/);
+  });
 });
 
 describe('handleRefundProjection', () => {

--- a/apps/medusa/src/api/hooks/payment-events/route.ts
+++ b/apps/medusa/src/api/hooks/payment-events/route.ts
@@ -424,6 +424,19 @@ export async function handleAwaitingDepositProjection(
   messageId: string,
   logger: { info: Function; warn: Function; debug: Function; error: Function },
 ) {
+  // offline-wait 이벤트는 채널이 아니라 결제수단(무통장) 기준으로 발행되므로, Medusa 체크아웃에서
+  // 비롯되지 않은 intent(멤버십/빌링 무통장 — Medusa 세션이 애초에 없음)도 여기에 도달한다.
+  // 그런 intent 는 선생성할 cart 가 없다. capture/cancel/refund 핸들러와 동일하게 terminal no-op
+  // (200 응답) 으로 끝내 무한 재시도/DLQ 를 피한다. 세션이 있으면 정상 무통장 복구를 진행한다.
+  const paymentModule = scope.resolve(Modules.PAYMENT);
+  const sessionId = await resolvePaymentSessionId(paymentModule, intentId);
+  if (!sessionId) {
+    logger.info(
+      `[payment-events] handleAwaitingDepositProjection: no Medusa payment session for intentId=${intentId}, skipping (messageId=${messageId})`,
+    );
+    return;
+  }
+
   // 주문을 '입금확인중'(awaiting_deposit) marker 와 함께 원자적으로 선생성.
   // marker 는 recoverBankTransferOrder 가 cart.metadata 에 심고 completeCartWorkflow 가 order.metadata
   // 로 복사하므로(=주문 생성과 marker 가 분리되지 않음), marker 없는 authorized 주문이 WMS 수집 게이트를 통과하는 창이 존재하지 않음.

--- a/apps/medusa/src/api/hooks/payment-events/route.ts
+++ b/apps/medusa/src/api/hooks/payment-events/route.ts
@@ -553,7 +553,13 @@ async function cleanupSourceCartItems(scope: any, intentId: string, logger: { in
  * 무통장 선생성 주문의 입금 상태 메타데이터(bank_transfer_status)를 갱신.
  * - 'awaiting_deposit' (선생성 시): 무조건 설정.
  * - 'confirmed' (입금확인 capture 시): onlyIfAwaiting 으로, 기존이 'awaiting_deposit' 인 무통장 주문에만 설정(카드 주문/복구 폴백 주문은 건드리지 않음).
- * best-effort — 실패해도 결제 projection 자체를 막지 않음.
+ *
+ * 실패는 swallow 하지 않고 propagate 한다(=재시도 가능). capturePaymentWorkflow 는 order 행을
+ * 건드리지 않으므로(payment capture + order_transaction insert + order_summary update 뿐), capture
+ * 이후 order.updated_at 을 올리는 유일한 쓰기가 이 updateOrders 다. channel-adapter 폴러는
+ * order.updated_at 으로 watermark 를 전진시키므로(증분 수집), 이 갱신을 best-effort 로 삼키면
+ * 결제된(captured) 주문이 watermark 에 추월당해 영영 수집(출고)되지 않을 수 있다. 따라서 throw →
+ * outer handler 500 → 재배달 시 handleCaptureProjection 이 captured_at 가드로 멱등 재진입해 재시도한다.
  */
 async function updateBankTransferOrderStatus(
   scope: any,
@@ -562,36 +568,31 @@ async function updateBankTransferOrderStatus(
   logger: { info: Function; warn: Function; debug: Function; error: Function },
   opts: { onlyIfAwaiting?: boolean } = {},
 ): Promise<void> {
-  try {
-    const orderId = await resolveOrderIdForIntent(scope, intentId);
-    if (!orderId) {
-      logger.warn(
-        `[payment-events] updateBankTransferOrderStatus: no order for intentId=${intentId}, skipping (status=${status})`,
-      );
-      return;
-    }
-    const orderModule = scope.resolve(Modules.ORDER);
-    const order = await orderModule.retrieveOrder(orderId, { select: ['id', 'metadata'] });
-    const meta = (order?.metadata as Record<string, unknown>) ?? {};
-    if (opts.onlyIfAwaiting && meta.bank_transfer_status !== 'awaiting_deposit') {
-      return;
-    }
-    // 방어: 이미 입금확정(confirmed)된 주문을 다시 '입금확인중' 으로 되돌리지 않음.
-    if (status === 'awaiting_deposit' && meta.bank_transfer_status === 'confirmed') {
-      return;
-    }
-    await orderModule.updateOrders([
-      { id: orderId, metadata: { ...meta, bank_transfer_status: status } },
-    ]);
-    logger.info(
-      `[payment-events] updateBankTransferOrderStatus: order ${orderId} bank_transfer_status=${status} (intentId=${intentId})`,
-    );
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    logger.error(
-      `[payment-events] updateBankTransferOrderStatus failed intentId=${intentId} status=${status}: ${msg}`,
+  const orderId = await resolveOrderIdForIntent(scope, intentId);
+  if (!orderId) {
+    // capture 이후엔 payment 행 존재 = 완료된 cart = 주문 존재가 보장된다. 여기서 null 이면
+    // 일시적 lookup 실패(order_cart 링크 eventual consistency 등)일 가능성이 높으므로 조용히
+    // 삼키지 말고 throw 해 재시도되게 한다 — load-bearing updated_at bump 의 silent 누락 방지.
+    throw new Error(
+      `[payment-events] updateBankTransferOrderStatus: no order for intentId=${intentId} (status=${status})`,
     );
   }
+  const orderModule = scope.resolve(Modules.ORDER);
+  const order = await orderModule.retrieveOrder(orderId, { select: ['id', 'metadata'] });
+  const meta = (order?.metadata as Record<string, unknown>) ?? {};
+  if (opts.onlyIfAwaiting && meta.bank_transfer_status !== 'awaiting_deposit') {
+    return;
+  }
+  // 방어: 이미 입금확정(confirmed)된 주문을 다시 '입금확인중' 으로 되돌리지 않음.
+  if (status === 'awaiting_deposit' && meta.bank_transfer_status === 'confirmed') {
+    return;
+  }
+  await orderModule.updateOrders([
+    { id: orderId, metadata: { ...meta, bank_transfer_status: status } },
+  ]);
+  logger.info(
+    `[payment-events] updateBankTransferOrderStatus: order ${orderId} bank_transfer_status=${status} (intentId=${intentId})`,
+  );
 }
 
 export async function handleCaptureProjection(

--- a/apps/medusa/src/api/hooks/payment-events/route.ts
+++ b/apps/medusa/src/api/hooks/payment-events/route.ts
@@ -437,12 +437,16 @@ export async function handleAwaitingDepositProjection(
     return;
   }
 
-  // 주문을 '입금확인중'(awaiting_deposit) marker 와 함께 원자적으로 선생성.
-  // marker 는 recoverBankTransferOrder 가 cart.metadata 에 심고 completeCartWorkflow 가 order.metadata
-  // 로 복사하므로(=주문 생성과 marker 가 분리되지 않음), marker 없는 authorized 주문이 WMS 수집 게이트를 통과하는 창이 존재하지 않음.
-  //
-  // 이벤트 순서 역전(관리자 즉시 입금확인 → capture 가 먼저 처리되어 주문이 이미 완료)인 경우, recoverBankTransferOrder 가 cart.completed_at 으로 멱등 skip 하여 marker 를 심지 않음(그 주문은 captured 라 게이트가 payment_status 로 정상 수집한다). 따라서 별도의 captured 가드 불필요.
+  // 주문을 '입금확인중'(awaiting_deposit) marker 와 함께 선생성.
+  // 정상 경로는 recoverBankTransferOrder 가 cart.metadata 에 marker 를 심고 completeCartWorkflow 가
+  // order.metadata 로 복사한다. 단, HTTP complete 가 웹훅보다 먼저 성공한 레이스에서는 이미
+  // marker 없는 authorized 주문이 있을 수 있으므로 recover 의 멱등 skip 이후 order marker 를
+  // 한 번 더 보장한다. captured 주문은 payment_status 로 WMS 수집 가능하므로 awaiting marker 를
+  // 뒤늦게 심지 않는다.
   await recoverBankTransferOrder(scope, intentId, messageId, logger, /* markAwaitingDeposit */ true);
+  await updateBankTransferOrderStatus(scope, intentId, 'awaiting_deposit', logger, {
+    skipIfCaptured: true,
+  });
 
   // 원본 장바구니에서 구매한 아이템 제거. 무통장은 callback 을 안 타므로 서버사이드에서 정리
   // 실패해도 주문엔 이미 marker 가 있어 WMS 수집은 막힌 채 재시도됨.
@@ -564,22 +568,20 @@ async function cleanupSourceCartItems(scope: any, intentId: string, logger: { in
 
 /**
  * 무통장 선생성 주문의 입금 상태 메타데이터(bank_transfer_status)를 갱신.
- * - 'awaiting_deposit' (선생성 시): 무조건 설정.
+ * - 'awaiting_deposit' (선생성/복구 시): uncaptured 주문에 marker 가 없으면 설정.
  * - 'confirmed' (입금확인 capture 시): onlyIfAwaiting 으로, 기존이 'awaiting_deposit' 인 무통장 주문에만 설정(카드 주문/복구 폴백 주문은 건드리지 않음).
  *
- * 실패는 swallow 하지 않고 propagate 한다(=재시도 가능). capturePaymentWorkflow 는 order 행을
- * 건드리지 않으므로(payment capture + order_transaction insert + order_summary update 뿐), capture
- * 이후 order.updated_at 을 올리는 유일한 쓰기가 이 updateOrders 다. channel-adapter 폴러는
- * order.updated_at 으로 watermark 를 전진시키므로(증분 수집), 이 갱신을 best-effort 로 삼키면
- * 결제된(captured) 주문이 watermark 에 추월당해 영영 수집(출고)되지 않을 수 있다. 따라서 throw →
- * outer handler 500 → 재배달 시 handleCaptureProjection 이 captured_at 가드로 멱등 재진입해 재시도한다.
+ * 실패는 swallow 하지 않고 propagate 한다(=재시도 가능). awaiting_deposit 은 marker 없는 authorized
+ * 주문이 WMS 게이트를 통과하지 못하게 하는 load-bearing write 고, confirmed 는 capture 이후
+ * order.updated_at 을 올리는 load-bearing write 다. 따라서 throw → outer handler 500 → 재배달 시
+ * 각 핸들러가 멱등 재진입해 재시도한다.
  */
 async function updateBankTransferOrderStatus(
   scope: any,
   intentId: string,
   status: 'awaiting_deposit' | 'confirmed',
   logger: { info: Function; warn: Function; debug: Function; error: Function },
-  opts: { onlyIfAwaiting?: boolean } = {},
+  opts: { onlyIfAwaiting?: boolean; skipIfCaptured?: boolean } = {},
 ): Promise<void> {
   const orderId = await resolveOrderIdForIntent(scope, intentId);
   if (!orderId) {
@@ -591,9 +593,25 @@ async function updateBankTransferOrderStatus(
     );
   }
   const orderModule = scope.resolve(Modules.ORDER);
-  const order = await orderModule.retrieveOrder(orderId, { select: ['id', 'metadata'] });
+  const order = (await orderModule.retrieveOrder(orderId, {
+    select: ['id', 'metadata', 'payment_status'],
+  })) as { id: string; metadata?: Record<string, unknown> | null; payment_status?: string | null } | null;
+  if (!order) {
+    throw new Error(
+      `[payment-events] updateBankTransferOrderStatus: retrieveOrder returned empty for order ${orderId} intentId=${intentId} (status=${status})`,
+    );
+  }
+  if (opts.skipIfCaptured && order.payment_status === 'captured') {
+    logger.debug(
+      `[payment-events] updateBankTransferOrderStatus: order ${orderId} already captured, skipping ${status} marker (intentId=${intentId})`,
+    );
+    return;
+  }
   const meta = (order?.metadata as Record<string, unknown>) ?? {};
   if (opts.onlyIfAwaiting && meta.bank_transfer_status !== 'awaiting_deposit') {
+    return;
+  }
+  if (meta.bank_transfer_status === status) {
     return;
   }
   // 방어: 이미 입금확정(confirmed)된 주문을 다시 '입금확인중' 으로 되돌리지 않음.

--- a/apps/medusa/src/api/hooks/payment-events/route.ts
+++ b/apps/medusa/src/api/hooks/payment-events/route.ts
@@ -1,5 +1,5 @@
 import { MedusaRequest, MedusaResponse } from '@medusajs/framework/http';
-import { ContainerRegistrationKeys, Modules } from '@medusajs/framework/utils';
+import { ContainerRegistrationKeys, MedusaError, Modules } from '@medusajs/framework/utils';
 import { capturePaymentWorkflow } from '@medusajs/core-flows';
 import { completeCartWorkflow, cancelOrderWorkflow, deleteLineItemsWorkflow } from '@medusajs/medusa/core-flows';
 
@@ -147,9 +147,23 @@ export async function handleCancelProjection(
     const orderId = await resolveOrderIdForIntent(scope, intentId);
     if (orderId) {
       const orderModule = scope.resolve(Modules.ORDER);
-      const order = await orderModule
-        .retrieveOrder(orderId, { select: ['id', 'status'] })
-        .catch(() => null);
+      // 일시적 lookup 오류를 null 로 삼키면 안 됨: cancelOrderWorkflow 를 건너뛴 채 아래에서
+      // payment.canceled_at 을 찍어버려 위 가드(payment.canceled_at)에 걸리고, 재배달 시 주문 취소를
+      // 다시 시도하지 못해 고아 주문 + 예약재고 누수가 영구화된다(위 워크플로 실패 경로와 동일한 불변식).
+      // 따라서 NotFound(이미 하드삭제돼 취소 대상이 없는 주문)만 no-op 로 통과시키고, 그 외 오류는
+      // throw → outer handler 500 → 재배달 시 재시도되게 한다.
+      let order: { id: string; status: string } | null = null;
+      try {
+        order = await orderModule.retrieveOrder(orderId, { select: ['id', 'status'] });
+      } catch (lookupErr) {
+        if (lookupErr instanceof MedusaError && lookupErr.type === MedusaError.Types.NOT_FOUND) {
+          logger.info(
+            `[payment-events] handleCancelProjection: order ${orderId} not found (already deleted), skipping order cancel. intentId=${intentId}`,
+          );
+        } else {
+          throw lookupErr;
+        }
+      }
       if (order && order.status !== 'canceled') {
         const { errors } = await cancelOrderWorkflow(scope).run({
           input: { order_id: orderId, no_notification: true },

--- a/apps/medusa/src/api/hooks/payment-events/route.ts
+++ b/apps/medusa/src/api/hooks/payment-events/route.ts
@@ -1,7 +1,7 @@
 import { MedusaRequest, MedusaResponse } from '@medusajs/framework/http';
 import { ContainerRegistrationKeys, Modules } from '@medusajs/framework/utils';
 import { capturePaymentWorkflow } from '@medusajs/core-flows';
-import { completeCartWorkflow } from '@medusajs/medusa/core-flows';
+import { completeCartWorkflow, cancelOrderWorkflow, deleteLineItemsWorkflow } from '@medusajs/medusa/core-flows';
 
 // Process-level idempotency store (in-memory, resets on restart).
 // DB-backed persistence is a follow-up (idempotency_keys table or payment_events table).
@@ -13,6 +13,11 @@ const CAPTURE_EVENT_TYPES = new Set([
   'payment.intent.captured',
   'payment.intent.succeeded',
   'PaymentCaptured',
+]);
+
+// 무통장입금 입금 대기 진입 — 주문을 '입금확인중' 으로 선생성
+const AWAITING_DEPOSIT_EVENT_TYPES = new Set([
+  'payment.intent.awaiting_deposit',
 ]);
 
 const CANCEL_EVENT_TYPES = new Set([
@@ -70,6 +75,8 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   try {
     if (CAPTURE_EVENT_TYPES.has(effectiveEventType)) {
       await handleCaptureProjection(req.scope, intentId, messageId, logger);
+    } else if (AWAITING_DEPOSIT_EVENT_TYPES.has(effectiveEventType)) {
+      await handleAwaitingDepositProjection(req.scope, intentId, messageId, logger);
     } else if (CANCEL_EVENT_TYPES.has(effectiveEventType)) {
       await handleCancelProjection(req.scope, intentId, messageId, logger);
     } else if (REFUND_EVENT_TYPES.has(effectiveEventType)) {
@@ -102,7 +109,7 @@ export async function handleCancelProjection(
   scope: any,
   intentId: string,
   messageId: string,
-  logger: { info: Function; warn: Function; debug: Function },
+  logger: { info: Function; warn: Function; debug: Function; error: Function },
 ) {
   const paymentModule = scope.resolve(Modules.PAYMENT);
   const sessionId = await resolvePaymentSessionId(paymentModule, intentId);
@@ -128,12 +135,56 @@ export async function handleCancelProjection(
     return;
   }
 
+  // 무통장 선생성 주문 정리. 미입금 취소/만료(payment.intent.canceled) 시 아직 입금
+  // 확정(capture)되지 않은 주문이면 주문을 취소하고 예약재고를 해제한다. cancelOrderWorkflow 가
+  // 주문 상태 변경 + 재고 예약 해제 + 결제 취소를 함께 처리한다(almond-payment.cancelPayment 는
+  // 이미 취소된 wallet intent 에 대해 no-op 이므로 충돌 없음). 입금 확정된 주문은 취소하지 않음.
+  //
+  // 중요: payment.canceled_at 표시보다 '먼저' 주문을 취소하고, 취소 실패 시 throw. payment 를
+  // 먼저 취소해버리면 위 가드(payment.canceled_at)에 걸려 재배달 시 주문 취소를 다시 시도하지 못해
+  // 고아 주문 + 예약재고 누수가 영구화됨. throw → outer handler 500 → 재배달 시 재시도됨.
+  if (!payment.captured_at) {
+    const orderId = await resolveOrderIdForIntent(scope, intentId);
+    if (orderId) {
+      const orderModule = scope.resolve(Modules.ORDER);
+      const order = await orderModule
+        .retrieveOrder(orderId, { select: ['id', 'status'] })
+        .catch(() => null);
+      if (order && order.status !== 'canceled') {
+        const { errors } = await cancelOrderWorkflow(scope).run({
+          input: { order_id: orderId, no_notification: true },
+          throwOnError: false,
+        });
+        if (errors?.length) {
+          const emsg = (errors[0]?.error as any)?.message ?? String(errors[0]?.error);
+          // retryable failure — payment 는 아직 canceled 로 표시하지 않은 상태이므로 안전하게 재시도됨.
+          throw new Error(
+            `[payment-events] handleCancelProjection: cancelOrderWorkflow failed for order ${orderId} intentId=${intentId}: ${emsg}`,
+          );
+        }
+        logger.info(
+          `[payment-events] handleCancelProjection: canceled order ${orderId} for unpaid intentId=${intentId}`,
+        );
+      }
+    }
+  }
+
+  // 주문 취소 성공(또는 주문 없음/카드/이미 취소) 후에만 payment projection 을 취소로 표시.
+  // cancelOrderWorkflow 가 결제까지 취소해 canceled_at 이 이미 찍혔으면 중복 표시를 피함.
+  const latest = (await paymentModule.listPayments({ id: payment.id }, {}))[0] ?? payment;
+  if (latest.canceled_at) {
+    logger.info(
+      `[payment-events] handleCancelProjection: payment_id=${payment.id} already canceled by workflow for intentId=${intentId}`,
+    );
+    return;
+  }
+
   // updatePayment is a DB-only operation — no provider side effect
   await paymentModule.updatePayment({
     id: payment.id,
     canceled_at: new Date(),
     metadata: {
-      ...((payment.metadata as object) ?? {}),
+      ...((latest.metadata as object) ?? {}),
       walletCancelMessageId: messageId,
     },
   });
@@ -344,11 +395,196 @@ async function resolvePaymentSessionId(
   return (sessions[0] as any)?.id ?? null;
 }
 
+/**
+ * 무통장입금 입금 대기 진입(payment.intent.awaiting_deposit) 시 주문을 '입금확인중' 으로 선생성.
+ *
+ * recoverBankTransferOrder 가 completeCartWorkflow 로 주문을 만든다 — almond-payment 가
+ * AWAITING_DEPOSIT 을 'authorized' 로 매핑하므로 cart 완료가 가능하다(결제는 authorized 상태,
+ * 실제 capture 는 관리자 입금확인 INTENT_CAPTURED 시점). 생성된 주문에는 metadata.bank_transfer_status='awaiting_deposit' 를 달아 storefront 주문내역에서 '입금확인중' 으로 표시.
+ *
+ * 멱등성: recoverBankTransferOrder 가 cart.completed_at / order_cart link 로 중복 생성을 막고, 이벤트가 유실돼도 입금확인(capture) 시 동일 복구 경로가 주문을 만든다(graceful degradation).
+ */
+export async function handleAwaitingDepositProjection(
+  scope: any,
+  intentId: string,
+  messageId: string,
+  logger: { info: Function; warn: Function; debug: Function; error: Function },
+) {
+  // 주문을 '입금확인중'(awaiting_deposit) marker 와 함께 원자적으로 선생성.
+  // marker 는 recoverBankTransferOrder 가 cart.metadata 에 심고 completeCartWorkflow 가 order.metadata
+  // 로 복사하므로(=주문 생성과 marker 가 분리되지 않음), marker 없는 authorized 주문이 WMS 수집 게이트를 통과하는 창이 존재하지 않음.
+  //
+  // 이벤트 순서 역전(관리자 즉시 입금확인 → capture 가 먼저 처리되어 주문이 이미 완료)인 경우, recoverBankTransferOrder 가 cart.completed_at 으로 멱등 skip 하여 marker 를 심지 않음(그 주문은 captured 라 게이트가 payment_status 로 정상 수집한다). 따라서 별도의 captured 가드 불필요.
+  await recoverBankTransferOrder(scope, intentId, messageId, logger, /* markAwaitingDeposit */ true);
+
+  // 원본 장바구니에서 구매한 아이템 제거. 무통장은 callback 을 안 타므로 서버사이드에서 정리
+  // 실패해도 주문엔 이미 marker 가 있어 WMS 수집은 막힌 채 재시도됨.
+  await cleanupSourceCartItems(scope, intentId, logger);
+}
+
+/**
+ * intentId 로 선생성된 Medusa 주문 ID 를 역추적.
+ * intent → payment_session(data.intentId) → payment_collection → cart → order_cart link
+ * 주문이 아직 없으면 null.
+ */
+async function resolveOrderIdForIntent(scope: any, intentId: string): Promise<string | null> {
+  const paymentModule = scope.resolve(Modules.PAYMENT);
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY);
+
+  const sessions = await paymentModule.listPaymentSessions(
+    { data: { intentId } } as any,
+    { select: ['id', 'payment_collection_id'] },
+  );
+  const session = sessions[0];
+  if (!session) return null;
+
+  const { data: collections } = await query.graph({
+    entity: 'payment_collection',
+    fields: ['id', 'cart.id'],
+    filters: { id: (session as any).payment_collection_id },
+  });
+  const cartId = (collections[0] as any)?.cart?.id as string | undefined;
+  if (!cartId) return null;
+
+  const { data: orderCartLinks } = await query.graph({
+    entity: 'order_cart',
+    fields: ['cart_id', 'order_id'],
+    filters: { cart_id: cartId },
+  });
+  return ((orderCartLinks[0] as any)?.order_id as string | undefined) ?? null;
+}
+
+/**
+ * intentId 로 결제용 checkout cart ID 를 역추적.
+ * intent → payment_session(data.intentId) → payment_collection → cart.
+ */
+async function resolveCheckoutCartIdForIntent(scope: any, intentId: string): Promise<string | null> {
+  const paymentModule = scope.resolve(Modules.PAYMENT);
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY);
+
+  const sessions = await paymentModule.listPaymentSessions(
+    { data: { intentId } } as any,
+    { select: ['id', 'payment_collection_id'] },
+  );
+  const session = sessions[0];
+  if (!session) return null;
+
+  const { data: collections } = await query.graph({
+    entity: 'payment_collection',
+    fields: ['id', 'cart.id'],
+    filters: { id: (session as any).payment_collection_id },
+  });
+  return ((collections[0] as any)?.cart?.id as string | undefined) ?? null;
+}
+
+/**
+ * 무통장입금 주문 선생성 직후, 고객이 보던 원본 장바구니에서 구매한 아이템을 제거.
+ *
+ * 카드 결제는 브라우저 callback(processPaymentCallback)에서 source cart 를 정리하지만, 무통장은
+ * wallet-web 입금대기 화면에서 멈춰 callback 을 타지 않으므로 원본 장바구니가 그대로 남는다.
+ * checkout cart 의 metadata.source_cart_id / source_line_item_ids 를 기준으로 서버사이드에서 제거.
+ *
+ * 멱등성: 원본 카트에 현재 존재하는 라인만 골라 삭제하므로 재시도해도 안전(이미 지워졌으면 no-op).
+ * 원본 카트 자체가 완료(주문 전환)됐으면 건드리지 않음.
+ * 실패 시 throw → hook 이 재시도(주문은 이미 생성됐고 recover 가 멱등이라 정리만 다시 시도됨).
+ */
+async function cleanupSourceCartItems(scope: any, intentId: string, logger: { info: Function; warn: Function; error: Function }): Promise<void> {
+  const checkoutCartId = await resolveCheckoutCartIdForIntent(scope, intentId);
+  if (!checkoutCartId) return;
+
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY);
+
+  const { data: checkoutCarts } = await query.graph({
+    entity: 'cart',
+    fields: ['id', 'metadata'],
+    filters: { id: checkoutCartId },
+  });
+  const meta = ((checkoutCarts[0] as any)?.metadata as Record<string, unknown> | null) ?? {};
+  const sourceCartId = typeof meta.source_cart_id === 'string' ? meta.source_cart_id : null;
+  const sourceLineItemIds = Array.isArray(meta.source_line_item_ids)
+    ? (meta.source_line_item_ids as unknown[]).filter((id): id is string => typeof id === 'string' && id.length > 0)
+    : [];
+
+  if (!sourceCartId || sourceCartId === checkoutCartId || sourceLineItemIds.length === 0) {
+    return;
+  }
+
+  // 원본 카트가 완료됐으면(자기 자신이 주문이 된 경우 등) 건드리지 않음. 현재 존재하는 라인만 삭제.
+  const { data: sourceCarts } = await query.graph({
+    entity: 'cart',
+    fields: ['id', 'completed_at', 'items.id'],
+    filters: { id: sourceCartId },
+  });
+  const sourceCart = sourceCarts[0] as { completed_at?: string | null; items?: Array<{ id: string }> } | undefined;
+  if (!sourceCart || sourceCart.completed_at) {
+    return;
+  }
+
+  const existingIds = new Set((sourceCart.items ?? []).map((it) => it.id));
+  const idsToDelete = sourceLineItemIds.filter((id) => existingIds.has(id));
+  if (idsToDelete.length === 0) {
+    return;
+  }
+
+  await deleteLineItemsWorkflow(scope).run({
+    input: { cart_id: sourceCartId, ids: idsToDelete },
+  });
+
+  logger.info(
+    `[payment-events] cleanupSourceCartItems: removed ${idsToDelete.length} purchased item(s) from source cart ${sourceCartId} (intentId=${intentId})`,
+  );
+}
+
+/**
+ * 무통장 선생성 주문의 입금 상태 메타데이터(bank_transfer_status)를 갱신.
+ * - 'awaiting_deposit' (선생성 시): 무조건 설정.
+ * - 'confirmed' (입금확인 capture 시): onlyIfAwaiting 으로, 기존이 'awaiting_deposit' 인 무통장 주문에만 설정(카드 주문/복구 폴백 주문은 건드리지 않음).
+ * best-effort — 실패해도 결제 projection 자체를 막지 않음.
+ */
+async function updateBankTransferOrderStatus(
+  scope: any,
+  intentId: string,
+  status: 'awaiting_deposit' | 'confirmed',
+  logger: { info: Function; warn: Function; debug: Function; error: Function },
+  opts: { onlyIfAwaiting?: boolean } = {},
+): Promise<void> {
+  try {
+    const orderId = await resolveOrderIdForIntent(scope, intentId);
+    if (!orderId) {
+      logger.warn(
+        `[payment-events] updateBankTransferOrderStatus: no order for intentId=${intentId}, skipping (status=${status})`,
+      );
+      return;
+    }
+    const orderModule = scope.resolve(Modules.ORDER);
+    const order = await orderModule.retrieveOrder(orderId, { select: ['id', 'metadata'] });
+    const meta = (order?.metadata as Record<string, unknown>) ?? {};
+    if (opts.onlyIfAwaiting && meta.bank_transfer_status !== 'awaiting_deposit') {
+      return;
+    }
+    // 방어: 이미 입금확정(confirmed)된 주문을 다시 '입금확인중' 으로 되돌리지 않음.
+    if (status === 'awaiting_deposit' && meta.bank_transfer_status === 'confirmed') {
+      return;
+    }
+    await orderModule.updateOrders([
+      { id: orderId, metadata: { ...meta, bank_transfer_status: status } },
+    ]);
+    logger.info(
+      `[payment-events] updateBankTransferOrderStatus: order ${orderId} bank_transfer_status=${status} (intentId=${intentId})`,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error(
+      `[payment-events] updateBankTransferOrderStatus failed intentId=${intentId} status=${status}: ${msg}`,
+    );
+  }
+}
+
 export async function handleCaptureProjection(
   scope: any,
   intentId: string,
   messageId: string,
-  logger: { info: Function; warn: Function; debug: Function },
+  logger: { info: Function; warn: Function; debug: Function; error: Function },
 ) {
   const paymentModule = scope.resolve(Modules.PAYMENT);
 
@@ -399,7 +635,10 @@ export async function handleCaptureProjection(
   }
 
   if (payment.captured_at) {
-    logger.debug(`[payment-events] handleCaptureProjection: already captured, skipping. payment_id=${payment.id}`);
+    logger.debug(`[payment-events] handleCaptureProjection: already captured, skipping capture. payment_id=${payment.id}`);
+    // 이전 시도에서 원본 카트 정리/상태 갱신이 실패했을 수 있으므로 다시 보장.
+    await cleanupSourceCartItems(scope, intentId, logger);
+    await updateBankTransferOrderStatus(scope, intentId, 'confirmed', logger, { onlyIfAwaiting: true });
     return;
   }
 
@@ -425,6 +664,15 @@ export async function handleCaptureProjection(
 
   await capturePaymentWorkflow(scope).run({
     input: { payment_id: payment.id },
+  });
+
+  // 입금확인(capture)으로 주문이 처음 확정된 폴백 경로(입금대기 이벤트 유실)에서도 원본 카트 정리 보장.
+  await cleanupSourceCartItems(scope, intentId, logger);
+
+  // 무통장 선생성 주문이라면 '입금확인중' → '입금확정' 으로 메타데이터를 갱신.
+  // onlyIfAwaiting 으로 무통장 주문에만 적용 (카드/복구 폴백 주문은 무시).
+  await updateBankTransferOrderStatus(scope, intentId, 'confirmed', logger, {
+    onlyIfAwaiting: true,
   });
 
   logger.info(`[payment-events] handleCaptureProjection: projected capture for payment_id=${payment.id} intentId=${intentId}`);
@@ -455,6 +703,9 @@ async function recoverBankTransferOrder(
   intentId: string,
   messageId: string,
   logger: { info: Function; warn: Function; debug: Function },
+  // 입금대기 경로: 주문 생성 전에 cart.metadata 에 bank_transfer_status='awaiting_deposit' 를
+  // 심어 order 가 marker 와 함께 원자적으로 생성되게 함. capture 폴백 경로는 false(=marker 없음).
+  markAwaitingDeposit = false,
 ): Promise<void> {
   const paymentModule = scope.resolve(Modules.PAYMENT);
   const query = scope.resolve(ContainerRegistrationKeys.QUERY);
@@ -480,11 +731,13 @@ async function recoverBankTransferOrder(
   // The link extends PaymentCollection with a 'cart' field alias — bidirectional.
   const { data: collections } = await query.graph({
     entity: 'payment_collection',
-    fields: ['id', 'cart.id', 'cart.completed_at'],
+    fields: ['id', 'cart.id', 'cart.completed_at', 'cart.metadata'],
     filters: { id: paymentCollectionId },
   });
 
-  const cart = (collections[0] as any)?.cart as { id: string; completed_at: string | null } | undefined;
+  const cart = (collections[0] as any)?.cart as
+    | { id: string; completed_at: string | null; metadata?: Record<string, unknown> | null }
+    | undefined;
 
   if (!cart?.id) {
     throw new Error(
@@ -514,6 +767,21 @@ async function recoverBankTransferOrder(
       `[payment-events] recoverBankTransferOrder: order already exists for cart ${cartId} (order_id=${(orderCartLinks[0] as any)?.order_id}), skipping. intentId=${intentId}`,
     );
     return;
+  }
+
+  // 무통장 입금대기 주문은 완료 '전에' cart.metadata 에 입금확인중 marker 를 심음.
+  // completeCartWorkflow 가 cart.metadata 를 order.metadata 로 복사하므로(core-flows complete-cart), 주문은 marker 와 함께 원자적으로 생성됨 → marker 없는 authorized 주문이 WMS 수집 게이트를 통과하는 창이 존재하지 않음. marker set 이 실패하면 throw → 재시도(주문 미생성 상태 유지).
+  if (markAwaitingDeposit) {
+    const cartModule = scope.resolve(Modules.CART);
+    await cartModule.updateCarts(cartId, {
+      metadata: {
+        ...((cart.metadata as object) ?? {}),
+        bank_transfer_status: 'awaiting_deposit',
+      },
+    });
+    logger.info(
+      `[payment-events] recoverBankTransferOrder: stamped awaiting_deposit on cart ${cartId} before completion intentId=${intentId}`,
+    );
   }
 
   // Step 5: complete the cart to create the order

--- a/apps/medusa/src/api/middlewares.ts
+++ b/apps/medusa/src/api/middlewares.ts
@@ -1,6 +1,7 @@
 import { authenticate, defineMiddlewares } from '@medusajs/framework/http';
 import { adminRouteMiddlewares } from './admin/middlewares';
 import { perCustomerLimitMiddleware } from './store/carts/middlewares/per-customer-limit';
+import { rejectAwaitingDepositCompleteMiddleware } from './store/carts/middlewares/reject-awaiting-deposit-complete';
 import { membershipPriceVisibilityMiddleware } from './store/products/middlewares/membership-price-visibility';
 
 // 멤버십가 표시 정책: 비회원 응답에서 멤버십가 metadata만 제거한다 (상품 숨김 아님).
@@ -57,6 +58,13 @@ export default defineMiddlewares({
         authenticate('customer', ['session', 'bearer'], { allowUnauthenticated: true }),
         perCustomerLimitMiddleware,
       ],
+    },
+    {
+      // 무통장 입금대기 intent 의 cart 를 HTTP 로 complete 하는 경로를 막는다(미입금 출고 방지).
+      // 정상 무통장 주문은 wallet 웹훅이 in-process 로 선생성하므로 이 라우트를 거치지 않는다.
+      matcher: '/store/carts/:id/complete',
+      method: 'POST',
+      middlewares: [rejectAwaitingDepositCompleteMiddleware],
     },
     {
       matcher: '/store/coupons/preview',

--- a/apps/medusa/src/api/store/carts/middlewares/__tests__/reject-awaiting-deposit-complete.unit.spec.ts
+++ b/apps/medusa/src/api/store/carts/middlewares/__tests__/reject-awaiting-deposit-complete.unit.spec.ts
@@ -1,0 +1,133 @@
+import { rejectAwaitingDepositCompleteMiddleware } from '../reject-awaiting-deposit-complete';
+
+type GraphArgs = { entity: string; fields?: string[]; filters?: Record<string, unknown> };
+type GraphFn = (args: GraphArgs) => Promise<{ data: any[] }> | { data: any[] };
+
+function makeReq(opts: { cartId?: string | undefined; graph?: GraphFn } = {}) {
+  const query = { graph: jest.fn(opts.graph ?? (async () => ({ data: [] }))) };
+  return {
+    params: { id: 'cartId' in opts ? opts.cartId : 'cart_1' },
+    // ContainerRegistrationKeys.QUERY === 'query'
+    scope: { resolve: jest.fn((key: string) => (key === 'query' ? query : undefined)) },
+    _query: query,
+  } as any;
+}
+
+function makeRes() {
+  const res: any = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+}
+
+const sessionGraph =
+  (provider: string, intentId: string | undefined): GraphFn =>
+  ({ entity }) => {
+    if (entity === 'cart') {
+      return {
+        data: [
+          {
+            id: 'cart_1',
+            payment_collection: {
+              payment_sessions: [{ provider_id: provider, data: intentId ? { intentId } : {} }],
+            },
+          },
+        ],
+      };
+    }
+    return { data: [] };
+  };
+
+const ALMOND = 'pp_almond-payment_almond-payment';
+
+function mockFetchStatus(status: string) {
+  (global as any).fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ status }),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.WALLET_BASE_URL = 'http://wallet.test';
+  process.env.WALLET_API_KEY = 'test-key';
+});
+
+describe('rejectAwaitingDepositCompleteMiddleware', () => {
+  it('AWAITING_DEPOSIT intent 의 cart complete 는 409 로 거부하고 next 를 호출하지 않는다', async () => {
+    mockFetchStatus('AWAITING_DEPOSIT');
+    const req = makeReq({ graph: sessionGraph(ALMOND, 'intent_1') });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await rejectAwaitingDepositCompleteMiddleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'BANK_TRANSFER_AWAITING_DEPOSIT' }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('카드 등 비-AWAITING_DEPOSIT intent 는 통과시킨다(next 호출, 409 없음)', async () => {
+    mockFetchStatus('CAPTURED');
+    const req = makeReq({ graph: sessionGraph(ALMOND, 'intent_1') });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await rejectAwaitingDepositCompleteMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('almond-payment 세션/intentId 가 없으면 wallet 조회 없이 통과시킨다', async () => {
+    (global as any).fetch = jest.fn();
+    const req = makeReq({ graph: sessionGraph('pp_system_default', 'intent_1') });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await rejectAwaitingDepositCompleteMiddleware(req, res, next);
+
+    expect((global as any).fetch).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('wallet 조회 실패(!ok)는 fail-open: 통과시킨다', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue({ ok: false, json: async () => ({}) });
+    const req = makeReq({ graph: sessionGraph(ALMOND, 'intent_1') });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await rejectAwaitingDepositCompleteMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('cart graph 조회 자체가 throw 하면 fail-open: 통과시킨다', async () => {
+    const req = makeReq({
+      graph: () => {
+        throw new Error('db down');
+      },
+    });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await rejectAwaitingDepositCompleteMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('cartId 파라미터가 없으면 즉시 통과시킨다', async () => {
+    const req = makeReq({ cartId: undefined });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await rejectAwaitingDepositCompleteMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req._query.graph).not.toHaveBeenCalled();
+  });
+});

--- a/apps/medusa/src/api/store/carts/middlewares/reject-awaiting-deposit-complete.ts
+++ b/apps/medusa/src/api/store/carts/middlewares/reject-awaiting-deposit-complete.ts
@@ -1,0 +1,77 @@
+import { ContainerRegistrationKeys } from '@medusajs/framework/utils';
+
+// 무통장 입금대기(AWAITING_DEPOSIT) intent 의 cart 를 HTTP 로 complete 하는 것을 막는다.
+//
+// 배경: almond-payment 가 AWAITING_DEPOSIT 을 'authorized' 로 매핑하므로, 이 상태에서
+// /store/carts/:id/complete 가 그대로 성공하면 marker(metadata.bank_transfer_status='awaiting_deposit')
+// 없는 authorized 주문이 만들어진다. channel-adapter 의 WMS 수집 게이트는 'authorized + marker' 로만
+// 미입금 주문을 거르므로, marker 없는 authorized 주문은 게이트를 통과해 미입금 출고로 샌다.
+//
+// 정상 무통장 주문은 wallet 의 awaiting_deposit 웹훅이 cart.metadata 에 marker 를 심은 뒤
+// completeCartWorkflow 를 in-process 로 실행해 선생성한다 — HTTP 라우트를 거치지 않으므로 이
+// 미들웨어에 절대 도달하지 않는다. 따라서 'HTTP 로 들어온 complete 인데 intent 가 AWAITING_DEPOSIT'
+// 이면 비정상(직접 호출 / 레이스)이므로 거부해도 정상 흐름에 영향이 없다(주문은 웹훅이 만든다).
+// 카드 intent 는 AWAITING_DEPOSIT 이 아니므로 항상 통과한다.
+
+const AWAITING_DEPOSIT_STATUS = 'AWAITING_DEPOSIT';
+
+/**
+ * wallet 에서 intent 의 실시간 상태를 조회한다. Medusa 의 payment_session.status 는 complete 전엔
+ * 아직 authorize 가 안 돼 'pending' 일 수 있고, authorize 후엔 AWAITING_DEPOSIT 과 카드-authorized 가
+ * 모두 'authorized' 로 보여 구별되지 않는다. 권위 있는 출처는 wallet intent 뿐이다.
+ *
+ * 조회 실패는 null 을 돌려 fail-open 한다(카드 결제 정상 완료를 막지 않기 위함 — storefront 의
+ * isAwaitingDepositIntent 와 동일 정책).
+ */
+async function fetchIntentStatus(intentId: string): Promise<string | null> {
+  const base = process.env.WALLET_BASE_URL;
+  const key = process.env.WALLET_API_KEY;
+  if (!base || !key) return null;
+
+  try {
+    const res = await fetch(`${base}/v1/payment-intents/${intentId}`, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${key}` },
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { status?: string };
+    return body?.status ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export const rejectAwaitingDepositCompleteMiddleware = async (req: any, res: any, next: any) => {
+  const cartId = req.params?.id as string | undefined;
+  if (!cartId) return next();
+
+  try {
+    const query = req.scope.resolve(ContainerRegistrationKeys.QUERY);
+    const { data: carts } = await query.graph({
+      entity: 'cart',
+      fields: ['id', 'payment_collection.payment_sessions.provider_id', 'payment_collection.payment_sessions.data'],
+      filters: { id: cartId },
+    });
+
+    const sessions = (carts?.[0] as any)?.payment_collection?.payment_sessions ?? [];
+    const intentId: string | undefined = sessions
+      .filter((s: any) => typeof s?.provider_id === 'string' && s.provider_id.includes('almond-payment'))
+      .map((s: any) => s?.data?.intentId)
+      .find((id: unknown): id is string => typeof id === 'string' && id.length > 0);
+
+    if (!intentId) return next();
+
+    const status = await fetchIntentStatus(intentId);
+    if (status === AWAITING_DEPOSIT_STATUS) {
+      return res.status(409).json({
+        message: '무통장 입금대기 주문은 입금 확인 후 자동으로 처리됩니다. 주문내역에서 확인해 주세요.',
+        code: 'BANK_TRANSFER_AWAITING_DEPOSIT',
+      });
+    }
+  } catch {
+    // cart/세션 조회 자체가 실패하면 fail-open: 카드 등 정상 결제 완료를 막지 않는다.
+    // (카드 intent 는 AWAITING_DEPOSIT 이 아니므로 marker 없는 미입금 주문이 생기지 않는다.)
+  }
+
+  return next();
+};

--- a/apps/medusa/src/api/store/customers/me/cart/route.ts
+++ b/apps/medusa/src/api/store/customers/me/cart/route.ts
@@ -10,18 +10,26 @@ import { autoFillShipping } from './auto-fill-shipping';
 async function getCustomerCart(query: any, customerId: string) {
   const { data: carts } = await query.graph({
     entity: 'cart',
-    fields: ['id', 'customer_id', 'completed_at', 'updated_at', ...defaultStoreCartFields],
+    fields: ['id', 'customer_id', 'completed_at', 'updated_at', 'metadata', ...defaultStoreCartFields],
     filters: {
       customer_id: customerId,
       completed_at: null,
     },
   });
 
+  // 결제용 checkout cart / 배송 미리보기 cart 는 일반 장바구니 복구 대상에서 제외.
+  // createCheckoutCartFromLineItems 가 checkout cart 도 고객에게 transfer 하므로, 무통장 입금 대기 (최대 72h) 동안 쿠키가 소실되면 결제용 cart 가 고객 장바구니로 복구되는 레이스가 생긴다.
+  // source_cart_id(원본 참조) / is_shipping_preview metadata 로 파생 cart 를 가려남.
+  const shoppingCarts = (carts || []).filter((cart: any) => {
+    const meta = (cart?.metadata ?? {}) as Record<string, unknown>;
+    return !meta.source_cart_id && meta.is_shipping_preview !== true;
+  });
+
   // 카트 선택 우선순위:
   // 1. updated_at 최신 카트 우선
   // 2. 동시간대면 아이템이 있는 카트를 우선
   // 3. 그래도 같으면 아이템 수가 많은 카트를 우선
-  const sortedCarts = (carts || []).sort((a: any, b: any) => {
+  const sortedCarts = shoppingCarts.sort((a: any, b: any) => {
     const dateA = new Date(a.updated_at || 0).getTime();
     const dateB = new Date(b.updated_at || 0).getTime();
 

--- a/apps/medusa/src/modules/almond-payment/service.ts
+++ b/apps/medusa/src/modules/almond-payment/service.ts
@@ -69,7 +69,11 @@ export class AlmondPaymentProviderService extends AbstractPaymentProvider<Almond
       case 'SUCCEEDED':
         return captured ? 'captured' : 'authorized'; // backward compat
       case 'AWAITING_DEPOSIT':
-        return 'pending'; // 무통장 입금 대기 — 아직 cart 완료 불가
+        // 무통장 입금 대기 — '입금확인중' 주문을 선생성하기 위해 authorized 로 매핑.
+        // 이렇게 해야 completeCartWorkflow 가 cart 를 완료(주문 생성)할 수 있다. 실제 입금
+        // 확정(capture)은 관리자 입금확인(INTENT_CAPTURED) 시점에 별도로 일어남.
+        // AWAITING_DEPOSIT 은 무통장 intent 만 도달하므로 카드/Toss 플로우엔 영향이 없음.
+        return 'authorized';
       case 'CANCELED':
         return 'canceled';
       case 'FAILED':

--- a/apps/wallet/src/jobs/expiration.job.ts
+++ b/apps/wallet/src/jobs/expiration.job.ts
@@ -5,6 +5,11 @@ import { and, eq, inArray, lte, sql } from 'drizzle-orm';
 import { WalletSchema, paymentIntents } from '../schema';
 import { StateTransitionService } from '../domain/state-transition/state-transition.service';
 import { ChargeReleaseService } from '../payment-intents/charge-release.service';
+import {
+  GATEWAY_AGGREGATE_TYPE,
+  GatewayEventType,
+  buildPaymentIntentEventPayload,
+} from '../messaging/gateway-event.builder';
 
 const DEFAULT_EXPIRATION_CRON = '*/10 * * * *';
 const DEFAULT_EXPIRATION_BATCH_SIZE = 100;
@@ -58,6 +63,7 @@ export class ExpirationJob {
         id: paymentIntents.id,
         userId: paymentIntents.userId,
         currency: paymentIntents.currency,
+        payableAmount: paymentIntents.payableAmount,
       })
       .from(paymentIntents)
       .where(
@@ -79,10 +85,26 @@ export class ExpirationJob {
         // Release provider-side holds (POINTS hold, TOSS authorize, …) before
         // cancelling, otherwise an expired composite intent leaks its points hold.
         await this.chargeReleaseService.releaseIntentCharges(intent, `expiration:${intent.id}`);
+        // 만료 취소도 INTENT_CANCELED 이벤트를 발행. 무통장입금처럼 Medusa 가
+        // 주문을 선생성한 경우, 미입금 만료 시 이 이벤트로 주문을 취소·정리(예약재고 해제).
+        // user/admin 취소 경로(CancelService)와 동일한 이벤트라 Medusa 측 처리가 일관됨.
+        // Medusa payment 가 없는 인텐트(멤버십/빌링 등)는 hook 에서 no-op 으로 안전 처리됨.
         await this.stateTransitionService.transitionIntent(intent.id, 'CANCELED', {
           correlationId: `expiration:${intent.id}`,
           reasonCode: 'INTENT_EXPIRED',
           reasonMessage: 'Payment intent expired',
+          outboxEvent: {
+            eventType: GatewayEventType.INTENT_CANCELED,
+            aggregateType: GATEWAY_AGGREGATE_TYPE,
+            aggregateId: intent.id,
+            payload: buildPaymentIntentEventPayload({
+              intentId: intent.id,
+              userId: intent.userId ?? '',
+              status: 'CANCELED',
+              payableAmount: intent.payableAmount,
+              currency: intent.currency,
+            }),
+          },
         });
         expired++;
       } catch (error) {

--- a/apps/wallet/src/messaging/gateway-event.builder.ts
+++ b/apps/wallet/src/messaging/gateway-event.builder.ts
@@ -93,6 +93,8 @@ export const GatewayEventType = {
   INTENT_FAILED: 'payment.intent.failed',
   INTENT_CANCELED: 'payment.intent.canceled',
   INTENT_CAPTURED: 'payment.intent.captured',
+  // 무통장입금 입금 대기 진입 — Medusa 가 주문을 '입금확인중' 으로 선생성하도록 트리거.
+  INTENT_AWAITING_DEPOSIT: 'payment.intent.awaiting_deposit',
   CHARGE_AUTHORIZED: 'gateway.charge.authorized',
   CHARGE_CAPTURED: 'gateway.charge.captured',
   CHARGE_FAILED: 'gateway.charge.failed',

--- a/apps/wallet/src/payment-intents/confirm.service.ts
+++ b/apps/wallet/src/payment-intents/confirm.service.ts
@@ -485,9 +485,24 @@ export class ConfirmService {
         if (phase1.plan.primary.provider.actionMode === 'offline-wait') {
           // 무통장: 오프라인 입금 대기. 긴 입금 윈도우(expiresAt)로 두고
           // actionExpiresAt은 찍지 않아 TossActionExpirationJob 대상에서 제외한다.
+          //
+          // INTENT_AWAITING_DEPOSIT 이벤트를 발행해 Medusa 가 주문을 '입금확인중' 상태로 선생성
+          // 입금대기 시점에 주문 내용이 고정되어, 이후 카트 수정이 주문/결제금액 불일치를 일으키는 문제를 차단. 이벤트가 유실돼도 관리자 입금확인 (INTENT_CAPTURED) 시 기존 복구 경로가 주문을 생성하므로 graceful degradation 됨.
           await this.stateTransitionService.transitionIntent(intentId, 'AWAITING_DEPOSIT', {
             correlationId,
             reasonCode: 'AWAITING_DEPOSIT',
+            outboxEvent: {
+              eventType: GatewayEventType.INTENT_AWAITING_DEPOSIT,
+              aggregateType: GATEWAY_AGGREGATE_TYPE,
+              aggregateId: intentId,
+              payload: buildPaymentIntentEventPayload({
+                intentId,
+                userId: phase1.userId,
+                status: 'AWAITING_DEPOSIT',
+                payableAmount: phase1.payableAmount,
+                currency: phase1.currency,
+              }),
+            },
           });
           await this.stampDepositExpiry(intentId);
         } else {

--- a/scripts/wallet/expire-bank-transfer-intent.ts
+++ b/scripts/wallet/expire-bank-transfer-intent.ts
@@ -1,0 +1,121 @@
+/**
+ * 무통장입금(AWAITING_DEPOSIT) intent 의 expires_at 을 과거로 당겨, wallet ExpirationJob 이
+ * 다음 주기(@Cron WALLET_EXPIRATION_CRON, 기본 10분)에 만료 처리하도록 만드는 **테스트 전용** 스크립트.
+ *
+ * 목적(#439 시나리오 ③ staging 검증):
+ *   expires_at 백데이트 → ExpirationJob 가 INTENT_EXPIRED 로 CANCELED 전이 + INTENT_CANCELED outbox 발행
+ *   → channel-adapter → Medusa /hooks/payment-events handleCancelProjection
+ *   → 선생성된 주문 cancelOrderWorkflow 취소 + 예약재고 해제.
+ *
+ * 실제 만료 경로(charge release + 상태 전이 + outbox)를 그대로 태운다(상태를 직접 손대지 않음).
+ *
+ * 사용법 (deployments/lcnine/services 에서, staging 스테이지로):
+ *   # dry-run (대상만 확인) — 특정 intent
+ *   npx sst shell --stage <staging-stage> -- npx tsx ../../../scripts/wallet/expire-bank-transfer-intent.ts <intentId>
+ *   # 실제 적용
+ *   npx sst shell --stage <staging-stage> -- npx tsx ../../../scripts/wallet/expire-bank-transfer-intent.ts <intentId> --apply
+ *   # intent 전체 대상(주의) — 반드시 dry-run 으로 먼저 확인
+ *   npx sst shell --stage <staging-stage> -- npx tsx ../../../scripts/wallet/expire-bank-transfer-intent.ts --all --apply
+ *
+ * 안전장치:
+ *   - live 스테이지(SST_STAGE=live)에서는 거부한다(실 고객 주문 취소 위험).
+ *   - intentId 또는 --all 중 하나는 필수.
+ *   - 기본 dry-run. 쓰기는 --apply 필요.
+ */
+import postgres from 'postgres';
+import { Resource } from 'sst';
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const ALL = args.includes('--all');
+const intentId = args.find((a) => !a.startsWith('--'));
+
+const stage = process.env.SST_STAGE ?? '';
+if (stage.toLowerCase() === 'live') {
+  console.error('거부: live 스테이지에서는 실행할 수 없습니다(실 고객 주문 취소 위험). staging 에서만 사용하세요.');
+  process.exit(1);
+}
+if (!intentId && !ALL) {
+  console.error('intentId 를 인자로 주거나 --all 을 지정하세요. (기본 dry-run, 쓰기는 --apply)');
+  process.exit(1);
+}
+
+function conn(database: string) {
+  const db = (Resource as any).Db;
+  return postgres({
+    host: db.host,
+    port: db.port,
+    username: db.username,
+    password: db.password,
+    database,
+    ssl: 'require',
+    max: 1,
+    connect_timeout: 30,
+  });
+}
+
+async function main() {
+  const wallet = conn('wallet');
+  try {
+    await wallet`SELECT 1`;
+
+    // 대상: AWAITING_DEPOSIT 상태. intentId 가 주어지면 그 한 건만.
+    const targets = intentId
+      ? await wallet`
+          SELECT id, status, expires_at, payable_amount, currency, user_id
+          FROM payment_intents
+          WHERE id = ${intentId} AND status = 'AWAITING_DEPOSIT'`
+      : await wallet`
+          SELECT id, status, expires_at, payable_amount, currency, user_id
+          FROM payment_intents
+          WHERE status = 'AWAITING_DEPOSIT'
+          ORDER BY created_at DESC
+          LIMIT 50`;
+
+    if ((targets as any[]).length === 0) {
+      if (intentId) {
+        console.log(`대상 없음: intent ${intentId} 가 AWAITING_DEPOSIT 상태가 아니거나 존재하지 않습니다.`);
+      } else {
+        console.log('대상 없음: AWAITING_DEPOSIT 상태의 intent 가 없습니다.');
+      }
+      return;
+    }
+
+    console.log(`=== 대상 AWAITING_DEPOSIT intent ${(targets as any[]).length}건 (stage=${stage || '(unknown)'}) ===`);
+    console.table(
+      (targets as any[]).map((t) => ({
+        id: t.id,
+        expires_at: t.expires_at,
+        amount: `${t.payable_amount} ${t.currency}`,
+        userId: t.user_id,
+      })),
+    );
+
+    if (!APPLY) {
+      console.log('\n[dry-run] 변경하지 않았습니다. 실제 적용하려면 --apply 를 붙이세요.');
+      console.log('적용 시: 위 intent 들의 expires_at 을 (now - 1분) 으로 당깁니다.');
+      console.log('이후 wallet ExpirationJob(@Cron, 기본 10분)이 만료 처리 → INTENT_CANCELED 발행 → 주문 취소/예약 해제.');
+      return;
+    }
+
+    const ids = (targets as any[]).map((t) => t.id);
+    const updated = await wallet`
+      UPDATE payment_intents
+      SET expires_at = now() - interval '1 minute', updated_at = now()
+      WHERE id = ANY(${ids}) AND status = 'AWAITING_DEPOSIT'
+      RETURNING id, expires_at`;
+
+    console.log(`\n✅ expires_at 백데이트 완료: ${(updated as any[]).length}건`);
+    console.table(updated);
+    console.log('\n다음 단계: wallet ExpirationJob 주기(기본 10분, 또는 WALLET_EXPIRATION_CRON)를 기다리거나');
+    console.log('wallet 인스턴스를 재기동하면 즉시 다음 주기에 만료됩니다.');
+    console.log('검증: Medusa "order".status=\'canceled\', reservation_item 0건, channel-adapter wms_order_mappings 0건.');
+  } finally {
+    await wallet.end({ timeout: 5 }).catch(() => {});
+  }
+}
+
+main().catch((err) => {
+  console.error('실패:', err?.message ?? err);
+  process.exit(1);
+});

--- a/scripts/wallet/expire-bank-transfer-intent.ts
+++ b/scripts/wallet/expire-bank-transfer-intent.ts
@@ -64,11 +64,11 @@ async function main() {
       ? await wallet`
           SELECT id, status, expires_at, payable_amount, currency, user_id
           FROM payment_intents
-          WHERE id = ${intentId} AND status = 'AWAITING_DEPOSIT'`
+          WHERE id = ${intentId} AND status::text = 'AWAITING_DEPOSIT'`
       : await wallet`
           SELECT id, status, expires_at, payable_amount, currency, user_id
           FROM payment_intents
-          WHERE status = 'AWAITING_DEPOSIT'
+          WHERE status::text = 'AWAITING_DEPOSIT'
           ORDER BY created_at DESC
           LIMIT 50`;
 
@@ -102,7 +102,7 @@ async function main() {
     const updated = await wallet`
       UPDATE payment_intents
       SET expires_at = now() - interval '1 minute', updated_at = now()
-      WHERE id = ANY(${ids}) AND status = 'AWAITING_DEPOSIT'
+      WHERE id = ANY(${ids}) AND status::text = 'AWAITING_DEPOSIT'
       RETURNING id, expires_at`;
 
     console.log(`\n✅ expires_at 백데이트 완료: ${(updated as any[]).length}건`);

--- a/web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/callback/actions.ts
+++ b/web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/callback/actions.ts
@@ -4,6 +4,7 @@ import {
   cartRequiresShipping,
   selectShippingOptionsForCart,
 } from "@/lib/api/medusa/shipping-method-policy"
+import { getIntent } from "@/lib/api/wallet"
 import { sdk } from "@/lib/config/medusa"
 import {
   getAuthHeaders,
@@ -114,6 +115,31 @@ interface ProcessPaymentResult {
   redirectUrl: string
 }
 
+/**
+ * 무통장입금 입금대기(AWAITING_DEPOSIT) intent 인지 wallet 에서 서버사이드로 확인.
+ *
+ * callback 의 status 쿼리는 wallet-web 이 붙이는 값이라 신뢰할 수 없다(누락/위조 가능). 무통장은
+ * almond-payment 가 AWAITING_DEPOSIT 을 'authorized' 로 매핑하므로, 이 상태에서 cart.complete() 가
+ * 그대로 성공해 marker 없는 주문이 생기고 WMS 게이트를 통과(미입금 출고)할 수 있다. 정상 흐름에선
+ * 무통장은 wallet-web 입금화면에 머물러 이 callback 에 오지 않으므로, 여기 도달했다면 수동 진입/레이스다.
+ * → 입금대기 intent 면 cart.complete() 를 막고 주문내역(웹훅이 선생성한 '입금확인중' 주문)으로 보낸다.
+ *
+ * 조회 실패(예: 크로스도메인 토큰 소실)는 fail-open: 카드 결제 정상 완료를 막지 않기 위해 진행시킨다.
+ * 카드 intent 는 AWAITING_DEPOSIT 이 아니므로 fail-open 이어도 marker 없는 미입금 주문이 생기지 않는다.
+ */
+async function isAwaitingDepositIntent(intentId: string): Promise<boolean> {
+  try {
+    const intent = await getIntent(intentId)
+    return intent.status === "AWAITING_DEPOSIT"
+  } catch (err) {
+    console.warn(
+      `[processPaymentCallback] intent status lookup failed, proceeding (intentId=${intentId})`,
+      err instanceof Error ? err.message : err
+    )
+    return false
+  }
+}
+
 interface SourceCartSelection {
   sourceCartId: string
   sourceLineItemIds: string[]
@@ -192,6 +218,15 @@ export async function processPaymentCallback(
   cartId?: string | null
 ): Promise<ProcessPaymentResult> {
   try {
+    // 무통장입금 입금대기 intent 는 cart.complete() 로 주문을 만들지 않는다(미입금 출고 방지).
+    // 주문은 wallet 의 awaiting_deposit 웹훅이 marker 와 함께 선생성하므로 주문내역으로 보낸다.
+    if (await isAwaitingDepositIntent(intentId)) {
+      return {
+        success: true,
+        redirectUrl: `/${countryCode}/mypage/order/list`,
+      }
+    }
+
     const targetCartId = cartId || (await getCartId())
     console.log("============== callback 디버그 ==============")
     console.log("intentId:", intentId)

--- a/web/almondyoung-storefront/src/app/[countryCode]/cart/page.tsx
+++ b/web/almondyoung-storefront/src/app/[countryCode]/cart/page.tsx
@@ -17,7 +17,10 @@ export default async function Cart({
 }) {
   const { countryCode } = await params
 
-  let cart = await retrieveCart().catch((error) => {
+  // 무통장입금 주문 선생성 시 원본 장바구니 아이템은 Medusa 서버사이드에서 제거됨.
+  // 그 정리는 storefront 의 carts 캐시 태그를 무효화하지 못하므로, 이미 force-dynamic 인 카트
+  // 페이지에서는 no-store 로 항상 최신 카트를 읽어 '구매한 상품이 장바구니에 남아있는' 오표시를 막음.
+  let cart = await retrieveCart(undefined, undefined, "no-store").catch((error) => {
     console.error(error)
     return notFound()
   })

--- a/web/almondyoung-storefront/src/domains/order/details/components/order-details-desktop.tsx
+++ b/web/almondyoung-storefront/src/domains/order/details/components/order-details-desktop.tsx
@@ -92,8 +92,11 @@ export const OrderDetailsDesktop = ({
     : tStatus(
         order.status === "canceled"
           ? "orderCancel"
-          : (order.metadata as Record<string, unknown> | null)
-                ?.bank_transfer_status === "awaiting_deposit"
+          : // captured 후 'confirmed' metadata 갱신 실패로 awaiting_deposit 가 남아도
+            // 결제완료(captured)면 '입금확인중' 으로 표시하지 않음 (WMS 수집 게이트와 동일 불변식)
+            (order.metadata as Record<string, unknown> | null)
+                  ?.bank_transfer_status === "awaiting_deposit" &&
+              order.payment_status !== "captured"
             ? "depositPending"
           : order.fulfillment_status === "fulfilled"
             ? "delivered"

--- a/web/almondyoung-storefront/src/domains/order/details/components/order-details-desktop.tsx
+++ b/web/almondyoung-storefront/src/domains/order/details/components/order-details-desktop.tsx
@@ -92,6 +92,9 @@ export const OrderDetailsDesktop = ({
     : tStatus(
         order.status === "canceled"
           ? "orderCancel"
+          : (order.metadata as Record<string, unknown> | null)
+                ?.bank_transfer_status === "awaiting_deposit"
+            ? "depositPending"
           : order.fulfillment_status === "fulfilled"
             ? "delivered"
             : order.fulfillment_status === "shipped"

--- a/web/almondyoung-storefront/src/domains/order/details/components/order-details-mobile.tsx
+++ b/web/almondyoung-storefront/src/domains/order/details/components/order-details-mobile.tsx
@@ -104,8 +104,11 @@ export const OrderDetailsMobile = ({
     : tStatus(
         order.status === "canceled"
           ? "orderCancel"
-          : (order.metadata as Record<string, unknown> | null)
-                ?.bank_transfer_status === "awaiting_deposit"
+          : // captured 후 'confirmed' metadata 갱신 실패로 awaiting_deposit 가 남아도
+            // 결제완료(captured)면 '입금확인중' 으로 표시하지 않음 (WMS 수집 게이트와 동일 불변식)
+            (order.metadata as Record<string, unknown> | null)
+                  ?.bank_transfer_status === "awaiting_deposit" &&
+              order.payment_status !== "captured"
             ? "depositPending"
           : order.fulfillment_status === "fulfilled"
             ? "delivered"

--- a/web/almondyoung-storefront/src/domains/order/details/components/order-details-mobile.tsx
+++ b/web/almondyoung-storefront/src/domains/order/details/components/order-details-mobile.tsx
@@ -104,6 +104,9 @@ export const OrderDetailsMobile = ({
     : tStatus(
         order.status === "canceled"
           ? "orderCancel"
+          : (order.metadata as Record<string, unknown> | null)
+                ?.bank_transfer_status === "awaiting_deposit"
+            ? "depositPending"
           : order.fulfillment_status === "fulfilled"
             ? "delivered"
             : order.fulfillment_status === "shipped"

--- a/web/almondyoung-storefront/src/domains/order/list/components/order-list.tsx
+++ b/web/almondyoung-storefront/src/domains/order/list/components/order-list.tsx
@@ -42,6 +42,13 @@ const LOAD_MORE_LIMIT = 20
 
 const getOrderStatusKey = (order: HttpTypes.StoreOrder): string => {
   if (order.status === "canceled") return "cancelled"
+  // 무통장입금 선생성 주문: 관리자 입금확인 전까지 '입금확인중' 으로 표시
+  // 결제는 authorized(미capture) 상태라 일반 로직에선 '상품 준비 중'으로 잘못 보이므로 최우선 처리
+  if (
+    (order.metadata as Record<string, unknown> | null)?.bank_transfer_status ===
+    "awaiting_deposit"
+  )
+    return "depositPending"
   if (order.payment_status === "awaiting") return "paymentPending"
   if (order.fulfillment_status === "fulfilled") return "delivered"
   if (order.fulfillment_status === "shipped") return "shipping"

--- a/web/almondyoung-storefront/src/domains/order/list/components/order-list.tsx
+++ b/web/almondyoung-storefront/src/domains/order/list/components/order-list.tsx
@@ -44,9 +44,13 @@ const getOrderStatusKey = (order: HttpTypes.StoreOrder): string => {
   if (order.status === "canceled") return "cancelled"
   // 무통장입금 선생성 주문: 관리자 입금확인 전까지 '입금확인중' 으로 표시
   // 결제는 authorized(미capture) 상태라 일반 로직에선 '상품 준비 중'으로 잘못 보이므로 최우선 처리
+  // payment_status 와 AND: 입금확인(capture) 후 'confirmed' metadata 갱신이 실패해 awaiting_deposit
+  // 가 남아도, captured 면 이미 결제완료이므로 '입금확인중' 으로 표시하지 않는다
+  // (channel-adapter 의 WMS 수집 게이트와 동일한 불변식).
   if (
     (order.metadata as Record<string, unknown> | null)?.bank_transfer_status ===
-    "awaiting_deposit"
+      "awaiting_deposit" &&
+    order.payment_status !== "captured"
   )
     return "depositPending"
   if (order.payment_status === "awaiting") return "paymentPending"

--- a/web/almondyoung-storefront/src/i18n/messages/en/mypage.json
+++ b/web/almondyoung-storefront/src/i18n/messages/en/mypage.json
@@ -371,6 +371,7 @@
     "status": {
       "cancelled": "Cancelled",
       "paymentPending": "Payment Pending",
+      "depositPending": "Awaiting Deposit",
       "delivered": "Delivered",
       "shipping": "Shipping",
       "partialShipping": "Partial Shipping",

--- a/web/almondyoung-storefront/src/i18n/messages/ja/mypage.json
+++ b/web/almondyoung-storefront/src/i18n/messages/ja/mypage.json
@@ -371,6 +371,7 @@
     "status": {
       "cancelled": "キャンセル済み",
       "paymentPending": "お支払い待ち",
+      "depositPending": "入金確認中",
       "delivered": "配送完了",
       "shipping": "配送中",
       "partialShipping": "一部配送",

--- a/web/almondyoung-storefront/src/i18n/messages/ko/mypage.json
+++ b/web/almondyoung-storefront/src/i18n/messages/ko/mypage.json
@@ -371,6 +371,7 @@
     "status": {
       "cancelled": "취소됨",
       "paymentPending": "결제 대기",
+      "depositPending": "입금확인중",
       "delivered": "배송 완료",
       "shipping": "배송 중",
       "partialShipping": "부분 배송",

--- a/web/almondyoung-storefront/src/lib/api/medusa/cart.ts
+++ b/web/almondyoung-storefront/src/lib/api/medusa/cart.ts
@@ -16,7 +16,11 @@ import { revalidateTag } from "next/cache"
 import { redirect } from "next/navigation"
 import { HttpApiError } from "../api-error"
 import { getRegion } from "./regions"
-import { retrieveCustomer, transferCart } from "./customer"
+import {
+  recoverCustomerCart,
+  retrieveCustomer,
+  transferCart,
+} from "./customer"
 import {
   cartRequiresShipping,
   selectShippingOptionsForCart,
@@ -43,6 +47,11 @@ export async function retrieveCart(
     return null
   }
 
+  // 완료(주문 전환)된 카트를 감지하려면 completed_at 이 응답에 포함
+  const effectiveFields = fields.includes("completed_at")
+    ? fields
+    : `${fields},completed_at`
+
   const headers = {
     ...(await getAuthHeaders()),
   }
@@ -55,16 +64,33 @@ export async function retrieveCart(
     .fetch<{ cart: HttpTypes.StoreCart }>(`/store/carts/${id}`, {
       method: "GET",
       query: {
-        fields,
+        fields: effectiveFields,
       },
       headers,
       next,
       cache,
     })
-    .then(({ cart }: { cart: HttpTypes.StoreCart }) => cart)
+    .then(async ({ cart }: { cart: HttpTypes.StoreCart }) => {
+      // completeCartWorkflow 로 주문 전환된 카트는 더 이상 장바구니가 아니다.
+      // 무통장입금처럼 브라우저가 완료 과정에 참여하지 않으면 쿠키가 남아
+      // 완료된 카트가 계속 장바구니로 노출. 쿠키를 정리하고 null 을 돌려 상위에서 새 카트 생성/복구로 흐르게
+      if (cart?.completed_at) {
+        // 렌더 컨텍스트에서는 쿠키 변경이 막힐 수 있어 best-effort 로 처리한
+        try {
+          await removeCartId()
+        } catch {
+          // Server Action/Route Handler 가 아닌 곳에서 호출되면 무시
+        }
+        return null
+      }
+      return cart
+    })
     .catch(async (error) => {
       if (error?.response?.status === 404) {
-        await removeCartId()
+        try {
+          await removeCartId()
+        } catch {
+        }
       }
       return null
     })
@@ -160,6 +186,18 @@ export async function getOrSetCart(countryCode: string) {
       // 다른 사용자의 장바구니이므로 쿠키 제거 후 새 장바구니 생성
       await removeCartId()
       cart = null
+    }
+  }
+
+  if (!cart) {
+    // 쿠키 소실(캐시 삭제 / 쿠키 만료 / 시크릿 모드 / 다른 기기)로 카트 쿠키가 없더라도
+    // 로그인 상태라면 새 카트를 만들기 전에 고객의 기존 미완료 카트를 먼저 복구
+    // recoverCustomerCart 는 GET /store/customers/me/cart 를 호출하며, 백엔드가 completed_at IS NULL 로 필터링하므로 완료(주문 전환)된 카트는 절대 복구되지 않는다.
+    if (headers.authorization) {
+      const recovered = await recoverCustomerCart()
+      if (recovered) {
+        cart = recovered
+      }
     }
   }
 

--- a/web/almondyoung-storefront/src/lib/api/medusa/cart.ts
+++ b/web/almondyoung-storefront/src/lib/api/medusa/cart.ts
@@ -75,9 +75,15 @@ export async function retrieveCart(
       // 무통장입금처럼 브라우저가 완료 과정에 참여하지 않으면 쿠키가 남아
       // 완료된 카트가 계속 장바구니로 노출. 쿠키를 정리하고 null 을 돌려 상위에서 새 카트 생성/복구로 흐르게
       if (cart?.completed_at) {
-        // 렌더 컨텍스트에서는 쿠키 변경이 막힐 수 있어 best-effort 로 처리한
+        // 쿠키는 '이 완료된 카트를 쿠키가 실제로 가리킬 때'만 정리한다. 명시적 cartId 로 완료된
+        // 파생 카트(체크아웃/배송 프리뷰 sub-cart)를 조회하는 경우, 쿠키가 가리키는 별개의 활성
+        // source 카트를 지워 남은 장바구니를 유실시키면 안 된다.
         try {
-          await removeCartId()
+          const cookieCartId = await getCartId()
+          if (cookieCartId && cookieCartId === id) {
+            // 렌더 컨텍스트에서는 쿠키 변경이 막힐 수 있어 best-effort 로 처리
+            await removeCartId()
+          }
         } catch {
           // Server Action/Route Handler 가 아닌 곳에서 호출되면 무시
         }

--- a/web/almondyoung-storefront/src/lib/api/medusa/orders.ts
+++ b/web/almondyoung-storefront/src/lib/api/medusa/orders.ts
@@ -54,7 +54,7 @@ export async function getOrders(params?: {
 }): Promise<HttpTypes.StoreOrderListResponse | null> {
   const filters: HttpTypes.StoreOrderFilters & Record<string, unknown> = {
     fields:
-      "id,display_id,status,fulfillment_status,payment_status,created_at,updated_at,total,currency_code,*items,*items.variant,*items.variant.product,*payment_collections,*payment_collections.payment_sessions",
+      "id,display_id,status,fulfillment_status,payment_status,created_at,updated_at,total,currency_code,metadata,*items,*items.variant,*items.variant.product,*payment_collections,*payment_collections.payment_sessions",
     order: "-created_at",
   }
 
@@ -107,7 +107,8 @@ export async function getOrder(
   }
 
   return await sdk.store.order
-    .retrieve(orderId, {}, headers)
+    // +metadata: 무통장 입금확인중(metadata.bank_transfer_status) 표시를 위해 기본 필드에 추가
+    .retrieve(orderId, { fields: "+metadata" }, headers)
     .then(({ order }) => order)
     .catch(async (error) => {
       await handleMedusaAuthError(error)


### PR DESCRIPTION


### #440 완료 카트 쿠키 정리
- `retrieveCart()` 가 `completed_at` 을 항상 요청 → 완료(주문 전환) 카트면 쿠키 정리 후 `null`

### #441 로그인 시 기존 카트 복구
- `getOrSetCart()` 쿠키 없음 + 로그인 시, 새 카트 생성 전 `recoverCustomerCart()` 선행
- Medusa `/store/customers/me/cart` 가 결제용 checkout/preview cart(`source_cart_id` / `is_shipping_preview`) 를 복구 대상에서 제외 → 입금대기(최대 72h) 중 쿠키 소실 시 checkoutCart 복구 레이스 차단

### #439 무통장 주문 선생성 + 미입금 취소·정리
- **wallet**: `AWAITING_DEPOSIT` 진입 시 `INTENT_AWAITING_DEPOSIT` 발행 / 만료 job 이 `INTENT_CANCELED` 발행(기존 무이벤트 → 미입금 정리 누락 보완)
- **channel-adapter**: 신규 이벤트 포워딩 + `awaiting_deposit && payment_status != captured` 주문은 WMS 수집(OrderCreated)에서 제외(미입금 출고 방지). capture 후 stale metadata 는 수집 허용(게이트 디커플)
- **medusa**:
  - `almond-payment.mapStatus(AWAITING_DEPOSIT) → 'authorized'` (무통장 intent 만 도달 → 카드/Toss 무영향)
  - 입금대기 시 `completeCartWorkflow` **호출 전** `cart.metadata` 에 `bank_transfer_status='awaiting_deposit'` 를 심어 order 와 **원자적**으로 선생성 → "marker 없는 authorized 주문"이 수집되는 창 제거
  - 취소/만료 시 `cancelOrderWorkflow` 로 주문 취소 + 예약재고 해제(미capture 주문만, 실패 시 throw→재시도)
  - 원본 장바구니의 구매 아이템을 서버사이드에서 정리(무통장은 브라우저 callback 미경유)
  - graceful degradation: 입금대기 이벤트 유실돼도 capture 시 동일 복구 경로가 주문 생성
- **storefront**: 주문내역/상세에 "입금확인중"(depositPending, ko/en/ja) 표시. 카트 페이지 `no-store`(서버사이드 정리 즉시 반영)

### #442 카트 allow_backorder
- develop 반영분 유지(`allow_backorder` 필드 + 재고 품절 차단; allow_backorder=true 면 미차단)
