### PR TITLE
fix: 외부채널(네이버/쿠팡) 디지털 상품 listing 차단 (#455 Part B)

### DIFF
--- a/apps/core/src/modules/catalog/core/channels/channel-listing.service.spec.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing.service.spec.ts
@@ -1,77 +1,89 @@
 import { ChannelListingService } from './channel-listing.service';
 
-// drizzle 쿼리 체인 mock: select()/insert() 호출마다 큐의 다음 결과를 반환하는 thenable 을 만든다.
+// drizzle 쿼리 체인 mock: select()/insert()/update() 호출마다 큐의 다음 결과를 반환하는 thenable.
 function makeClient(results: any[]) {
   let i = 0;
   const makeChain = () => {
     const result = results[i++];
     const chain: any = {};
-    for (const m of ['from', 'innerJoin', 'where', 'limit', 'values', 'returning']) {
+    for (const m of ['from', 'innerJoin', 'where', 'limit', 'values', 'returning', 'set']) {
       chain[m] = () => chain;
     }
     chain.then = (res: any, rej: any) => Promise.resolve(result).then(res, rej);
     return chain;
   };
-  return { select: () => makeChain(), insert: () => makeChain() };
+  return { select: () => makeChain(), insert: () => makeChain(), update: () => makeChain() };
 }
 
 function makeService(results: any[]) {
-  const client = makeClient(results);
-  const db = { db: client } as any;
+  const db = { db: makeClient(results) } as any;
   const productSellableQuantity = { recalculateAndPublishForVariant: jest.fn().mockResolvedValue(undefined) } as any;
   return new ChannelListingService(db, productSellableQuantity);
 }
 
-const baseDto = {
-  variantId: 'var-1',
-  salesChannelId: 'ch-1',
-  channelItemId: 'item-1',
-} as any;
+const baseDto = { variantId: 'var-1', salesChannelId: 'ch-1', channelItemId: 'item-1' } as any;
 
 describe('ChannelListingService createListing — 외부채널 디지털 차단 (#455)', () => {
+  // 큐 순서: variant존재 → channel존재 → (assert)channel site → (assert)isDigitalVariant → insert
   it('외부채널(naver) + 디지털 variant 는 listing 을 차단한다', async () => {
-    // 큐: variant존재, channel(site=naver), isDigitalVariant(digital)
     const service = makeService([
       [{ id: 'var-1' }],
-      [{ id: 'ch-1', site: 'naver' }],
+      [{ id: 'ch-1' }],
+      [{ site: 'naver' }],
       [{ fulfillmentKind: 'digital' }],
     ]);
-
     await expect(service.createListing(baseDto)).rejects.toThrow('디지털 상품을 지원하지 않습니다');
   });
 
   it('외부채널(coupang) + 물리 variant 는 listing 을 허용한다', async () => {
-    // 큐: variant존재, channel(site=coupang), isDigitalVariant(physical), insert
     const service = makeService([
       [{ id: 'var-1' }],
-      [{ id: 'ch-1', site: 'coupang' }],
+      [{ id: 'ch-1' }],
+      [{ site: 'coupang' }],
       [{ fulfillmentKind: 'physical' }],
-      [{ id: 'listing-1', variantId: 'var-1', salesChannelId: 'ch-1' }],
+      [{ id: 'listing-1', variantId: 'var-1' }],
     ]);
-
     await expect(service.createListing(baseDto)).resolves.toMatchObject({ id: 'listing-1' });
   });
 
-  it('medusa(자사몰) 채널은 디지털이어도 listing 을 허용한다', async () => {
-    // 큐: variant존재, channel(site=medusa), insert (isDigitalVariant 는 외부채널이 아니라 호출 안 됨)
+  it('medusa(자사몰) 채널은 디지털이어도 listing 을 허용한다 (외부채널 아님 → digital 조회 skip)', async () => {
     const service = makeService([
       [{ id: 'var-1' }],
-      [{ id: 'ch-1', site: 'medusa' }],
-      [{ id: 'listing-2', variantId: 'var-1', salesChannelId: 'ch-1' }],
+      [{ id: 'ch-1' }],
+      [{ site: 'medusa' }],
+      [{ id: 'listing-2', variantId: 'var-1' }],
     ]);
-
     await expect(service.createListing(baseDto)).resolves.toMatchObject({ id: 'listing-2' });
+  });
+});
+
+describe('ChannelListingService activateListing — 외부채널 디지털 재활성 차단 (#455)', () => {
+  // 큐 순서: getListingById → (assert)channel site → (assert)isDigitalVariant → update
+  it('비활성 외부채널(naver) 디지털 listing 재활성을 차단한다', async () => {
+    const service = makeService([
+      [{ id: 'l-1', variantId: 'var-1', salesChannelId: 'ch-1' }],
+      [{ site: 'naver' }],
+      [{ fulfillmentKind: 'digital' }],
+    ]);
+    await expect(service.activateListing('l-1')).rejects.toThrow('디지털 상품을 지원하지 않습니다');
+  });
+
+  it('medusa 채널 listing 은 재활성을 허용한다', async () => {
+    const service = makeService([
+      [{ id: 'l-2', variantId: 'var-1', salesChannelId: 'ch-1' }],
+      [{ site: 'medusa' }],
+      [{ id: 'l-2', variantId: 'var-1' }],
+    ]);
+    await expect(service.activateListing('l-2')).resolves.toBeUndefined();
   });
 });
 
 describe('ChannelListingService.isExternalMarketplaceSite', () => {
   const service = makeService([]);
-
   it('naver/coupang 는 외부 마켓플레이스', () => {
     expect((service as any).isExternalMarketplaceSite('naver')).toBe(true);
     expect((service as any).isExternalMarketplaceSite('coupang')).toBe(true);
   });
-
   it('medusa/phone_order/other 는 외부 마켓플레이스가 아니다', () => {
     expect((service as any).isExternalMarketplaceSite('medusa')).toBe(false);
     expect((service as any).isExternalMarketplaceSite('phone_order')).toBe(false);

--- a/apps/core/src/modules/catalog/core/channels/channel-listing.service.spec.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing.service.spec.ts
@@ -1,0 +1,80 @@
+import { ChannelListingService } from './channel-listing.service';
+
+// drizzle 쿼리 체인 mock: select()/insert() 호출마다 큐의 다음 결과를 반환하는 thenable 을 만든다.
+function makeClient(results: any[]) {
+  let i = 0;
+  const makeChain = () => {
+    const result = results[i++];
+    const chain: any = {};
+    for (const m of ['from', 'innerJoin', 'where', 'limit', 'values', 'returning']) {
+      chain[m] = () => chain;
+    }
+    chain.then = (res: any, rej: any) => Promise.resolve(result).then(res, rej);
+    return chain;
+  };
+  return { select: () => makeChain(), insert: () => makeChain() };
+}
+
+function makeService(results: any[]) {
+  const client = makeClient(results);
+  const db = { db: client } as any;
+  const productSellableQuantity = { recalculateAndPublishForVariant: jest.fn().mockResolvedValue(undefined) } as any;
+  return new ChannelListingService(db, productSellableQuantity);
+}
+
+const baseDto = {
+  variantId: 'var-1',
+  salesChannelId: 'ch-1',
+  channelItemId: 'item-1',
+} as any;
+
+describe('ChannelListingService createListing — 외부채널 디지털 차단 (#455)', () => {
+  it('외부채널(naver) + 디지털 variant 는 listing 을 차단한다', async () => {
+    // 큐: variant존재, channel(site=naver), isDigitalVariant(digital)
+    const service = makeService([
+      [{ id: 'var-1' }],
+      [{ id: 'ch-1', site: 'naver' }],
+      [{ fulfillmentKind: 'digital' }],
+    ]);
+
+    await expect(service.createListing(baseDto)).rejects.toThrow('디지털 상품을 지원하지 않습니다');
+  });
+
+  it('외부채널(coupang) + 물리 variant 는 listing 을 허용한다', async () => {
+    // 큐: variant존재, channel(site=coupang), isDigitalVariant(physical), insert
+    const service = makeService([
+      [{ id: 'var-1' }],
+      [{ id: 'ch-1', site: 'coupang' }],
+      [{ fulfillmentKind: 'physical' }],
+      [{ id: 'listing-1', variantId: 'var-1', salesChannelId: 'ch-1' }],
+    ]);
+
+    await expect(service.createListing(baseDto)).resolves.toMatchObject({ id: 'listing-1' });
+  });
+
+  it('medusa(자사몰) 채널은 디지털이어도 listing 을 허용한다', async () => {
+    // 큐: variant존재, channel(site=medusa), insert (isDigitalVariant 는 외부채널이 아니라 호출 안 됨)
+    const service = makeService([
+      [{ id: 'var-1' }],
+      [{ id: 'ch-1', site: 'medusa' }],
+      [{ id: 'listing-2', variantId: 'var-1', salesChannelId: 'ch-1' }],
+    ]);
+
+    await expect(service.createListing(baseDto)).resolves.toMatchObject({ id: 'listing-2' });
+  });
+});
+
+describe('ChannelListingService.isExternalMarketplaceSite', () => {
+  const service = makeService([]);
+
+  it('naver/coupang 는 외부 마켓플레이스', () => {
+    expect((service as any).isExternalMarketplaceSite('naver')).toBe(true);
+    expect((service as any).isExternalMarketplaceSite('coupang')).toBe(true);
+  });
+
+  it('medusa/phone_order/other 는 외부 마켓플레이스가 아니다', () => {
+    expect((service as any).isExternalMarketplaceSite('medusa')).toBe(false);
+    expect((service as any).isExternalMarketplaceSite('phone_order')).toBe(false);
+    expect((service as any).isExternalMarketplaceSite('other')).toBe(false);
+  });
+});

--- a/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
@@ -151,7 +151,7 @@ export class ChannelListingService {
 
     // Channel 존재 확인
     const channel = await client
-      .select({ id: salesChannels.id, site: salesChannels.site })
+      .select({ id: salesChannels.id })
       .from(salesChannels)
       .where(eq(salesChannels.id, dto.salesChannelId))
       .limit(1);
@@ -160,14 +160,8 @@ export class ChannelListingService {
       throw new NotFoundError(`Sales channel not found: ${dto.salesChannelId}`);
     }
 
-    // 외부 마켓플레이스(네이버/쿠팡)는 비로그인 주문이라 구매자 식별(customerId)이 없어 디지털 소유권을
-    // 부여할 수 없다. 따라서 디지털 상품은 외부채널에 listing(판매 노출)하지 못하게 막는다.
-    // 디지털은 Medusa(자사몰)에서만 판매한다. (#455)
-    if (this.isExternalMarketplaceSite(channel[0].site) && (await this.isDigitalVariant(dto.variantId, tx))) {
-      throw new BadRequestError(
-        `외부 채널(${channel[0].site})은 디지털 상품을 지원하지 않습니다. 디지털 상품은 Medusa(자사몰)에서만 판매할 수 있습니다.`,
-      );
-    }
+    // 외부 마켓플레이스(네이버/쿠팡)는 디지털 판매를 지원하지 않는다 — 생성 차단. (#455)
+    await this.assertDigitalAllowedForChannel(dto.variantId, dto.salesChannelId, tx);
 
     const [listing] = await client
       .insert(channelVariantListings)
@@ -296,6 +290,13 @@ export class ChannelListingService {
   async activateListing(listingId: string, tx?: DbTransaction): Promise<void> {
     const client = this.getClient(tx);
 
+    // 생성뿐 아니라 재활성도 동일 가드를 타야 한다 — 비활성 외부채널 디지털 listing 의 재활성 우회 차단. (#455)
+    const existing = await this.getListingById(listingId, tx);
+    if (!existing) {
+      return;
+    }
+    await this.assertDigitalAllowedForChannel(existing.variantId, existing.salesChannelId, tx);
+
     const [updated] = await client
       .update(channelVariantListings)
       .set({ isActive: true, updatedAt: new Date() })
@@ -342,8 +343,28 @@ export class ChannelListingService {
   }
 
   /**
-   * 특정 매핑 조회
+   * 외부채널 디지털 판매 차단 가드 (생성/재활성 공유).
+   * 외부 마켓플레이스(네이버/쿠팡)는 비로그인 주문이라 구매자 식별(customerId)이 없어 디지털 소유권을
+   * 부여할 수 없다. 디지털은 Medusa(자사몰)에서만 판매한다. (#455)
    */
+  private async assertDigitalAllowedForChannel(
+    variantId: string,
+    salesChannelId: string,
+    tx?: DbTransaction,
+  ): Promise<void> {
+    const client = this.getClient(tx);
+    const [ch] = await client
+      .select({ site: salesChannels.site })
+      .from(salesChannels)
+      .where(eq(salesChannels.id, salesChannelId))
+      .limit(1);
+    if (ch && this.isExternalMarketplaceSite(ch.site) && (await this.isDigitalVariant(variantId, tx))) {
+      throw new BadRequestError(
+        `외부 채널(${ch.site})은 디지털 상품을 지원하지 않습니다. 디지털 상품은 Medusa(자사몰)에서만 판매할 수 있습니다.`,
+      );
+    }
+  }
+
   /** 외부 마켓플레이스(비로그인 주문 → customerId 없음) 채널인지. 디지털 판매 차단 대상. */
   private isExternalMarketplaceSite(site: string): boolean {
     return site === 'naver' || site === 'coupang';
@@ -361,6 +382,9 @@ export class ChannelListingService {
     return row?.fulfillmentKind === 'digital';
   }
 
+  /**
+   * 특정 매핑 조회
+   */
   async getListingById(listingId: string, tx?: DbTransaction): Promise<ChannelVariantListing | null> {
     const client = this.getClient(tx);
 

--- a/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { NotFoundError } from '@app/shared';
+import { NotFoundError, BadRequestError } from '@app/shared';
 import { DbService, InjectDb } from '@app/db';
 import { ChannelVariantListing, NewChannelVariantListing, DbTransaction } from '../../catalog.types';
 import {
@@ -151,13 +151,22 @@ export class ChannelListingService {
 
     // Channel 존재 확인
     const channel = await client
-      .select({ id: salesChannels.id })
+      .select({ id: salesChannels.id, site: salesChannels.site })
       .from(salesChannels)
       .where(eq(salesChannels.id, dto.salesChannelId))
       .limit(1);
 
     if (channel.length === 0) {
       throw new NotFoundError(`Sales channel not found: ${dto.salesChannelId}`);
+    }
+
+    // 외부 마켓플레이스(네이버/쿠팡)는 비로그인 주문이라 구매자 식별(customerId)이 없어 디지털 소유권을
+    // 부여할 수 없다. 따라서 디지털 상품은 외부채널에 listing(판매 노출)하지 못하게 막는다.
+    // 디지털은 Medusa(자사몰)에서만 판매한다. (#455)
+    if (this.isExternalMarketplaceSite(channel[0].site) && (await this.isDigitalVariant(dto.variantId, tx))) {
+      throw new BadRequestError(
+        `외부 채널(${channel[0].site})은 디지털 상품을 지원하지 않습니다. 디지털 상품은 Medusa(자사몰)에서만 판매할 수 있습니다.`,
+      );
     }
 
     const [listing] = await client
@@ -335,6 +344,23 @@ export class ChannelListingService {
   /**
    * 특정 매핑 조회
    */
+  /** 외부 마켓플레이스(비로그인 주문 → customerId 없음) 채널인지. 디지털 판매 차단 대상. */
+  private isExternalMarketplaceSite(site: string): boolean {
+    return site === 'naver' || site === 'coupang';
+  }
+
+  /** variant 의 active 버전이 디지털(fulfillmentKind='digital')인지. */
+  private async isDigitalVariant(variantId: string, tx?: DbTransaction): Promise<boolean> {
+    const client = this.getClient(tx);
+    const [row] = await client
+      .select({ fulfillmentKind: productMasterVersions.fulfillmentKind })
+      .from(productMasterVariants)
+      .innerJoin(productMasterVersions, eq(productMasterVariants.versionId, productMasterVersions.id))
+      .where(and(eq(productMasterVariants.variantId, variantId), eq(productMasterVersions.status, 'active')))
+      .limit(1);
+    return row?.fulfillmentKind === 'digital';
+  }
+
   async getListingById(listingId: string, tx?: DbTransaction): Promise<ChannelVariantListing | null> {
     const client = this.getClient(tx);
 

--- a/apps/core/src/modules/catalog/core/channels/channel-products.service.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-products.service.ts
@@ -29,6 +29,42 @@ export class ChannelProductsService {
     return tx ?? this.db.db;
   }
 
+  /** 외부 마켓플레이스(비로그인 주문 → customerId 없음) 채널인지. 디지털 판매 차단 대상. */
+  private isExternalMarketplaceSite(site: string): boolean {
+    return site === 'naver' || site === 'coupang';
+  }
+
+  /**
+   * 외부채널 디지털 판매 차단 가드 (채널 상품 생성/활성 공유).
+   * 외부 마켓플레이스(네이버/쿠팡)는 비로그인 주문이라 디지털 소유권을 부여할 수 없어, 디지털 master 의
+   * 채널 상품 생성/활성을 막는다. 디지털은 Medusa(자사몰)에서만 판매한다. (#455)
+   */
+  private async assertDigitalAllowedForChannelMaster(
+    masterId: string,
+    channelId: string,
+    tx?: DbTransaction,
+  ): Promise<void> {
+    const client = this.getClient(tx);
+    const [ch] = await client
+      .select({ site: salesChannels.site })
+      .from(salesChannels)
+      .where(eq(salesChannels.id, channelId))
+      .limit(1);
+    if (!ch || !this.isExternalMarketplaceSite(ch.site)) {
+      return;
+    }
+    const [m] = await client
+      .select({ fulfillmentKind: productMasterVersions.fulfillmentKind })
+      .from(productMasterVersions)
+      .where(and(eq(productMasterVersions.masterId, masterId), eq(productMasterVersions.status, 'active')))
+      .limit(1);
+    if (m?.fulfillmentKind === 'digital') {
+      throw new BadRequestError(
+        `외부 채널(${ch.site})은 디지털 상품을 지원하지 않습니다. 디지털 상품은 Medusa(자사몰)에서만 판매할 수 있습니다.`,
+      );
+    }
+  }
+
   async createChannelProduct(data: CreateChannelProductDto, tx?: DbTransaction): Promise<ChannelProduct> {
     if (!data.masterId || !data.channelId) {
       throw new BadRequestError('Master ID and Channel ID are required');
@@ -55,6 +91,9 @@ export class ChannelProductsService {
     if (channelExists.length === 0) {
       throw new NotFoundError(`Channel not found: ${data.channelId}`);
     }
+
+    // 외부 마켓플레이스(네이버/쿠팡)는 디지털 판매 미지원 — 채널 상품 생성 차단. (#455)
+    await this.assertDigitalAllowedForChannelMaster(data.masterId, data.channelId, tx);
 
     // 3. 중복 확인
     const alreadyExists = await this.existsChannelProduct(data.masterId, data.channelId, tx);
@@ -422,6 +461,11 @@ export class ChannelProductsService {
     const existing = await this.getChannelProduct(channelProductId, tx);
     if (!existing) {
       throw new NotFoundError(`Channel product not found: ${channelProductId}`);
+    }
+
+    // 활성화(재활성 포함) 시 외부 마켓플레이스 디지털 차단. (#455)
+    if (isActive) {
+      await this.assertDigitalAllowedForChannelMaster(existing.masterId, existing.channelId, tx);
     }
 
     // 2. 활성 상태 설정


### PR DESCRIPTION
- 디지털 판매 허용 = Medusa(자사몰, site='medusa')만. `phone_order`/`other`(수동 채널)는 admin 이 직접 처리 

refs #455
