### PR TITLE
feat: 현금영수증 발급/조회(고객·관리자) + 사업자번호 자동 채우기 (#480, #485)

### DIFF
--- a/apps/admin-web/src/features/customers/detail-window/components/admin-cash-receipt-section.tsx
+++ b/apps/admin-web/src/features/customers/detail-window/components/admin-cash-receipt-section.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { walletApi } from '@/lib/api/domains/wallet';
+import type { AdminCashReceiptType } from '@/lib/types/dto/wallet';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Spinner } from '@/components/ui/spinner';
+
+const TYPE_LABEL: Record<AdminCashReceiptType, string> = {
+  소득공제: '소득공제 (개인)',
+  지출증빙: '지출증빙 (사업자)',
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  ISSUED: '발급완료',
+  CANCELED: '취소됨',
+  FAILED: '발급실패',
+};
+
+/**
+ * 주문 상세 다이얼로그 안의 현금영수증 섹션 (관리자).
+ * 발급 내역 조회 + 미발급 시 관리자 직접 발급. 무통장입금·결제완료 건만 발급 가능(백엔드 검증).
+ */
+export function AdminCashReceiptSection({ intentId }: { intentId?: string }) {
+  const queryClient = useQueryClient();
+  const [type, setType] = useState<AdminCashReceiptType>('소득공제');
+  const [identityNumber, setIdentityNumber] = useState('');
+
+  const queryKey = ['admin-cash-receipts', intentId];
+  const { data: receipts, isLoading } = useQuery({
+    queryKey,
+    queryFn: () => walletApi.getCashReceipts(intentId!),
+    enabled: !!intentId,
+  });
+
+  const issueMutation = useMutation({
+    mutationFn: () =>
+      walletApi.issueCashReceipt({
+        intentId: intentId!,
+        type,
+        customerIdentityNumber: identityNumber.replace(/[^0-9]/g, ''),
+      }),
+    onSuccess: () => {
+      toast.success('현금영수증이 발급되었습니다.');
+      setIdentityNumber('');
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onError: (err: unknown) => {
+      const message =
+        (err as { response?: { data?: { message?: string } } })?.response?.data
+          ?.message ?? '현금영수증 발급에 실패했습니다.';
+      toast.error(message);
+    },
+  });
+
+  const issued = (receipts ?? []).filter((r) => r.status === 'ISSUED');
+  const canIssue = !!intentId && issued.length === 0;
+
+  function handleIssue() {
+    const digits = identityNumber.replace(/[^0-9]/g, '');
+    if (type === '소득공제' && (digits.length < 10 || digits.length > 11)) {
+      toast.error('휴대폰번호를 정확히 입력해주세요.');
+      return;
+    }
+    if (type === '지출증빙' && digits.length !== 10) {
+      toast.error('사업자등록번호 10자리를 정확히 입력해주세요.');
+      return;
+    }
+    issueMutation.mutate();
+  }
+
+  return (
+    <section className="rounded-md border border-gray-100 bg-gray-50 px-3 py-3">
+      <div className="mb-2 text-sm font-semibold text-gray-800">현금영수증</div>
+
+      {!intentId ? (
+        <p className="text-xs text-gray-400">
+          결제 정보(intent)를 찾을 수 없어 현금영수증을 조회할 수 없습니다.
+        </p>
+      ) : isLoading ? (
+        <div className="flex justify-center py-4">
+          <Spinner />
+        </div>
+      ) : (
+        <>
+          {/* 발급 내역 */}
+          {issued.length > 0 ? (
+            <ul className="space-y-2">
+              {issued.map((r) => (
+                <li
+                  key={r.id}
+                  className="rounded border border-gray-200 bg-white px-3 py-2 text-xs"
+                >
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                    <span className="text-gray-500">종류</span>
+                    <span className="text-gray-900">{TYPE_LABEL[r.type]}</span>
+                    <span className="text-gray-500">상태</span>
+                    <span className="font-medium text-emerald-600">
+                      {STATUS_LABEL[r.status] ?? r.status}
+                    </span>
+                  </div>
+                  {r.issueNumber && (
+                    <div className="mt-1 text-gray-600">
+                      발급번호: {r.issueNumber}
+                    </div>
+                  )}
+                  {r.receiptUrl && (
+                    <a
+                      href={r.receiptUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-1 inline-block font-medium text-blue-600 underline underline-offset-2"
+                    >
+                      영수증 보기
+                    </a>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-xs text-gray-400">발급된 현금영수증이 없습니다.</p>
+          )}
+
+          {/* 관리자 발급 폼 (미발급 시) */}
+          {canIssue && (
+            <div className="mt-3 space-y-2 border-t border-gray-200 pt-3">
+              <div className="flex items-center gap-2">
+                <Select
+                  value={type}
+                  onValueChange={(v) => setType(v as AdminCashReceiptType)}
+                >
+                  <SelectTrigger className="h-8 w-[140px] text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="소득공제">소득공제 (개인)</SelectItem>
+                    <SelectItem value="지출증빙">지출증빙 (사업자)</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Input
+                  value={identityNumber}
+                  onChange={(e) => setIdentityNumber(e.target.value)}
+                  placeholder={
+                    type === '소득공제' ? '휴대폰번호' : '사업자등록번호(10자리)'
+                  }
+                  inputMode="numeric"
+                  className="h-8 flex-1 text-xs"
+                />
+                <Button
+                  size="sm"
+                  className="h-8"
+                  disabled={issueMutation.isPending}
+                  onClick={handleIssue}
+                >
+                  {issueMutation.isPending ? '발급 중…' : '발급'}
+                </Button>
+              </div>
+              <p className="text-[11px] text-gray-400">
+                무통장입금·결제완료 주문만 발급됩니다.
+              </p>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/admin-web/src/features/customers/detail-window/components/tabs/home-tab.tsx
+++ b/apps/admin-web/src/features/customers/detail-window/components/tabs/home-tab.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useState } from 'react';
 import { Star, User } from 'lucide-react';
+import { OrderDetailDialog } from './orders-tab';
 import { Button } from '@/components/ui/button';
 import { useCustomerById } from '@/lib/services/customers';
 import {
@@ -52,6 +54,8 @@ function Field({ label, value }: { label: string; value: string | null }) {
 export function HomeTab({ customerId }: { customerId: string }) {
   const { data: customer, isLoading } = useCustomerById(customerId);
   const profile = customer?.profile;
+  // 주문정보 행 클릭 시 주문내역 탭과 동일한 상세 다이얼로그(현금영수증 포함)를 연다.
+  const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
 
   // user-service 회원 ↔ Medusa 고객은 이메일로 매칭한다.
   const email = customer?.email ?? '';
@@ -175,7 +179,8 @@ export function HomeTab({ customerId }: { customerId: string }) {
                 {orders.map((order) => (
                   <tr
                     key={order.id}
-                    className="border-b border-gray-100 last:border-0"
+                    onClick={() => setSelectedOrderId(order.id)}
+                    className="cursor-pointer border-b border-gray-100 last:border-0 hover:bg-gray-50"
                   >
                     <td className="py-2 pr-3 text-gray-900">
                       #{order.display_id}
@@ -199,6 +204,11 @@ export function HomeTab({ customerId }: { customerId: string }) {
           </div>
         )}
       </section>
+
+      <OrderDetailDialog
+        orderId={selectedOrderId}
+        onClose={() => setSelectedOrderId(null)}
+      />
     </div>
   );
 }

--- a/apps/admin-web/src/features/customers/detail-window/components/tabs/orders-tab.tsx
+++ b/apps/admin-web/src/features/customers/detail-window/components/tabs/orders-tab.tsx
@@ -39,6 +39,7 @@ import {
   useMedusaOrderById,
 } from '@/lib/services/medusa-customers';
 import type { AdminOrder } from '@/lib/api/domains/medusa';
+import { AdminCashReceiptSection } from '../admin-cash-receipt-section';
 import {
   formatDateTime,
   computeDateRange,
@@ -170,8 +171,8 @@ function AmountRow({
   );
 }
 
-/** 주문 상세 다이얼로그 (단건 조회로 라인 아이템/배송지/금액 표시) */
-function OrderDetailDialog({
+/** 주문 상세 다이얼로그 (단건 조회로 라인 아이템/배송지/금액 + 현금영수증 표시) */
+export function OrderDetailDialog({
   orderId,
   onClose,
 }: {
@@ -182,6 +183,12 @@ function OrderDetailDialog({
   const order = data?.order;
   const currency = order?.currency_code;
   const address = order?.shipping_address;
+  // 현금영수증 조회용 wallet intentId — 결제 세션 data 에 들어있음.
+  const intentId = (
+    order?.payment_collections?.[0]?.payment_sessions?.[0]?.data as
+      | Record<string, unknown>
+      | undefined
+  )?.intentId as string | undefined;
 
   return (
     <Dialog open={!!orderId} onOpenChange={(open) => !open && onClose()}>
@@ -338,6 +345,8 @@ function OrderDetailDialog({
                 </div>
               </section>
             )}
+
+            <AdminCashReceiptSection intentId={intentId} />
           </div>
         )}
       </DialogContent>

--- a/apps/admin-web/src/lib/api/domains/medusa/index.ts
+++ b/apps/admin-web/src/lib/api/domains/medusa/index.ts
@@ -197,6 +197,8 @@ const ORDER_DETAIL_FIELDS = [
   'items.detail.shipped_quantity',
   'items.detail.delivered_quantity',
   '*shipping_address',
+  // 현금영수증 조회용 wallet intentId 가 결제 세션 data 에 들어있음.
+  'payment_collections.payment_sessions.data',
 ].join(',');
 
 export const medusaOrderApi = {

--- a/apps/admin-web/src/lib/api/domains/wallet/index.ts
+++ b/apps/admin-web/src/lib/api/domains/wallet/index.ts
@@ -25,6 +25,8 @@ import {
   UpdateRegionPayload,
   RegionMethodMatrixResponse,
   PutRegionMethodItem,
+  AdminCashReceiptDto,
+  IssueCashReceiptPayload,
 } from '@/lib/types/dto/wallet';
 import { client } from '../../client';
 
@@ -47,6 +49,26 @@ function idempotencyConfig() {
 }
 
 export const walletApi = {
+  // ── Cash Receipts (현금영수증, 관리자) ─────────────────────────────────────
+
+  getCashReceipts: async (intentId: string): Promise<AdminCashReceiptDto[]> => {
+    const res = await client.get(
+      `${BASE}/v1/admin/cash-receipts?intentId=${encodeURIComponent(intentId)}`
+    );
+    return res.data;
+  },
+
+  issueCashReceipt: async (
+    payload: IssueCashReceiptPayload
+  ): Promise<AdminCashReceiptDto> => {
+    const res = await client.post(
+      `${BASE}/v1/admin/cash-receipts`,
+      payload,
+      idempotencyConfig()
+    );
+    return res.data;
+  },
+
   // ── Payment Intents ──────────────────────────────────────────────────────
 
   listPaymentIntents: async (

--- a/apps/admin-web/src/lib/types/dto/wallet.ts
+++ b/apps/admin-web/src/lib/types/dto/wallet.ts
@@ -352,3 +352,25 @@ export interface AdminRecurringBillingListQuery {
   paymentIntentId?: string;
   providerType?: 'CMS_BATCH' | 'TOSS_BILLING' | 'NICEPAY_BILLING';
 }
+
+// ── 현금영수증 (관리자) ──────────────────────────────────────────────────────
+export type AdminCashReceiptType = '소득공제' | '지출증빙';
+
+export interface AdminCashReceiptDto {
+  id: string;
+  intentId: string;
+  type: AdminCashReceiptType;
+  status: 'ISSUED' | 'CANCELED' | 'FAILED';
+  amount: number;
+  currency: string;
+  receiptUrl: string | null;
+  issueNumber: string | null;
+  errorMessage: string | null;
+  createdAt: string;
+}
+
+export interface IssueCashReceiptPayload {
+  intentId: string;
+  type: AdminCashReceiptType;
+  customerIdentityNumber: string;
+}

--- a/apps/user-service/src/api/business-licenses/business-licenses.controller.ts
+++ b/apps/user-service/src/api/business-licenses/business-licenses.controller.ts
@@ -40,7 +40,6 @@ export class BusinessLicensesController {
   @ApiResponse({ status: 200, description: '사업자 등록 정보 조회 성공' })
   @ApiResponse({ status: 401, description: '인증되지 않은 사용자' })
   @ApiResponse({ status: 403, description: '권한 없음' })
-  @RequireScopes('user:read')
   async getMyBusinessLicense(@CurrentUser() user: JwtPayload): Promise<BusinessLicenseResponseDto | null> {
     return this.businessLicensesService.getMyBusinessLicense(user.id);
   }

--- a/apps/user-service/src/api/business-licenses/business-licenses.controller.ts
+++ b/apps/user-service/src/api/business-licenses/business-licenses.controller.ts
@@ -1,11 +1,12 @@
 import { RequireScopes, JwtPayload } from '@app/authorization';
 import { CurrentUser } from '@app/shared/decorators/current-user.decorator';
-import { Body, Controller, Delete, Get, Param, Post, Put } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Put } from '@nestjs/common';
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { BusinessLicensesService } from './business-licenses.service';
 import {
   CreateBusinessLicenseDto,
   FetchBusinessLicenseDto,
+  FillBusinessNumberDto,
   UpdateBusinessLicenseDto,
 } from './dto/business-license.dto';
 import { BusinessLicenseResponseDto } from './dto/business-license.response.dto';
@@ -42,6 +43,22 @@ export class BusinessLicensesController {
   @ApiResponse({ status: 403, description: '권한 없음' })
   async getMyBusinessLicense(@CurrentUser() user: JwtPayload): Promise<BusinessLicenseResponseDto | null> {
     return this.businessLicensesService.getMyBusinessLicense(user.id);
+  }
+
+  @Patch('/me/business-number')
+  @ApiOperation({
+    summary: '내 사업자번호 채우기 (비어있을 때만)',
+    description:
+      '이미지로만 등록해 사업자번호가 비어있는 경우(#485), 결제 시 입력한 번호를 본인 사업자정보에 채운다. ' +
+      '이미 번호가 있으면 덮어쓰지 않는다. wallet-web 등 RP 가 호출하므로 self-scope(스코프 없음).',
+  })
+  @ApiBody({ type: FillBusinessNumberDto })
+  @ApiResponse({ status: 200, description: '{ saved: boolean } — 실제 저장 여부' })
+  async fillMyBusinessNumber(
+    @Body() dto: FillBusinessNumberDto,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<{ saved: boolean }> {
+    return this.businessLicensesService.fillMyBusinessNumberIfEmpty(user.id, dto.businessNumber);
   }
 
   @ApiOperation({

--- a/apps/user-service/src/api/business-licenses/business-licenses.service.ts
+++ b/apps/user-service/src/api/business-licenses/business-licenses.service.ts
@@ -102,6 +102,32 @@ export class BusinessLicensesService {
 
     return result ?? null;
   }
+
+  /**
+   * 사용자가 지출증빙 현금영수증 등에서 입력한 사업자번호를, 기존 사업자정보의 번호가 비어있을 때만 채운다.
+   */
+  async fillMyBusinessNumberIfEmpty(userId: string, businessNumber: string): Promise<{ saved: boolean }> {
+    const digits = businessNumber.replace(/\D/g, '');
+    if (digits.length !== 10) {
+      throw new BadRequestException('사업자등록번호는 10자리여야 합니다.');
+    }
+
+    const license = await this.findBusinessLicenseByUserId(userId);
+    if (!license) return { saved: false }; // 등록 정보 없음 — 제약상 대표자명/파일이 필요해 생성은 하지 않음
+    if (license.businessNumber?.trim()) return { saved: false }; // 이미 값 있음 — 덮어쓰지 않음
+
+    try {
+      await this.dbService.db
+        .update(businessLicenses)
+        .set({ businessNumber: digits, updatedAt: new Date() })
+        .where(eq(businessLicenses.id, license.id));
+      return { saved: true };
+    } catch (error) {
+      // 사업자번호 unique 위반(23505) 등 — 저장만 실패, 예외를 위로 던지지 않는다.
+      if ((error as { code?: string })?.code === '23505') return { saved: false };
+      throw error;
+    }
+  }
   /**
    * 사업자 정보 외부 조회 (국세청 상태조회).
    *

--- a/apps/user-service/src/api/business-licenses/dto/business-license.dto.ts
+++ b/apps/user-service/src/api/business-licenses/dto/business-license.dto.ts
@@ -63,6 +63,15 @@ export class UpdateBusinessLicenseDto {
   metadata?: BusinessMetadata;
 }
 
+// 내 사업자번호 채우기용 dto
+export class FillBusinessNumberDto {
+  @Transform(({ value }) => value?.replace(/-/g, ''))
+  @IsNotEmpty({ message: '사업자번호는 필수입니다.' })
+  @Length(10, 10, { message: '사업자번호는 10자리여야 합니다.' })
+  @IsString({ message: '사업자번호는 문자열이어야 합니다.' })
+  businessNumber: string;
+}
+
 // 사업자 정보 외부 조회용 dto (상태조회는 사업자번호만 필요)
 export class FetchBusinessLicenseDto {
   @Transform(({ value }) => value?.replace(/-/g, ''))

--- a/apps/wallet-web/app/api/business-license/route.ts
+++ b/apps/wallet-web/app/api/business-license/route.ts
@@ -1,0 +1,33 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { SESSION_COOKIE_NAMES } from '@/lib/auth/session-cookies';
+
+// 내 사업자번호 채우기(비어있을 때만)
+export async function POST(request: Request): Promise<Response> {
+  const base = process.env.OIDC_ISSUER_URL?.replace(/\/$/, '');
+  const token = (await cookies()).get(SESSION_COOKIE_NAMES.ACCESS_TOKEN)?.value;
+  if (!base || !token) return NextResponse.json({ saved: false });
+
+  let businessNumber = '';
+  try {
+    const body = (await request.json()) as { businessNumber?: unknown };
+    businessNumber = String(body?.businessNumber ?? '');
+  } catch {
+    return NextResponse.json({ saved: false });
+  }
+
+  try {
+    const res = await fetch(`${base}/business-licenses/me/business-number`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ businessNumber }),
+      cache: 'no-store',
+    });
+    if (!res.ok) return NextResponse.json({ saved: false });
+    const data = (await res.json().catch(() => ({ saved: false }))) as { data?: { saved?: boolean }; saved?: boolean };
+
+    return NextResponse.json({ saved: Boolean(data?.data?.saved ?? data?.saved) });
+  } catch {
+    return NextResponse.json({ saved: false });
+  }
+}

--- a/apps/wallet-web/app/api/cash-receipts/route.ts
+++ b/apps/wallet-web/app/api/cash-receipts/route.ts
@@ -1,0 +1,96 @@
+import { refreshTokens, type TokenSet } from '../../../lib/auth/oidc-client';
+import {
+  SESSION_COOKIE_NAMES,
+  backendAuthCookieFromToken,
+  writeSessionCookies,
+} from '../../../lib/auth/session-cookies';
+import { createWebLogger } from '@packages/web-observability';
+
+// ponytail: payment-intent proxy 와 같은 cookie-forward + 401 one-shot refresh 패턴.
+// 현금영수증도 "결제 후 화면에 머무는 동안 access token 만료" 시나리오가 동일해 재사용.
+
+const logger = createWebLogger({
+  component: 'wallet-web.cash-receipt-proxy',
+  route: '/api/cash-receipts',
+});
+
+function getWalletApiUrl(): string {
+  return process.env.WALLET_API_URL ?? process.env.NEXT_PUBLIC_WALLET_API_URL ?? 'http://localhost:3100';
+}
+
+function readCookie(cookieHeader: string | null, name: string): string | null {
+  if (!cookieHeader) return null;
+  for (const part of cookieHeader.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === name) return part.slice(eq + 1).trim();
+  }
+  return null;
+}
+
+function cookieJar(headers: Headers) {
+  return {
+    set(
+      name: string,
+      value: string,
+      options: { httpOnly?: boolean; secure?: boolean; sameSite?: 'lax' | 'strict' | 'none'; path?: string; maxAge?: number } = {},
+    ): void {
+      let cookie = `${name}=${value}`;
+      if (options.maxAge !== undefined) cookie += `; Max-Age=${options.maxAge}`;
+      cookie += `; Path=${options.path ?? '/'}`;
+      if (options.httpOnly) cookie += '; HttpOnly';
+      if (options.secure) cookie += '; Secure';
+      if (options.sameSite) cookie += `; SameSite=${options.sameSite[0].toUpperCase()}${options.sameSite.slice(1)}`;
+      headers.append('Set-Cookie', cookie);
+    },
+  };
+}
+
+async function proxy(request: Request, method: 'GET' | 'POST', search = ''): Promise<Response> {
+  const url = `${getWalletApiUrl()}/v1/cash-receipts${search}`;
+  const body = method === 'POST' ? await request.text() : undefined;
+  const rawCookie = request.headers.get('Cookie');
+
+  const call = (cookie: string | null): Promise<Response> => {
+    const headers: Record<string, string> = {};
+    if (cookie) headers.Cookie = cookie;
+    if (method === 'POST') headers['Content-Type'] = 'application/json';
+    return fetch(url, { method, headers, body, cache: 'no-store' });
+  };
+
+  let upstream = await call(rawCookie);
+  let refreshed: TokenSet | null = null;
+
+  if (upstream.status === 401) {
+    const refreshToken = readCookie(rawCookie, SESSION_COOKIE_NAMES.REFRESH_TOKEN);
+    if (refreshToken) {
+      try {
+        refreshed = await refreshTokens(refreshToken);
+        upstream = await call(backendAuthCookieFromToken(refreshed.accessToken));
+      } catch {
+        refreshed = null;
+      }
+    }
+  }
+
+  const responseBody = await upstream.text();
+  const headers = new Headers();
+  const contentType = upstream.headers.get('Content-Type');
+  if (contentType) headers.set('Content-Type', contentType);
+  if (refreshed) writeSessionCookies(cookieJar(headers), refreshed);
+
+  if (upstream.status >= 500) {
+    logger.error('wallet.cash_receipt.upstream_5xx', { attributes: { method, upstream_status: upstream.status } });
+  }
+
+  return new Response(responseBody || null, { status: upstream.status, headers });
+}
+
+export async function POST(request: Request): Promise<Response> {
+  return proxy(request, 'POST');
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const intentId = new URL(request.url).searchParams.get('intentId') ?? '';
+  return proxy(request, 'GET', `?intentId=${encodeURIComponent(intentId)}`);
+}

--- a/apps/wallet-web/app/billing-change/page.tsx
+++ b/apps/wallet-web/app/billing-change/page.tsx
@@ -5,6 +5,8 @@ import { isAccessTokenUsable, selfOrigin } from '@/lib/auth/access-token';
 import { SESSION_COOKIE_NAMES, getBackendAuthCookie } from '@/lib/auth/session-cookies';
 import { BillingChangeForm } from './billing-change-form';
 
+export const dynamic = 'force-dynamic';
+
 interface Props {
   searchParams: Promise<{
     returnUrl?: string;

--- a/apps/wallet-web/app/cash-receipt/[intentId]/cash-receipt-form.tsx
+++ b/apps/wallet-web/app/cash-receipt/[intentId]/cash-receipt-form.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useState } from 'react';
+import { issueCashReceipt, type CashReceipt, type CashReceiptType } from '@/lib/wallet-api';
+import { isWalletSessionExpiredError, redirectToWalletLogin } from '@/lib/auth-expired';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+interface Props {
+  intentId: string;
+  active: CashReceipt | null;
+}
+
+export function CashReceiptForm({ intentId, active }: Props) {
+  const [issued, setIssued] = useState<CashReceipt | null>(active);
+  const [type, setType] = useState<CashReceiptType>('소득공제');
+  const [number, setNumber] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  if (issued) {
+    return (
+      <Alert>
+        <AlertDescription>
+          현금영수증이 발급되었습니다 ({issued.type}).{' '}
+          {issued.receiptUrl && (
+            <a href={issued.receiptUrl} target="_blank" rel="noreferrer" className="underline">
+              영수증 보기
+            </a>
+          )}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    // 숫자만 (하이픈 제거) — 휴대폰번호/사업자번호 공통
+    const digits = number.replace(/[^0-9]/g, '');
+    if (digits.length < 8) {
+      setError(type === '소득공제' ? '휴대폰번호를 정확히 입력해 주세요.' : '사업자등록번호를 정확히 입력해 주세요.');
+      return;
+    }
+    setLoading(true);
+    try {
+      const receipt = await issueCashReceipt(intentId, type, digits);
+      setIssued(receipt);
+    } catch (err) {
+      if (isWalletSessionExpiredError(err)) {
+        redirectToWalletLogin();
+        return;
+      }
+      setError(err instanceof Error ? err.message : '발급에 실패했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">발급 용도</legend>
+        <label className="flex items-center gap-2 text-sm">
+          <input type="radio" name="type" checked={type === '소득공제'} onChange={() => setType('소득공제')} />
+          소득공제 (개인 — 휴대폰번호)
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input type="radio" name="type" checked={type === '지출증빙'} onChange={() => setType('지출증빙')} />
+          지출증빙 (사업자 — 사업자등록번호)
+        </label>
+      </fieldset>
+
+      <div className="space-y-1">
+        <label htmlFor="cr-number" className="text-sm font-medium">
+          {type === '소득공제' ? '휴대폰번호' : '사업자등록번호'}
+        </label>
+        <input
+          id="cr-number"
+          inputMode="numeric"
+          autoComplete="off"
+          value={number}
+          onChange={(e) => setNumber(e.target.value)}
+          placeholder={type === '소득공제' ? '01012345678' : '1234567890'}
+          className="w-full rounded-md border px-3 py-2 text-sm"
+        />
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <Button type="submit" disabled={loading} className="w-full">
+        {loading ? '발급 중…' : '현금영수증 발급'}
+      </Button>
+    </form>
+  );
+}

--- a/apps/wallet-web/app/cash-receipt/[intentId]/page.tsx
+++ b/apps/wallet-web/app/cash-receipt/[intentId]/page.tsx
@@ -1,0 +1,45 @@
+import { cookies } from 'next/headers';
+import { notFound, redirect } from 'next/navigation';
+import { isAccessTokenUsable, selfOrigin } from '@/lib/auth/access-token';
+import { SESSION_COOKIE_NAMES, backendAuthCookieFromToken } from '@/lib/auth/session-cookies';
+import { getCashReceipts, getPaymentIntent } from '@/lib/wallet-api';
+import { CashReceiptForm } from './cash-receipt-form';
+
+interface Props {
+  params: Promise<{ intentId: string }>;
+}
+
+export default async function CashReceiptPage({ params }: Props) {
+  const { intentId } = await params;
+  const cookieStore = await cookies();
+
+  // /pay 와 동일한 인증 가드: access token 못 쓰면 /auth/ensure 로 refresh 우선.
+  const accessToken = cookieStore.get(SESSION_COOKIE_NAMES.ACCESS_TOKEN)?.value;
+  if (!(await isAccessTokenUsable(accessToken))) {
+    const ensurePath = `/auth/ensure?redirect_to=${encodeURIComponent(`/cash-receipt/${intentId}`)}`;
+    const origin = selfOrigin();
+    redirect(origin ? `${origin}${ensurePath}` : ensurePath);
+  }
+
+  const cookieHeader = backendAuthCookieFromToken(accessToken);
+
+  let intent;
+  try {
+    intent = await getPaymentIntent(intentId, cookieHeader);
+  } catch {
+    notFound();
+  }
+
+  const receipts = await getCashReceipts(intentId, cookieHeader);
+  const active = receipts.find((r) => r.status === 'ISSUED') ?? null;
+
+  return (
+    <main className="mx-auto max-w-md p-6">
+      <h1 className="mb-1 text-xl font-semibold">현금영수증 발급</h1>
+      <p className="mb-6 text-sm text-muted-foreground">
+        결제금액 {intent.payableAmount.toLocaleString()}원 ({intent.currency})
+      </p>
+      <CashReceiptForm intentId={intentId} active={active} />
+    </main>
+  );
+}

--- a/apps/wallet-web/app/cash-receipt/[intentId]/page.tsx
+++ b/apps/wallet-web/app/cash-receipt/[intentId]/page.tsx
@@ -5,6 +5,9 @@ import { SESSION_COOKIE_NAMES, backendAuthCookieFromToken } from '@/lib/auth/ses
 import { getCashReceipts, getPaymentIntent } from '@/lib/wallet-api';
 import { CashReceiptForm } from './cash-receipt-form';
 
+// 쿠키 기반 인증 가드 + 주문별 데이터라 정적 프리렌더/ISR 캐시 금지 (404 캐시 방지).
+export const dynamic = 'force-dynamic';
+
 interface Props {
   params: Promise<{ intentId: string }>;
 }

--- a/apps/wallet-web/app/pay/[intentId]/billing-setup/page.tsx
+++ b/apps/wallet-web/app/pay/[intentId]/billing-setup/page.tsx
@@ -4,6 +4,8 @@ import { isAccessTokenUsable, selfOrigin } from '@/lib/auth/access-token';
 import { SESSION_COOKIE_NAMES } from '@/lib/auth/session-cookies';
 import { BillingSetupForm } from './billing-setup-form';
 
+export const dynamic = 'force-dynamic';
+
 interface Props {
   params: Promise<{ intentId: string }>;
   searchParams: Promise<{ returnUrl?: string; fail?: string; msg?: string; mode?: string }>;

--- a/apps/wallet-web/app/pay/[intentId]/page.tsx
+++ b/apps/wallet-web/app/pay/[intentId]/page.tsx
@@ -8,6 +8,7 @@ import {
   getPointsBalance,
   getBillingMethods,
   getAvailablePaymentMethods,
+  getMyBusinessLicense,
 } from '@/lib/wallet-api';
 import { buildReturnUrl } from '@/lib/return-url';
 import { PayForm } from './pay-form';
@@ -15,6 +16,10 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { CheckCircle2, XCircle } from 'lucide-react';
+
+// 쿠키 기반 인증 가드 + 결제별 동적 데이터라 CloudFront/Next 캐시 금지.
+// (이게 없으면 엣지가 옛 HTML 을 캐시해 옛 청크를 가리키는 stale 페이지가 서빙됨)
+export const dynamic = 'force-dynamic';
 
 interface Props {
   params: Promise<{ intentId: string }>;
@@ -99,6 +104,9 @@ export default async function PayPage({ params, searchParams }: Props) {
 
   const pointsBalance = await getPointsBalance(cookieHeader).catch(() => ({ confirmed: 0, reserved: 0, available: 0 }));
 
+  // 사업자 정보(사업자번호/대표자명) — 세금계산서·지출증빙 현금영수증 prefill 용. 없으면 null.
+  const businessInfo = await getMyBusinessLicense(accessToken);
+
   if (intent.status === 'CANCELED') {
     return (
       <div className="min-h-screen bg-muted/40 flex items-center justify-center p-4">
@@ -128,6 +136,7 @@ export default async function PayPage({ params, searchParams }: Props) {
       availableMethods={availableMethods}
       region={region ?? null}
       tossFailed={toss_fail === '1'}
+      businessInfo={businessInfo}
     />
   );
 }

--- a/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
+++ b/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
@@ -165,17 +165,11 @@ export function PayForm({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [bankTransferPending, setBankTransferPending] = useState<BankTransferPendingAction | null>(null);
-  // 증빙 신청 (무통장입금 시) — 택일. 현금영수증과 세금계산서는 동시발급 불가.
-  // 현금영수증: 입금확인 완료 시 자동 발급. 세금계산서: 현재 UI/입력만 (발행 로직 미구현).
-  const [evidenceType, setEvidenceType] = useState<'NONE' | 'CASH_INCOME' | 'CASH_EXPENSE' | 'TAX_INVOICE'>('NONE');
+  // 증빙 신청 (무통장입금 시) — 현금영수증만. 입금확인 완료 시 자동 발급.
+  const [evidenceType, setEvidenceType] = useState<'NONE' | 'CASH_INCOME' | 'CASH_EXPENSE'>('NONE');
   // 소득공제 발급방법: 휴대폰 or 현금영수증카드 (토스 customerIdentityNumber 는 둘 다 허용)
   const [cashReceiptMethod, setCashReceiptMethod] = useState<'PHONE' | 'CARD'>('PHONE');
   const [cashReceiptNumber, setCashReceiptNumber] = useState('');
-  // 세금계산서(사업자) 입력값 — 사업자번호/대표자명은 로그인 사용자 사업자정보로 prefill.
-  // ponytail: 현재 수집/검증 UI만, 백엔드 발행 연동은 트랙 B에서. 수신이메일은 발신 미연동이라 제외.
-  const [taxBizName, setTaxBizName] = useState('');
-  const [taxBizNumber, setTaxBizNumber] = useState(businessInfo?.businessNumber ?? '');
-  const [taxRepName, setTaxRepName] = useState(businessInfo?.representativeName ?? '');
 
   const userPhone = (businessInfo?.phoneNumber ?? '').replace(/[^0-9]/g, '');
   const userBizNumber = businessInfo?.businessNumber ?? '';
@@ -274,13 +268,6 @@ export function PayForm({
           return;
         }
         cashReceipt = { type: '지출증빙', customerIdentityNumber: digits };
-      } else if (evidenceType === 'TAX_INVOICE') {
-        // ponytail: 세금계산서는 현재 입력/검증 UI 만 — 발행/저장 연동은 트랙 B(팝빌 등)에서.
-        const bizDigits = taxBizNumber.replace(/[^0-9]/g, '');
-        if (!taxBizName.trim() || bizDigits.length !== 10 || !taxRepName.trim()) {
-          setError('세금계산서 정보를 모두 정확히 입력해주세요 (사업자번호 10자리).');
-          return;
-        }
       }
     }
     setLoading(true);
@@ -707,7 +694,6 @@ export function PayForm({
                         <SelectItem value="NONE">신청 안 함</SelectItem>
                         <SelectItem value="CASH_INCOME">현금영수증 (개인소득공제용)</SelectItem>
                         <SelectItem value="CASH_EXPENSE">현금영수증 (사업자지출증빙용)</SelectItem>
-                        <SelectItem value="TAX_INVOICE">세금계산서 (사업자)</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>
@@ -770,46 +756,6 @@ export function PayForm({
                         />
                       </div>
                       <p className="text-xs text-muted-foreground">입금이 확인되면 현금영수증이 자동 발급됩니다.</p>
-                    </div>
-                  )}
-
-                  {/* 세금계산서 사업자 정보 (UI/입력만 — 발행 연동은 트랙 B) */}
-                  {evidenceType === 'TAX_INVOICE' && (
-                    <div className="mt-3 space-y-3">
-                      <div className="flex items-center gap-3">
-                        <label className="w-20 shrink-0 text-sm text-muted-foreground">상호</label>
-                        <input
-                          autoComplete="off"
-                          value={taxBizName}
-                          onChange={(e) => setTaxBizName(e.target.value)}
-                          placeholder="회사명"
-                          className="flex-1 rounded-md border px-3 py-2 text-sm"
-                        />
-                      </div>
-                      <div className="flex items-center gap-3">
-                        <label className="w-20 shrink-0 text-sm text-muted-foreground">사업자번호</label>
-                        <input
-                          inputMode="numeric"
-                          autoComplete="off"
-                          value={taxBizNumber}
-                          onChange={(e) => setTaxBizNumber(e.target.value)}
-                          placeholder="1234567890"
-                          className="flex-1 rounded-md border px-3 py-2 text-sm"
-                        />
-                      </div>
-                      <div className="flex items-center gap-3">
-                        <label className="w-20 shrink-0 text-sm text-muted-foreground">대표자명</label>
-                        <input
-                          autoComplete="off"
-                          value={taxRepName}
-                          onChange={(e) => setTaxRepName(e.target.value)}
-                          placeholder="대표자명"
-                          className="flex-1 rounded-md border px-3 py-2 text-sm"
-                        />
-                      </div>
-                      <p className="text-xs text-muted-foreground">
-                        입금 확인 후 영업일 기준 1~2일 내 세금계산서가 발행됩니다.
-                      </p>
                     </div>
                   )}
                 </CardContent>

--- a/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
+++ b/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
@@ -2,7 +2,12 @@
 
 import { useState, useEffect, type ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
-import { confirmPaymentIntent, cancelPaymentIntent, abandonPaymentIntent } from '@/lib/wallet-api';
+import {
+  confirmPaymentIntent,
+  cancelPaymentIntent,
+  abandonPaymentIntent,
+  saveMyBusinessNumber,
+} from '@/lib/wallet-api';
 import { isWalletSessionExpiredError, redirectToWalletLogin } from '@/lib/auth-expired';
 import { buildReturnUrl } from '@/lib/return-url';
 import type {
@@ -268,6 +273,11 @@ export function PayForm({
           return;
         }
         cashReceipt = { type: '지출증빙', customerIdentityNumber: digits };
+        // #485: 사업자정보에 번호가 없던 사용자면(이미지로만 등록 등) 입력값 저장을 제안한다.
+        // 비어있을 때만 채우는 self-endpoint 라 best-effort — 결제 흐름을 막지 않는다.
+        if (!userBizNumber && window.confirm('입력하신 사업자번호를 저장할까요?\n다음 결제부터 자동으로 입력됩니다.')) {
+          void saveMyBusinessNumber(digits);
+        }
       }
     }
     setLoading(true);

--- a/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
+++ b/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
@@ -443,7 +443,7 @@ export function PayForm({
                   <p className="text-3xl font-bold">{formatAmount(intent.payableAmount, intent.currency)}</p>
                 </div>
                 {intent.expiresAt && (
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-xs text-muted-foreground" suppressHydrationWarning>
                     만료: {new Date(intent.expiresAt).toLocaleString('ko-KR')}
                   </p>
                 )}

--- a/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
+++ b/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
@@ -5,12 +5,19 @@ import { useRouter } from 'next/navigation';
 import { confirmPaymentIntent, cancelPaymentIntent, abandonPaymentIntent } from '@/lib/wallet-api';
 import { isWalletSessionExpiredError, redirectToWalletLogin } from '@/lib/auth-expired';
 import { buildReturnUrl } from '@/lib/return-url';
-import type { AvailablePaymentMethod, PaymentIntent, PaymentMethod, PointsBalance } from '@/lib/wallet-api';
+import type {
+  AvailablePaymentMethod,
+  BusinessLicenseInfo,
+  PaymentIntent,
+  PaymentMethod,
+  PointsBalance,
+} from '@/lib/wallet-api';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import {
   Lock,
   CreditCard,
@@ -37,6 +44,8 @@ interface Props {
   region?: string | null;
   /** Toss 결제가 실패/취소로 돌아왔을 때(failUrl ?toss_fail=1) true. mount 시 abandon 신호 전송. */
   tossFailed?: boolean;
+  /** 로그인 사용자의 사업자 정보 — 세금계산서/지출증빙 prefill 용. 없으면 null. */
+  businessInfo?: BusinessLicenseInfo | null;
 }
 
 interface BankTransferPendingAction {
@@ -129,6 +138,7 @@ export function PayForm({
   availableMethods,
   region,
   tossFailed,
+  businessInfo,
 }: Props) {
   const router = useRouter();
   const availableMethodMap = availableMethods ? new Map(availableMethods.map((method) => [method.code, method])) : null;
@@ -155,10 +165,39 @@ export function PayForm({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [bankTransferPending, setBankTransferPending] = useState<BankTransferPendingAction | null>(null);
-  // 현금영수증 (무통장입금 시): 입금확인 완료 시점에 자동 발급된다.
-  const [cashReceiptEnabled, setCashReceiptEnabled] = useState(false);
-  const [cashReceiptType, setCashReceiptType] = useState<'소득공제' | '지출증빙'>('소득공제');
+  // 증빙 신청 (무통장입금 시) — 택일. 현금영수증과 세금계산서는 동시발급 불가.
+  // 현금영수증: 입금확인 완료 시 자동 발급. 세금계산서: 현재 UI/입력만 (발행 로직 미구현).
+  const [evidenceType, setEvidenceType] = useState<'NONE' | 'CASH_INCOME' | 'CASH_EXPENSE' | 'TAX_INVOICE'>('NONE');
+  // 소득공제 발급방법: 휴대폰 or 현금영수증카드 (토스 customerIdentityNumber 는 둘 다 허용)
+  const [cashReceiptMethod, setCashReceiptMethod] = useState<'PHONE' | 'CARD'>('PHONE');
   const [cashReceiptNumber, setCashReceiptNumber] = useState('');
+  // 세금계산서(사업자) 입력값 — 사업자번호/대표자명은 로그인 사용자 사업자정보로 prefill.
+  // ponytail: 현재 수집/검증 UI만, 백엔드 발행 연동은 트랙 B에서. 수신이메일은 발신 미연동이라 제외.
+  const [taxBizName, setTaxBizName] = useState('');
+  const [taxBizNumber, setTaxBizNumber] = useState(businessInfo?.businessNumber ?? '');
+  const [taxRepName, setTaxRepName] = useState(businessInfo?.representativeName ?? '');
+
+  const userPhone = (businessInfo?.phoneNumber ?? '').replace(/[^0-9]/g, '');
+  const userBizNumber = businessInfo?.businessNumber ?? '';
+
+  // 증빙 종류 선택 시 번호 prefill: 소득공제·휴대폰 → 사용자 휴대폰, 지출증빙 → 사업자번호.
+  function handleEvidenceChange(next: typeof evidenceType) {
+    setEvidenceType(next);
+    if (next === 'CASH_INCOME') {
+      setCashReceiptMethod('PHONE');
+      setCashReceiptNumber(userPhone);
+    } else if (next === 'CASH_EXPENSE') {
+      setCashReceiptNumber(userBizNumber);
+    } else {
+      setCashReceiptNumber('');
+    }
+  }
+
+  // 소득공제 발급방법 변경: 휴대폰 → 사용자 휴대폰 prefill, 현금영수증카드 → 비움(수동 입력).
+  function handleCashMethodChange(method: 'PHONE' | 'CARD') {
+    setCashReceiptMethod(method);
+    setCashReceiptNumber(method === 'PHONE' ? userPhone : '');
+  }
 
   // Toss 결제 실패/취소로 돌아온 경우(failUrl ?toss_fail=1) abandon 신호를 보내 REQUIRES_ACTION 으로
   // 묶인 포인트 hold 를 즉시 해제하고 intent 를 CREATED 로 soft reset 한다. best-effort — 실패해도
@@ -214,17 +253,35 @@ export function PayForm({
       setError('결제 수단을 선택해주세요.');
       return;
     }
-    // 무통장 + 현금영수증 신청 시 번호 검증 (숫자 8자리 이상)
+    // 무통장 + 증빙 신청 검증 (현금영수증/세금계산서 택일)
     let cashReceipt: { type: '소득공제' | '지출증빙'; customerIdentityNumber: string } | undefined;
-    if (isBankTransferSelected && cashReceiptEnabled) {
-      const digits = cashReceiptNumber.replace(/[^0-9]/g, '');
-      if (digits.length < 8) {
-        setError(
-          cashReceiptType === '소득공제' ? '휴대폰번호를 정확히 입력해주세요.' : '사업자등록번호를 정확히 입력해주세요.',
-        );
-        return;
+    if (isBankTransferSelected) {
+      if (evidenceType === 'CASH_INCOME') {
+        const digits = cashReceiptNumber.replace(/[^0-9]/g, '');
+        if (cashReceiptMethod === 'PHONE' && (digits.length < 10 || digits.length > 11)) {
+          setError('휴대폰번호를 정확히 입력해주세요.');
+          return;
+        }
+        if (cashReceiptMethod === 'CARD' && (digits.length < 13 || digits.length > 19)) {
+          setError('현금영수증 카드번호를 정확히 입력해주세요.');
+          return;
+        }
+        cashReceipt = { type: '소득공제', customerIdentityNumber: digits };
+      } else if (evidenceType === 'CASH_EXPENSE') {
+        const digits = cashReceiptNumber.replace(/[^0-9]/g, '');
+        if (digits.length !== 10) {
+          setError('사업자등록번호를 정확히 입력해주세요 (10자리).');
+          return;
+        }
+        cashReceipt = { type: '지출증빙', customerIdentityNumber: digits };
+      } else if (evidenceType === 'TAX_INVOICE') {
+        // ponytail: 세금계산서는 현재 입력/검증 UI 만 — 발행/저장 연동은 트랙 B(팝빌 등)에서.
+        const bizDigits = taxBizNumber.replace(/[^0-9]/g, '');
+        if (!taxBizName.trim() || bizDigits.length !== 10 || !taxRepName.trim()) {
+          setError('세금계산서 정보를 모두 정확히 입력해주세요 (사업자번호 10자리).');
+          return;
+        }
       }
-      cashReceipt = { type: cashReceiptType, customerIdentityNumber: digits };
     }
     setLoading(true);
     setError(null);
@@ -339,14 +396,14 @@ export function PayForm({
           <Card className="w-full border shadow-sm border-border/60">
             <CardContent className="p-6 space-y-5">
               <div className="flex items-start gap-3">
-                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
-                  <Landmark className="h-5 w-5" />
+                <div className="flex items-center justify-center rounded-full h-11 w-11 shrink-0 bg-primary/10 text-primary">
+                  <Landmark className="w-5 h-5" />
                 </div>
                 <div className="space-y-1">
                   <h1 className="text-lg font-semibold">주문이 접수되었습니다</h1>
                   <p className="text-sm text-muted-foreground">
-                    주문이 &lsquo;입금확인중&rsquo; 상태로 접수되었어요. 아래 계좌로 입금하시면
-                    관리자 확인 후 배송이 진행됩니다.
+                    주문이 &lsquo;입금확인중&rsquo; 상태로 접수되었어요. 아래 계좌로 입금하시면 관리자 확인 후 배송이
+                    진행됩니다.
                   </p>
                 </div>
               </div>
@@ -380,9 +437,9 @@ export function PayForm({
               <Alert>
                 <AlertCircle className="w-4 h-4" />
                 <AlertDescription>
-                  주문이 이미 <span className="font-medium">‘입금확인중’</span> 상태로 접수되어, 지금 바로
-                  아래 <span className="font-medium">‘주문 내역에서 확인’</span> 버튼으로 확인하실 수 있어요.
-                  입금이 확인되면 관리자 승인 후 결제가 완료됩니다.
+                  주문이 이미 <span className="font-medium">‘입금확인중’</span> 상태로 접수되어, 지금 바로 아래{' '}
+                  <span className="font-medium">‘주문 내역에서 확인’</span> 버튼으로 확인하실 수 있어요. 입금이 확인되면
+                  관리자 승인 후 결제가 완료됩니다.
                 </AlertDescription>
               </Alert>
 
@@ -594,7 +651,7 @@ export function PayForm({
             {remainingAmount > 0 && isTossSelected && TOSS_SUB_METHODS.length > 1 && (
               <Card className="border shadow-sm border-border/60">
                 <CardContent className="p-6">
-                  <span className="mb-4 block text-sm font-semibold">결제 방식 선택</span>
+                  <span className="block mb-4 text-sm font-semibold">결제 방식 선택</span>
                   <div className="space-y-2">
                     {TOSS_SUB_METHODS.map(({ value, label, desc }) => {
                       const isSelected = tossSubMethod === value;
@@ -630,49 +687,129 @@ export function PayForm({
               </Card>
             )}
 
-            {/* 현금영수증 (무통장입금 선택 시). 입금확인 완료 시점에 자동 발급된다. */}
+            {/* 증빙 신청 (무통장입금 선택 시) — 현금영수증/세금계산서 택일 */}
             {remainingAmount > 0 && isBankTransferSelected && (
               <Card className="border shadow-sm border-border/60">
                 <CardContent className="p-6">
-                  <label className="flex items-center gap-2 text-sm font-semibold">
-                    <input
-                      type="checkbox"
-                      checked={cashReceiptEnabled}
-                      onChange={(e) => setCashReceiptEnabled(e.target.checked)}
-                    />
-                    현금영수증 신청
-                  </label>
-                  {cashReceiptEnabled && (
-                    <div className="mt-4 space-y-3">
-                      <div className="flex gap-4 text-sm">
-                        <label className="flex items-center gap-1.5">
-                          <input
-                            type="radio"
-                            name="cashReceiptType"
-                            checked={cashReceiptType === '소득공제'}
-                            onChange={() => setCashReceiptType('소득공제')}
-                          />
-                          소득공제(개인)
-                        </label>
-                        <label className="flex items-center gap-1.5">
-                          <input
-                            type="radio"
-                            name="cashReceiptType"
-                            checked={cashReceiptType === '지출증빙'}
-                            onChange={() => setCashReceiptType('지출증빙')}
-                          />
-                          지출증빙(사업자)
-                        </label>
+                  <span className="mb-4 block text-sm font-semibold">증빙 신청 (선택)</span>
+
+                  {/* 증빙 종류 select */}
+                  <div className="flex items-center gap-3">
+                    <label className="w-20 shrink-0 text-sm text-muted-foreground">증빙</label>
+                    <Select
+                      value={evidenceType}
+                      onValueChange={(v) => handleEvidenceChange(v as typeof evidenceType)}
+                    >
+                      <SelectTrigger className="flex-1">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="NONE">신청 안 함</SelectItem>
+                        <SelectItem value="CASH_INCOME">현금영수증 (개인소득공제용)</SelectItem>
+                        <SelectItem value="CASH_EXPENSE">현금영수증 (사업자지출증빙용)</SelectItem>
+                        <SelectItem value="TAX_INVOICE">세금계산서 (사업자)</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  {/* 소득공제: 발급방법(휴대폰/현금영수증카드) + 번호 */}
+                  {evidenceType === 'CASH_INCOME' && (
+                    <div className="mt-3 space-y-3">
+                      <div className="flex items-center gap-3">
+                        <label className="w-20 shrink-0 text-sm text-muted-foreground">발급방법</label>
+                        <div className="flex gap-4 text-sm">
+                          <label className="flex items-center gap-1.5">
+                            <input
+                              type="radio"
+                              name="cashMethod"
+                              checked={cashReceiptMethod === 'PHONE'}
+                              onChange={() => handleCashMethodChange('PHONE')}
+                            />
+                            휴대폰
+                          </label>
+                          <label className="flex items-center gap-1.5">
+                            <input
+                              type="radio"
+                              name="cashMethod"
+                              checked={cashReceiptMethod === 'CARD'}
+                              onChange={() => handleCashMethodChange('CARD')}
+                            />
+                            현금영수증카드
+                          </label>
+                        </div>
                       </div>
-                      <input
-                        inputMode="numeric"
-                        autoComplete="off"
-                        value={cashReceiptNumber}
-                        onChange={(e) => setCashReceiptNumber(e.target.value)}
-                        placeholder={cashReceiptType === '소득공제' ? '휴대폰번호 (01012345678)' : '사업자등록번호 (1234567890)'}
-                        className="w-full rounded-md border px-3 py-2 text-sm"
-                      />
+                      <div className="flex items-center gap-3">
+                        <label className="w-20 shrink-0 text-sm text-muted-foreground">
+                          {cashReceiptMethod === 'PHONE' ? '휴대폰' : '카드번호'}
+                        </label>
+                        <input
+                          inputMode="numeric"
+                          autoComplete="off"
+                          value={cashReceiptNumber}
+                          onChange={(e) => setCashReceiptNumber(e.target.value)}
+                          placeholder={cashReceiptMethod === 'PHONE' ? '01012345678' : '현금영수증 카드번호'}
+                          className="flex-1 rounded-md border px-3 py-2 text-sm"
+                        />
+                      </div>
                       <p className="text-xs text-muted-foreground">입금이 확인되면 현금영수증이 자동 발급됩니다.</p>
+                    </div>
+                  )}
+
+                  {/* 지출증빙: 사업자번호 */}
+                  {evidenceType === 'CASH_EXPENSE' && (
+                    <div className="mt-3 space-y-3">
+                      <div className="flex items-center gap-3">
+                        <label className="w-20 shrink-0 text-sm text-muted-foreground">사업자번호</label>
+                        <input
+                          inputMode="numeric"
+                          autoComplete="off"
+                          value={cashReceiptNumber}
+                          onChange={(e) => setCashReceiptNumber(e.target.value)}
+                          placeholder="사업자등록번호 (1234567890)"
+                          className="flex-1 rounded-md border px-3 py-2 text-sm"
+                        />
+                      </div>
+                      <p className="text-xs text-muted-foreground">입금이 확인되면 현금영수증이 자동 발급됩니다.</p>
+                    </div>
+                  )}
+
+                  {/* 세금계산서 사업자 정보 (UI/입력만 — 발행 연동은 트랙 B) */}
+                  {evidenceType === 'TAX_INVOICE' && (
+                    <div className="mt-3 space-y-3">
+                      <div className="flex items-center gap-3">
+                        <label className="w-20 shrink-0 text-sm text-muted-foreground">상호</label>
+                        <input
+                          autoComplete="off"
+                          value={taxBizName}
+                          onChange={(e) => setTaxBizName(e.target.value)}
+                          placeholder="회사명"
+                          className="flex-1 rounded-md border px-3 py-2 text-sm"
+                        />
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <label className="w-20 shrink-0 text-sm text-muted-foreground">사업자번호</label>
+                        <input
+                          inputMode="numeric"
+                          autoComplete="off"
+                          value={taxBizNumber}
+                          onChange={(e) => setTaxBizNumber(e.target.value)}
+                          placeholder="1234567890"
+                          className="flex-1 rounded-md border px-3 py-2 text-sm"
+                        />
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <label className="w-20 shrink-0 text-sm text-muted-foreground">대표자명</label>
+                        <input
+                          autoComplete="off"
+                          value={taxRepName}
+                          onChange={(e) => setTaxRepName(e.target.value)}
+                          placeholder="대표자명"
+                          className="flex-1 rounded-md border px-3 py-2 text-sm"
+                        />
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        입금 확인 후 영업일 기준 1~2일 내 세금계산서가 발행됩니다.
+                      </p>
                     </div>
                   )}
                 </CardContent>

--- a/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
+++ b/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
@@ -155,6 +155,10 @@ export function PayForm({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [bankTransferPending, setBankTransferPending] = useState<BankTransferPendingAction | null>(null);
+  // 현금영수증 (무통장입금 시): 입금확인 완료 시점에 자동 발급된다.
+  const [cashReceiptEnabled, setCashReceiptEnabled] = useState(false);
+  const [cashReceiptType, setCashReceiptType] = useState<'소득공제' | '지출증빙'>('소득공제');
+  const [cashReceiptNumber, setCashReceiptNumber] = useState('');
 
   // Toss 결제 실패/취소로 돌아온 경우(failUrl ?toss_fail=1) abandon 신호를 보내 REQUIRES_ACTION 으로
   // 묶인 포인트 hold 를 즉시 해제하고 intent 를 CREATED 로 soft reset 한다. best-effort — 실패해도
@@ -178,6 +182,7 @@ export function PayForm({
   }, [tossFailed, intent.id, region, router]);
 
   const isTossSelected = externalMethods.find((m) => m.id === selectedMethodId)?.type === 'TOSS';
+  const isBankTransferSelected = externalMethods.find((m) => m.id === selectedMethodId)?.type === 'BANK_TRANSFER';
 
   const isRecurring = intent.metadata?.billingMode === 'recurring';
   const isZeroAmount = intent.payableAmount === 0;
@@ -209,6 +214,18 @@ export function PayForm({
       setError('결제 수단을 선택해주세요.');
       return;
     }
+    // 무통장 + 현금영수증 신청 시 번호 검증 (숫자 8자리 이상)
+    let cashReceipt: { type: '소득공제' | '지출증빙'; customerIdentityNumber: string } | undefined;
+    if (isBankTransferSelected && cashReceiptEnabled) {
+      const digits = cashReceiptNumber.replace(/[^0-9]/g, '');
+      if (digits.length < 8) {
+        setError(
+          cashReceiptType === '소득공제' ? '휴대폰번호를 정확히 입력해주세요.' : '사업자등록번호를 정확히 입력해주세요.',
+        );
+        return;
+      }
+      cashReceipt = { type: cashReceiptType, customerIdentityNumber: digits };
+    }
     setLoading(true);
     setError(null);
     try {
@@ -216,6 +233,7 @@ export function PayForm({
         intent.id,
         remaining > 0 ? selectedMethodId : null,
         pts > 0 ? pts : undefined,
+        cashReceipt,
       );
 
       if (result.status === 'REQUIRES_ACTION' && result.nextAction?.type === 'TOSS_CHECKOUT') {
@@ -608,6 +626,55 @@ export function PayForm({
                       );
                     })}
                   </div>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* 현금영수증 (무통장입금 선택 시). 입금확인 완료 시점에 자동 발급된다. */}
+            {remainingAmount > 0 && isBankTransferSelected && (
+              <Card className="border shadow-sm border-border/60">
+                <CardContent className="p-6">
+                  <label className="flex items-center gap-2 text-sm font-semibold">
+                    <input
+                      type="checkbox"
+                      checked={cashReceiptEnabled}
+                      onChange={(e) => setCashReceiptEnabled(e.target.checked)}
+                    />
+                    현금영수증 신청
+                  </label>
+                  {cashReceiptEnabled && (
+                    <div className="mt-4 space-y-3">
+                      <div className="flex gap-4 text-sm">
+                        <label className="flex items-center gap-1.5">
+                          <input
+                            type="radio"
+                            name="cashReceiptType"
+                            checked={cashReceiptType === '소득공제'}
+                            onChange={() => setCashReceiptType('소득공제')}
+                          />
+                          소득공제(개인)
+                        </label>
+                        <label className="flex items-center gap-1.5">
+                          <input
+                            type="radio"
+                            name="cashReceiptType"
+                            checked={cashReceiptType === '지출증빙'}
+                            onChange={() => setCashReceiptType('지출증빙')}
+                          />
+                          지출증빙(사업자)
+                        </label>
+                      </div>
+                      <input
+                        inputMode="numeric"
+                        autoComplete="off"
+                        value={cashReceiptNumber}
+                        onChange={(e) => setCashReceiptNumber(e.target.value)}
+                        placeholder={cashReceiptType === '소득공제' ? '휴대폰번호 (01012345678)' : '사업자등록번호 (1234567890)'}
+                        className="w-full rounded-md border px-3 py-2 text-sm"
+                      />
+                      <p className="text-xs text-muted-foreground">입금이 확인되면 현금영수증이 자동 발급됩니다.</p>
+                    </div>
+                  )}
                 </CardContent>
               </Card>
             )}

--- a/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
+++ b/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
@@ -273,7 +273,6 @@ export function PayForm({
           return;
         }
         cashReceipt = { type: '지출증빙', customerIdentityNumber: digits };
-        // #485: 사업자정보에 번호가 없던 사용자면(이미지로만 등록 등) 입력값 저장을 제안한다.
         // 비어있을 때만 채우는 self-endpoint 라 best-effort — 결제 흐름을 막지 않는다.
         if (!userBizNumber && window.confirm('입력하신 사업자번호를 저장할까요?\n다음 결제부터 자동으로 입력됩니다.')) {
           void saveMyBusinessNumber(digits);
@@ -688,15 +687,12 @@ export function PayForm({
             {remainingAmount > 0 && isBankTransferSelected && (
               <Card className="border shadow-sm border-border/60">
                 <CardContent className="p-6">
-                  <span className="mb-4 block text-sm font-semibold">증빙 신청 (선택)</span>
+                  <span className="block mb-4 text-sm font-semibold">증빙 신청 (선택)</span>
 
                   {/* 증빙 종류 select */}
                   <div className="flex items-center gap-3">
-                    <label className="w-20 shrink-0 text-sm text-muted-foreground">증빙</label>
-                    <Select
-                      value={evidenceType}
-                      onValueChange={(v) => handleEvidenceChange(v as typeof evidenceType)}
-                    >
+                    <label className="w-20 text-sm shrink-0 text-muted-foreground">증빙</label>
+                    <Select value={evidenceType} onValueChange={(v) => handleEvidenceChange(v as typeof evidenceType)}>
                       <SelectTrigger className="flex-1">
                         <SelectValue />
                       </SelectTrigger>
@@ -712,7 +708,7 @@ export function PayForm({
                   {evidenceType === 'CASH_INCOME' && (
                     <div className="mt-3 space-y-3">
                       <div className="flex items-center gap-3">
-                        <label className="w-20 shrink-0 text-sm text-muted-foreground">발급방법</label>
+                        <label className="w-20 text-sm shrink-0 text-muted-foreground">발급방법</label>
                         <div className="flex gap-4 text-sm">
                           <label className="flex items-center gap-1.5">
                             <input
@@ -735,7 +731,7 @@ export function PayForm({
                         </div>
                       </div>
                       <div className="flex items-center gap-3">
-                        <label className="w-20 shrink-0 text-sm text-muted-foreground">
+                        <label className="w-20 text-sm shrink-0 text-muted-foreground">
                           {cashReceiptMethod === 'PHONE' ? '휴대폰' : '카드번호'}
                         </label>
                         <input
@@ -744,7 +740,7 @@ export function PayForm({
                           value={cashReceiptNumber}
                           onChange={(e) => setCashReceiptNumber(e.target.value)}
                           placeholder={cashReceiptMethod === 'PHONE' ? '01012345678' : '현금영수증 카드번호'}
-                          className="flex-1 rounded-md border px-3 py-2 text-sm"
+                          className="flex-1 px-3 py-2 text-sm border rounded-md"
                         />
                       </div>
                       <p className="text-xs text-muted-foreground">입금이 확인되면 현금영수증이 자동 발급됩니다.</p>
@@ -755,14 +751,14 @@ export function PayForm({
                   {evidenceType === 'CASH_EXPENSE' && (
                     <div className="mt-3 space-y-3">
                       <div className="flex items-center gap-3">
-                        <label className="w-20 shrink-0 text-sm text-muted-foreground">사업자번호</label>
+                        <label className="w-20 text-sm shrink-0 text-muted-foreground">사업자번호</label>
                         <input
                           inputMode="numeric"
                           autoComplete="off"
                           value={cashReceiptNumber}
                           onChange={(e) => setCashReceiptNumber(e.target.value)}
                           placeholder="사업자등록번호 (1234567890)"
-                          className="flex-1 rounded-md border px-3 py-2 text-sm"
+                          className="flex-1 px-3 py-2 text-sm border rounded-md"
                         />
                       </div>
                       <p className="text-xs text-muted-foreground">입금이 확인되면 현금영수증이 자동 발급됩니다.</p>

--- a/apps/wallet-web/app/pay/[intentId]/toss-complete/page.tsx
+++ b/apps/wallet-web/app/pay/[intentId]/toss-complete/page.tsx
@@ -5,6 +5,9 @@ import { getBackendAuthCookie } from '@/lib/auth/session-cookies';
 import { buildReturnUrl } from '@/lib/return-url';
 import { createWebLogger } from '@packages/web-observability';
 
+// 쿠키 기반 + 동적 승인 처리라 CloudFront/Next 캐시 금지 (stale HTML/청크 방지).
+export const dynamic = 'force-dynamic';
+
 interface Props {
   params: Promise<{ intentId: string }>;
   searchParams: Promise<{ paymentKey?: string; orderId?: string; amount?: string; region?: string }>;

--- a/apps/wallet-web/lib/wallet-api.ts
+++ b/apps/wallet-web/lib/wallet-api.ts
@@ -411,6 +411,25 @@ export async function getMyBusinessLicense(accessToken: string | undefined): Pro
   };
 }
 
+/**
+ * 지출증빙 현금영수증 입력 시, 사업자정보에 번호가 비어있던 사용자의 입력값을 저장 제안(#485).
+ * 서버 route handler 가 user-service self-endpoint 로 전달하며, 비어있을 때만 채운다. best-effort.
+ */
+export async function saveMyBusinessNumber(businessNumber: string): Promise<{ saved: boolean }> {
+  try {
+    const res = await fetch('/api/business-license', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ businessNumber }),
+    });
+    if (!res.ok) return { saved: false };
+    return (await res.json()) as { saved: boolean };
+  } catch {
+    return { saved: false };
+  }
+}
+
 // ─── Cash receipts (현금영수증) ────────────────────────────────────────────────
 
 export type CashReceiptType = '소득공제' | '지출증빙';

--- a/apps/wallet-web/lib/wallet-api.ts
+++ b/apps/wallet-web/lib/wallet-api.ts
@@ -369,6 +369,48 @@ export async function abandonPaymentIntent(intentId: string): Promise<void> {
   }
 }
 
+// ─── Business license (사업자 정보 — 세금계산서/지출증빙 prefill용) ──────────────
+
+export interface BusinessLicenseInfo {
+  businessNumber: string | null;
+  representativeName: string | null;
+  phoneNumber: string | null;
+}
+
+/** 저장된 전화번호(+8210…, E.164)를 국내 표기(010…)로. 이미 0으로 시작하면 그대로. */
+function toKrLocalPhone(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const d = raw.replace(/[^0-9]/g, '');
+  return d.startsWith('82') ? `0${d.slice(2)}` : d;
+}
+
+export async function getMyBusinessLicense(accessToken: string | undefined): Promise<BusinessLicenseInfo | null> {
+  const base = process.env.OIDC_ISSUER_URL?.replace(/\/$/, '');
+  if (!base || !accessToken) return null;
+  const headers = { Authorization: `Bearer ${accessToken}` };
+
+  // user-service 는 전역 인터셉터로 응답을 { success, data } 로 감싼다. data 를 벗겨 반환.
+  const fetchJson = async (path: string): Promise<Record<string, unknown> | null> => {
+    try {
+      const res = await fetch(`${base}${path}`, { headers, cache: 'no-store' });
+      if (!res.ok) return null;
+      const json = (await res.json()) as { data?: Record<string, unknown> } | Record<string, unknown> | null;
+      return ((json as { data?: Record<string, unknown> })?.data ?? json) as Record<string, unknown> | null;
+    } catch {
+      return null;
+    }
+  };
+
+  const [license, profile] = await Promise.all([fetchJson('/business-licenses/me'), fetchJson('/users/me/profile')]);
+  const profileObj = (profile?.profile ?? null) as { phoneNumber?: string | null } | null;
+
+  return {
+    businessNumber: (license?.businessNumber as string | null) ?? null,
+    representativeName: (license?.representativeName as string | null) ?? null,
+    phoneNumber: toKrLocalPhone(profileObj?.phoneNumber ?? (profile?.phoneNumber as string | null)),
+  };
+}
+
 // ─── Cash receipts (현금영수증) ────────────────────────────────────────────────
 
 export type CashReceiptType = '소득공제' | '지출증빙';

--- a/apps/wallet-web/lib/wallet-api.ts
+++ b/apps/wallet-web/lib/wallet-api.ts
@@ -367,3 +367,49 @@ export async function abandonPaymentIntent(intentId: string): Promise<void> {
     throw new Error(body?.message ?? `Abandon failed (${res.status})`);
   }
 }
+
+// ─── Cash receipts (현금영수증) ────────────────────────────────────────────────
+
+export type CashReceiptType = '소득공제' | '지출증빙';
+
+export interface CashReceipt {
+  id: string;
+  intentId: string;
+  type: CashReceiptType;
+  status: 'ISSUED' | 'CANCELED' | 'FAILED';
+  amount: number;
+  currency: string;
+  receiptUrl: string | null;
+  issueNumber: string | null;
+  errorMessage: string | null;
+  createdAt: string;
+}
+
+/** 서버 컴포넌트용: 주문의 현금영수증 목록. cookieHeader = cookies().toString(). */
+export async function getCashReceipts(intentId: string, cookieHeader: string): Promise<CashReceipt[]> {
+  const res = await fetch(`${BASE_URL}/v1/cash-receipts?intentId=${encodeURIComponent(intentId)}`, {
+    headers: { Cookie: cookieHeader },
+    cache: 'no-store',
+  });
+  if (!res.ok) return [];
+  return res.json();
+}
+
+/** 클라이언트용: 현금영수증 발급 요청 (프록시 경유). */
+export async function issueCashReceipt(
+  intentId: string,
+  type: CashReceiptType,
+  customerIdentityNumber: string,
+): Promise<CashReceipt> {
+  const res = await fetchWithAuthBounce('/api/cash-receipts', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ intentId, type, customerIdentityNumber }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.message ?? `현금영수증 발급 실패 (${res.status})`);
+  }
+  return res.json();
+}

--- a/apps/wallet-web/lib/wallet-api.ts
+++ b/apps/wallet-web/lib/wallet-api.ts
@@ -147,6 +147,7 @@ export async function confirmPaymentIntent(
   intentId: string,
   paymentMethodId: string | null,
   pointsToApply?: number,
+  cashReceipt?: { type: CashReceiptType; customerIdentityNumber: string },
 ): Promise<ConfirmResult> {
   const res = await fetchWithAuthBounce(paymentIntentRoute(intentId, 'confirm'), {
     method: 'POST',
@@ -155,7 +156,7 @@ export async function confirmPaymentIntent(
       'Idempotency-Key': crypto.randomUUID(),
     },
     credentials: 'include',
-    body: JSON.stringify({ paymentMethodId, pointsToApply }),
+    body: JSON.stringify({ paymentMethodId, pointsToApply, cashReceipt }),
   });
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));

--- a/apps/wallet/drizzle/20260630052942_add-cash-receipts.sql
+++ b/apps/wallet/drizzle/20260630052942_add-cash-receipts.sql
@@ -1,0 +1,32 @@
+CREATE TYPE "public"."cash_receipt_status" AS ENUM('ISSUED', 'CANCELED', 'FAILED');--> statement-breakpoint
+CREATE TYPE "public"."cash_receipt_type" AS ENUM('소득공제', '지출증빙');--> statement-breakpoint
+CREATE TABLE "cash_receipts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"charge_id" uuid NOT NULL,
+	"intent_id" uuid NOT NULL,
+	"user_id" varchar(128),
+	"type" "cash_receipt_type" NOT NULL,
+	"customer_identity_number" varchar(30) NOT NULL,
+	"amount" integer NOT NULL,
+	"currency" varchar(3) NOT NULL,
+	"status" "cash_receipt_status" NOT NULL,
+	"canceled_amount" integer DEFAULT 0 NOT NULL,
+	"receipt_key" varchar(200),
+	"issue_number" varchar(9),
+	"receipt_url" text,
+	"error_code" varchar(128),
+	"error_message" text,
+	"request_payload" jsonb,
+	"response_payload" jsonb,
+	"issued_at" timestamp with time zone,
+	"canceled_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "cash_receipts_amount_positive" CHECK ("cash_receipts"."amount" > 0)
+);
+--> statement-breakpoint
+ALTER TABLE "cash_receipts" ADD CONSTRAINT "cash_receipts_charge_id_charges_id_fk" FOREIGN KEY ("charge_id") REFERENCES "public"."charges"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cash_receipts" ADD CONSTRAINT "cash_receipts_intent_id_payment_intents_id_fk" FOREIGN KEY ("intent_id") REFERENCES "public"."payment_intents"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_cash_receipts_active_charge" ON "cash_receipts" USING btree ("charge_id") WHERE "cash_receipts"."status" = 'ISSUED';--> statement-breakpoint
+CREATE INDEX "idx_cash_receipts_intent" ON "cash_receipts" USING btree ("intent_id");--> statement-breakpoint
+CREATE INDEX "idx_cash_receipts_user_created_at" ON "cash_receipts" USING btree ("user_id","created_at");

--- a/apps/wallet/drizzle/meta/20260630052942_snapshot.json
+++ b/apps/wallet/drizzle/meta/20260630052942_snapshot.json
@@ -1,0 +1,4453 @@
+{
+  "id": "3e393a9d-34e9-42f8-a2af-3a9543d9025c",
+  "prevId": "86b0cbe2-3404-46f8-a378-47d698c3b57d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.billing_agreements": {
+      "name": "billing_agreements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_method_id": {
+          "name": "billing_method_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriber_ref": {
+          "name": "subscriber_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriber_type": {
+          "name": "subscriber_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "billing_agreement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_billing_agreements_subscriber": {
+          "name": "uq_billing_agreements_subscriber",
+          "columns": [
+            {
+              "expression": "subscriber_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscriber_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_billing_agreements_user_id": {
+          "name": "idx_billing_agreements_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_billing_agreements_billing_method_id": {
+          "name": "idx_billing_agreements_billing_method_id",
+          "columns": [
+            {
+              "expression": "billing_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_agreements_billing_method_id_billing_methods_id_fk": {
+          "name": "billing_agreements_billing_method_id_billing_methods_id_fk",
+          "tableFrom": "billing_agreements",
+          "tableTo": "billing_methods",
+          "columnsFrom": [
+            "billing_method_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_methods": {
+      "name": "billing_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_key": {
+          "name": "billing_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_key": {
+          "name": "customer_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cms_member_id": {
+          "name": "cms_member_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "billing_method_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_billing_methods_user_id": {
+          "name": "idx_billing_methods_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_billing_methods_user_provider_status": {
+          "name": "idx_billing_methods_user_provider_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cash_receipts": {
+      "name": "cash_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "charge_id": {
+          "name": "charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "cash_receipt_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_identity_number": {
+          "name": "customer_identity_number",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cash_receipt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canceled_amount": {
+          "name": "canceled_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "receipt_key": {
+          "name": "receipt_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_payload": {
+          "name": "request_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_payload": {
+          "name": "response_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_cash_receipts_active_charge": {
+          "name": "uq_cash_receipts_active_charge",
+          "columns": [
+            {
+              "expression": "charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cash_receipts\".\"status\" = 'ISSUED'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cash_receipts_intent": {
+          "name": "idx_cash_receipts_intent",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cash_receipts_user_created_at": {
+          "name": "idx_cash_receipts_user_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cash_receipts_charge_id_charges_id_fk": {
+          "name": "cash_receipts_charge_id_charges_id_fk",
+          "tableFrom": "cash_receipts",
+          "tableTo": "charges",
+          "columnsFrom": [
+            "charge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cash_receipts_intent_id_payment_intents_id_fk": {
+          "name": "cash_receipts_intent_id_payment_intents_id_fk",
+          "tableFrom": "cash_receipts",
+          "tableTo": "payment_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cash_receipts_amount_positive": {
+          "name": "cash_receipts_amount_positive",
+          "value": "\"cash_receipts\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.charges": {
+      "name": "charges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "charge_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "charge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_transaction_id": {
+          "name": "provider_transaction_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_idempotency_key": {
+          "name": "provider_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_payload": {
+          "name": "request_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_payload": {
+          "name": "response_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_charges_provider_idempotency_key": {
+          "name": "uq_charges_provider_idempotency_key",
+          "columns": [
+            {
+              "expression": "provider_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_charges_active_intent_operation": {
+          "name": "uq_charges_active_intent_operation",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"charges\".\"status\" in ('CREATED', 'PENDING', 'REQUIRES_ACTION')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_charges_intent_created_at": {
+          "name": "idx_charges_intent_created_at",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_charges_status_created_at": {
+          "name": "idx_charges_status_created_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "charges_intent_id_payment_intents_id_fk": {
+          "name": "charges_intent_id_payment_intents_id_fk",
+          "tableFrom": "charges",
+          "tableTo": "payment_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "charges_payment_method_id_payment_methods_id_fk": {
+          "name": "charges_payment_method_id_payment_methods_id_fk",
+          "tableFrom": "charges",
+          "tableTo": "payment_methods",
+          "columnsFrom": [
+            "payment_method_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "charges_amount_positive": {
+          "name": "charges_amount_positive",
+          "value": "\"charges\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.checkout_sessions": {
+      "name": "checkout_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "intent_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "success_url": {
+          "name": "success_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_url": {
+          "name": "cancel_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allow_composite": {
+          "name": "allow_composite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "checkout_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_checkout_sessions_user_status": {
+          "name": "idx_checkout_sessions_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_checkout_sessions_status_expires_at": {
+          "name": "idx_checkout_sessions_status_expires_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "checkout_sessions_intent_id_payment_intents_id_fk": {
+          "name": "checkout_sessions_intent_id_payment_intents_id_fk",
+          "tableFrom": "checkout_sessions",
+          "tableTo": "payment_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cms_agreements": {
+      "name": "cms_agreements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cms_member_id": {
+          "name": "cms_member_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_key": {
+          "name": "agreement_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_extension": {
+          "name": "file_extension",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_code": {
+          "name": "result_code",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_message": {
+          "name": "result_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cms_agreements_cms_member_id": {
+          "name": "idx_cms_agreements_cms_member_id",
+          "columns": [
+            {
+              "expression": "cms_member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cms_members": {
+      "name": "cms_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "billing_method_id": {
+          "name": "billing_method_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cms_member_id": {
+          "name": "cms_member_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_company": {
+          "name": "payment_company",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_name": {
+          "name": "payer_name",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_number": {
+          "name": "payer_number",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cms_member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "result_code": {
+          "name": "result_code",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_message": {
+          "name": "result_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_cms_members_cms_member_id": {
+          "name": "uq_cms_members_cms_member_id",
+          "columns": [
+            {
+              "expression": "cms_member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cms_members_billing_method_id": {
+          "name": "idx_cms_members_billing_method_id",
+          "columns": [
+            {
+              "expression": "billing_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cms_members_user_id": {
+          "name": "idx_cms_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cms_members_status": {
+          "name": "idx_cms_members_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cms_members_billing_method_id_billing_methods_id_fk": {
+          "name": "cms_members_billing_method_id_billing_methods_id_fk",
+          "tableFrom": "cms_members",
+          "tableTo": "billing_methods",
+          "columnsFrom": [
+            "billing_method_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cms_withdrawals": {
+      "name": "cms_withdrawals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cms_member_id": {
+          "name": "cms_member_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "charge_id": {
+          "name": "charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_date": {
+          "name": "payment_date",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cms_withdrawal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REQUESTED'"
+        },
+        "result_code": {
+          "name": "result_code",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_message": {
+          "name": "result_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual_amount": {
+          "name": "actual_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee": {
+          "name": "fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_cms_withdrawals_transaction_id": {
+          "name": "uq_cms_withdrawals_transaction_id",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cms_withdrawals_intent_id": {
+          "name": "idx_cms_withdrawals_intent_id",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cms_withdrawals_status_payment_date": {
+          "name": "idx_cms_withdrawals_status_payment_date",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cms_withdrawals_charge_id_charges_id_fk": {
+          "name": "cms_withdrawals_charge_id_charges_id_fk",
+          "tableFrom": "cms_withdrawals",
+          "tableTo": "charges",
+          "columnsFrom": [
+            "charge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cms_withdrawals_intent_id_payment_intents_id_fk": {
+          "name": "cms_withdrawals_intent_id_payment_intents_id_fk",
+          "tableFrom": "cms_withdrawals",
+          "tableTo": "payment_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_path": {
+          "name": "request_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outbox_events": {
+      "name": "outbox_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_type": {
+          "name": "aggregate_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partition_key": {
+          "name": "partition_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "wallet_outbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_letter_reason": {
+          "name": "dead_letter_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_outbox_events_message_id": {
+          "name": "uq_outbox_events_message_id",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outbox_events_status_next_attempt_at": {
+          "name": "idx_outbox_events_status_next_attempt_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outbox_events_partition_created_at": {
+          "name": "idx_outbox_events_partition_created_at",
+          "columns": [
+            {
+              "expression": "partition_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_intent_item_discounts": {
+      "name": "payment_intent_item_discounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_ref_id": {
+          "name": "discount_ref_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "payment_intent_item_discount_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_intent_item_discounts_intent": {
+          "name": "idx_payment_intent_item_discounts_intent",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_intent_item_discounts_item": {
+          "name": "idx_payment_intent_item_discounts_item",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_intent_item_discounts_intent_id_payment_intents_id_fk": {
+          "name": "payment_intent_item_discounts_intent_id_payment_intents_id_fk",
+          "tableFrom": "payment_intent_item_discounts",
+          "tableTo": "payment_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_intent_item_discounts_item_id_payment_intent_items_id_fk": {
+          "name": "payment_intent_item_discounts_item_id_payment_intent_items_id_fk",
+          "tableFrom": "payment_intent_item_discounts",
+          "tableTo": "payment_intent_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payment_intent_item_discounts_amount_positive": {
+          "name": "payment_intent_item_discounts_amount_positive",
+          "value": "\"payment_intent_item_discounts\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_intent_items": {
+      "name": "payment_intent_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "payment_intent_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_ref_id": {
+          "name": "item_ref_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_amount": {
+          "name": "base_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_discount_per_unit_total": {
+          "name": "item_discount_per_unit_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "item_discount_flat_total": {
+          "name": "item_discount_flat_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "payable_amount": {
+          "name": "payable_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_payment_intent_items_intent_line": {
+          "name": "uq_payment_intent_items_intent_line",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_intent_items_intent_created_at": {
+          "name": "idx_payment_intent_items_intent_created_at",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_intent_items_intent_id_payment_intents_id_fk": {
+          "name": "payment_intent_items_intent_id_payment_intents_id_fk",
+          "tableFrom": "payment_intent_items",
+          "tableTo": "payment_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payment_intent_items_unit_price_non_negative": {
+          "name": "payment_intent_items_unit_price_non_negative",
+          "value": "\"payment_intent_items\".\"unit_price\" >= 0"
+        },
+        "payment_intent_items_quantity_positive": {
+          "name": "payment_intent_items_quantity_positive",
+          "value": "\"payment_intent_items\".\"quantity\" > 0"
+        },
+        "payment_intent_items_base_amount_non_negative": {
+          "name": "payment_intent_items_base_amount_non_negative",
+          "value": "\"payment_intent_items\".\"base_amount\" >= 0"
+        },
+        "payment_intent_items_discount_per_unit_non_negative": {
+          "name": "payment_intent_items_discount_per_unit_non_negative",
+          "value": "\"payment_intent_items\".\"item_discount_per_unit_total\" >= 0"
+        },
+        "payment_intent_items_discount_flat_non_negative": {
+          "name": "payment_intent_items_discount_flat_non_negative",
+          "value": "\"payment_intent_items\".\"item_discount_flat_total\" >= 0"
+        },
+        "payment_intent_items_payable_amount_non_negative": {
+          "name": "payment_intent_items_payable_amount_non_negative",
+          "value": "\"payment_intent_items\".\"payable_amount\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_intent_order_discounts": {
+      "name": "payment_intent_order_discounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_ref_id": {
+          "name": "discount_ref_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "payment_intent_order_discount_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ORDER'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_intent_order_discounts_intent": {
+          "name": "idx_payment_intent_order_discounts_intent",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_intent_order_discounts_intent_id_payment_intents_id_fk": {
+          "name": "payment_intent_order_discounts_intent_id_payment_intents_id_fk",
+          "tableFrom": "payment_intent_order_discounts",
+          "tableTo": "payment_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payment_intent_order_discounts_amount_positive": {
+          "name": "payment_intent_order_discounts_amount_positive",
+          "value": "\"payment_intent_order_discounts\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_intents": {
+      "name": "payment_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "payable_amount": {
+          "name": "payable_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "intent_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PURCHASE'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_url": {
+          "name": "return_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_expires_at": {
+          "name": "action_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_payment_intents_client_secret": {
+          "name": "uq_payment_intents_client_secret",
+          "columns": [
+            {
+              "expression": "client_secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_intents_status_expires_at": {
+          "name": "idx_payment_intents_status_expires_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_intents_status_action_expires_at": {
+          "name": "idx_payment_intents_status_action_expires_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_intents_user_created_at": {
+          "name": "idx_payment_intents_user_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_intents_billing_idempotency_key": {
+          "name": "idx_payment_intents_billing_idempotency_key",
+          "columns": [
+            {
+              "expression": "(\"metadata\"->>'idempotencyKey')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_intents\".\"metadata\"->>'idempotencyKey' IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_intents_payment_method_id_payment_methods_id_fk": {
+          "name": "payment_intents_payment_method_id_payment_methods_id_fk",
+          "tableFrom": "payment_intents",
+          "tableTo": "payment_methods",
+          "columnsFrom": [
+            "payment_method_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payment_intents_payable_amount_non_negative": {
+          "name": "payment_intents_payable_amount_non_negative",
+          "value": "\"payment_intents\".\"payable_amount\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_method_catalog": {
+      "name": "payment_method_catalog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_payment_method_catalog_code": {
+          "name": "uq_payment_method_catalog_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "payment_method_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_reusable": {
+          "name": "is_reusable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_data": {
+          "name": "provider_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_methods_user_id": {
+          "name": "idx_payment_methods_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_methods_user_type": {
+          "name": "idx_payment_methods_user_type",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_state_transitions": {
+      "name": "payment_state_transitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "payment_state_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_status": {
+          "name": "previous_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_message": {
+          "name": "reason_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_type": {
+          "name": "triggered_by_type",
+          "type": "payment_state_trigger_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by_id": {
+          "name": "triggered_by_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "causation_id": {
+          "name": "causation_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_state_transitions_entity": {
+          "name": "idx_payment_state_transitions_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_state_transitions_correlation": {
+          "name": "idx_payment_state_transitions_correlation",
+          "columns": [
+            {
+              "expression": "correlation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.point_event_details": {
+      "name": "point_event_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "point_event_id": {
+          "name": "point_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "point_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_event_detail_id": {
+          "name": "earned_event_detail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_event_detail_id": {
+          "name": "original_event_detail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_point_event_details_user_earned_created_at": {
+          "name": "idx_point_event_details_user_earned_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_event_detail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_point_event_details_point_event_created_at": {
+          "name": "idx_point_event_details_point_event_created_at",
+          "columns": [
+            {
+              "expression": "point_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "point_event_details_point_event_id_point_events_id_fk": {
+          "name": "point_event_details_point_event_id_point_events_id_fk",
+          "tableFrom": "point_event_details",
+          "tableTo": "point_events",
+          "columnsFrom": [
+            "point_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "point_event_details_earned_event_detail_id_point_event_details_id_fk": {
+          "name": "point_event_details_earned_event_detail_id_point_event_details_id_fk",
+          "tableFrom": "point_event_details",
+          "tableTo": "point_event_details",
+          "columnsFrom": [
+            "earned_event_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "point_event_details_original_event_detail_id_point_event_details_id_fk": {
+          "name": "point_event_details_original_event_detail_id_point_event_details_id_fk",
+          "tableFrom": "point_event_details",
+          "tableTo": "point_event_details",
+          "columnsFrom": [
+            "original_event_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "point_event_details_amount_non_zero": {
+          "name": "point_event_details_amount_non_zero",
+          "value": "\"point_event_details\".\"amount\" <> 0"
+        },
+        "point_event_details_type_amount_consistency": {
+          "name": "point_event_details_type_amount_consistency",
+          "value": "(\n        (\"point_event_details\".\"event_type\" in ('EARN', 'REDEEM_CANCEL') and \"point_event_details\".\"amount\" > 0)\n        or\n        (\"point_event_details\".\"event_type\" in ('REDEEM', 'EARN_CANCEL') and \"point_event_details\".\"amount\" < 0)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.point_events": {
+      "name": "point_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "point_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_event_id": {
+          "name": "original_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leg_id": {
+          "name": "leg_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_idempotency_key": {
+          "name": "provider_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_transaction_id": {
+          "name": "provider_transaction_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_message": {
+          "name": "reason_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_point_events_provider_idempotency_key": {
+          "name": "uq_point_events_provider_idempotency_key",
+          "columns": [
+            {
+              "expression": "provider_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_point_events_user_created_at": {
+          "name": "idx_point_events_user_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_point_events_intent_leg_created_at": {
+          "name": "idx_point_events_intent_leg_created_at",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "leg_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_point_events_expires_at": {
+          "name": "idx_point_events_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "point_events_amount_non_zero": {
+          "name": "point_events_amount_non_zero",
+          "value": "\"point_events\".\"amount\" <> 0"
+        },
+        "point_events_type_amount_consistency": {
+          "name": "point_events_type_amount_consistency",
+          "value": "(\n        (\"point_events\".\"event_type\" in ('EARN', 'REDEEM_CANCEL') and \"point_events\".\"amount\" > 0)\n        or\n        (\"point_events\".\"event_type\" in ('REDEEM', 'EARN_CANCEL') and \"point_events\".\"amount\" < 0)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.point_hold_details": {
+      "name": "point_hold_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_event_detail_id": {
+          "name": "earned_event_detail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_point_hold_details_hold_earned_detail": {
+          "name": "uq_point_hold_details_hold_earned_detail",
+          "columns": [
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_event_detail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_point_hold_details_earned_event_detail_id": {
+          "name": "idx_point_hold_details_earned_event_detail_id",
+          "columns": [
+            {
+              "expression": "earned_event_detail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "point_hold_details_hold_id_point_holds_id_fk": {
+          "name": "point_hold_details_hold_id_point_holds_id_fk",
+          "tableFrom": "point_hold_details",
+          "tableTo": "point_holds",
+          "columnsFrom": [
+            "hold_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "point_hold_details_earned_event_detail_id_point_event_details_id_fk": {
+          "name": "point_hold_details_earned_event_detail_id_point_event_details_id_fk",
+          "tableFrom": "point_hold_details",
+          "tableTo": "point_event_details",
+          "columnsFrom": [
+            "earned_event_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "point_hold_details_amount_positive": {
+          "name": "point_hold_details_amount_positive",
+          "value": "\"point_hold_details\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.point_holds": {
+      "name": "point_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leg_id": {
+          "name": "leg_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorize_attempt_id": {
+          "name": "authorize_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorize_provider_idempotency_key": {
+          "name": "authorize_provider_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "point_hold_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_event_id": {
+          "name": "captured_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_attempt_id": {
+          "name": "capture_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_provider_idempotency_key": {
+          "name": "capture_provider_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_attempt_id": {
+          "name": "cancel_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_provider_idempotency_key": {
+          "name": "cancel_provider_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_point_holds_authorize_provider_idempotency_key": {
+          "name": "uq_point_holds_authorize_provider_idempotency_key",
+          "columns": [
+            {
+              "expression": "authorize_provider_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_point_holds_capture_provider_idempotency_key": {
+          "name": "uq_point_holds_capture_provider_idempotency_key",
+          "columns": [
+            {
+              "expression": "capture_provider_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"point_holds\".\"capture_provider_idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_point_holds_cancel_provider_idempotency_key": {
+          "name": "uq_point_holds_cancel_provider_idempotency_key",
+          "columns": [
+            {
+              "expression": "cancel_provider_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"point_holds\".\"cancel_provider_idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_point_holds_leg_authorized": {
+          "name": "uq_point_holds_leg_authorized",
+          "columns": [
+            {
+              "expression": "leg_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"point_holds\".\"status\" = 'AUTHORIZED'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_point_holds_user_status_created_at": {
+          "name": "idx_point_holds_user_status_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_point_holds_leg_created_at": {
+          "name": "idx_point_holds_leg_created_at",
+          "columns": [
+            {
+              "expression": "leg_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "point_holds_captured_event_id_point_events_id_fk": {
+          "name": "point_holds_captured_event_id_point_events_id_fk",
+          "tableFrom": "point_holds",
+          "tableTo": "point_events",
+          "columnsFrom": [
+            "captured_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "point_holds_amount_positive": {
+          "name": "point_holds_amount_positive",
+          "value": "\"point_holds\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.provider_webhook_receipts": {
+      "name": "provider_webhook_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "provider_webhook_receipt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_provider_webhook_receipts_provider_event": {
+          "name": "uq_provider_webhook_receipts_provider_event",
+          "columns": [
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_receipts_status_received_at": {
+          "name": "idx_provider_webhook_receipts_status_received_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refunds": {
+      "name": "refunds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "charge_id": {
+          "name": "charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "refund_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_message": {
+          "name": "reason_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_refund_id": {
+          "name": "provider_refund_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_refunds_charge_id": {
+          "name": "idx_refunds_charge_id",
+          "columns": [
+            {
+              "expression": "charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refunds_intent_id": {
+          "name": "idx_refunds_intent_id",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refunds_status_created_at": {
+          "name": "idx_refunds_status_created_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refunds_charge_id_charges_id_fk": {
+          "name": "refunds_charge_id_charges_id_fk",
+          "tableFrom": "refunds",
+          "tableTo": "charges",
+          "columnsFrom": [
+            "charge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "refunds_intent_id_payment_intents_id_fk": {
+          "name": "refunds_intent_id_payment_intents_id_fk",
+          "tableFrom": "refunds",
+          "tableTo": "payment_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "refunds_amount_positive": {
+          "name": "refunds_amount_positive",
+          "value": "\"refunds\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.region_payment_methods": {
+      "name": "region_payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_id": {
+          "name": "catalog_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_region_payment_methods_region_catalog": {
+          "name": "uq_region_payment_methods_region_catalog",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "catalog_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_region_payment_methods_region": {
+          "name": "idx_region_payment_methods_region",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "region_payment_methods_region_id_regions_id_fk": {
+          "name": "region_payment_methods_region_id_regions_id_fk",
+          "tableFrom": "region_payment_methods",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "region_payment_methods_catalog_id_payment_method_catalog_id_fk": {
+          "name": "region_payment_methods_catalog_id_payment_method_catalog_id_fk",
+          "tableFrom": "region_payment_methods",
+          "tableTo": "payment_method_catalog",
+          "columnsFrom": [
+            "catalog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_regions_code": {
+          "name": "uq_regions_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "regions_code_lowercase": {
+          "name": "regions_code_lowercase",
+          "value": "\"regions\".\"code\" = lower(\"regions\".\"code\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "event.outbox_events": {
+      "name": "outbox_events",
+      "schema": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_type": {
+          "name": "aggregate_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "outbox_status_idx": {
+          "name": "outbox_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_processing_started_idx": {
+          "name": "outbox_processing_started_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processing_started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_topic_idx": {
+          "name": "outbox_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "event.event_resource_links": {
+      "name": "event_resource_links",
+      "schema": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(26)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "erl_chain_idx": {
+          "name": "erl_chain_idx",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "erl_resource_idx": {
+          "name": "erl_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "erl_event_idx": {
+          "name": "erl_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.role_scope_mapping": {
+      "name": "role_scope_mapping",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_scope_unique_idx": {
+          "name": "role_scope_unique_idx",
+          "columns": [
+            {
+              "expression": "role_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_scope_mapping_scope_id_scopes_id_fk": {
+          "name": "role_scope_mapping_scope_id_scopes_id_fk",
+          "tableFrom": "role_scope_mapping",
+          "tableTo": "scopes",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.scopes": {
+      "name": "scopes",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microservice_name": {
+          "name": "microservice_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scopes_key_unique": {
+          "name": "scopes_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.billing_agreement_status": {
+      "name": "billing_agreement_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "SUSPENDED",
+        "REVOKED"
+      ]
+    },
+    "public.billing_method_status": {
+      "name": "billing_method_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "REVOKED",
+        "DELETED",
+        "EXPIRED"
+      ]
+    },
+    "public.cash_receipt_status": {
+      "name": "cash_receipt_status",
+      "schema": "public",
+      "values": [
+        "ISSUED",
+        "CANCELED",
+        "FAILED"
+      ]
+    },
+    "public.cash_receipt_type": {
+      "name": "cash_receipt_type",
+      "schema": "public",
+      "values": [
+        "소득공제",
+        "지출증빙"
+      ]
+    },
+    "public.charge_operation": {
+      "name": "charge_operation",
+      "schema": "public",
+      "values": [
+        "AUTHORIZE",
+        "CAPTURE",
+        "CANCEL",
+        "REFUND"
+      ]
+    },
+    "public.charge_status": {
+      "name": "charge_status",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "PENDING",
+        "SUCCEEDED",
+        "FAILED",
+        "CANCELED",
+        "REFUNDED",
+        "REQUIRES_ACTION"
+      ]
+    },
+    "public.checkout_session_status": {
+      "name": "checkout_session_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "COMPLETED",
+        "EXPIRED",
+        "CANCELED"
+      ]
+    },
+    "public.cms_member_status": {
+      "name": "cms_member_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "REGISTERED",
+        "FAILED",
+        "DELETED"
+      ]
+    },
+    "public.cms_withdrawal_status": {
+      "name": "cms_withdrawal_status",
+      "schema": "public",
+      "values": [
+        "REQUESTED",
+        "PROCESSING",
+        "SUCCEEDED",
+        "FAILED",
+        "DELETED"
+      ]
+    },
+    "public.intent_purpose": {
+      "name": "intent_purpose",
+      "schema": "public",
+      "values": [
+        "PURCHASE",
+        "SUBSCRIPTION",
+        "REPAYMENT",
+        "PAYOUT"
+      ]
+    },
+    "public.wallet_outbox_status": {
+      "name": "wallet_outbox_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "PROCESSING",
+        "PUBLISHED",
+        "FAILED",
+        "DEAD_LETTER"
+      ]
+    },
+    "public.payment_intent_item_discount_kind": {
+      "name": "payment_intent_item_discount_kind",
+      "schema": "public",
+      "values": [
+        "ITEM_PER_UNIT",
+        "ITEM_FLAT"
+      ]
+    },
+    "public.payment_intent_item_type": {
+      "name": "payment_intent_item_type",
+      "schema": "public",
+      "values": [
+        "PRODUCT",
+        "SUBSCRIPTION",
+        "SHIPPING_FEE",
+        "OTHER"
+      ]
+    },
+    "public.payment_intent_order_discount_kind": {
+      "name": "payment_intent_order_discount_kind",
+      "schema": "public",
+      "values": [
+        "ORDER"
+      ]
+    },
+    "public.payment_intent_status": {
+      "name": "payment_intent_status",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "PROCESSING",
+        "REQUIRES_ACTION",
+        "AWAITING_DEPOSIT",
+        "AUTHORIZED",
+        "CAPTURED",
+        "SUCCEEDED",
+        "FAILED",
+        "CANCELED",
+        "PENDING_SETTLEMENT",
+        "PARTIALLY_CAPTURED"
+      ]
+    },
+    "public.payment_method_type": {
+      "name": "payment_method_type",
+      "schema": "public",
+      "values": [
+        "POINTS",
+        "CARD",
+        "BANK_TRANSFER",
+        "BNPL",
+        "TOSS",
+        "NICEPAY",
+        "TOSS_BILLING",
+        "NICEPAY_BILLING",
+        "CMS_BATCH"
+      ]
+    },
+    "public.payment_state_entity_type": {
+      "name": "payment_state_entity_type",
+      "schema": "public",
+      "values": [
+        "INTENT",
+        "CHARGE",
+        "REFUND"
+      ]
+    },
+    "public.payment_state_trigger_type": {
+      "name": "payment_state_trigger_type",
+      "schema": "public",
+      "values": [
+        "SYSTEM",
+        "USER",
+        "ADMIN",
+        "WEBHOOK",
+        "COMMAND"
+      ]
+    },
+    "public.point_event_type": {
+      "name": "point_event_type",
+      "schema": "public",
+      "values": [
+        "EARN",
+        "REDEEM",
+        "EARN_CANCEL",
+        "REDEEM_CANCEL"
+      ]
+    },
+    "public.point_hold_status": {
+      "name": "point_hold_status",
+      "schema": "public",
+      "values": [
+        "AUTHORIZED",
+        "CAPTURED",
+        "CANCELLED"
+      ]
+    },
+    "public.provider_webhook_receipt_status": {
+      "name": "provider_webhook_receipt_status",
+      "schema": "public",
+      "values": [
+        "RECEIVED",
+        "PROCESSED",
+        "IGNORED_DUPLICATE",
+        "FAILED"
+      ]
+    },
+    "public.refund_status": {
+      "name": "refund_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "SUCCEEDED",
+        "FAILED"
+      ]
+    }
+  },
+  "schemas": {
+    "event": "event",
+    "auth": "auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/wallet/drizzle/meta/_journal.json
+++ b/apps/wallet/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1782095327159,
       "tag": "20260622022847_add-awaiting-deposit-status",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1782797382964,
+      "tag": "20260630052942_add-cash-receipts",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wallet/src/admin/bank-transfer-admin.service.ts
+++ b/apps/wallet/src/admin/bank-transfer-admin.service.ts
@@ -4,6 +4,7 @@ import { PaginatedResponseDto } from '@app/shared';
 import { and, count, desc, eq, inArray, sql } from 'drizzle-orm';
 import { WalletSchema, charges, paymentIntents, paymentMethods } from '../schema';
 import { ChargesService } from '../charges/charges.service';
+import { CashReceiptsService } from '../cash-receipts/cash-receipts.service';
 import { StateTransitionService } from '../domain/state-transition/state-transition.service';
 import {
   GATEWAY_AGGREGATE_TYPE,
@@ -19,6 +20,7 @@ export class BankTransferAdminService {
   constructor(
     private readonly dbService: DbService<WalletSchema>,
     private readonly chargesService: ChargesService,
+    private readonly cashReceiptsService: CashReceiptsService,
     private readonly stateTransitionService: StateTransitionService,
   ) {}
 
@@ -177,5 +179,20 @@ export class BankTransferAdminService {
     });
 
     this.logger.log(`confirmDeposit succeeded: intentId=${intentId}`);
+
+    // 결제완료(입금확인) 시점에 현금영수증 자동 발급 — confirm 단계에서 고객이 신청한 경우.
+    // best-effort: 발급 실패가 입금확인을 되돌리지 않는다 (결제는 이미 완료됨).
+    const cashReceipt = intent.metadata?.cashReceipt as
+      | { type: '소득공제' | '지출증빙'; customerIdentityNumber: string }
+      | undefined;
+    if (cashReceipt && intent.userId) {
+      try {
+        await this.cashReceiptsService.issue({ intentId, ...cashReceipt }, intent.userId);
+        this.logger.log(`cash receipt issued on deposit confirm: intentId=${intentId}`);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.error(`cash receipt auto-issue failed (deposit confirmed): intentId=${intentId}, error=${message}`);
+      }
+    }
   }
 }

--- a/apps/wallet/src/admin/cash-receipts-admin.controller.ts
+++ b/apps/wallet/src/admin/cash-receipts-admin.controller.ts
@@ -1,0 +1,47 @@
+import { Body, Controller, Get, HttpCode, Post, Query } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { WalletAdminAuth } from '../wallet-admin-auth.decorator';
+import { CashReceiptsService } from '../cash-receipts/cash-receipts.service';
+import { CashReceiptResponseDto, IssueCashReceiptDto } from '../cash-receipts/dto';
+import { CashReceipt } from '../types';
+
+/**
+ * 관리자용 현금영수증 API. 고객 셀프 발급(v1/cash-receipts)과 달리 소유권 스코프가 없어
+ * 임의 주문에 대해 조회/발급할 수 있다. 발급 검증(결제완료·무통장·이중발급 방지)은 동일하게 적용됨.
+ */
+@ApiTags('Admin CashReceipts')
+@WalletAdminAuth()
+@Controller('v1/admin/cash-receipts')
+export class CashReceiptsAdminController {
+  constructor(private readonly service: CashReceiptsService) {}
+
+  @Get()
+  @ApiOperation({ summary: '주문의 현금영수증 조회 (관리자)' })
+  async list(@Query('intentId') intentId: string): Promise<CashReceiptResponseDto[]> {
+    const receipts = await this.service.findByIntentForAdmin(intentId);
+    return receipts.map((r) => this.toResponse(r));
+  }
+
+  @Post()
+  @HttpCode(201)
+  @ApiOperation({ summary: '현금영수증 발급 (관리자)' })
+  async issue(@Body() dto: IssueCashReceiptDto): Promise<CashReceiptResponseDto> {
+    const receipt = await this.service.issueAsAdmin(dto);
+    return this.toResponse(receipt);
+  }
+
+  private toResponse(r: CashReceipt): CashReceiptResponseDto {
+    return {
+      id: r.id,
+      intentId: r.intentId,
+      type: r.type,
+      status: r.status,
+      amount: r.amount,
+      currency: r.currency,
+      receiptUrl: r.receiptUrl,
+      issueNumber: r.issueNumber,
+      errorMessage: r.errorMessage,
+      createdAt: r.createdAt,
+    };
+  }
+}

--- a/apps/wallet/src/cash-receipts/cash-receipts.controller.ts
+++ b/apps/wallet/src/cash-receipts/cash-receipts.controller.ts
@@ -1,0 +1,50 @@
+import { Body, Controller, Get, HttpCode, Post, Query, Req, UnauthorizedException } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { WalletJwtAuth } from '../wallet-auth.decorator';
+import { AuthenticatedRequest } from '../wallet.module';
+import { CashReceiptsService } from './cash-receipts.service';
+import { CashReceiptResponseDto, IssueCashReceiptDto } from './dto';
+import { CashReceipt } from '../types';
+
+@ApiTags('CashReceipts')
+@Controller('v1/cash-receipts')
+export class CashReceiptsController {
+  constructor(private readonly service: CashReceiptsService) {}
+
+  @Post()
+  @HttpCode(201)
+  @WalletJwtAuth()
+  @ApiOperation({ summary: '현금영수증 발급 (고객 셀프, JWT 쿠키 인증)' })
+  async issue(@Req() req: AuthenticatedRequest, @Body() dto: IssueCashReceiptDto): Promise<CashReceiptResponseDto> {
+    if (!req.jwtUserId) throw new UnauthorizedException('JWT authentication required');
+    const receipt = await this.service.issue(dto, req.jwtUserId);
+    return this.toResponse(receipt);
+  }
+
+  @Get()
+  @WalletJwtAuth()
+  @ApiOperation({ summary: '주문의 현금영수증 조회' })
+  async findByIntent(
+    @Req() req: AuthenticatedRequest,
+    @Query('intentId') intentId: string,
+  ): Promise<CashReceiptResponseDto[]> {
+    if (!req.jwtUserId) throw new UnauthorizedException('JWT authentication required');
+    const receipts = await this.service.findByIntent(intentId, req.jwtUserId);
+    return receipts.map((r) => this.toResponse(r));
+  }
+
+  private toResponse(r: CashReceipt): CashReceiptResponseDto {
+    return {
+      id: r.id,
+      intentId: r.intentId,
+      type: r.type,
+      status: r.status,
+      amount: r.amount,
+      currency: r.currency,
+      receiptUrl: r.receiptUrl,
+      issueNumber: r.issueNumber,
+      errorMessage: r.errorMessage,
+      createdAt: r.createdAt,
+    };
+  }
+}

--- a/apps/wallet/src/cash-receipts/cash-receipts.service.spec.ts
+++ b/apps/wallet/src/cash-receipts/cash-receipts.service.spec.ts
@@ -1,0 +1,174 @@
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+import { CashReceiptsService } from './cash-receipts.service';
+
+const INTENT_ID = 'intent-001';
+const CHARGE_ID = 'charge-001';
+const PM_ID = 'pm-001';
+const USER_ID = 'user-001';
+
+function makeIntent(overrides: Partial<{ userId: string; status: string }> = {}) {
+  return {
+    id: INTENT_ID,
+    userId: overrides.userId ?? USER_ID,
+    status: overrides.status ?? 'SUCCEEDED',
+    payableAmount: 10000,
+    currency: 'KRW',
+  };
+}
+
+function makeCharge(overrides: Partial<{ amount: number }> = {}) {
+  return { id: CHARGE_ID, intentId: INTENT_ID, paymentMethodId: PM_ID, amount: overrides.amount ?? 10000, currency: 'KRW' };
+}
+
+function makeReceipt(overrides: Partial<{ amount: number; canceledAmount: number; status: string }> = {}) {
+  return {
+    id: 'cr-001',
+    chargeId: CHARGE_ID,
+    intentId: INTENT_ID,
+    amount: overrides.amount ?? 10000,
+    canceledAmount: overrides.canceledAmount ?? 0,
+    status: overrides.status ?? 'ISSUED',
+    receiptKey: 'rk-001',
+    canceledAt: null,
+  };
+}
+
+/**
+ * db.select() 는 호출 순서대로 selectQueue 의 결과를 반환한다 (limit/orderBy 공통).
+ * issue() 의 select 순서: 1) findIntentOrThrow  2) findActiveByCharge  3) buildOrderName(items)
+ * cancelForRefund() 의 select 순서: 1) findActiveByCharge
+ */
+function makeContext(opts: {
+  selectQueue?: unknown[][];
+  refundableCharges?: ReturnType<typeof makeCharge>[];
+  methodType?: string;
+  tossIssue?: { ok: boolean; data?: any; error?: any };
+  tossCancel?: { ok: boolean; data?: any; error?: any };
+} = {}) {
+  const selectQueue = [...(opts.selectQueue ?? [])];
+  const updateCalls: Array<Record<string, unknown>> = [];
+  const resultPromise = () => Promise.resolve(selectQueue.shift() ?? []);
+
+  const db = {
+    db: {
+      select: jest.fn().mockImplementation(() => ({
+        from: () => ({
+          where: () => ({ limit: () => resultPromise(), orderBy: () => resultPromise() }),
+        }),
+      })),
+      insert: jest.fn().mockImplementation(() => ({
+        values: (vals: any) => ({ returning: () => Promise.resolve([{ id: 'cr-new', ...vals }]) }),
+      })),
+      update: jest.fn().mockImplementation(() => ({
+        set: (vals: Record<string, unknown>) => ({
+          where: () => {
+            updateCalls.push(vals);
+            return Promise.resolve();
+          },
+        }),
+      })),
+    },
+  };
+
+  const chargesService = {
+    findRefundableByIntent: jest.fn().mockResolvedValue(opts.refundableCharges ?? [makeCharge()]),
+  };
+  const paymentMethodsService = {
+    findById: jest.fn().mockResolvedValue({ id: PM_ID, type: opts.methodType ?? 'BANK_TRANSFER' }),
+  };
+  const tossApiClient = {
+    issueCashReceipt: jest.fn().mockResolvedValue(opts.tossIssue ?? { ok: true, data: {} }),
+    cancelCashReceipt: jest.fn().mockResolvedValue(opts.tossCancel ?? { ok: true, data: {} }),
+  };
+
+  const service = new CashReceiptsService(
+    db as any,
+    chargesService as any,
+    paymentMethodsService as any,
+    tossApiClient as any,
+  );
+  return { service, tossApiClient, updateCalls };
+}
+
+const DTO = { intentId: INTENT_ID, type: '소득공제' as const, customerIdentityNumber: '01012345678' };
+
+describe('CashReceiptsService', () => {
+  describe('issue() 가드', () => {
+    it('다른 유저의 인텐트면 NotFound', async () => {
+      const { service, tossApiClient } = makeContext({ selectQueue: [[makeIntent({ userId: 'other' })]] });
+      await expect(service.issue(DTO, USER_ID)).rejects.toBeInstanceOf(NotFoundException);
+      expect(tossApiClient.issueCashReceipt).not.toHaveBeenCalled();
+    });
+
+    it('결제 미완료 상태면 BadRequest', async () => {
+      const { service } = makeContext({ selectQueue: [[makeIntent({ status: 'CREATED' })]] });
+      await expect(service.issue(DTO, USER_ID)).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('카드결제(무통장 charge 없음)면 BadRequest (NOT_ELIGIBLE)', async () => {
+      const { service, tossApiClient } = makeContext({ selectQueue: [[makeIntent()]], methodType: 'TOSS' });
+      await expect(service.issue(DTO, USER_ID)).rejects.toThrow('무통장입금 결제만');
+      expect(tossApiClient.issueCashReceipt).not.toHaveBeenCalled();
+    });
+
+    it('이미 ISSUED 영수증이 있으면 Conflict', async () => {
+      const { service } = makeContext({ selectQueue: [[makeIntent()], [makeReceipt()]] });
+      await expect(service.issue(DTO, USER_ID)).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('무통장 결제면 charge.amount 로 발급', async () => {
+      const { service, tossApiClient } = makeContext({
+        selectQueue: [[makeIntent()], [], [{ name: '상품A' }]],
+        refundableCharges: [makeCharge({ amount: 7000 })],
+        tossIssue: { ok: true, data: { receiptKey: 'rk', issueNumber: '123', receiptUrl: 'http://x' } },
+      });
+      const r = await service.issue(DTO, USER_ID);
+      expect(tossApiClient.issueCashReceipt).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: 7000, orderId: INTENT_ID, type: '소득공제' }),
+      );
+      expect(r.status).toBe('ISSUED');
+    });
+  });
+
+  describe('cancelForRefund() — 환불 연동', () => {
+    it('전액 취소 시 status=CANCELED, canceledAt 설정', async () => {
+      const { service, tossApiClient, updateCalls } = makeContext({ selectQueue: [[makeReceipt({ amount: 10000 })]] });
+      await service.cancelForRefund(CHARGE_ID, 10000);
+      expect(tossApiClient.cancelCashReceipt).toHaveBeenCalledWith('rk-001', 10000);
+      expect(updateCalls[0]).toMatchObject({ canceledAmount: 10000, status: 'CANCELED' });
+      expect(updateCalls[0].canceledAt).toBeInstanceOf(Date);
+    });
+
+    it('부분 취소 시 status는 ISSUED 유지, canceledAmount 누적', async () => {
+      const { service, updateCalls } = makeContext({
+        selectQueue: [[makeReceipt({ amount: 10000, canceledAmount: 3000 })]],
+      });
+      await service.cancelForRefund(CHARGE_ID, 4000);
+      expect(updateCalls[0]).toMatchObject({ canceledAmount: 7000, status: 'ISSUED' });
+      expect(updateCalls[0].canceledAt).toBeNull();
+    });
+
+    it('환불금액이 잔여 취소가능액을 넘으면 잔여분만 취소', async () => {
+      const { service, tossApiClient } = makeContext({
+        selectQueue: [[makeReceipt({ amount: 10000, canceledAmount: 8000 })]],
+      });
+      await service.cancelForRefund(CHARGE_ID, 5000);
+      expect(tossApiClient.cancelCashReceipt).toHaveBeenCalledWith('rk-001', 2000);
+    });
+
+    it('ISSUED 영수증이 없으면 토스 호출 안 함', async () => {
+      const { service, tossApiClient } = makeContext({ selectQueue: [[]] });
+      await service.cancelForRefund(CHARGE_ID, 5000);
+      expect(tossApiClient.cancelCashReceipt).not.toHaveBeenCalled();
+    });
+
+    it('토스 취소 실패 시 DB 업데이트 안 함 (환불은 유지)', async () => {
+      const { service, updateCalls } = makeContext({
+        selectQueue: [[makeReceipt()]],
+        tossCancel: { ok: false, error: { code: 'X', message: 'fail' } },
+      });
+      await service.cancelForRefund(CHARGE_ID, 10000);
+      expect(updateCalls).toHaveLength(0);
+    });
+  });
+});

--- a/apps/wallet/src/cash-receipts/cash-receipts.service.ts
+++ b/apps/wallet/src/cash-receipts/cash-receipts.service.ts
@@ -10,6 +10,10 @@ import { TossApiClient } from '../providers/toss/toss-api.client';
 // 발급 가능한 인텐트 상태 (결제 완료된 건만)
 const PAYABLE_STATUSES = ['CAPTURED', 'SUCCEEDED'] as const;
 
+// intent_id 는 uuid 컬럼. 비-UUID(더미 intentId 등)로 조회하면 postgres 가 uuid 캐스팅에서
+// 터져 500 이 난다. 조회 전 형식을 검증해 안전하게 처리한다.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 @Injectable()
 export class CashReceiptsService {
   private readonly logger = new Logger(CashReceiptsService.name);
@@ -142,10 +146,38 @@ export class CashReceiptsService {
   }
 
   async findByIntent(intentId: string, userId: string): Promise<CashReceipt[]> {
+    if (!UUID_RE.test(intentId)) return [];
     return this.dbService.db
       .select()
       .from(cashReceipts)
       .where(and(eq(cashReceipts.intentId, intentId), eq(cashReceipts.userId, userId)))
+      .orderBy(asc(cashReceipts.createdAt));
+  }
+
+  // ─── 관리자용 ───
+  /** 관리자 발급: 인텐트 소유자(userId)를 조회해 그 사용자 명의로 발급한다. */
+  async issueAsAdmin(dto: {
+    intentId: string;
+    type: CashReceiptType;
+    customerIdentityNumber: string;
+  }): Promise<CashReceipt> {
+    const intent = await this.findIntentOrThrow(dto.intentId);
+    if (!intent.userId) {
+      throw new BadRequestException({
+        error: 'INTENT_HAS_NO_USER',
+        message: `주문에 사용자 정보가 없어 현금영수증을 발급할 수 없습니다: ${dto.intentId}`,
+      });
+    }
+    return this.issue(dto, intent.userId);
+  }
+
+  /** 관리자 조회: 소유자 스코프 없이 인텐트의 전체 현금영수증. */
+  async findByIntentForAdmin(intentId: string): Promise<CashReceipt[]> {
+    if (!UUID_RE.test(intentId)) return [];
+    return this.dbService.db
+      .select()
+      .from(cashReceipts)
+      .where(eq(cashReceipts.intentId, intentId))
       .orderBy(asc(cashReceipts.createdAt));
   }
 
@@ -177,11 +209,10 @@ export class CashReceiptsService {
   }
 
   private async findIntentOrThrow(intentId: string) {
-    const rows = await this.dbService.db
-      .select()
-      .from(paymentIntents)
-      .where(eq(paymentIntents.id, intentId))
-      .limit(1);
+    if (!UUID_RE.test(intentId)) {
+      throw new NotFoundException({ error: 'INTENT_NOT_FOUND', message: `Intent not found: ${intentId}` });
+    }
+    const rows = await this.dbService.db.select().from(paymentIntents).where(eq(paymentIntents.id, intentId)).limit(1);
     const intent = rows[0];
     if (!intent) {
       throw new NotFoundException({ error: 'INTENT_NOT_FOUND', message: `Intent not found: ${intentId}` });

--- a/apps/wallet/src/cash-receipts/cash-receipts.service.ts
+++ b/apps/wallet/src/cash-receipts/cash-receipts.service.ts
@@ -1,0 +1,203 @@
+import { BadRequestException, ConflictException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { DbService } from '@app/db';
+import { and, asc, eq } from 'drizzle-orm';
+import { CashReceiptType, WalletSchema, cashReceipts, paymentIntentItems, paymentIntents } from '../schema';
+import { CashReceipt } from '../types';
+import { ChargesService } from '../charges/charges.service';
+import { PaymentMethodsService } from '../payment-methods/payment-methods.service';
+import { TossApiClient } from '../providers/toss/toss-api.client';
+
+// 발급 가능한 인텐트 상태 (결제 완료된 건만)
+const PAYABLE_STATUSES = ['CAPTURED', 'SUCCEEDED'] as const;
+
+@Injectable()
+export class CashReceiptsService {
+  private readonly logger = new Logger(CashReceiptsService.name);
+
+  constructor(
+    private readonly dbService: DbService<WalletSchema>,
+    private readonly chargesService: ChargesService,
+    private readonly paymentMethodsService: PaymentMethodsService,
+    private readonly tossApiClient: TossApiClient,
+  ) {}
+
+  async issue(
+    dto: { intentId: string; type: CashReceiptType; customerIdentityNumber: string },
+    userId: string,
+  ): Promise<CashReceipt> {
+    const intent = await this.findIntentOrThrow(dto.intentId);
+
+    if (intent.userId !== userId) {
+      throw new NotFoundException({ error: 'INTENT_NOT_FOUND', message: `Intent not found: ${dto.intentId}` });
+    }
+    if (!PAYABLE_STATUSES.includes(intent.status as (typeof PAYABLE_STATUSES)[number])) {
+      throw new BadRequestException({
+        error: 'INTENT_NOT_PAID',
+        message: `결제 완료된 주문만 현금영수증을 발급할 수 있습니다: ${intent.status}`,
+      });
+    }
+
+    // 안전 게이트: 카드(TOSS/NICEPAY)·포인트가 아닌 현금성(무통장) charge 만 발급 대상.
+    // 카드는 매출전표가 증빙이라 현금영수증을 또 끊으면 안 됨.
+    const charge = await this.findCashChargeOrThrow(dto.intentId);
+
+    // 이중발급 방지 (DB partial unique index 와 짝)
+    const existing = await this.findActiveByCharge(charge.id);
+    if (existing) {
+      throw new ConflictException({
+        error: 'CASH_RECEIPT_ALREADY_ISSUED',
+        message: '이미 현금영수증이 발급된 주문입니다.',
+      });
+    }
+
+    const orderName = await this.buildOrderName(dto.intentId);
+
+    const result = await this.tossApiClient.issueCashReceipt({
+      amount: charge.amount,
+      orderId: dto.intentId,
+      orderName,
+      type: dto.type,
+      customerIdentityNumber: dto.customerIdentityNumber,
+    });
+
+    if (!result.ok) {
+      this.logger.error(`Cash receipt issue failed: intent=${dto.intentId}, error=${result.error.message}`);
+      const failed = await this.dbService.db
+        .insert(cashReceipts)
+        .values({
+          chargeId: charge.id,
+          intentId: dto.intentId,
+          userId,
+          type: dto.type,
+          customerIdentityNumber: dto.customerIdentityNumber,
+          amount: charge.amount,
+          currency: charge.currency,
+          status: 'FAILED',
+          errorCode: result.error.code,
+          errorMessage: result.error.message.slice(0, 500),
+        })
+        .returning();
+      throw new BadRequestException({
+        error: 'CASH_RECEIPT_ISSUE_FAILED',
+        message: result.error.message,
+        receiptId: failed[0]?.id,
+      });
+    }
+
+    const data = result.data;
+    const inserted = await this.dbService.db
+      .insert(cashReceipts)
+      .values({
+        chargeId: charge.id,
+        intentId: dto.intentId,
+        userId,
+        type: dto.type,
+        customerIdentityNumber: dto.customerIdentityNumber,
+        amount: charge.amount,
+        currency: charge.currency,
+        status: 'ISSUED',
+        receiptKey: data.receiptKey,
+        issueNumber: data.issueNumber,
+        receiptUrl: data.receiptUrl,
+        responsePayload: data,
+        issuedAt: new Date(),
+      })
+      .returning();
+
+    const row = inserted[0];
+    if (!row) throw new Error('CASH_RECEIPT_INSERT_FAILED');
+    return row;
+  }
+
+  /**
+   * 환불 시 호출 — 해당 charge 의 ISSUED 현금영수증을 환불금액만큼 토스에서 취소한다.
+   * 돈은 이미 환불됐으므로 영수증 취소 실패가 환불을 막아선 안 된다 (best-effort, 로깅만).
+   */
+  async cancelForRefund(chargeId: string, amount: number): Promise<void> {
+    const receipt = await this.findActiveByCharge(chargeId);
+    if (!receipt || !receipt.receiptKey) return;
+
+    const cancelAmount = Math.min(amount, receipt.amount - receipt.canceledAmount);
+    if (cancelAmount <= 0) return;
+
+    const result = await this.tossApiClient.cancelCashReceipt(receipt.receiptKey, cancelAmount);
+    if (!result.ok) {
+      this.logger.error(
+        `Cash receipt cancel failed (refund continues): charge=${chargeId}, receipt=${receipt.id}, error=${result.error.message}`,
+      );
+      return;
+    }
+
+    const newCanceled = receipt.canceledAmount + cancelAmount;
+    const fullyCanceled = newCanceled >= receipt.amount;
+    await this.dbService.db
+      .update(cashReceipts)
+      .set({
+        canceledAmount: newCanceled,
+        status: fullyCanceled ? 'CANCELED' : receipt.status,
+        canceledAt: fullyCanceled ? new Date() : receipt.canceledAt,
+        updatedAt: new Date(),
+      })
+      .where(eq(cashReceipts.id, receipt.id));
+  }
+
+  async findByIntent(intentId: string, userId: string): Promise<CashReceipt[]> {
+    return this.dbService.db
+      .select()
+      .from(cashReceipts)
+      .where(and(eq(cashReceipts.intentId, intentId), eq(cashReceipts.userId, userId)))
+      .orderBy(asc(cashReceipts.createdAt));
+  }
+
+  /** 현금영수증 발급 대상 charge = 환불 source charge 중 결제수단이 BANK_TRANSFER(무통장) 인 것. */
+  private async findCashChargeOrThrow(intentId: string) {
+    const charges = await this.chargesService.findRefundableByIntent(intentId);
+    const cashCharges: typeof charges = [];
+    for (const charge of charges) {
+      const method = await this.paymentMethodsService.findById(charge.paymentMethodId);
+      if (method?.type === 'BANK_TRANSFER') cashCharges.push(charge);
+    }
+    if (cashCharges.length === 0) {
+      throw new BadRequestException({
+        error: 'CASH_RECEIPT_NOT_ELIGIBLE',
+        message: '현금영수증은 무통장입금 결제만 발급할 수 있습니다. 카드결제는 매출전표가 증빙입니다.',
+      });
+    }
+    // ponytail: intent 당 무통장 charge 는 사실상 1건. 여러 건이면 첫 건으로 발급, 분할발급은 추후.
+    return cashCharges[0];
+  }
+
+  private async findActiveByCharge(chargeId: string): Promise<CashReceipt | null> {
+    const rows = await this.dbService.db
+      .select()
+      .from(cashReceipts)
+      .where(and(eq(cashReceipts.chargeId, chargeId), eq(cashReceipts.status, 'ISSUED')))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  private async findIntentOrThrow(intentId: string) {
+    const rows = await this.dbService.db
+      .select()
+      .from(paymentIntents)
+      .where(eq(paymentIntents.id, intentId))
+      .limit(1);
+    const intent = rows[0];
+    if (!intent) {
+      throw new NotFoundException({ error: 'INTENT_NOT_FOUND', message: `Intent not found: ${intentId}` });
+    }
+    return intent;
+  }
+
+  private async buildOrderName(intentId: string): Promise<string> {
+    const items = await this.dbService.db
+      .select({ name: paymentIntentItems.name })
+      .from(paymentIntentItems)
+      .where(eq(paymentIntentItems.intentId, intentId))
+      .orderBy(asc(paymentIntentItems.createdAt));
+    if (items.length === 0) return '주문';
+    const first = items[0].name;
+    const name = items.length > 1 ? `${first} 외 ${items.length - 1}건` : first;
+    return name.slice(0, 100);
+  }
+}

--- a/apps/wallet/src/cash-receipts/dto/index.ts
+++ b/apps/wallet/src/cash-receipts/dto/index.ts
@@ -1,0 +1,54 @@
+import { IsIn, IsNotEmpty, IsString, Matches, MaxLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { CashReceiptStatus, CashReceiptType } from '../../schema';
+
+export class IssueCashReceiptDto {
+  @ApiProperty({ description: '현금영수증을 발급할 결제 인텐트 ID' })
+  @IsString()
+  @IsNotEmpty()
+  intentId: string;
+
+  @ApiProperty({ description: '소득공제(개인) 또는 지출증빙(사업자)', enum: ['소득공제', '지출증빙'] })
+  @IsIn(['소득공제', '지출증빙'])
+  type: CashReceiptType;
+
+  @ApiProperty({
+    description: '소득공제: 휴대폰번호, 지출증빙: 사업자등록번호 (숫자만, 하이픈 제거)',
+    maxLength: 30,
+  })
+  @IsString()
+  @Matches(/^[0-9]{8,30}$/, { message: 'customerIdentityNumber must be 8-30 digits' })
+  customerIdentityNumber: string;
+}
+
+export class CashReceiptResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  intentId: string;
+
+  @ApiProperty()
+  type: CashReceiptType;
+
+  @ApiProperty()
+  status: CashReceiptStatus;
+
+  @ApiProperty()
+  amount: number;
+
+  @ApiProperty()
+  currency: string;
+
+  @ApiPropertyOptional({ description: '토스 영수증 조회 URL' })
+  receiptUrl: string | null;
+
+  @ApiPropertyOptional({ description: '국세청 발급번호' })
+  issueNumber: string | null;
+
+  @ApiPropertyOptional()
+  errorMessage: string | null;
+
+  @ApiProperty()
+  createdAt: Date;
+}

--- a/apps/wallet/src/payment-intents/confirm.service.ts
+++ b/apps/wallet/src/payment-intents/confirm.service.ts
@@ -16,6 +16,8 @@ import {
 import { ChargePlan, ChargeSlot } from './charge-plan';
 import { ChargeResult } from '../providers/payment-provider.interface';
 
+type CashReceiptRequest = { type: '소득공제' | '지출증빙'; customerIdentityNumber: string };
+
 interface Phase1Result {
   plan: ChargePlan;
   userId: string;
@@ -43,7 +45,7 @@ export class ConfirmService {
 
   async confirm(
     intentId: string,
-    dto: { paymentMethodId?: string; pointsToApply?: number },
+    dto: { paymentMethodId?: string; pointsToApply?: number; cashReceipt?: CashReceiptRequest },
     correlationId: string,
   ): Promise<{ nextAction?: Record<string, unknown> }> {
     let phase1: Phase1Result | null = null;
@@ -60,7 +62,7 @@ export class ConfirmService {
 
   private async phase1Setup(
     intentId: string,
-    dto: { paymentMethodId?: string; pointsToApply?: number },
+    dto: { paymentMethodId?: string; pointsToApply?: number; cashReceipt?: CashReceiptRequest },
     correlationId: string,
     tx: DbTx,
   ): Promise<Phase1Result | null> {
@@ -187,11 +189,16 @@ export class ConfirmService {
     }
 
     // 9. Set intent.paymentMethodId and transition to PROCESSING
+    // 현금영수증 신청이 있으면 metadata 에 저장 — 무통장 입금확인(confirmDeposit) 완료 시 자동 발급에 사용.
     const intentPaymentMethodId = plan.primary.paymentMethodId;
+    const nextMetadata = dto.cashReceipt
+      ? { ...(intent.metadata ?? {}), cashReceipt: dto.cashReceipt }
+      : undefined;
     await tx
       .update(paymentIntents)
       .set({
         paymentMethodId: intentPaymentMethodId,
+        ...(nextMetadata ? { metadata: nextMetadata } : {}),
         version: sql`${paymentIntents.version} + 1`,
         updatedAt: new Date(),
       })

--- a/apps/wallet/src/payment-intents/dto/index.ts
+++ b/apps/wallet/src/payment-intents/dto/index.ts
@@ -155,6 +155,18 @@ export class CreatePaymentIntentDto {
 
 // ─── Confirm Intent ───────────────────────────────────────────────────────────
 
+export class CashReceiptRequestDto {
+  @ApiProperty({ description: '소득공제(개인) 또는 지출증빙(사업자)', enum: ['소득공제', '지출증빙'] })
+  @IsEnum({ 소득공제: '소득공제', 지출증빙: '지출증빙' })
+  type: '소득공제' | '지출증빙';
+
+  @ApiProperty({ description: '소득공제: 휴대폰번호, 지출증빙: 사업자등록번호 (숫자만)' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(30)
+  customerIdentityNumber: string;
+}
+
 export class ConfirmPaymentIntentDto {
   @ApiPropertyOptional({
     description: 'Payment method ID to use for this payment (not required if pointsToApply covers the full amount)',
@@ -169,6 +181,12 @@ export class ConfirmPaymentIntentDto {
   @IsInt()
   @Min(0)
   pointsToApply?: number;
+
+  @ApiPropertyOptional({ description: '현금영수증 신청 정보 (무통장입금 시). 입금확인 완료 시 자동 발급.', type: CashReceiptRequestDto })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CashReceiptRequestDto)
+  cashReceipt?: CashReceiptRequestDto;
 }
 
 // ─── Toss Approve ─────────────────────────────────────────────────────────────

--- a/apps/wallet/src/payment-intents/payment-intents.service.ts
+++ b/apps/wallet/src/payment-intents/payment-intents.service.ts
@@ -226,7 +226,7 @@ export class PaymentIntentsService {
     const correlationId = `confirm:${intentId}:${Date.now()}`;
     return this.confirmService.confirm(
       intentId,
-      { paymentMethodId: dto.paymentMethodId, pointsToApply: dto.pointsToApply },
+      { paymentMethodId: dto.paymentMethodId, pointsToApply: dto.pointsToApply, cashReceipt: dto.cashReceipt },
       correlationId,
     );
   }

--- a/apps/wallet/src/providers/toss/toss-api.client.ts
+++ b/apps/wallet/src/providers/toss/toss-api.client.ts
@@ -29,6 +29,17 @@ export interface TossBillingConfirmResponse {
   [key: string]: unknown;
 }
 
+export interface TossCashReceiptResponse {
+  receiptKey: string;
+  issueNumber: string;
+  issueStatus: 'IN_PROGRESS' | 'COMPLETED' | 'FAILED';
+  transactionType: 'CONFIRM' | 'CANCEL';
+  receiptUrl: string;
+  amount: number;
+  taxFreeAmount: number;
+  [key: string]: unknown;
+}
+
 export interface TossApiError {
   code: string;
   message: string;
@@ -84,6 +95,31 @@ export class TossApiClient {
       orderId,
       orderName: orderName ?? '정기결제',
     });
+  }
+
+  async issueCashReceipt(params: {
+    amount: number;
+    orderId: string;
+    orderName: string;
+    type: '소득공제' | '지출증빙';
+    customerIdentityNumber: string;
+    taxFreeAmount?: number;
+  }): Promise<TossApiResult<TossCashReceiptResponse>> {
+    const body: Record<string, unknown> = {
+      amount: params.amount,
+      orderId: params.orderId,
+      orderName: params.orderName,
+      type: params.type,
+      customerIdentityNumber: params.customerIdentityNumber,
+    };
+    if (params.taxFreeAmount !== undefined) body.taxFreeAmount = params.taxFreeAmount;
+    return this.post<TossCashReceiptResponse>('/cash-receipts', body);
+  }
+
+  async cancelCashReceipt(receiptKey: string, amount?: number): Promise<TossApiResult<TossCashReceiptResponse>> {
+    const body: Record<string, unknown> = {};
+    if (amount !== undefined) body.amount = amount;
+    return this.post<TossCashReceiptResponse>(`/cash-receipts/${receiptKey}/cancel`, body);
   }
 
   private async post<T>(

--- a/apps/wallet/src/refunds/refunds.service.spec.ts
+++ b/apps/wallet/src/refunds/refunds.service.spec.ts
@@ -152,9 +152,11 @@ function makeContext(options: {
     }));
   }
 
+  const cashReceiptsService = { cancelForRefund: async () => undefined };
   const service = new RefundsService(
     db as any,
     chargesService as any,
+    cashReceiptsService as any,
     paymentMethodsService as any,
     providerRegistry as any,
     stateTransitionService as any,

--- a/apps/wallet/src/refunds/refunds.service.ts
+++ b/apps/wallet/src/refunds/refunds.service.ts
@@ -4,6 +4,7 @@ import { and, asc, eq, inArray, sql } from 'drizzle-orm';
 import { WalletSchema, charges as chargesTable, refunds, paymentIntents } from '../schema';
 import { DbTx, Refund } from '../types';
 import { ChargesService } from '../charges/charges.service';
+import { CashReceiptsService } from '../cash-receipts/cash-receipts.service';
 import { PaymentMethodsService } from '../payment-methods/payment-methods.service';
 import { ProviderRegistry } from '../providers/provider.registry';
 import { StateTransitionService } from '../domain/state-transition/state-transition.service';
@@ -17,10 +18,21 @@ export class RefundsService {
   constructor(
     private readonly dbService: DbService<WalletSchema>,
     private readonly chargesService: ChargesService,
+    private readonly cashReceiptsService: CashReceiptsService,
     private readonly paymentMethodsService: PaymentMethodsService,
     private readonly providerRegistry: ProviderRegistry,
     private readonly stateTransitionService: StateTransitionService,
   ) {}
+
+  /** 환불 성공 시 발급된 현금영수증을 환불금액만큼 취소. best-effort — 실패해도 환불은 유지. */
+  private async cancelCashReceiptBestEffort(chargeId: string, amount: number): Promise<void> {
+    try {
+      await this.cashReceiptsService.cancelForRefund(chargeId, amount);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Cash receipt cancel-on-refund failed (refund kept): charge=${chargeId}, error=${message}`);
+    }
+  }
 
   async create(dto: CreateRefundDto): Promise<Refund> {
     // 1. Early validation (no lock needed)
@@ -177,6 +189,7 @@ export class RefundsService {
           );
         }
       });
+      await this.cancelCashReceiptBestEffort(charge.id, dto.amount);
     } else if (providerResult.status === 'PENDING') {
       // Refund is processing asynchronously
       await this.dbService.db.update(refunds).set({ updatedAt: new Date() }).where(eq(refunds.id, refund.id));
@@ -355,6 +368,7 @@ export class RefundsService {
         );
       }
     });
+    await this.cancelCashReceiptBestEffort(refund.chargeId, refund.amount);
 
     return this.findByIdOrThrow(refundId);
   }

--- a/apps/wallet/src/schema.ts
+++ b/apps/wallet/src/schema.ts
@@ -18,7 +18,17 @@ import { idempotencyKeys } from './domain/idempotency/idempotency.schema';
 
 // ─── Enums ───────────────────────────────────────────────────────────────────
 
-export const paymentMethodTypeEnum = pgEnum('payment_method_type', ['POINTS', 'CARD', 'BANK_TRANSFER', 'BNPL', 'TOSS', 'NICEPAY', 'TOSS_BILLING', 'NICEPAY_BILLING', 'CMS_BATCH']);
+export const paymentMethodTypeEnum = pgEnum('payment_method_type', [
+  'POINTS',
+  'CARD',
+  'BANK_TRANSFER',
+  'BNPL',
+  'TOSS',
+  'NICEPAY',
+  'TOSS_BILLING',
+  'NICEPAY_BILLING',
+  'CMS_BATCH',
+]);
 
 export const paymentIntentStatusEnum = pgEnum('payment_intent_status', [
   'CREATED',
@@ -47,6 +57,9 @@ export const chargeStatusEnum = pgEnum('charge_status', [
 ]);
 
 export const refundStatusEnum = pgEnum('refund_status', ['PENDING', 'SUCCEEDED', 'FAILED']);
+
+export const cashReceiptTypeEnum = pgEnum('cash_receipt_type', ['소득공제', '지출증빙']);
+export const cashReceiptStatusEnum = pgEnum('cash_receipt_status', ['ISSUED', 'CANCELED', 'FAILED']);
 
 export const paymentStateEntityTypeEnum = pgEnum('payment_state_entity_type', ['INTENT', 'CHARGE', 'REFUND']);
 
@@ -93,7 +106,12 @@ export const paymentIntentOrderDiscountKindEnum = pgEnum('payment_intent_order_d
 
 export const intentPurposeEnum = pgEnum('intent_purpose', ['PURCHASE', 'SUBSCRIPTION', 'REPAYMENT', 'PAYOUT']);
 
-export const checkoutSessionStatusEnum = pgEnum('checkout_session_status', ['PENDING', 'COMPLETED', 'EXPIRED', 'CANCELED']);
+export const checkoutSessionStatusEnum = pgEnum('checkout_session_status', [
+  'PENDING',
+  'COMPLETED',
+  'EXPIRED',
+  'CANCELED',
+]);
 
 export const billingMethodStatusEnum = pgEnum('billing_method_status', ['ACTIVE', 'REVOKED', 'DELETED', 'EXPIRED']);
 
@@ -101,7 +119,13 @@ export const billingAgreementStatusEnum = pgEnum('billing_agreement_status', ['A
 
 export const cmsMemberStatusEnum = pgEnum('cms_member_status', ['PENDING', 'REGISTERED', 'FAILED', 'DELETED']);
 
-export const cmsWithdrawalStatusEnum = pgEnum('cms_withdrawal_status', ['REQUESTED', 'PROCESSING', 'SUCCEEDED', 'FAILED', 'DELETED']);
+export const cmsWithdrawalStatusEnum = pgEnum('cms_withdrawal_status', [
+  'REQUESTED',
+  'PROCESSING',
+  'SUCCEEDED',
+  'FAILED',
+  'DELETED',
+]);
 
 // ─── Tables ──────────────────────────────────────────────────────────────────
 
@@ -373,6 +397,50 @@ export const refunds = pgTable(
   ],
 );
 
+export const cashReceipts = pgTable(
+  'cash_receipts',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    // 현금성(무통장) charge 에 매달린다 — 카드/포인트 charge 는 발급 대상 아님.
+    chargeId: uuid('charge_id')
+      .notNull()
+      .references(() => charges.id),
+    intentId: uuid('intent_id')
+      .notNull()
+      .references(() => paymentIntents.id),
+    userId: varchar('user_id', { length: 128 }),
+    type: cashReceiptTypeEnum('type').notNull(),
+    // 휴대폰번호(소득공제) 또는 사업자등록번호(지출증빙). 토스 customerIdentityNumber.
+    customerIdentityNumber: varchar('customer_identity_number', { length: 30 }).notNull(),
+    amount: integer('amount').notNull(),
+    currency: varchar('currency', { length: 3 }).notNull(),
+    status: cashReceiptStatusEnum('status').notNull(),
+    // 환불 연동: 누적 취소금액. canceledAmount >= amount 면 status='CANCELED'.
+    canceledAmount: integer('canceled_amount').notNull().default(0),
+    // 토스 응답값
+    receiptKey: varchar('receipt_key', { length: 200 }),
+    issueNumber: varchar('issue_number', { length: 9 }),
+    receiptUrl: text('receipt_url'),
+    errorCode: varchar('error_code', { length: 128 }),
+    errorMessage: text('error_message'),
+    requestPayload: jsonb('request_payload').$type<Record<string, unknown> | null>(),
+    responsePayload: jsonb('response_payload').$type<Record<string, unknown> | null>(),
+    issuedAt: timestamp('issued_at', { withTimezone: true }),
+    canceledAt: timestamp('canceled_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    check('cash_receipts_amount_positive', sql`${table.amount} > 0`),
+    // charge 당 살아있는(ISSUED) 현금영수증은 하나만 — 이중발급 방지
+    uniqueIndex('uq_cash_receipts_active_charge')
+      .on(table.chargeId)
+      .where(sql`${table.status} = 'ISSUED'`),
+    index('idx_cash_receipts_intent').on(table.intentId),
+    index('idx_cash_receipts_user_created_at').on(table.userId, table.createdAt),
+  ],
+);
+
 export const paymentStateTransitions = pgTable(
   'payment_state_transitions',
   {
@@ -609,7 +677,9 @@ export const billingAgreements = pgTable(
   {
     id: uuid('id').defaultRandom().primaryKey(),
     userId: varchar('user_id', { length: 128 }).notNull(),
-    billingMethodId: uuid('billing_method_id').notNull().references(() => billingMethods.id),
+    billingMethodId: uuid('billing_method_id')
+      .notNull()
+      .references(() => billingMethods.id),
     subscriberRef: varchar('subscriber_ref', { length: 255 }).notNull(),
     subscriberType: varchar('subscriber_type', { length: 64 }).notNull(),
     status: billingAgreementStatusEnum('status').notNull().default('ACTIVE'),
@@ -631,7 +701,10 @@ export const checkoutSessions = pgTable(
     amount: integer('amount').notNull(),
     currency: varchar('currency', { length: 3 }).notNull(),
     purpose: intentPurposeEnum('purpose').notNull(),
-    metadata: jsonb('metadata').$type<Record<string, unknown>>().notNull().default(sql`'{}'::jsonb`),
+    metadata: jsonb('metadata')
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default(sql`'{}'::jsonb`),
     successUrl: text('success_url').notNull(),
     cancelUrl: text('cancel_url').notNull(),
     allowComposite: boolean('allow_composite').notNull().default(false),
@@ -651,7 +724,9 @@ export const cmsMembers = pgTable(
   'cms_members',
   {
     id: uuid('id').defaultRandom().primaryKey(),
-    billingMethodId: uuid('billing_method_id').notNull().references(() => billingMethods.id),
+    billingMethodId: uuid('billing_method_id')
+      .notNull()
+      .references(() => billingMethods.id),
     userId: varchar('user_id', { length: 128 }).notNull(),
     cmsMemberId: varchar('cms_member_id', { length: 20 }).notNull(),
     paymentCompany: varchar('payment_company', { length: 3 }).notNull(),
@@ -677,8 +752,12 @@ export const cmsWithdrawals = pgTable(
     id: uuid('id').defaultRandom().primaryKey(),
     cmsMemberId: varchar('cms_member_id', { length: 20 }).notNull(),
     transactionId: varchar('transaction_id', { length: 30 }).notNull(),
-    chargeId: uuid('charge_id').notNull().references(() => charges.id),
-    intentId: uuid('intent_id').notNull().references(() => paymentIntents.id),
+    chargeId: uuid('charge_id')
+      .notNull()
+      .references(() => charges.id),
+    intentId: uuid('intent_id')
+      .notNull()
+      .references(() => paymentIntents.id),
     paymentDate: varchar('payment_date', { length: 8 }).notNull(),
     amount: integer('amount').notNull(),
     status: cmsWithdrawalStatusEnum('status').notNull().default('REQUESTED'),
@@ -710,9 +789,7 @@ export const cmsAgreements = pgTable(
     createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
   },
-  (table) => [
-    index('idx_cms_agreements_cms_member_id').on(table.cmsMemberId),
-  ],
+  (table) => [index('idx_cms_agreements_cms_member_id').on(table.cmsMemberId)],
 );
 
 // ─── Type exports ─────────────────────────────────────────────────────────────
@@ -722,6 +799,8 @@ export type PaymentIntentStatus = (typeof paymentIntentStatusEnum.enumValues)[nu
 export type ChargeOperation = (typeof chargeOperationEnum.enumValues)[number];
 export type ChargeStatus = (typeof chargeStatusEnum.enumValues)[number];
 export type RefundStatus = (typeof refundStatusEnum.enumValues)[number];
+export type CashReceiptType = (typeof cashReceiptTypeEnum.enumValues)[number];
+export type CashReceiptStatus = (typeof cashReceiptStatusEnum.enumValues)[number];
 export type PaymentStateEntityType = (typeof paymentStateEntityTypeEnum.enumValues)[number];
 export type PaymentStateTriggerType = (typeof paymentStateTriggerTypeEnum.enumValues)[number];
 export type OutboxStatus = (typeof outboxStatusEnum.enumValues)[number];
@@ -750,6 +829,7 @@ export const walletSchema = {
   paymentIntentOrderDiscounts,
   charges,
   refunds,
+  cashReceipts,
   paymentStateTransitions,
   outboxEvents,
   providerWebhookReceipts,

--- a/apps/wallet/src/types.ts
+++ b/apps/wallet/src/types.ts
@@ -25,6 +25,7 @@ import {
   pointHolds,
   providerWebhookReceipts,
   refunds,
+  cashReceipts,
 } from './schema';
 
 export type WalletDb = DbService<WalletSchema>['db'];
@@ -67,6 +68,10 @@ export type UpdateCharge = Partial<Omit<NewCharge, 'id' | 'createdAt' | 'updated
 export type Refund = InferSelectModel<typeof refunds>;
 export type NewRefund = InferInsertModel<typeof refunds>;
 export type UpdateRefund = Partial<Omit<NewRefund, 'id' | 'createdAt' | 'updatedAt'>>;
+
+export type CashReceipt = InferSelectModel<typeof cashReceipts>;
+export type NewCashReceipt = InferInsertModel<typeof cashReceipts>;
+export type UpdateCashReceipt = Partial<Omit<NewCashReceipt, 'id' | 'createdAt' | 'updatedAt'>>;
 
 export type PaymentStateTransition = InferSelectModel<typeof paymentStateTransitions>;
 export type NewPaymentStateTransition = InferInsertModel<typeof paymentStateTransitions>;

--- a/apps/wallet/src/wallet.module.ts
+++ b/apps/wallet/src/wallet.module.ts
@@ -62,6 +62,7 @@ import { RefundsController } from './refunds/refunds.controller';
 // Cash receipts (현금영수증)
 import { CashReceiptsService } from './cash-receipts/cash-receipts.service';
 import { CashReceiptsController } from './cash-receipts/cash-receipts.controller';
+import { CashReceiptsAdminController } from './admin/cash-receipts-admin.controller';
 
 // Admin
 import { PointsAdminService } from './admin/points-admin.service';
@@ -379,6 +380,7 @@ async function resolveCanActivate(result: boolean | Promise<boolean> | unknown):
     PaymentMethodsController,
     RefundsController,
     CashReceiptsController,
+    CashReceiptsAdminController,
     PointsAdminController,
     PaymentIntentAdminController,
     RefundAdminController,

--- a/apps/wallet/src/wallet.module.ts
+++ b/apps/wallet/src/wallet.module.ts
@@ -59,6 +59,10 @@ import { TossApproveService } from './payment-intents/toss-approve.service';
 import { RefundsService } from './refunds/refunds.service';
 import { RefundsController } from './refunds/refunds.controller';
 
+// Cash receipts (현금영수증)
+import { CashReceiptsService } from './cash-receipts/cash-receipts.service';
+import { CashReceiptsController } from './cash-receipts/cash-receipts.controller';
+
 // Admin
 import { PointsAdminService } from './admin/points-admin.service';
 import { PointsAdminController } from './admin/points-admin.controller';
@@ -374,6 +378,7 @@ async function resolveCanActivate(result: boolean | Promise<boolean> | unknown):
     PaymentIntentsController,
     PaymentMethodsController,
     RefundsController,
+    CashReceiptsController,
     PointsAdminController,
     PaymentIntentAdminController,
     RefundAdminController,
@@ -462,6 +467,9 @@ async function resolveCanActivate(result: boolean | Promise<boolean> | unknown):
 
     // Refunds
     RefundsService,
+
+    // Cash receipts (현금영수증)
+    CashReceiptsService,
 
     // Admin
     PointsAdminService,

--- a/deployments/lcnine/auth/infra/services.ts
+++ b/deployments/lcnine/auth/infra/services.ts
@@ -20,10 +20,10 @@ export function setup(infra: IdpInfra) {
   const twilioAuthToken = new sst.Secret('TwilioAuthToken');
   const twilioServiceId = new sst.Secret('TwilioServiceId');
 
-  const cafe24ClientId = new sst.Secret("Cafe24ClientId");
-  const cafe24ClientSecret = new sst.Secret("Cafe24ClientSecret");
-  const cafe24ServiceKey = new sst.Secret("Cafe24ServiceKey");
-  const dataGoKrServiceKey = new sst.Secret("DataGoKrServiceKey");
+  const cafe24ClientId = new sst.Secret('Cafe24ClientId');
+  const cafe24ClientSecret = new sst.Secret('Cafe24ClientSecret');
+  const cafe24ServiceKey = new sst.Secret('Cafe24ServiceKey');
+  const dataGoKrServiceKey = new sst.Secret('DataGoKrServiceKey');
 
   // const awsS3AccessKeyId = new sst.Secret("AwsS3AccessKeyId");
   // const awsS3SecretAccessKey = new sst.Secret("AwsS3SecretAccessKey");
@@ -127,6 +127,7 @@ export function setup(infra: IdpInfra) {
       OAUTH_JWT_PUBLIC_KEY: oauthJwtPublicKey.value,
       OAUTH_JWT_KID: `lcnine-auth-${$app.stage}-1`,
       OAUTH_ISSUER_URL: userServiceUrl,
+      OIDC_ISSUER_URL: userServiceUrl,
       // ─── 기능별 Secret 미세팅 상태 (후속 활성화 시 주석 해제) ───
       // KAKAO_CLIENT_ID: kakaoClientId.value,
       // KAKAO_CLIENT_SECRET: kakaoClientSecret.value,
@@ -138,7 +139,7 @@ export function setup(infra: IdpInfra) {
       CAFE24_CLIENT_ID: cafe24ClientId.value,
       CAFE24_CLIENT_SECRET: cafe24ClientSecret.value,
       CAFE24_SERVICE_KEY: cafe24ServiceKey.value,
-      CAFE24_MALL_ID: "lcnine",
+      CAFE24_MALL_ID: 'lcnine',
       DATA_GO_KR_SERVICE_KEY: dataGoKrServiceKey.value,
       // AWS_ACCESS_KEY_ID: awsS3AccessKeyId.value,
       // AWS_SECRET_ACCESS_KEY: awsS3SecretAccessKey.value,

--- a/web/almondyoung-storefront/src/app/[countryCode]/(mypage)/mypage/account/profile/page.tsx
+++ b/web/almondyoung-storefront/src/app/[countryCode]/(mypage)/mypage/account/profile/page.tsx
@@ -34,10 +34,7 @@ export default async function AccountProfilePage() {
       <MypageLayout>
         <div className="bg-white px-3 py-4 md:min-h-screen md:px-6">
           <PageTitle>{t("profile")}</PageTitle>
-          <ProfileEdit
-            userData={userData}
-            identitiesState={identitiesState}
-          />
+          <ProfileEdit userData={userData} identitiesState={identitiesState} />
         </div>
       </MypageLayout>
       <Suspense fallback={null}>

--- a/web/almondyoung-storefront/src/app/[countryCode]/(mypage)/mypage/order/details/page.tsx
+++ b/web/almondyoung-storefront/src/app/[countryCode]/(mypage)/mypage/order/details/page.tsx
@@ -4,6 +4,7 @@ import { OrderDetailsDesktop } from "domains/order/details/components/order-deta
 import { OrderDetailsMobile } from "domains/order/details/components/order-details-mobile"
 import { getOrder } from "@/lib/api/medusa/orders"
 import { getOrderActionsByMedusaId } from "@/lib/api/orders/store-orders"
+import { getCashReceipts } from "@/lib/api/wallet"
 
 interface OrderDetailsPageProps {
   params: Promise<{ countryCode: string }>
@@ -24,6 +25,14 @@ export default async function OrderDetailsPage({
       : Promise.resolve(null),
   ])
 
+  // 결제 세션 data.intentId(wallet) 로 발급된 현금영수증 조회. 없으면 빈 배열.
+  const intentId = (
+    order?.payment_collections?.[0]?.payment_sessions?.[0]?.data as
+      | Record<string, unknown>
+      | undefined
+  )?.intentId as string | undefined
+  const cashReceipts = intentId ? await getCashReceipts(intentId) : []
+
   return (
     <WithHeaderLayout
       config={{
@@ -39,6 +48,7 @@ export default async function OrderDetailsPage({
             order={order}
             countryCode={countryCode}
             coreActions={coreActions ?? undefined}
+            cashReceipts={cashReceipts}
           />
         </MypageLayout>
       </div>
@@ -49,6 +59,7 @@ export default async function OrderDetailsPage({
           order={order}
           countryCode={countryCode}
           coreActions={coreActions ?? undefined}
+          cashReceipts={cashReceipts}
         />
       </div>
     </WithHeaderLayout>

--- a/web/almondyoung-storefront/src/domains/mypage/components/account/address-book-section.tsx
+++ b/web/almondyoung-storefront/src/domains/mypage/components/account/address-book-section.tsx
@@ -173,109 +173,111 @@ export function AddressBookSection() {
                   return 0
                 })
                 .map((address) => {
-                const fullAddress = buildAddressLine({
-                  province: address.province,
-                  city: address.city,
-                  address1: address.address_1,
-                  address2: address.address_2,
-                })
-                const name = [address.first_name, address.last_name]
-                  .filter(Boolean)
-                  .join(" ")
-                const addressName =
-                  (address.metadata?.shipping_address_name as string) ??
-                  address.address_name
-                const postalCode = address.postal_code ?? ""
-                const address1 = address.address_1 ?? ""
-                const address2 = address.address_2 ?? ""
-                const isActionLoading = actionLoadingId === address.id
+                  const fullAddress = buildAddressLine({
+                    province: address.province,
+                    city: address.city,
+                    address1: address.address_1,
+                    address2: address.address_2,
+                  })
+                  const name = [address.first_name, address.last_name]
+                    .filter(Boolean)
+                    .join(" ")
+                  const addressName =
+                    (address.metadata?.shipping_address_name as string) ??
+                    address.address_name
+                  const postalCode = address.postal_code ?? ""
+                  const address1 = address.address_1 ?? ""
+                  const address2 = address.address_2 ?? ""
+                  const isActionLoading = actionLoadingId === address.id
 
-                return (
-                  <div
-                    key={address.id}
-                    className={`relative rounded-lg border border-gray-200 p-4 transition-colors hover:border-gray-300 ${
-                      isActionLoading ? "pointer-events-none opacity-50" : ""
-                    }`}
-                  >
-                    <div className="flex items-start justify-between">
-                      <div className="flex-1 pr-8">
-                        <div className="flex items-center gap-2">
-                          {addressName && (
-                            <span className="font-medium text-gray-900">
-                              {addressName}
-                            </span>
-                          )}
-                          <span
-                            className={
-                              addressName
-                                ? "text-sm text-gray-600"
-                                : "font-medium text-gray-900"
-                            }
-                          >
-                            {name}
-                          </span>
-                          {address.is_default_shipping && (
-                            <span className="rounded bg-[#e8f6ea] px-2 py-0.5 text-[11px] font-semibold text-[#2ba24c]">
-                              {t("defaultBadge")}
-                            </span>
-                          )}
-                        </div>
-                        {address.phone && (
-                          <p className="mt-1 text-sm text-gray-600">
-                            {formatPhoneNumber(address.phone)}
-                          </p>
-                        )}
-                        <dl className="mt-1 space-y-1 text-sm text-gray-600">
-                          <AddressRow
-                            label={tLabels("postcode")}
-                            value={postalCode}
-                          />
-                          <AddressRow
-                            label={tLabels("address")}
-                            value={address1 || fullAddress}
-                          />
-                          <AddressRow
-                            label={tLabels("addressDetail")}
-                            value={address2}
-                          />
-                        </dl>
-                      </div>
-
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <button
-                            type="button"
-                            className="rounded p-1 hover:bg-gray-100"
-                          >
-                            <MoreVertical className="h-4 w-4 text-gray-500" />
-                          </button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          <DropdownMenuItem onClick={() => handleEdit(address)}>
-                            <Pencil className="mr-2 h-4 w-4" />
-                            {t("edit")}
-                          </DropdownMenuItem>
-                          {!address.is_default_shipping && (
-                            <DropdownMenuItem
-                              onClick={() => handleSetDefault(address.id)}
+                  return (
+                    <div
+                      key={address.id}
+                      className={`relative rounded-lg border border-gray-200 p-4 transition-colors hover:border-gray-300 ${
+                        isActionLoading ? "pointer-events-none opacity-50" : ""
+                      }`}
+                    >
+                      <div className="flex items-start justify-between">
+                        <div className="flex-1 pr-8">
+                          <div className="flex items-center gap-2">
+                            {addressName && (
+                              <span className="font-medium text-gray-900">
+                                {addressName}
+                              </span>
+                            )}
+                            <span
+                              className={
+                                addressName
+                                  ? "text-sm text-gray-600"
+                                  : "font-medium text-gray-900"
+                              }
                             >
-                              <Star className="mr-2 h-4 w-4" />
-                              {t("setDefault")}
-                            </DropdownMenuItem>
+                              {name}
+                            </span>
+                            {address.is_default_shipping && (
+                              <span className="rounded bg-[#e8f6ea] px-2 py-0.5 text-[11px] font-semibold text-[#2ba24c]">
+                                {t("defaultBadge")}
+                              </span>
+                            )}
+                          </div>
+                          {address.phone && (
+                            <p className="mt-1 text-sm text-gray-600">
+                              {formatPhoneNumber(address.phone)}
+                            </p>
                           )}
-                          <DropdownMenuItem
-                            onClick={() => handleDelete(address.id)}
-                            className="text-red-600 focus:text-red-600"
-                          >
-                            <Trash2 className="mr-2 h-4 w-4" />
-                            {t("delete")}
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
+                          <dl className="mt-1 space-y-1 text-sm text-gray-600">
+                            <AddressRow
+                              label={tLabels("postcode")}
+                              value={postalCode}
+                            />
+                            <AddressRow
+                              label={tLabels("address")}
+                              value={address1 || fullAddress}
+                            />
+                            <AddressRow
+                              label={tLabels("addressDetail")}
+                              value={address2}
+                            />
+                          </dl>
+                        </div>
+
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <button
+                              type="button"
+                              className="rounded p-1 hover:bg-gray-100"
+                            >
+                              <MoreVertical className="h-4 w-4 text-gray-500" />
+                            </button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onClick={() => handleEdit(address)}
+                            >
+                              <Pencil className="mr-2 h-4 w-4" />
+                              {t("edit")}
+                            </DropdownMenuItem>
+                            {!address.is_default_shipping && (
+                              <DropdownMenuItem
+                                onClick={() => handleSetDefault(address.id)}
+                              >
+                                <Star className="mr-2 h-4 w-4" />
+                                {t("setDefault")}
+                              </DropdownMenuItem>
+                            )}
+                            <DropdownMenuItem
+                              onClick={() => handleDelete(address.id)}
+                              className="text-red-600 focus:text-red-600"
+                            >
+                              <Trash2 className="mr-2 h-4 w-4" />
+                              {t("delete")}
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
                     </div>
-                  </div>
-                )
-              })}
+                  )
+                })}
             </div>
           )}
         </CardContent>
@@ -293,7 +295,13 @@ export function AddressBookSection() {
   )
 }
 
-function AddressRow({ label, value }: { label: string; value?: string | null }) {
+function AddressRow({
+  label,
+  value,
+}: {
+  label: string
+  value?: string | null
+}) {
   return (
     <div className="flex items-start gap-2">
       <dt className="min-w-14 text-gray-500">{label}</dt>

--- a/web/almondyoung-storefront/src/domains/order/details/components/cash-receipt-info.tsx
+++ b/web/almondyoung-storefront/src/domains/order/details/components/cash-receipt-info.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import type { IssuedCashReceiptDto } from "@/lib/types/dto/wallet"
+
+// wallet 이 저장하는 현금영수증 type(한글 리터럴) → i18n 키 매핑
+const TYPE_KEY: Record<string, string> = {
+  소득공제: "typeIncome",
+  지출증빙: "typeExpense",
+}
+
+/**
+ * 주문상세의 결제 정보 섹션에 붙는 현금영수증 정보 블록.
+ * 발급완료(ISSUED)된 영수증이 없으면 아무것도 렌더하지 않는다 (기존 화면과 동일).
+ */
+export const CashReceiptInfo = ({
+  cashReceipts,
+}: {
+  cashReceipts: IssuedCashReceiptDto[]
+}) => {
+  const t = useTranslations("mypage.order.cashReceipt")
+  const issued = cashReceipts.filter((r) => r.status === "ISSUED")
+  if (issued.length === 0) return null
+
+  return (
+    <div className="mt-3 space-y-2 rounded-md bg-gray-50 p-3">
+      <p className="text-sm font-medium text-gray-700">{t("sectionTitle")}</p>
+      {issued.map((r) => (
+        <div key={r.id} className="space-y-1">
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-gray-500">{t("typeLabel")}:</span>
+            <span className="text-xs text-gray-800">
+              {t(TYPE_KEY[r.type] ?? "typeIncome")}
+            </span>
+          </div>
+          {r.issueNumber && (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-gray-500">{t("issueNumber")}:</span>
+              <span className="text-xs text-gray-800">{r.issueNumber}</span>
+            </div>
+          )}
+          {r.receiptUrl && (
+            <a
+              href={r.receiptUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block text-xs font-medium text-blue-600 underline underline-offset-2"
+            >
+              {t("viewReceipt")}
+            </a>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/almondyoung-storefront/src/domains/order/details/components/order-details-desktop.tsx
+++ b/web/almondyoung-storefront/src/domains/order/details/components/order-details-desktop.tsx
@@ -25,6 +25,8 @@ import {
   type CancelReasonCode,
 } from "@/components/orders/cancel-reason-form"
 import type { StoreOrderActionsResponse, StoreRefundStatus, RefundSummary } from "@/lib/api/orders/store-orders"
+import type { IssuedCashReceiptDto } from "@/lib/types/dto/wallet"
+import { CashReceiptInfo } from "./cash-receipt-info"
 import { cancelOrderByMedusaId } from "@/lib/api/orders/store-orders"
 import { HttpTypes } from "@medusajs/types"
 import { useTranslations } from "next-intl"
@@ -41,10 +43,12 @@ const KAKAO_CS_URL = "https://pf.kakao.com/_xaxgxazs"
 export const OrderDetailsDesktop = ({
   order,
   coreActions,
+  cashReceipts = [],
 }: {
   order: HttpTypes.StoreOrder | null
   countryCode: string
   coreActions?: StoreOrderActionsResponse
+  cashReceipts?: IssuedCashReceiptDto[]
 }) => {
   const tLabels = useTranslations("mypage.order.labels")
   const tStatus = useTranslations("mypage.order.status")
@@ -348,6 +352,7 @@ export const OrderDetailsDesktop = ({
                   ) : null}
                 </div>
               )}
+              <CashReceiptInfo cashReceipts={cashReceipts} />
             </div>
             <dl className="bg-gray-background space-y-2 p-3.5">
               <div className="flex items-center justify-between">

--- a/web/almondyoung-storefront/src/domains/order/details/components/order-details-mobile.tsx
+++ b/web/almondyoung-storefront/src/domains/order/details/components/order-details-mobile.tsx
@@ -32,6 +32,8 @@ import {
 } from "@/components/orders/cancel-reason-form"
 import type { StoreOrderActionsResponse, StoreRefundStatus, RefundSummary } from "@/lib/api/orders/store-orders"
 import { cancelOrderByMedusaId } from "@/lib/api/orders/store-orders"
+import type { IssuedCashReceiptDto } from "@/lib/types/dto/wallet"
+import { CashReceiptInfo } from "./cash-receipt-info"
 import { HttpTypes } from "@medusajs/types"
 import { useTranslations } from "next-intl"
 import { useState, useTransition } from "react"
@@ -47,10 +49,12 @@ const KAKAO_CS_URL = "https://pf.kakao.com/_xaxgxazs"
 export const OrderDetailsMobile = ({
   order,
   coreActions,
+  cashReceipts = [],
 }: {
   order: HttpTypes.StoreOrder | null
   countryCode: string
   coreActions?: StoreOrderActionsResponse
+  cashReceipts?: IssuedCashReceiptDto[]
 }) => {
   const tLabels = useTranslations("mypage.order.labels")
   const tStatus = useTranslations("mypage.order.status")
@@ -368,6 +372,7 @@ export const OrderDetailsMobile = ({
                 ) : null}
               </div>
             )}
+            <CashReceiptInfo cashReceipts={cashReceipts} />
           </OrderInfoCardRoot>
         </section>
         )}

--- a/web/almondyoung-storefront/src/i18n/messages/en/mypage.json
+++ b/web/almondyoung-storefront/src/i18n/messages/en/mypage.json
@@ -559,6 +559,14 @@
         "failed": "Refund issue"
       }
     },
+    "cashReceipt": {
+      "sectionTitle": "Cash Receipt",
+      "typeLabel": "Type",
+      "typeIncome": "Income deduction",
+      "typeExpense": "Expense proof",
+      "issueNumber": "Issue No.",
+      "viewReceipt": "View receipt"
+    },
     "cancelDialog": {
       "reasonLabel": "Cancellation Reason",
       "otherPlaceholder": "Please enter your cancellation reason (up to 500 characters)",

--- a/web/almondyoung-storefront/src/i18n/messages/ja/mypage.json
+++ b/web/almondyoung-storefront/src/i18n/messages/ja/mypage.json
@@ -559,6 +559,14 @@
         "failed": "返金確認が必要"
       }
     },
+    "cashReceipt": {
+      "sectionTitle": "現金領収書",
+      "typeLabel": "種類",
+      "typeIncome": "所得控除用",
+      "typeExpense": "支出証憑用",
+      "issueNumber": "発行番号",
+      "viewReceipt": "領収書を見る"
+    },
     "cancelDialog": {
       "reasonLabel": "キャンセル理由",
       "otherPlaceholder": "キャンセル理由を入力してください（最大500文字）",

--- a/web/almondyoung-storefront/src/i18n/messages/ko/mypage.json
+++ b/web/almondyoung-storefront/src/i18n/messages/ko/mypage.json
@@ -559,6 +559,14 @@
         "failed": "환불 확인 필요"
       }
     },
+    "cashReceipt": {
+      "sectionTitle": "현금영수증",
+      "typeLabel": "종류",
+      "typeIncome": "소득공제용",
+      "typeExpense": "지출증빙용",
+      "issueNumber": "발급번호",
+      "viewReceipt": "영수증 보기"
+    },
     "cancelDialog": {
       "reasonLabel": "취소 사유",
       "otherPlaceholder": "취소 사유를 입력해주세요 (최대 500자)",

--- a/web/almondyoung-storefront/src/lib/api/medusa/orders.ts
+++ b/web/almondyoung-storefront/src/lib/api/medusa/orders.ts
@@ -111,7 +111,12 @@ export async function getOrder(
     // +items.requires_shipping/product_type: 디지털 판별(다운로드 CTA·배송정보 숨김)에 필요 — 기본 필드에 없어 명시 요청
     .retrieve(
       orderId,
-      { fields: "+metadata,+items.requires_shipping,+items.product_type" },
+      {
+        // +payment_collections.payment_sessions: 세션 data.intentId(wallet 결제 intent)로
+        // 현금영수증(GET /v1/cash-receipts?intentId=)을 조회하기 위함.
+        fields:
+          "+metadata,+items.requires_shipping,+items.product_type,+payment_collections.payment_sessions.data",
+      },
       headers
     )
     .then(({ order }) => order)

--- a/web/almondyoung-storefront/src/lib/api/wallet/index.ts
+++ b/web/almondyoung-storefront/src/lib/api/wallet/index.ts
@@ -15,6 +15,7 @@ import type {
   CreateIntentRequestDto,
   CreateIntentResponseDto,
   IntentDto,
+  IssuedCashReceiptDto,
   OnboardHmsBnplResponse,
   PointsBalanceDto,
   PointsEventRowDto,
@@ -521,6 +522,21 @@ export async function getIntent(intentId: string): Promise<IntentDto> {
     method: "GET",
     withAuth: true,
   })
+}
+
+/** 주문(intent)의 발급된 현금영수증 목록. 실패/미발급이면 빈 배열 (주문상세 표시용). */
+export async function getCashReceipts(
+  intentId: string
+): Promise<IssuedCashReceiptDto[]> {
+  try {
+    return await api<IssuedCashReceiptDto[]>("wallet", "/v1/cash-receipts", {
+      method: "GET",
+      params: { intentId },
+      withAuth: true,
+    })
+  } catch {
+    return []
+  }
 }
 
 // ==========================================

--- a/web/almondyoung-storefront/src/lib/types/dto/wallet.ts
+++ b/web/almondyoung-storefront/src/lib/types/dto/wallet.ts
@@ -293,3 +293,17 @@ export interface CashReceiptData {
   name: string // 상호명 또는 성명
   number: string // 사업자등록번호 또는 휴대폰번호
 }
+
+/** wallet 이 실제 발급한 현금영수증 레코드 (GET /v1/cash-receipts?intentId=) */
+export type IssuedCashReceiptDto = {
+  id: string
+  intentId: string
+  type: "소득공제" | "지출증빙"
+  status: "ISSUED" | "CANCELED" | "FAILED"
+  amount: number
+  currency: string
+  receiptUrl: string | null
+  issueNumber: string | null
+  errorMessage: string | null
+  createdAt: string
+}


### PR DESCRIPTION
## 개요
결제 무통장입금 건에 대한 **현금영수증(소득공제/사업자지출증빙) 발급·조회**를 고객/관리자 양쪽에 완성하고, 사업자 정보를 이미지로만 등록해 번호가 비어있는 사용자의 반복 입력 문제를 해결합니다.

Closes #480
Closes #485

## #480 — 현금영수증 발급/조회
- **결제화면(wallet-web)**: 무통장 선택 시 증빙 신청(소득공제/지출증빙). 사업자번호·휴대폰 자동 prefill. 입금확인 시 토스 자체발급 API로 자동 발급.
- **고객 주문상세(storefront)**: 결제정보에 발급된 현금영수증(종류/발급번호/영수증 PDF 링크) 인라인 표시. ko/en/ja i18n.
- **관리자(admin-web)**: 회원 주문상세 다이얼로그에서 현금영수증 조회 + 미발급 무통장·결제완료 건 직접 발급.
- **wallet 백엔드**: 관리자용 `GET/POST /v1/admin/cash-receipts`, 비-UUID intentId 방어(500 방지).
- 방향 확정에 따라 **세금계산서(UI만 있던 미구현) 제거** — 토스 현금영수증 2종만 유지.

## #485 — 사업자번호 자동 채우기
- 사업자 정보를 이미지(fileUrl)로만 등록해 사업자번호 텍스트가 비어있는 사용자는, 지출증빙 현금영수증 때 매번 수동 입력해야 했음.
- 지출증빙 입력 후 결제 시 **"입력하신 사업자번호를 저장할까요?"** 확인 → 예 → 본인 사업자정보에 저장(**비어있을 때만**, 기존값/검증상태 불변).
- user-service `PATCH /business-licenses/me/business-number` (self-scope), wallet-web route handler로 토큰 프록시.
