### PR TITLE
fix: 디지털 상품 주문/체크아웃 배송 처리 안정화 (#450 #453 #458)

### DIFF
--- a/apps/channel-adapter/src/adapters/medusa/medusa.client.spec.ts
+++ b/apps/channel-adapter/src/adapters/medusa/medusa.client.spec.ts
@@ -246,6 +246,58 @@ describe('MedusaClient product sellable inventory projection', () => {
     expect(upsertProjectionInventoryLevel).toHaveBeenCalledWith('iitem_projection', 0);
   });
 
+  it('skips stock projection and removes projection links for digital products', async () => {
+    const client = Object.create(MedusaClient.prototype) as MedusaClient;
+    (client as any).logger = logger;
+    (client as any).getProductWithVariantDetails = jest.fn().mockResolvedValue({
+      id: 'prod_digital',
+      metadata: { fulfillmentKind: 'digital', requiresShipping: false },
+      variants: [
+        {
+          id: 'variant_medusa_1',
+          title: '기본 품목',
+          sku: 'SKU-D',
+          manage_inventory: false,
+          metadata: { pimVariantId: 'pim-var-1' },
+          inventory_items: [
+            {
+              inventory_item_id: 'iitem_projection',
+              inventory: {
+                sku: 'psq_pim-var-1',
+                metadata: { projectionType: 'product_sellable_quantity', pimVariantId: 'pim-var-1' },
+              },
+            },
+          ],
+        },
+      ],
+    });
+    const removeProjectionInventoryLinks = jest.fn().mockResolvedValue(undefined);
+    const ensureVariantInventoryLinks = jest.fn();
+    const batchVariants = jest.fn();
+    (client as any).removeProjectionInventoryLinks = removeProjectionInventoryLinks;
+    (client as any).ensureVariantInventoryLinks = ensureVariantInventoryLinks;
+    (client as any).sdk = { admin: { product: { batchVariants } } };
+
+    const result = await client.applyProductSellableQuantityProjection({
+      medusaProductId: 'prod_digital',
+      variantId: 'pim-var-1',
+      masterId: 'master-1',
+      sellableQuantity: 7,
+      isSellable: true,
+      reason: 'SELLABLE',
+      calculatedAt: '2026-05-27T00:00:00.000Z',
+    });
+
+    expect(result).toEqual({ soldOutChanged: false });
+    // 디지털은 projection inventory 를 만들지 않고 기존 링크를 제거한다.
+    expect(removeProjectionInventoryLinks).toHaveBeenCalledWith(
+      'prod_digital',
+      expect.objectContaining({ id: 'prod_digital' }),
+    );
+    expect(ensureVariantInventoryLinks).not.toHaveBeenCalled();
+    expect(batchVariants).not.toHaveBeenCalled();
+  });
+
   it('turns on managed inventory and stores sellable quantity for stock-gated projection events', async () => {
     const batchVariants = jest.fn().mockResolvedValue({});
     const upsertProjectionInventoryLevel = jest.fn().mockResolvedValue(undefined);

--- a/apps/channel-adapter/src/adapters/medusa/medusa.client.ts
+++ b/apps/channel-adapter/src/adapters/medusa/medusa.client.ts
@@ -947,7 +947,7 @@ export class MedusaClient {
   private async getProductWithVariantDetails(productId: string): Promise<MedusaProduct> {
     const { product } = await this.sdk.admin.product.retrieve(productId, {
       fields:
-        'id,*variants,+variants.metadata,+variants.manage_inventory,+variants.sku,+variants.title,' +
+        'id,metadata,*variants,+variants.metadata,+variants.manage_inventory,+variants.sku,+variants.title,' +
         '+variants.inventory_items,+variants.inventory_items.inventory.id,+variants.inventory_items.inventory.sku,' +
         '+variants.inventory_items.inventory.metadata',
     });
@@ -1009,6 +1009,7 @@ export class MedusaClient {
   private async getOrCreateSellableProjectionInventoryItem(params: {
     pimVariantId: string;
     title: string;
+    requiresShipping?: boolean;
   }): Promise<string> {
     const sku = toMedusaProductSellableInventorySku(params.pimVariantId);
     const existing = await this.sdk.admin.inventoryItem.list({
@@ -1025,7 +1026,8 @@ export class MedusaClient {
       const created = await this.sdk.admin.inventoryItem.create({
         sku,
         title: params.title,
-        requires_shipping: true,
+        // 디지털은 projection inventory를 만들지 않으므로 호출부에서 걸러지지만, 정책값을 받아 하드코딩을 피한다.
+        requires_shipping: params.requiresShipping ?? true,
         metadata: {
           projectionType: 'product_sellable_quantity',
           projectionSource: 'core',
@@ -1157,6 +1159,7 @@ export class MedusaClient {
         (await this.getOrCreateSellableProjectionInventoryItem({
           pimVariantId: target.pimVariantId,
           title: target.title,
+          requiresShipping: options.requiresShipping,
         }));
 
       ensured.set(target.pimVariantId, { variantId: target.variantId, inventoryItemId });
@@ -1367,6 +1370,20 @@ export class MedusaClient {
       throw new Error(
         `Medusa variant with pimVariantId=${input.variantId} not found on product ${input.medusaProductId}`,
       );
+    }
+
+    // 디지털 상품은 재고/품절/배송 projection 대상이 아니다. sellable quantity 이벤트가 와도
+    // projection inventory를 만들지 않고, 남아 있으면 제거한다.
+    const productMetadata = (product as { metadata?: Record<string, unknown> | null }).metadata ?? {};
+    const isDigitalProduct =
+      productMetadata.fulfillmentKind === 'digital' || productMetadata.requiresShipping === false;
+    if (isDigitalProduct) {
+      await this.removeProjectionInventoryLinks(product.id, product);
+      this.logger.log(
+        `Skipped sellable quantity projection for digital product: medusaProduct=${product.id}, ` +
+          `pimVariantId=${input.variantId}`,
+      );
+      return { soldOutChanged: false };
     }
 
     const ensuredLinks = await this.ensureVariantInventoryLinks(

--- a/apps/medusa/src/scripts/lib/sellable-inventory-projection.ts
+++ b/apps/medusa/src/scripts/lib/sellable-inventory-projection.ts
@@ -33,6 +33,7 @@ type ProductVariantWithInventoryLinks = {
 type ProductWithVariants = {
   id: string;
   handle?: string | null;
+  metadata?: Record<string, unknown> | null;
   variants?: ProductVariantWithInventoryLinks[];
 };
 
@@ -98,6 +99,7 @@ export async function ensureSellableInventoryProjectionLinks(container: any, inp
     fields: [
       'id',
       'handle',
+      'metadata',
       'variants.id',
       'variants.title',
       'variants.sku',
@@ -115,6 +117,35 @@ export async function ensureSellableInventoryProjectionLinks(container: any, inp
   let variantsSeen = 0;
 
   for (const product of products) {
+    // 디지털 상품은 배송이 없으므로 sellable projection inventory(requires_shipping=true)를 만들지 않는다.
+    // 런타임 동기화 경로(medusa.client ensureVariantInventoryLinks)와 동일하게 기존 projection 링크는 제거한다.
+    const isDigital =
+      product.metadata?.fulfillmentKind === 'digital' || product.metadata?.requiresShipping === false;
+
+    if (isDigital) {
+      for (const variant of product.variants || []) {
+        const pimVariantId = variant.metadata?.pimVariantId;
+        if (typeof pimVariantId !== 'string' || !pimVariantId) continue;
+        variantsSeen += 1;
+
+        const projectionSku = toMedusaProductSellableInventorySku(pimVariantId);
+        for (const link of variant.inventory_items || []) {
+          const isProjection =
+            !!link.inventory_item_id &&
+            (link.inventory?.sku === projectionSku ||
+              (link.inventory?.metadata?.pimVariantId === pimVariantId &&
+                isMedusaProductSellableInventoryItem(link.inventory)));
+          if (isProjection) {
+            linksToDismiss.push({
+              [Modules.PRODUCT]: { variant_id: variant.id },
+              [Modules.INVENTORY]: { inventory_item_id: link.inventory_item_id as string },
+            });
+          }
+        }
+      }
+      continue;
+    }
+
     for (const variant of product.variants || []) {
       const pimVariantId = variant.metadata?.pimVariantId;
       if (typeof pimVariantId !== 'string' || !pimVariantId) continue;

--- a/web/almondyoung-storefront/src/domains/checkout/templates/checkout-template.tsx
+++ b/web/almondyoung-storefront/src/domains/checkout/templates/checkout-template.tsx
@@ -6,6 +6,7 @@ import { PaymentTotalSection } from "@/domains/checkout/components/sections/paym
 import { ShippingSection } from "@/domains/checkout/components/sections/shipping"
 import type { ShippingMemo } from "@/domains/checkout/components/sections/shipping/types"
 import { initiatePaymentSession, updateCart } from "@/lib/api/medusa/cart"
+import { cartRequiresShipping } from "@/lib/api/medusa/shipping-method-policy"
 import { mintPaymentHandoffToken } from "@/lib/api/users/auth/payment-handoff"
 import { CartResponseDto } from "@/lib/types/dto/medusa"
 import type { CartTotals, ShippingInfo } from "@/lib/types/ui/cart"
@@ -87,6 +88,10 @@ export default function CheckoutTemplate({
     [cart.items, selectedIds]
   )
 
+  // 배송 필요 여부는 선택된 상품 기준으로 판단(부분 선택 대응). 디지털만 선택하면 배송 불필요.
+  // 판별은 line item requires_shipping 우선, 없으면 product_type 폴백.
+  const requiresShipping = cartRequiresShipping(selectedItems)
+
   // 가격 계산 - 선택된 아이템 기준
   const cartTotals: CartTotals = useMemo(() => {
     const { currency_code } = getCartTotals(cart)
@@ -116,24 +121,27 @@ export default function CheckoutTemplate({
     // 할인 전 정가 기준 상품 금액 (compare_at_unit_price 기준)
     const original_item_subtotal = item_subtotal + membershipDiscount
 
+    // 배송 불필요(디지털 단독)면 배송비 0
+    const effectiveShipping = requiresShipping ? shipping.amount : 0
+
     const totalDiscount = discount_subtotal
     const finalTotal = Math.max(
       0,
-      item_subtotal + shipping.amount - totalDiscount
+      item_subtotal + effectiveShipping - totalDiscount
     )
 
     return {
       currency_code,
       item_subtotal,
       original_item_subtotal,
-      shipping: shipping.amount,
+      shipping: effectiveShipping,
       discount_subtotal,
       membershipDiscount,
       pointsUsed: 0,
       totalDiscount,
       finalTotal,
     }
-  }, [cart, shipping, selectedItems, isMembership])
+  }, [cart, shipping, selectedItems, isMembership, requiresShipping])
 
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -151,19 +159,22 @@ export default function CheckoutTemplate({
   }, [])
 
   const handlePayment = async () => {
-    if (!cart?.shipping_address?.address_1) {
-      return toast.error(tProcess("toasts.setShipping"))
-    }
-    if (!shippingMemo.type) {
-      return toast.error(tProcess("toasts.selectMemo"))
-    }
-    // 문 앞 선택 + 공동현관 있음 체크 시 비밀번호 필수
-    if (
-      shippingMemo.type === "door" &&
-      shippingMemo.hasEntrance &&
-      !shippingMemo.entrancePassword.trim()
-    ) {
-      return toast.error(tProcess("toasts.enterEntrancePw"))
+    // 배송이 필요할 때만 배송지/배송메모를 강제한다.
+    if (requiresShipping) {
+      if (!cart?.shipping_address?.address_1) {
+        return toast.error(tProcess("toasts.setShipping"))
+      }
+      if (!shippingMemo.type) {
+        return toast.error(tProcess("toasts.selectMemo"))
+      }
+      // 문 앞 선택 + 공동현관 있음 체크 시 비밀번호 필수
+      if (
+        shippingMemo.type === "door" &&
+        shippingMemo.hasEntrance &&
+        !shippingMemo.entrancePassword.trim()
+      ) {
+        return toast.error(tProcess("toasts.enterEntrancePw"))
+      }
     }
     processPayment()
   }
@@ -179,23 +190,25 @@ export default function CheckoutTemplate({
         return
       }
 
-      // 결제 전 배송 메모 저장
-      await updateCart(
-        {
-          metadata: {
-            shipping_memo_type: shippingMemo.type,
-            shipping_memo_custom:
-              shippingMemo.type === "other" ? shippingMemo.custom : "",
-            has_entrance:
-              shippingMemo.type === "door" ? shippingMemo.hasEntrance : false,
-            entrance_password:
-              shippingMemo.type === "door" && shippingMemo.hasEntrance
-                ? shippingMemo.entrancePassword
-                : "",
+      // 결제 전 배송 메모 저장 (배송이 필요한 카트에서만)
+      if (requiresShipping) {
+        await updateCart(
+          {
+            metadata: {
+              shipping_memo_type: shippingMemo.type,
+              shipping_memo_custom:
+                shippingMemo.type === "other" ? shippingMemo.custom : "",
+              has_entrance:
+                shippingMemo.type === "door" ? shippingMemo.hasEntrance : false,
+              entrance_password:
+                shippingMemo.type === "door" && shippingMemo.hasEntrance
+                  ? shippingMemo.entrancePassword
+                  : "",
+            },
           },
-        },
-        checkoutCartId
-      )
+          checkoutCartId
+        )
+      }
 
       const returnUrl = `${window.location.origin}/${countryCode}/checkout/callback`
 
@@ -209,9 +222,10 @@ export default function CheckoutTemplate({
               count: payLineItems.length - 1,
             })
 
+      // 배송이 필요할 때만 배송비를 결제항목에 포함(화면 총액과 일치)
       const paymentItems = buildPaymentItems(
         payLineItems,
-        cart.shipping_methods
+        requiresShipping ? cart.shipping_methods : []
       )
 
       const result = await initiatePaymentSession(cart, {
@@ -278,13 +292,17 @@ export default function CheckoutTemplate({
         <MobileHeader onClose={() => router.push(`/${countryCode}/cart`)} />
 
         <div className="mx-auto lg:max-w-[820px]">
-          <ShippingSection
-            cartId={checkoutCartId}
-            shippingAddress={cart?.shipping_address || null}
-            addressName={cart?.metadata?.shipping_address_name as string | null}
-            shippingMemo={shippingMemo}
-            onShippingMemoChange={handleShippingMemoChange}
-          />
+          {requiresShipping && (
+            <ShippingSection
+              cartId={checkoutCartId}
+              shippingAddress={cart?.shipping_address || null}
+              addressName={
+                cart?.metadata?.shipping_address_name as string | null
+              }
+              shippingMemo={shippingMemo}
+              onShippingMemoChange={handleShippingMemoChange}
+            />
+          )}
           <OrderProductsSection
             cartId={checkoutCartId}
             products={cart?.items}


### PR DESCRIPTION
디지털 상품(전자책/캔바 등) 포함 주문이 배송 프로필 부재로 생성되지 않던 #450의 재발 방지 코드 수정과, 디지털 단독 카트가 체크아웃에서 막히던 #453을 함께 안정화합니다.
(라이브 임시 보정(디지털 inventory 148개 `requires_shipping=false`)은 이미 적용 완료)

## 변경
### 백엔드 / 동기화 (#450, #458)
- `apps/medusa/.../sellable-inventory-projection.ts`(백필): 디지털 상품이면 sellable projection inventory를 만들지 않고 기존 projection 링크 제거(런타임 경로와 정책 일치).
- `apps/channel-adapter/.../medusa.client.ts`:
  - projection inventory 생성의 `requires_shipping` 하드코딩 제거(호출부 정책값 수신).
  - `applyProductSellableQuantityProjection()`에 디지털 skip 가드추가 — sellable-quantity 이벤트가 와도 디지털은 projection을 만들지 않고 링크 제거(재동기화로 digital이 된 상품이 이후 이벤트로 다시 깨지지 않게).
  - `getProductWithVariantDetails` fields에 product `metadata` 추가.

### 스토어프론트 (#453)
- `web/almondyoung-storefront/.../checkout-template.tsx`: 배송 필요 여부를 selectedItems 기준`cartRequiresShipping`로 판단. 배송 불필요면 배송지/배송메모 검증·ShippingSection·배송메모 저장 생략, `cartTotals` 배송비와 `buildPaymentItems` 배송 항목도 `requiresShipping` 기준으로 맞춰 화면 총액과 결제창 항목 일치.


## 별도 이슈
- 체크아웃 부분 선택 시 표시(선택분)와 실제 payment/completeCart 대상(전체 카트) 동기화는 기존 이슈로 분리. 이 PR의 blocker 아님.
- 디지털 마킹 영구 해결(#452 재동기화), 이벤트 계약 보강(#454), ownership 정합성(#455), 고객/어드민 UX(#456/#457)는 후속.

refs #450 #453 #458
