### PR TITLE
ops: 디지털 상품 재동기화(#452) 런북·검증 스크립트·backfill 도구 보강

### DIFF
--- a/apps/channel-adapter/scripts/backfill-v2.ts
+++ b/apps/channel-adapter/scripts/backfill-v2.ts
@@ -17,6 +17,9 @@
  *   # With options
  *   npx ts-node apps/channel-adapter/scripts/backfill-v2.ts --batch-size=50 --limit=100 --concurrency=5
  *
+ *   # 특정 master 만 재동기화 (부분 타겟팅, 예: 디지털 상품)
+ *   npx ts-node apps/channel-adapter/scripts/backfill-v2.ts --master-ids=uuid1,uuid2,uuid3
+ *
  *   # Resume from checkpoint
  *   npx ts-node apps/channel-adapter/scripts/backfill-v2.ts --resume=backfill-1737600000-abc12345
  */
@@ -29,6 +32,7 @@ import { PimSnapshotBuilder } from './lib/pim-snapshot-builder';
 import { MigrationSessionService } from './lib/migration-session.service';
 import { syncWithRetry, classifyError } from './lib/error-classifier';
 import { PimMedusaSyncService } from '../src/adapters/medusa/pim-medusa-sync.service';
+import { StorefrontRevalidateService } from '../src/adapters/medusa/storefront-revalidate.service';
 import { MedusaClient } from '../src/adapters/medusa/medusa.client';
 import { PimMedusaMappingRepository } from '../src/adapters/medusa/pim-medusa-mapping.repository';
 
@@ -39,6 +43,7 @@ interface BackfillOptions {
   limit?: number;
   concurrency: number;
   rateLimitMs: number;
+  masterIds?: string[];
 }
 
 const DEFAULT_CONCURRENCY = 3;
@@ -79,12 +84,19 @@ function parseArgs(): BackfillOptions {
   const rawRateLimit = rateLimitRaw ? parseInt(rateLimitRaw, 10) : DEFAULT_RATE_LIMIT_MS;
   const rateLimitMs = Math.max(0, Number.isFinite(rawRateLimit) ? rawRateLimit : DEFAULT_RATE_LIMIT_MS);
 
+  // --master-ids=uuid1,uuid2 : 지정한 master 만 재동기화(부분 타겟팅). 미지정 시 전체.
+  const masterIdsRaw = getArgValue(args, 'master-ids');
+  const masterIds = masterIdsRaw
+    ? masterIdsRaw.split(',').map((s) => s.trim()).filter(Boolean)
+    : undefined;
+
   return {
     batchSize: batchSizeRaw ? parseInt(batchSizeRaw, 10) : 100,
     resumeSessionId: resumeRaw,
     limit: limitRaw ? parseInt(limitRaw, 10) : undefined,
     concurrency,
     rateLimitMs,
+    masterIds: masterIds?.length ? masterIds : undefined,
   };
 }
 
@@ -175,7 +187,13 @@ async function main() {
   const sessionService = new MigrationSessionService(channelDb);
   const medusaClient = new MedusaClient(configService);
   const mappingRepo = new PimMedusaMappingRepository({ db: channelDb } as any);
-  const syncService = new PimMedusaSyncService(medusaClient, mappingRepo);
+  // StorefrontRevalidateService 는 무인자 생성(환경변수 없으면 no-op). 생성자 3번째 인자 누락으로
+  // backfill-v2 가 깨져 있던 것을 함께 보정한다.
+  const syncService = new PimMedusaSyncService(
+    medusaClient,
+    mappingRepo,
+    new StorefrontRevalidateService(),
+  );
 
   // 카테고리/태그/타입/세일즈채널 캐시를 미리 채워 product 당 list/verify HTTP 호출을
   // 0 회에 가깝게 줄인다. 이후 cacheOnly 모드를 활성화해 paginated LIST 조회도 회피.
@@ -222,8 +240,8 @@ async function main() {
     while (true) {
       console.log(`\n📊 Batch ${batchNumber}: Fetching ${session.batchSize} products from offset ${offset}...`);
 
-      // Fetch batch
-      const snapshots = await snapshotBuilder.fetchActiveMasters(session.batchSize, offset);
+      // Fetch batch (masterIds 지정 시 해당 master 만 대상)
+      const snapshots = await snapshotBuilder.fetchActiveMasters(session.batchSize, offset, options.masterIds);
 
       if (snapshots.length === 0) {
         console.log('✅ No more products to process');

--- a/apps/channel-adapter/scripts/lib/pim-snapshot-builder.ts
+++ b/apps/channel-adapter/scripts/lib/pim-snapshot-builder.ts
@@ -1,6 +1,6 @@
 // apps/channel-adapter/scripts/lib/pim-snapshot-builder.ts
 import * as postgres from 'postgres';
-import type { PimProductSnapshot, PimPurchaseConstraint } from '../../src/types';
+import type { PimFulfillmentKind, PimProductSnapshot, PimPurchaseConstraint } from '../../src/types';
 
 // Database row types
 interface MasterRow {
@@ -16,6 +16,7 @@ interface MasterRow {
   seo_description?: string;
   seo_keywords?: string[];
   product_type?: string;
+  fulfillment_kind?: PimFulfillmentKind | null;
   status: string;
   is_wholesale_only: boolean;
   hide_membership_price_for_non_members: boolean;
@@ -88,11 +89,11 @@ export class PimSnapshotBuilder {
   /**
    * Fetch active product masters with full snapshots
    */
-  async fetchActiveMasters(limit: number, offset: number): Promise<PimProductSnapshot[]> {
+  async fetchActiveMasters(limit: number, offset: number, targetMasterIds?: string[]): Promise<PimProductSnapshot[]> {
     console.log(`[PimSnapshotBuilder] Fetching ${limit} masters from offset ${offset}...`);
 
     // Step 1: Query active masters + versions
-    const masters = await this.queryMasters(limit, offset);
+    const masters = await this.queryMasters(limit, offset, targetMasterIds);
 
     if (masters.length === 0) {
       console.log(`[PimSnapshotBuilder] No masters found`);
@@ -124,7 +125,9 @@ export class PimSnapshotBuilder {
   /**
    * Query active masters with version data
    */
-  private async queryMasters(limit: number, offset: number): Promise<MasterRow[]> {
+  private async queryMasters(limit: number, offset: number, targetMasterIds?: string[]): Promise<MasterRow[]> {
+    // targetMasterIds 가 주어지면 해당 master 만 대상으로 한다(디지털 재동기화 등 부분 타겟팅).
+    const masterFilter = targetMasterIds?.length ? this.pimDb`AND pm.id = ANY(${targetMasterIds})` : this.pimDb``;
     return await this.pimDb<MasterRow[]>`
       SELECT
         pm.id AS master_id,
@@ -139,6 +142,7 @@ export class PimSnapshotBuilder {
         pmv.seo_description,
         pmv.seo_keywords,
         pmv.product_type,
+        pmv.fulfillment_kind,
         pmv.status,
         pmv.is_wholesale_only,
         pmv.hide_membership_price_for_non_members,
@@ -149,6 +153,7 @@ export class PimSnapshotBuilder {
       WHERE pmv.status = 'active'
         AND pmv.deleted_at IS NULL
         AND pm.deleted_at IS NULL
+        ${masterFilter}
       ORDER BY pm.created_at DESC
       LIMIT ${limit} OFFSET ${offset}
     `;
@@ -391,6 +396,7 @@ export class PimSnapshotBuilder {
         seoKeywords: master.seo_keywords || [],
         brand: master.brand,
         productType: master.product_type,
+        fulfillmentKind: master.fulfillment_kind ?? undefined,
         categories: masterCategories,
         categoryIds: masterCategories.map((c) => c.id),
         variants: masterVariants,

--- a/docs/runbooks/452-digital-resync.md
+++ b/docs/runbooks/452-digital-resync.md
@@ -1,0 +1,77 @@
+# Runbook: #452 디지털 상품 Core→Medusa 재동기화
+
+> 상태: **준비 완료 / 라이브 미실행.** 관련 PR(#459 등) 머지·배포 후 실행.
+> 목적: Medusa 에 디지털로 마킹되지 않은 디지털 상품 150개를 Core(SoT) 기준으로 재동기화하여
+> `metadata.fulfillmentKind='digital'` / `requiresShipping=false` / `shipping_profile_id=null` / projection 링크 제거 상태로 정합화.
+
+## 왜 이 작업이 따로 필요한가 (동영님 검토 포인트)
+
+- **코드 배포(#459 등)** = "앞으로 재동기화/신규 동기화/이벤트가 와도 디지털이 안 깨지게" 한다. 이미 잘못 들어간 기존 데이터는 자동으로 안 고쳐진다.
+- **#452 재동기화** = 이미 Medusa 에 잘못 들어간 150개의 기존 데이터를 SoT 기준으로 실제 보정한다.
+- 지금은 #450 임시 보정(projection inventory 148개 `requires_shipping=false`)으로 **주문 장애는 이미 해소**됨. 따라서 #452 는 즉시 장애복구가 아니라 **영구 정합성 복구**.
+
+## SoT / 방법 결정 근거
+
+- **SoT = Core `product_master_versions.fulfillment_kind`.** 라이브 Core 에서 이미 디지털 150개가 `fulfillment_kind='digital'`. 즉 데이터 정정이 아니라 **재동기화**가 영구 해결.
+- **Medusa 직접 백필이 아니라 Core→Medusa 재동기화**인 이유: Medusa 만 직접 고치면 이후 Core 재동기화 때 다시 덮어써져 깨진다. SoT 경로로 밀어야 안정.
+- **재동기화 경로 = channel-adapter `scripts/backfill-v2.ts`** (Core SoT → `PimSnapshotBuilder` → `PimMedusaSyncService.upsert` = 프로덕션 transformer/`ensureVariantInventoryLinks` 그대로). 이벤트 재발행 경로는 Core 에 전용 트리거가 없어(버전 변경 시 outbox 발행만) 제외.
+
+## 선행 조건 (A-0 검증 결과)
+
+| 항목 | 상태 |
+|---|---|
+| 라이브 channel-adapter transformer 가 `fulfillmentKind`/`requiresShipping`/`shipping_profile_id=null` 를 싣는가 | ✅ 충족. 배포된 `dist/apps/channel-adapter/main.js` 에 `fulfillmentKind`(8)·`requiresShipping`(9) 포함 확인(ECS Exec) |
+| #459(applyProductSellableQuantityProjection 디지털 skip) 라이브 배포 | ❌ **미배포.** 재동기화 후 sellable-quantity 이벤트가 오면 projection 이 재생성되어 재깨짐 → **#459 배포가 재동기화보다 먼저여야 함** |
+| Core digital active master | 150개 |
+| Medusa 매핑 | 150/150 (미매핑 0) |
+| backfill-v2 의 특정 masterId 타겟 | ✅ 구현됨(이 PR). `--master-ids=<csv>` |
+| backfill 스냅샷에 `fulfillment_kind` 포함 | ✅ 구현됨(이 PR). 기존 snapshot-builder 는 `fulfillment_kind` 를 SELECT 하지 않아 backfill 재동기화 시 디지털이 physical 로 마킹되던 버그를 함께 수정 |
+
+### 재동기화 도구 변경 (이 PR 에 포함)
+`apps/channel-adapter/scripts/lib/pim-snapshot-builder.ts` + `backfill-v2.ts`:
+- **`--master-ids=<csv>` 필터**: `queryMasters` 에 `AND pm.id = ANY($ids)` 옵션 → 전체 1만개가 아니라 디지털 150개만 안전하게 타겟.
+- **`fulfillment_kind` 스냅샷 반영**: snapshot-builder 가 `pmv.fulfillment_kind` 를 SELECT 하지 않아, backfill 경로 재동기화 시 `snapshot.fulfillmentKind` 가 비어 디지털이 physical 로 마킹되던 버그 수정. (프로덕션 이벤트 경로는 이벤트 payload 에 fulfillmentKind 가 있어 영향 없었음)
+- **backfill-v2 생성자 보정**: `PimMedusaSyncService` 가 3번째 인자(`StorefrontRevalidateService`)를 요구하는데 backfill-v2 가 2개만 넘겨 깨져 있던 것 보정(무인자 생성, env 없으면 no-op).
+
+## 대상 산출 / 검증 스크립트 (READ-ONLY)
+
+`scripts/ops/452-digital-resync-prep.ts` — Core digital master + Medusa 매핑 + Medusa 현재 상태 집계.
+재동기화 **전/후 동일 실행**으로 검증한다.
+
+실행: `cd deployments/lcnine/services && npx sst shell --stage live -- npx tsx ../../../scripts/ops/452-digital-resync-prep.ts`
+
+### Baseline (재동기화 전, 2026-06-24 측정)
+```
+Core digital active master : 150
+Medusa 매핑                 : 150 / 150 (미매핑 0)
+product 집계               : total=150, marked_digital=2, no_fk=148, has_profile=0
+projection requires_shipping=true : 0   (#450 임시보정 유지됨)
+```
+
+### 기대치 (재동기화 후)
+```
+marked_digital = 150   (no_fk = 0)
+has_profile = 0        (디지털은 프로필 null 유지)
+projection requires_shipping=true = 0
++ 디지털 라인아이템 requires_shipping=false (신규 카트 기준)
+```
+
+## 실행 순서 (PR 머지·배포 후)
+
+1. **선행**: #459 포함 관련 PR 머지 → 라이브 배포 완료 확인.
+2. **baseline 측정**: `_resync-prep.ts` 실행, 위 baseline 기록.
+3. **dry-run 1건**: 디지털 1개만 재동기화.
+   - 후보: `[캔바/한글] 샵인샵 계약서` (`prod_01KT8JA8MD2J3FVC8VCPSMN0FG`)
+   - 검증(해당 1건): Medusa `metadata.fulfillmentKind='digital'`, `shipping_profile_id=null`, projection 링크 제거, (카트 담아) line item `requires_shipping=false`.
+4. **1건 성공 시 전체 150 재동기화** (`--master-ids` 150개).
+5. **집계 검증**: `_resync-prep.ts` 재실행 → 기대치 충족 확인. "프로필 없음 + requires_shipping=true projection" 0개 재확인.
+6. 결과 보고(코드/라이브 검증 분리).
+
+## 롤백 / 안전장치
+- backfill-v2 는 upsert(기존 product 갱신). 디지털 상품에 한정(150 masterId 화이트리스트)하여 물리상품 영향 0.
+- 단계적(dry-run 1 → 전체) + 전/후 집계 비교로 이상 즉시 감지.
+- 실패/이상 시: 해당 product 는 Core SoT 가 정답이므로 재실행으로 수렴(멱등 upsert).
+
+## 관련
+- 코드 PR: #459 (#450/#453/#458 안정화)
+- 이슈: #450, #452, #458

--- a/docs/runbooks/452-digital-resync.md
+++ b/docs/runbooks/452-digital-resync.md
@@ -67,6 +67,24 @@ projection requires_shipping=true = 0
 5. **집계 검증**: `_resync-prep.ts` 재실행 → 기대치 충족 확인. "프로필 없음 + requires_shipping=true projection" 0개 재확인.
 6. 결과 보고(코드/라이브 검증 분리).
 
+## #461(디지털 물리출고 제외) 배포 전후 검증 — 기존 backlog 점검
+#461 의 `sales_order_lines.fulfillment_kind/requires_shipping` 는 nullable 이고 **기존 라인은 backfill 되지 않는다**(null=물리 간주). 따라서 #461 배포 전 이미 생성된 디지털 SO line/backlog 는 새 게이트로 자동 제외되지 않는다. (현재 장애 주문 대부분은 #450 에서 주문 생성 자체가 막혔고 Core FO void-matching 방어도 있어 blocker 는 아님.)
+
+배포 전후로 **open(pending/awaiting_matching) backlog 중 디지털 의심 라인**을 점검한다 (Core DB, READ-ONLY):
+```sql
+-- backlog 의 sales_order_lines 를 PIM fulfillment_kind 와 대조해 디지털 의심 라인 탐지.
+-- (variant_id → master 매핑은 product_master_variants 등으로 연결)
+SELECT b.id AS backlog_id, b.status, sol.id AS line_id, sol.variant_id, pmv.fulfillment_kind
+FROM fulfillment_order_creation_backlogs b
+JOIN sales_order_lines sol ON sol.sales_order_id = b.sales_order_id
+JOIN product_master_variants pmvar ON pmvar.variant_id = sol.variant_id
+JOIN product_master_versions pmv ON pmv.master_id = pmvar.master_id AND pmv.status = 'active'
+WHERE b.status IN ('pending', 'awaiting_matching')
+  AND pmv.fulfillment_kind = 'digital';
+```
+- 결과가 있으면 해당 backlog 를 수동으로 `not_required` 처리(또는 재처리)한다.
+- 결과가 0건이면 추가 조치 불필요.
+
 ## 롤백 / 안전장치
 - backfill-v2 는 upsert(기존 product 갱신). 디지털 상품에 한정(150 masterId 화이트리스트)하여 물리상품 영향 0.
 - 단계적(dry-run 1 → 전체) + 전/후 집계 비교로 이상 즉시 감지.

--- a/scripts/ops/452-digital-resync-prep.ts
+++ b/scripts/ops/452-digital-resync-prep.ts
@@ -1,0 +1,67 @@
+/**
+ * A-0 준비(READ-ONLY): #452 재동기화 대상/검증 지표 산출. 라이브 변경 없음.
+ * - Core: fulfillment_kind='digital' active master 목록
+ * - channel_adapter: pim_medusa_mappings 로 medusa_product_id 매핑
+ * - Medusa: 현재 상태 집계(fulfillmentKind 마킹/프로필/projection requires_shipping) = 재동기화 전/후 검증 지표
+ */
+import postgres from 'postgres';
+import { Resource } from 'sst';
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+async function wr<T>(l: string, fn: () => Promise<T>): Promise<T> {
+  let e: any; for (let i = 1; i <= 6; i++) { try { return await fn(); } catch (x: any) { e = x; console.error(`(${l} ${i}/6 ${x.code ?? x.message})`); await sleep(1200 * i); } } throw e;
+}
+async function main() {
+  const db = (Resource as any).Db;
+  const mk = (d: string) => postgres({ host: db.host, port: db.port, username: db.username, password: db.password, database: d, ssl: 'require', max: 1, connect_timeout: 30 });
+  const core = mk('core'), ca = mk('channel_adapter'), med = mk('medusa');
+  await wr('warm', () => core`SELECT 1`);
+  try {
+    console.log('=== 1) Core: digital active master ===');
+    const masters = await core`
+      SELECT DISTINCT pmv.master_id, pmv.name
+      FROM product_master_versions pmv
+      WHERE pmv.fulfillment_kind = 'digital' AND pmv.status = 'active'`;
+    const masterIds = (masters as any[]).map((m) => m.master_id);
+    console.log(`digital active master: ${masterIds.length}개`);
+
+    console.log('\n=== 2) channel_adapter: medusa 매핑 ===');
+    const maps = await ca`
+      SELECT pim_master_id, medusa_product_id, medusa_handle
+      FROM pim_medusa_mappings
+      WHERE pim_master_id = ANY(${masterIds}) AND medusa_product_id IS NOT NULL`;
+    const medIds = (maps as any[]).map((m) => m.medusa_product_id);
+    console.log(`매핑된 medusa product: ${medIds.length}개 (미매핑 ${masterIds.length - medIds.length}개)`);
+
+    console.log('\n=== 3) Medusa 현재 상태 집계 (재동기화 전 baseline / 후 검증용) ===');
+    const agg = await med`
+      SELECT
+        count(*)::int total,
+        count(*) FILTER (WHERE p.metadata->>'fulfillmentKind' = 'digital')::int marked_digital,
+        count(*) FILTER (WHERE p.metadata->>'fulfillmentKind' IS NULL)::int no_fk,
+        count(*) FILTER (WHERE EXISTS (SELECT 1 FROM product_shipping_profile psp WHERE psp.product_id=p.id AND psp.deleted_at IS NULL))::int has_profile
+      FROM product p WHERE p.id = ANY(${medIds})`;
+    console.log('product 집계:', JSON.stringify((agg as any[])[0]));
+    const proj = await med`
+      SELECT count(DISTINCT ii.id)::int projection_requires_shipping_true
+      FROM inventory_item ii
+      JOIN product_variant_inventory_item pvii ON pvii.inventory_item_id=ii.id AND pvii.deleted_at IS NULL
+      JOIN product_variant v ON v.id=pvii.variant_id
+      JOIN product p ON p.id=v.product_id
+      WHERE p.id = ANY(${medIds}) AND ii.requires_shipping=true AND ii.deleted_at IS NULL AND ii.sku LIKE 'psq_%'`;
+    console.log('projection inventory(requires_shipping=true):', JSON.stringify((proj as any[])[0]));
+
+    console.log('\n=== 4) dry-run 후보 1건 (마킹 누락 + 매핑됨) ===');
+    const cand = await med`
+      SELECT p.id medusa_id, p.title, p.metadata->>'fulfillmentKind' fk
+      FROM product p
+      WHERE p.id = ANY(${medIds}) AND p.metadata->>'fulfillmentKind' IS NULL
+      ORDER BY p.title LIMIT 3`;
+    for (const c of cand as any[]) console.log('  후보:', JSON.stringify(c));
+
+    console.log('\n=== 5) backfill 필터용 masterId (처음 5개 + 총수) ===');
+    console.log('총', masterIds.length, '개. 예:', masterIds.slice(0, 5));
+  } finally {
+    await core.end({ timeout: 5 }).catch(() => {}); await ca.end({ timeout: 5 }).catch(() => {}); await med.end({ timeout: 5 }).catch(() => {});
+  }
+}
+main().catch((e) => { console.error('ERR', e?.message ?? e); process.exit(1); });


### PR DESCRIPTION
디지털 상품 Medusa 재동기화 실행. #459 머지·배포 후 별도로 재동기화를 실행하기 위한

관련 PR(#459 등) 머지·배포 완료 후, 런북의 dry-run 1건 → 검증 → 전체 150 → 집계검증 순으로 별도 운영 작업.

refs #452 #450 #458
