### PR TITLE
어드민 주문내역 서버 필터·페이지네이션 전환 + KST 일자 + 상품 이미지

### DIFF
--- a/apps/admin-web/src/components/common/merged-data-table.tsx
+++ b/apps/admin-web/src/components/common/merged-data-table.tsx
@@ -40,6 +40,8 @@ type BaseProps<T> = {
     getRowClassName?: (row: T, globalIndex: number) => string;
     /** 행 클릭 시 이동할 URL (DataTable과 동일) */
     navigateTo?: (row: T) => string;
+    /** 긴 목록 스크롤 시 헤더를 상단에 고정 (opt-in) */
+    stickyHeader?: boolean;
 };
 
 type WithSelection<T> = BaseProps<T> & {
@@ -95,6 +97,7 @@ export function MergedDataTable<T extends Record<string, unknown>>(
         emptyMessage = '데이터가 없습니다.',
         getRowClassName,
         navigateTo,
+        stickyHeader = false,
     } = props;
 
     const {
@@ -224,7 +227,7 @@ export function MergedDataTable<T extends Record<string, unknown>>(
                 <Table.Header>
                     <Table.Row>
                         {selectable && (
-                            <Table.Head className="w-[40px] text-center">
+                            <Table.Head className={cn('w-[40px] text-center', stickyHeader && 'sticky top-0 z-20 bg-background')}>
                                 <div className="flex justify-center items-center">
                                     <Checkbox
                                         className="w-4 h-4"
@@ -247,6 +250,7 @@ export function MergedDataTable<T extends Record<string, unknown>>(
                                     : col.align === 'left' ? 'text-left'
                                     : 'text-center',
                                     col.sortable && 'cursor-pointer hover:bg-muted/80',
+                                    stickyHeader && 'sticky top-0 z-20 bg-background',
                                 )}
                                 style={col.width ? { width: col.width } : undefined}
                                 onClick={() => col.sortable && handleSort(col.key)}

--- a/apps/admin-web/src/features/order/history/components/filter-box/index.tsx
+++ b/apps/admin-web/src/features/order/history/components/filter-box/index.tsx
@@ -47,7 +47,11 @@ export default function FilterBox() {
         }
         const to = dayjs().subtract(opt.toDays, 'day').format('YYYY-MM-DD');
         const from = dayjs().subtract(opt.fromDays, 'day').format('YYYY-MM-DD');
-        setLocal((prev) => ({ ...prev, quickDate: opt.key, dateFrom: from, dateTo: to }));
+        const next = { ...local, quickDate: opt.key, dateFrom: from, dateTo: to };
+        setLocal(next);
+        // 빠른 일자 선택은 즉시 조회 (검색 버튼 재클릭 불필요)
+        setFilter(next);
+        triggerSearch();
     };
 
     const onSearch = () => {
@@ -173,7 +177,7 @@ export default function FilterBox() {
                     <input
                         type="checkbox"
                         checked={local.refundIssueOnly}
-                        onChange={(e) => setLocal({ ...local, refundIssueOnly: e.target.checked, excludeTerminal: e.target.checked ? false : local.excludeTerminal })}
+                        onChange={(e) => setLocal({ ...local, refundIssueOnly: e.target.checked, excludeTerminal: e.target.checked ? false : local.excludeTerminal, type: e.target.checked ? 'all' : local.type })}
                         className="accent-orange-600"
                     />
                     환불 실패/수동처리만

--- a/apps/admin-web/src/features/order/history/components/table/index.tsx
+++ b/apps/admin-web/src/features/order/history/components/table/index.tsx
@@ -1,17 +1,19 @@
 // src/features/order/history/components/table/index.tsx
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import dayjs from 'dayjs';
 import { toast } from 'sonner';
 import { useOrderHistoryFilter } from '../../contexts/filter.context';
 import type {
   SalesOrderBusinessTimelineItemDto,
   SalesOrdersQuery,
+  OrderTypeGroup,
+  OrderKeywordType,
 } from '@/lib/types/dto/orders';
 import { useSalesOrderRows } from '../../hooks/use-order-rows';
-import { filterRefundIssueRows } from '../../hooks/refund-filter.utils';
 import type { OrderLineRow } from '../../hooks/use-order-rows';
+import { ProductThumbnailCell } from '@/components/table/table-cells/product-thumbnail-cell';
 import { useSalesOrder, useAdminRetryRefund } from '@/lib/services/orders';
 import { MergedDataTable } from '@/components/common/merged-data-table';
 import type { MergedTableColumn } from '@/components/common/merged-data-table';
@@ -35,15 +37,35 @@ import { ManualRefundCompleteModal } from '../modals/manual-refund-complete-moda
 
 const PAGE_SIZE = 50;
 
+const KEYWORD_TYPE_MAP: Record<string, OrderKeywordType> = {
+  통합검색: 'all',
+  주문번호: 'orderNo',
+  수령자: 'receiver',
+  연락처: 'phone',
+  상품명: 'product',
+};
+
 function buildQuery(
-  filter: ReturnType<typeof useOrderHistoryFilter>['filter']
+  filter: ReturnType<typeof useOrderHistoryFilter>['filter'],
+  page: number
 ): SalesOrdersQuery {
+  const keyword = filter.keyword?.trim() || undefined;
+  // 환불이슈 모드는 '취소주문 중 환불 실패/수동'이므로 구분(typeGroup)·취소제외와 상충한다.
+  // 이 모드에선 구분/취소제외를 무시해 항상 정상 조회되게 한다.
+  const refundIssueOnly = filter.refundIssueOnly || undefined;
   return {
     channel: filter.channel as SalesOrdersQuery['channel'] | undefined,
     startDate: filter.dateFrom,
     endDate: filter.dateTo,
-    limit: 200,
-    offset: 0,
+    typeGroup: refundIssueOnly ? undefined : (filter.type as OrderTypeGroup),
+    // 취소/타임아웃 제외는 '전체' 구분일 때만 의미
+    excludeTerminal:
+      !refundIssueOnly && filter.type === 'all' ? filter.excludeTerminal : undefined,
+    refundIssueOnly,
+    keyword,
+    keywordType: keyword ? (KEYWORD_TYPE_MAP[filter.keywordType] ?? 'all') : undefined,
+    limit: PAGE_SIZE,
+    offset: page * PAGE_SIZE,
   };
 }
 
@@ -70,13 +92,14 @@ function StatusBadge({ row }: { row: OrderLineRow }) {
     );
   if (!isMatched)
     return (
-      <span className="inline-flex rounded-full bg-gray-100 text-gray-500 text-[11px] font-medium px-2 py-0.5 whitespace-nowrap">
-        매칭 없음
+      <span className="inline-flex rounded-full bg-orange-100 text-orange-600 text-[11px] font-medium px-2 py-0.5 whitespace-nowrap">
+        매칭 대기
       </span>
     );
+  // 매칭 완료 · 재고차감 전 (pending/matched)
   return (
-    <span className="inline-flex rounded-full bg-orange-100 text-orange-600 text-[11px] font-medium px-2 py-0.5 whitespace-nowrap">
-      매칭 안됨
+    <span className="inline-flex rounded-full bg-gray-100 text-gray-600 text-[11px] font-medium px-2 py-0.5 whitespace-nowrap">
+      출고 대기
     </span>
   );
 }
@@ -590,85 +613,36 @@ function BusinessTimelineModal({
 
 export default function OrderTable() {
   const { filter, searchToken } = useOrderHistoryFilter();
+
+  /* 페이지네이션 (서버측 — offset/limit) */
+  const [page, setPage] = useState(0); // 0-based index
+  // 검색/필터 변경(searchToken) 시 렌더 중 첫 페이지로 리셋.
+  // (useEffect 로 하면 1렌더 늦어 옛 offset 으로 한 번 낭비 요청이 나감)
+  const [prevSearchToken, setPrevSearchToken] = useState(searchToken);
+  if (prevSearchToken !== searchToken) {
+    setPrevSearchToken(searchToken);
+    setPage(0);
+  }
+
   const queryObj = useMemo(
-    () => ({ ...buildQuery(filter), _t: searchToken }),
-    [filter, searchToken]
+    () => ({ ...buildQuery(filter, page), _t: searchToken }),
+    [filter, page, searchToken]
   );
+  const { data, isInitialLoading, isFetching, total, lineTotal, pageCount } =
+    useSalesOrderRows(queryObj);
 
-  const { data, isLoading, isFetching } = useSalesOrderRows(queryObj);
-
-  /* 클라이언트 사이드 필터 */
-  const rows: OrderLineRow[] = useMemo(() => {
-    let items = data?.items ?? [];
-
-    if (filter.type !== 'all') {
-      items = items.filter((r) => {
-        switch (filter.type) {
-          case 'pending':
-            return r.orderStatus === 'pending';
-          case 'hold':
-            return r.isUnavailable;
-          case 'partial':
-            return r.isReadyToShip && !r.isOrderFullyAllocated;
-          case 'ready':
-            return r.isOrderFullyAllocated;
-          case 'unmatched':
-            return !r.isMatched;
-          case 'direct':
-            return r.isDirect;
-          default:
-            return true;
-        }
-      });
-    } else if (filter.excludeTerminal) {
-      items = items.filter(
-        (r) => r.orderStatus !== 'cancelled' && r.orderStatus !== 'timeout'
-      );
-    }
-
-    // 환불 이슈 필터: order 단위 — 해당 orderId의 모든 행 포함
-    if (filter.refundIssueOnly) {
-      items = filterRefundIssueRows(items);
-    }
-
-    if (filter.keyword) {
-      const kw = filter.keyword.toLowerCase();
-      items = items.filter((r) => {
-        switch (filter.keywordType) {
-          case '주문번호':
-            return r.orderNo.toLowerCase().includes(kw);
-          case '수령자':
-            return (r.receiverName ?? '').toLowerCase().includes(kw);
-          case '연락처':
-            return (r.phone ?? '').includes(kw);
-          case '상품명':
-            return r.productName.toLowerCase().includes(kw);
-          default:
-            return (
-              r.orderNo.toLowerCase().includes(kw) ||
-              (r.receiverName ?? '').toLowerCase().includes(kw) ||
-              (r.customerName ?? '').toLowerCase().includes(kw) ||
-              (r.phone ?? '').includes(kw) ||
-              r.productName.toLowerCase().includes(kw)
-            );
-        }
-      });
-    }
-
-    return items;
-  }, [
-    data?.items,
-    filter.type,
-    filter.excludeTerminal,
-    filter.refundIssueOnly,
-    filter.keyword,
-    filter.keywordType,
-  ]);
+  // 구분·키워드·환불이슈·기간 필터와 페이지네이션 모두 서버가 처리 → 클라이언트 필터/슬라이스 없음.
+  // 한 페이지 = 주문 ≤ PAGE_SIZE (라인 rowspan 병합은 테이블이 처리).
+  const rows: OrderLineRow[] = data?.items ?? [];
 
   /* 선택 상태 (groupKey = orderId 기준) */
   const [selectedOrderIds, setSelectedOrderIds] = useState<Set<string>>(
     new Set()
   );
+  // 검색/필터 변경 시 선택 초기화 — 서버 페이지네이션에서 다른 페이지의 유령 선택 방지
+  useEffect(() => {
+    setSelectedOrderIds(new Set());
+  }, [searchToken]);
 
   const isOrderSelectable = (r: OrderLineRow) =>
     r.isOrderFullyAllocated && r.orderStatus === 'confirmed';
@@ -683,17 +657,6 @@ export default function OrderTable() {
   const [showCancelModal, setShowCancelModal] = useState(false);
   const [showManualRefundModal, setShowManualRefundModal] = useState(false);
   const [selectedOrder, setSelectedOrder] = useState<OrderLineRow | null>(null);
-
-  /* 페이지네이션 */
-  const [page, setPage] = useState(0); // 0-based index (DataTable 방식)
-  const totalPages = useMemo(
-    () => Math.ceil(rows.length / PAGE_SIZE),
-    [rows.length]
-  );
-  const pageRows = useMemo(
-    () => rows.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE),
-    [rows, page]
-  );
 
   /* 컬럼 정의 */
   const columns: MergedTableColumn<OrderLineRow>[] = useMemo(
@@ -763,17 +726,8 @@ export default function OrderTable() {
       {
         key: 'imageUrl',
         label: '이미지',
-        width: '52px',
-        render: (_, r) =>
-          r.imageUrl ? (
-            <img
-              src={r.imageUrl}
-              alt={r.productName}
-              className="w-10 h-10 object-cover rounded border"
-            />
-          ) : (
-            <div className="w-10 h-10 rounded border bg-gray-50" />
-          ),
+        width: '64px',
+        render: (_, r) => <ProductThumbnailCell thumbnail={r.imageUrl} />,
       },
       {
         key: 'quantity',
@@ -1003,7 +957,9 @@ export default function OrderTable() {
         <div className="flex items-center justify-between p-3 border-b gap-2 flex-wrap">
           <div className="flex items-center gap-4">
             <div className="text-sm font-medium">
-              총 <b className="text-blue-600">{rows.length}</b>건
+              총 주문 <b className="text-blue-600">{total.toLocaleString()}</b>건
+              <span className="mx-1.5 text-gray-300">·</span>
+              상품 <b className="text-gray-700">{lineTotal.toLocaleString()}</b>라인
             </div>
             {isFetching && (
               <span className="text-xs text-gray-400">(갱신 중)</span>
@@ -1038,10 +994,11 @@ export default function OrderTable() {
 
         {/* 테이블 */}
         <MergedDataTable<OrderLineRow>
-          data={pageRows}
+          data={rows}
           columns={columns as MergedTableColumn<OrderLineRow>[]}
           rowKey="rowId"
           groupKey="orderId"
+          stickyHeader
           selectable
           mergeCheckbox
           selectedRowKeys={selectedOrderIds}
@@ -1052,8 +1009,8 @@ export default function OrderTable() {
             '조회된 주문이 없습니다. "검색" 버튼을 눌러 조회하세요.'
           }
           className="p-0"
-          loading={isLoading}
-          isFetching={isFetching}
+          loading={isInitialLoading}
+          isFetching={false}
           getRowClassName={(r) =>
             r.orderStatus === 'cancelled' ? 'opacity-50' : ''
           }
@@ -1061,14 +1018,14 @@ export default function OrderTable() {
 
         {/* 페이지네이션 - DataTable과 동일한 방식 */}
         <Table.Pagination
-          count={rows.length}
+          count={total}
           pageSize={PAGE_SIZE}
           pageIndex={page}
-          pageCount={totalPages}
+          pageCount={pageCount}
           canPreviousPage={page > 0}
-          canNextPage={page < totalPages - 1}
+          canNextPage={page < pageCount - 1}
           previousPage={() => setPage((p) => Math.max(0, p - 1))}
-          nextPage={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+          nextPage={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
           goPage={(idx) => setPage(idx)}
         />
       </div>

--- a/apps/admin-web/src/features/order/history/hooks/use-order-rows.ts
+++ b/apps/admin-web/src/features/order/history/hooks/use-order-rows.ts
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { customerApi, orders } from '@/lib/api/domains';
 import { useVariantsBatch } from '@/lib/services/products';
 import type { SalesOrdersQuery } from '@/lib/types/dto/orders';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 export { filterRefundIssueRows } from './refund-filter.utils';
 
 /** 테이블에서 1행 = 주문 라인 1개 */
@@ -82,20 +82,25 @@ export type OrderLineRow = {
 };
 
 export function useSalesOrderRows(query: SalesOrdersQuery & { _t?: number }) {
-  // 1) 목록
+  // 1) 목록 (서버 페이지네이션 — 필터·페이지 모두 백엔드가 처리, 한 페이지 = 주문 ≤ limit)
   const listQuery = useQuery({
     queryKey: ['sales-orders', 'list-view', query],
     queryFn: () => orders.salesOrders.getSalesOrders(query),
     staleTime: 30 * 1000,
+    // 재조회 중에도 이전 결과를 유지 → 빈 화면/스켈레톤 깜빡임 방지
+    placeholderData: keepPreviousData,
   });
 
-  // 2) 상세 병렬 (최대 50건)
-  const orderIds =
-    listQuery.data?.data.map((i: any) => i.id).slice(0, 50) ?? [];
+  // 2) 상세 병렬 — 현재 페이지의 모든 주문 (페이지가 이미 ≤ limit 이므로 캡 불필요)
+  const listOrderIds: string[] =
+    listQuery.data?.data.map((i: any) => i.id) ?? [];
+  const orderIds = listOrderIds;
   const detailQueries = useQuery({
     queryKey: ['sales-orders', 'details', orderIds],
     enabled: orderIds.length > 0,
     staleTime: 30 * 1000,
+    // 페이지 이동으로 대상 주문이 바뀌어도 이전 enrichment 를 유지 (테이블 깜빡임 방지)
+    placeholderData: keepPreviousData,
     queryFn: async () => {
       if (!orderIds.length) return [];
       const details = await Promise.all(
@@ -112,6 +117,12 @@ export function useSalesOrderRows(query: SalesOrdersQuery & { _t?: number }) {
   const allVariantIds = new Set<string>();
   detailQueries.data?.forEach((detail) => {
     detail?.lines?.forEach((item: any) => {
+      if (item?.variantId) allVariantIds.add(item.variantId);
+    });
+  });
+  // 개별 상세조회 실패(reject) 시 목록 응답의 lines 로 폴백하므로 그 variantId 도 포함
+  listQuery.data?.data?.forEach((li: any) => {
+    li?.lines?.forEach((item: any) => {
       if (item?.variantId) allVariantIds.add(item.variantId);
     });
   });
@@ -204,7 +215,10 @@ export function useSalesOrderRows(query: SalesOrdersQuery & { _t?: number }) {
             undefined)
           : undefined;
 
-      const lines: any[] = detail?.lines ?? [];
+      // 상세조회 실패/미도착 시 목록 응답의 lines 로 폴백한다.
+      // (목록 엔드포인트가 이미 lines[productName/quantity/금액]을 반환함 → "상품 정보 없음" 방지)
+      const lines: any[] =
+        detail?.lines?.length ? detail.lines : (listItem.lines ?? []);
 
       // 주문의 모든 라인이 stock_deducted인지 확인
       const isOrderFullyAllocated =
@@ -294,7 +308,7 @@ export function useSalesOrderRows(query: SalesOrdersQuery & { _t?: number }) {
           address,
           personalCustomsCode,
           totalAmount: detail?.totalAmount ?? listItem.totalAmount,
-          shippingFee: detail?.shippingFee ?? 0,
+          shippingFee: detail?.shippingFee ?? listItem.shippingFee ?? 0,
           orderStatus: listItem.status,
           memo: detail?.memo,
           workLogs: detail?.workLogs ?? [],
@@ -305,7 +319,8 @@ export function useSalesOrderRows(query: SalesOrdersQuery & { _t?: number }) {
           quantity: Number(line.quantity ?? 1),
           unitPrice: line.unitPrice ?? undefined,
           totalPrice: line.totalPrice ?? undefined,
-          imageUrl: line.imageUrl,
+          // 주문 라인에는 이미지가 없어 PIM Variant(마스터 썸네일)에서 가져온다. (products-list 와 동일 소스)
+          imageUrl: line.imageUrl ?? variant?.thumbnail ?? undefined,
           skuId: line.skuId,
 
           isMatched,
@@ -387,6 +402,12 @@ export function useSalesOrderRows(query: SalesOrdersQuery & { _t?: number }) {
 
   return {
     data: transformedData,
+    // 필터 결과 전체 주문 수 / 상품 라인 수 / 페이지 수 (전 페이지 기준, 서버 집계)
+    total: (listQuery.data as any)?.total ?? 0,
+    lineTotal: (listQuery.data as any)?.lineTotal ?? 0,
+    pageCount: (listQuery.data as any)?.totalPages ?? 0,
+    // 최초 목록 로딩만 스켈레톤 대상 (페이지 재조회는 이전 데이터 유지하므로 제외)
+    isInitialLoading: listQuery.isLoading,
     isLoading:
       listQuery.isLoading ||
       detailQueries.isLoading ||

--- a/apps/admin-web/src/lib/api/domains/products/variants.client.ts
+++ b/apps/admin-web/src/lib/api/domains/products/variants.client.ts
@@ -23,6 +23,8 @@ export type BatchVariantInfo = {
   masterId: string;
   masterName: string;
   optionLabel?: string;
+  /** 마스터 대표 썸네일 (파일 ID 또는 절대 URL) */
+  thumbnail?: string | null;
 };
 
 export const variantsClient = {

--- a/apps/admin-web/src/lib/types/dto/orders.ts
+++ b/apps/admin-web/src/lib/types/dto/orders.ts
@@ -144,6 +144,8 @@ export interface OrderSalesChannel {
 export interface SalesOrdersResponseDto {
   data: SalesOrderDto[];
   total: number;
+  /** 필터 결과 전체 상품 라인 수 (전 페이지 합계) */
+  lineTotal?: number;
   page: number;
   limit: number;
   totalPages: number;
@@ -405,11 +407,34 @@ export interface OrderStatsDto {
 
 // ===== 쿼리 타입들 =====
 /** WMS SalesOrderFilterDto와 일치 */
+export type OrderTypeGroup =
+  | 'all'
+  | 'pending'
+  | 'ready'
+  | 'partial'
+  | 'hold'
+  | 'unmatched'
+  | 'direct';
+export type OrderKeywordType =
+  | 'all'
+  | 'orderNo'
+  | 'receiver'
+  | 'phone'
+  | 'product';
+
 export interface SalesOrdersQuery {
   status?: SalesOrderStatus;
   channel?: 'medusa' | 'naver' | 'coupang' | '3pl';
   startDate?: string;
   endDate?: string;
+  /** 구분 (재고/매칭 상태) — 서버측 필터 */
+  typeGroup?: OrderTypeGroup;
+  /** 취소/타임아웃 제외 (typeGroup='all'일 때) */
+  excludeTerminal?: boolean;
+  /** 환불 실패/수동처리 주문만 */
+  refundIssueOnly?: boolean;
+  keyword?: string;
+  keywordType?: OrderKeywordType;
   limit?: number;
   offset?: number;
 }

--- a/apps/core/drizzle/20260722064941_add-order-list-perf-indexes.sql
+++ b/apps/core/drizzle/20260722064941_add-order-list-perf-indexes.sql
@@ -1,0 +1,5 @@
+-- 라이브 무중단 적용: db:migrate 전에 CREATE INDEX CONCURRENTLY 로 선생성하면 아래 IF NOT EXISTS 는
+-- no-op 이 된다. 절차는 docs/runbooks/order-list-perf-indexes.md 참고.
+-- 새/로컬/작은 DB 에서는 이 파일만으로 생성된다(짧은 락 허용).
+CREATE INDEX IF NOT EXISTS "idx_sales_order_lines_sales_order_id" ON "sales_order_lines" USING btree ("sales_order_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_sales_orders_order_date" ON "sales_orders" USING btree ("order_date");

--- a/apps/core/drizzle/meta/20260722064941_snapshot.json
+++ b/apps/core/drizzle/meta/20260722064941_snapshot.json
@@ -1,0 +1,20299 @@
+{
+  "id": "f3e311e1-cc12-44fb-8fc0-bcc1c4ec7fa0",
+  "prevId": "84cb6e35-da8d-4ac4-9c71-bc53e70c0994",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.banner_groups": {
+      "name": "banner_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pc_width": {
+          "name": "pc_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pc_height": {
+          "name": "pc_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile_width": {
+          "name": "mobile_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile_height": {
+          "name": "mobile_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_banner_groups_code": {
+          "name": "idx_banner_groups_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banner_groups_category": {
+          "name": "idx_banner_groups_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banner_groups_active": {
+          "name": "idx_banner_groups_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banner_groups_deleted_at": {
+          "name": "idx_banner_groups_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "banner_groups_code_unique": {
+          "name": "banner_groups_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banners": {
+      "name": "banners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "banner_group_id": {
+          "name": "banner_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pc_image_file_id": {
+          "name": "pc_image_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mobile_image_file_id": {
+          "name": "mobile_image_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_product_master_ids": {
+          "name": "linked_product_master_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "display_start_at": {
+          "name": "display_start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_end_at": {
+          "name": "display_end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_banners_group_id": {
+          "name": "idx_banners_group_id",
+          "columns": [
+            {
+              "expression": "banner_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banners_active": {
+          "name": "idx_banners_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banners_display_period": {
+          "name": "idx_banners_display_period",
+          "columns": [
+            {
+              "expression": "display_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banners_deleted_at": {
+          "name": "idx_banners_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banners_group_sort": {
+          "name": "idx_banners_group_sort",
+          "columns": [
+            {
+              "expression": "banner_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banners_banner_group_id_banner_groups_id_fk": {
+          "name": "banners_banner_group_id_banner_groups_id_fk",
+          "tableFrom": "banners",
+          "tableTo": "banner_groups",
+          "columnsFrom": [
+            "banner_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_tag_groups": {
+      "name": "category_tag_groups",
+      "schema": "",
+      "columns": {
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_group_id": {
+          "name": "tag_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "applies_to_descendants": {
+          "name": "applies_to_descendants",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_category_tag_groups_category": {
+          "name": "idx_category_tag_groups_category",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_category_tag_groups_group": {
+          "name": "idx_category_tag_groups_group",
+          "columns": [
+            {
+              "expression": "tag_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_category_tag_groups_display_order": {
+          "name": "idx_category_tag_groups_display_order",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "category_tag_groups_category_id_product_categories_id_fk": {
+          "name": "category_tag_groups_category_id_product_categories_id_fk",
+          "tableFrom": "category_tag_groups",
+          "tableTo": "product_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "category_tag_groups_tag_group_id_tag_groups_id_fk": {
+          "name": "category_tag_groups_tag_group_id_tag_groups_id_fk",
+          "tableFrom": "category_tag_groups",
+          "tableTo": "tag_groups",
+          "columnsFrom": [
+            "tag_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "category_tag_groups_category_id_tag_group_id_pk": {
+          "name": "category_tag_groups_category_id_tag_group_id_pk",
+          "columns": [
+            "category_id",
+            "tag_group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_categories": {
+      "name": "channel_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channel_categories_order": {
+          "name": "idx_channel_categories_order",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_products": {
+      "name": "channel_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "channel_specific_data": {
+          "name": "channel_specific_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channel_products_master": {
+          "name": "idx_channel_products_master",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_products_channel": {
+          "name": "idx_channel_products_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_products_active": {
+          "name": "idx_channel_products_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_master_channel": {
+          "name": "unique_master_channel",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_products_master_id_product_masters_id_fk": {
+          "name": "channel_products_master_id_product_masters_id_fk",
+          "tableFrom": "channel_products",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_products_channel_id_sales_channels_id_fk": {
+          "name": "channel_products_channel_id_sales_channels_id_fk",
+          "tableFrom": "channel_products",
+          "tableTo": "sales_channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_variant_listings": {
+      "name": "channel_variant_listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_channel_id": {
+          "name": "sales_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_item_id": {
+          "name": "channel_item_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_item_name": {
+          "name": "channel_item_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_option_name": {
+          "name": "channel_option_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_price": {
+          "name": "channel_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_product_url": {
+          "name": "channel_product_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_channel_variant_listing": {
+          "name": "uq_channel_variant_listing",
+          "columns": [
+            {
+              "expression": "sales_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_listings_variant": {
+          "name": "idx_channel_listings_variant",
+          "columns": [
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_listings_channel": {
+          "name": "idx_channel_listings_channel",
+          "columns": [
+            {
+              "expression": "sales_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_variant_listings_variant_id_product_variants_id_fk": {
+          "name": "channel_variant_listings_variant_id_product_variants_id_fk",
+          "tableFrom": "channel_variant_listings",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_variant_listings_sales_channel_id_sales_channels_id_fk": {
+          "name": "channel_variant_listings_sales_channel_id_sales_channels_id_fk",
+          "tableFrom": "channel_variant_listings",
+          "tableTo": "sales_channels",
+          "columnsFrom": [
+            "sales_channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notices": {
+      "name": "notices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "badge": {
+          "name": "badge",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_start_at": {
+          "name": "display_start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_end_at": {
+          "name": "display_end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_notices_category": {
+          "name": "idx_notices_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notices_active": {
+          "name": "idx_notices_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notices_pinned": {
+          "name": "idx_notices_pinned",
+          "columns": [
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notices_display_period": {
+          "name": "idx_notices_display_period",
+          "columns": [
+            {
+              "expression": "display_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notices_deleted_at": {
+          "name": "idx_notices_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notices_sort": {
+          "name": "idx_notices_sort",
+          "columns": [
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pricing_rules": {
+      "name": "pricing_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "layer": {
+          "name": "layer",
+          "type": "pricing_rule_layer",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "pricing_rule_scope_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_target_ids": {
+          "name": "scope_target_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "pricing_rule_operation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_value": {
+          "name": "operation_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_quantity": {
+          "name": "min_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_approval_history": {
+      "name": "product_approval_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_approval_history_version": {
+          "name": "idx_approval_history_version",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_approval_history_status": {
+          "name": "idx_approval_history_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_approval_history_date": {
+          "name": "idx_approval_history_date",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_approval_history_version_id_product_master_versions_id_fk": {
+          "name": "product_approval_history_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_approval_history",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_audit_log": {
+      "name": "product_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_audit_log_version": {
+          "name": "idx_audit_log_version",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_action": {
+          "name": "idx_audit_log_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_timestamp": {
+          "name": "idx_audit_log_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_user": {
+          "name": "idx_audit_log_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_categories": {
+      "name": "product_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_settings": {
+          "name": "display_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_config": {
+          "name": "seo_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_config": {
+          "name": "template_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_categories_parent_id": {
+          "name": "idx_categories_parent_id",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_categories_level": {
+          "name": "idx_categories_level",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_categories_path": {
+          "name": "idx_categories_path",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_categories_slug": {
+          "name": "idx_categories_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_categories_active": {
+          "name": "idx_categories_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_categories_sort_order": {
+          "name": "idx_categories_sort_order",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_categories_parent_id_product_categories_id_fk": {
+          "name": "product_categories_parent_id_product_categories_id_fk",
+          "tableFrom": "product_categories",
+          "tableTo": "product_categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "product_categories_slug_unique": {
+          "name": "product_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_images": {
+      "name": "product_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_product_images_version": {
+          "name": "idx_product_images_version",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_product_images_primary": {
+          "name": "idx_product_images_primary",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_product_images_sort": {
+          "name": "idx_product_images_sort",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_product_primary_image": {
+          "name": "unique_product_primary_image",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"product_images\".\"is_primary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_images_version_id_product_master_versions_id_fk": {
+          "name": "product_images_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_import_items": {
+      "name": "product_import_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_number": {
+          "name": "row_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_key": {
+          "name": "product_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "product_import_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_import_items_session": {
+          "name": "idx_import_items_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_import_items_session_id_product_import_sessions_id_fk": {
+          "name": "product_import_items_session_id_product_import_sessions_id_fk",
+          "tableFrom": "product_import_items",
+          "tableTo": "product_import_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_import_sessions": {
+      "name": "product_import_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_rows": {
+          "name": "total_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_count": {
+          "name": "created_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "product_import_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_import_sessions_uploaded_by": {
+          "name": "idx_import_sessions_uploaded_by",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_import_sessions_created_at": {
+          "name": "idx_import_sessions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_master_categories": {
+      "name": "product_master_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_master_categories_master_version": {
+          "name": "idx_master_categories_master_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_master_categories_category": {
+          "name": "idx_master_categories_category",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_master_categories_primary": {
+          "name": "idx_master_categories_primary",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_master_category_version": {
+          "name": "unique_master_category_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_master_categories_master_id_product_masters_id_fk": {
+          "name": "product_master_categories_master_id_product_masters_id_fk",
+          "tableFrom": "product_master_categories",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_categories_category_id_product_categories_id_fk": {
+          "name": "product_master_categories_category_id_product_categories_id_fk",
+          "tableFrom": "product_master_categories",
+          "tableTo": "product_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_categories_version_id_product_master_versions_id_fk": {
+          "name": "product_master_categories_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_master_categories",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_master_option_groups": {
+      "name": "product_master_option_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_group_id": {
+          "name": "option_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_master_option_groups_master_version": {
+          "name": "idx_master_option_groups_master_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_master_option_group_version": {
+          "name": "unique_master_option_group_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "option_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_master_option_groups_master_id_product_masters_id_fk": {
+          "name": "product_master_option_groups_master_id_product_masters_id_fk",
+          "tableFrom": "product_master_option_groups",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_option_groups_option_group_id_product_option_groups_id_fk": {
+          "name": "product_master_option_groups_option_group_id_product_option_groups_id_fk",
+          "tableFrom": "product_master_option_groups",
+          "tableTo": "product_option_groups",
+          "columnsFrom": [
+            "option_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_option_groups_version_id_product_master_versions_id_fk": {
+          "name": "product_master_option_groups_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_master_option_groups",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_master_pricing_rules": {
+      "name": "product_master_pricing_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing_rule_id": {
+          "name": "pricing_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_master_pricing_rules_master_version": {
+          "name": "idx_master_pricing_rules_master_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_master_pricing_rule_version": {
+          "name": "unique_master_pricing_rule_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pricing_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_master_pricing_rules_master_id_product_masters_id_fk": {
+          "name": "product_master_pricing_rules_master_id_product_masters_id_fk",
+          "tableFrom": "product_master_pricing_rules",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_pricing_rules_pricing_rule_id_pricing_rules_id_fk": {
+          "name": "product_master_pricing_rules_pricing_rule_id_pricing_rules_id_fk",
+          "tableFrom": "product_master_pricing_rules",
+          "tableTo": "pricing_rules",
+          "columnsFrom": [
+            "pricing_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_pricing_rules_version_id_product_master_versions_id_fk": {
+          "name": "product_master_pricing_rules_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_master_pricing_rules",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_master_purchase_constraints": {
+      "name": "product_master_purchase_constraints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_constraint_id": {
+          "name": "purchase_constraint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_master_purchase_constraints_master_version": {
+          "name": "idx_master_purchase_constraints_master_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_master_purchase_constraints_constraint": {
+          "name": "idx_master_purchase_constraints_constraint",
+          "columns": [
+            {
+              "expression": "purchase_constraint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_purchase_constraint_version": {
+          "name": "unique_purchase_constraint_version",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_master_purchase_constraint_version": {
+          "name": "unique_master_purchase_constraint_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_master_purchase_constraints_master_id_product_masters_id_fk": {
+          "name": "product_master_purchase_constraints_master_id_product_masters_id_fk",
+          "tableFrom": "product_master_purchase_constraints",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_purchase_constraints_version_id_product_master_versions_id_fk": {
+          "name": "product_master_purchase_constraints_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_master_purchase_constraints",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_purchase_constraints_purchase_constraint_id_product_purchase_constraints_id_fk": {
+          "name": "product_master_purchase_constraints_purchase_constraint_id_product_purchase_constraints_id_fk",
+          "tableFrom": "product_master_purchase_constraints",
+          "tableTo": "product_purchase_constraints",
+          "columnsFrom": [
+            "purchase_constraint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_master_variants": {
+      "name": "product_master_variants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_master_variants_master_version": {
+          "name": "idx_master_variants_master_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_master_variant_version": {
+          "name": "unique_master_variant_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_master_variants_master_id_product_masters_id_fk": {
+          "name": "product_master_variants_master_id_product_masters_id_fk",
+          "tableFrom": "product_master_variants",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_variants_variant_id_product_variants_id_fk": {
+          "name": "product_master_variants_variant_id_product_variants_id_fk",
+          "tableFrom": "product_master_variants",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_variants_version_id_product_master_versions_id_fk": {
+          "name": "product_master_variants_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_master_variants",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_master_versions": {
+      "name": "product_master_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "product_master_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "draft_owner_id": {
+          "name": "draft_owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'새 상품'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_title": {
+          "name": "seo_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_description": {
+          "name": "seo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_keywords": {
+          "name": "seo_keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_html": {
+          "name": "description_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_wholesale_only": {
+          "name": "is_wholesale_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_membership_only": {
+          "name": "is_membership_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hide_membership_price_for_non_members": {
+          "name": "hide_membership_price_for_non_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_visible_to_members_only": {
+          "name": "is_visible_to_members_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_overseas": {
+          "name": "is_overseas",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "product_type": {
+          "name": "product_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular_sale'"
+        },
+        "fulfillment_kind": {
+          "name": "fulfillment_kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'physical'"
+        },
+        "product_code": {
+          "name": "product_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alternative_name": {
+          "name": "alternative_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "material": {
+          "name": "material",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_classification": {
+          "name": "sales_classification",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_classification": {
+          "name": "purchase_classification",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_method_id": {
+          "name": "shipping_method_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "market_price": {
+          "name": "market_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supply_price": {
+          "name": "supply_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_restriction": {
+          "name": "age_restriction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "min_quantity": {
+          "name": "min_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "max_quantity": {
+          "name": "max_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_start_date": {
+          "name": "sales_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_end_date": {
+          "name": "sales_end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_status": {
+          "name": "approval_status",
+          "type": "product_master_version_approval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seller": {
+          "name": "seller",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_date": {
+          "name": "registration_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_versions_master_id": {
+          "name": "idx_versions_master_id",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_status": {
+          "name": "idx_versions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_master_version": {
+          "name": "idx_versions_master_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_name": {
+          "name": "idx_versions_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_brand": {
+          "name": "idx_versions_brand",
+          "columns": [
+            {
+              "expression": "brand",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_created_at": {
+          "name": "idx_versions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_product_type": {
+          "name": "idx_versions_product_type",
+          "columns": [
+            {
+              "expression": "product_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_product_code": {
+          "name": "idx_versions_product_code",
+          "columns": [
+            {
+              "expression": "product_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_approval_status": {
+          "name": "idx_versions_approval_status",
+          "columns": [
+            {
+              "expression": "approval_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_deleted_at": {
+          "name": "idx_versions_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_supplier": {
+          "name": "idx_versions_supplier",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_draft_owner": {
+          "name": "idx_versions_draft_owner",
+          "columns": [
+            {
+              "expression": "draft_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_sales_dates": {
+          "name": "idx_versions_sales_dates",
+          "columns": [
+            {
+              "expression": "sales_start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sales_end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_master_active_version": {
+          "name": "unique_master_active_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"product_master_versions\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_active_product_code": {
+          "name": "unique_active_product_code",
+          "columns": [
+            {
+              "expression": "product_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"product_master_versions\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_master_version": {
+          "name": "unique_master_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_master_versions_master_id_product_masters_id_fk": {
+          "name": "product_master_versions_master_id_product_masters_id_fk",
+          "tableFrom": "product_master_versions",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_versions_parent_version_id_product_master_versions_id_fk": {
+          "name": "product_master_versions_parent_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_master_versions",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "parent_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_masters": {
+      "name": "product_masters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_masters_created_at": {
+          "name": "idx_masters_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_masters_deleted_at": {
+          "name": "idx_masters_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_option_group_displays": {
+      "name": "product_option_group_displays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "option_group_id": {
+          "name": "option_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ko-KR'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_option_group_displays_lookup": {
+          "name": "idx_option_group_displays_lookup",
+          "columns": [
+            {
+              "expression": "option_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_option_group_display": {
+          "name": "unique_option_group_display",
+          "columns": [
+            {
+              "expression": "option_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_option_group_displays_option_group_id_product_option_groups_id_fk": {
+          "name": "product_option_group_displays_option_group_id_product_option_groups_id_fk",
+          "tableFrom": "product_option_group_displays",
+          "tableTo": "product_option_groups",
+          "columnsFrom": [
+            "option_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_option_group_displays_master_id_product_masters_id_fk": {
+          "name": "product_option_group_displays_master_id_product_masters_id_fk",
+          "tableFrom": "product_option_group_displays",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_option_group_displays_version_id_product_master_versions_id_fk": {
+          "name": "product_option_group_displays_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_option_group_displays",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_option_groups": {
+      "name": "product_option_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_option_value_displays": {
+      "name": "product_option_value_displays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "option_value_id": {
+          "name": "option_value_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ko-KR'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color_code": {
+          "name": "color_code",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_option_value_displays_lookup": {
+          "name": "idx_option_value_displays_lookup",
+          "columns": [
+            {
+              "expression": "option_value_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_option_value_display": {
+          "name": "unique_option_value_display",
+          "columns": [
+            {
+              "expression": "option_value_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_option_value_displays_option_value_id_product_option_values_id_fk": {
+          "name": "product_option_value_displays_option_value_id_product_option_values_id_fk",
+          "tableFrom": "product_option_value_displays",
+          "tableTo": "product_option_values",
+          "columnsFrom": [
+            "option_value_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_option_value_displays_master_id_product_masters_id_fk": {
+          "name": "product_option_value_displays_master_id_product_masters_id_fk",
+          "tableFrom": "product_option_value_displays",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_option_value_displays_version_id_product_master_versions_id_fk": {
+          "name": "product_option_value_displays_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_option_value_displays",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_option_values": {
+      "name": "product_option_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "option_group_id": {
+          "name": "option_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_option_values_group": {
+          "name": "idx_option_values_group",
+          "columns": [
+            {
+              "expression": "option_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_option_values_option_group_id_product_option_groups_id_fk": {
+          "name": "product_option_values_option_group_id_product_option_groups_id_fk",
+          "tableFrom": "product_option_values",
+          "tableTo": "product_option_groups",
+          "columnsFrom": [
+            "option_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_purchase_constraints": {
+      "name": "product_purchase_constraints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requires_membership": {
+          "name": "requires_membership",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lifetime_quantity_limit": {
+          "name": "lifetime_quantity_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_product_purchase_constraints_lifetime_quantity_limit_positive": {
+          "name": "chk_product_purchase_constraints_lifetime_quantity_limit_positive",
+          "value": "\"lifetime_quantity_limit\" IS NULL OR \"lifetime_quantity_limit\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.product_tag_values": {
+      "name": "product_tag_values",
+      "schema": "",
+      "columns": {
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_value_id": {
+          "name": "tag_value_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_product_tag_values_master_version": {
+          "name": "idx_product_tag_values_master_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_product_tag_values_tag": {
+          "name": "idx_product_tag_values_tag",
+          "columns": [
+            {
+              "expression": "tag_value_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_tag_values_master_id_product_masters_id_fk": {
+          "name": "product_tag_values_master_id_product_masters_id_fk",
+          "tableFrom": "product_tag_values",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_tag_values_version_id_product_master_versions_id_fk": {
+          "name": "product_tag_values_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_tag_values",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_tag_values_tag_value_id_tag_values_id_fk": {
+          "name": "product_tag_values_tag_value_id_tag_values_id_fk",
+          "tableFrom": "product_tag_values",
+          "tableTo": "tag_values",
+          "columnsFrom": [
+            "tag_value_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "product_tag_values_master_id_version_id_tag_value_id_pk": {
+          "name": "product_tag_values_master_id_version_id_tag_value_id_pk",
+          "columns": [
+            "master_id",
+            "version_id",
+            "tag_value_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_variant_price_cache": {
+      "name": "product_variant_price_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_price": {
+          "name": "base_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_price": {
+          "name": "membership_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tiered_prices": {
+          "name": "tiered_prices",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variant_price_cache_version": {
+          "name": "idx_variant_price_cache_version",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variant_price_cache_variant": {
+          "name": "idx_variant_price_cache_variant",
+          "columns": [
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_variant_price_cache_version_variant": {
+          "name": "unique_variant_price_cache_version_variant",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_variant_price_cache_version_id_product_master_versions_id_fk": {
+          "name": "product_variant_price_cache_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_variant_price_cache",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_variant_price_cache_variant_id_product_variants_id_fk": {
+          "name": "product_variant_price_cache_variant_id_product_variants_id_fk",
+          "tableFrom": "product_variant_price_cache",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_variants": {
+      "name": "product_variants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "variant_name": {
+          "name": "variant_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variants_status": {
+          "name": "idx_variants_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variants_is_default": {
+          "name": "idx_variants_is_default",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variants_created_at": {
+          "name": "idx_variants_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variants_code": {
+          "name": "idx_variants_code",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.promotion_products": {
+      "name": "promotion_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "promotion_id": {
+          "name": "promotion_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "promotion_products_promotion_id_promotions_id_fk": {
+          "name": "promotion_products_promotion_id_promotions_id_fk",
+          "tableFrom": "promotion_products",
+          "tableTo": "promotions",
+          "columnsFrom": [
+            "promotion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "promotion_products_master_id_product_masters_id_fk": {
+          "name": "promotion_products_master_id_product_masters_id_fk",
+          "tableFrom": "promotion_products",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "promotion_products_variant_id_product_variants_id_fk": {
+          "name": "promotion_products_variant_id_product_variants_id_fk",
+          "tableFrom": "promotion_products",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.promotions": {
+      "name": "promotions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sales_channels": {
+      "name": "sales_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ONLINE'"
+        },
+        "site": {
+          "name": "site",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "api_endpoint": {
+          "name": "api_endpoint",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sales_channels_type": {
+          "name": "idx_sales_channels_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_channels_site": {
+          "name": "idx_sales_channels_site",
+          "columns": [
+            {
+              "expression": "site",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_channels_category": {
+          "name": "idx_sales_channels_category",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_channels_active": {
+          "name": "idx_sales_channels_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sales_channels_category_id_channel_categories_id_fk": {
+          "name": "sales_channels_category_id_channel_categories_id_fk",
+          "tableFrom": "sales_channels",
+          "tableTo": "channel_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_groups": {
+      "name": "tag_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tag_groups_active": {
+          "name": "idx_tag_groups_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tag_groups_display_order": {
+          "name": "idx_tag_groups_display_order",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_values": {
+      "name": "tag_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tag_values_group_id": {
+          "name": "idx_tag_values_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tag_values_active": {
+          "name": "idx_tag_values_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tag_values_display_order": {
+          "name": "idx_tag_values_display_order",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_tag_values_group_name": {
+          "name": "unique_tag_values_group_name",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tag_values_group_id_tag_groups_id_fk": {
+          "name": "tag_values_group_id_tag_groups_id_fk",
+          "tableFrom": "tag_values",
+          "tableTo": "tag_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant_option_values": {
+      "name": "variant_option_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_value_id": {
+          "name": "option_value_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_variant_options_variant": {
+          "name": "idx_variant_options_variant",
+          "columns": [
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variant_options_value": {
+          "name": "idx_variant_options_value",
+          "columns": [
+            {
+              "expression": "option_value_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_variant_option_values": {
+          "name": "unique_variant_option_values",
+          "columns": [
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "option_value_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_option_values_variant_id_product_variants_id_fk": {
+          "name": "variant_option_values_variant_id_product_variants_id_fk",
+          "tableFrom": "variant_option_values",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_option_values_option_value_id_product_option_values_id_fk": {
+          "name": "variant_option_values_option_value_id_product_option_values_id_fk",
+          "tableFrom": "variant_option_values",
+          "tableTo": "product_option_values",
+          "columnsFrom": [
+            "option_value_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "audit_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "audit_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INFO'"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_name": {
+          "name": "resource_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes_before": {
+          "name": "changes_before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes_after": {
+          "name": "changes_after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module": {
+          "name": "module",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stack_trace": {
+          "name": "stack_trace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_timestamp": {
+          "name": "idx_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event_type": {
+          "name": "idx_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_resource_type": {
+          "name": "idx_audit_resource_type",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_resource_id": {
+          "name": "idx_audit_resource_id",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_module": {
+          "name": "idx_audit_module",
+          "columns": [
+            {
+              "expression": "module",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_severity": {
+          "name": "idx_audit_severity",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_user_id": {
+          "name": "idx_audit_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_correlation_id": {
+          "name": "idx_audit_correlation_id",
+          "columns": [
+            {
+              "expression": "correlation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_resource_search": {
+          "name": "idx_audit_resource_search",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_time_module": {
+          "name": "idx_audit_time_module",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "module",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.batch_inventory_session_balances": {
+      "name": "batch_inventory_session_balances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_location_id": {
+          "name": "source_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custody_type": {
+          "name": "custody_type",
+          "type": "batch_inventory_custody_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custody_ref": {
+          "name": "custody_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipment_line_id": {
+          "name": "shipment_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qty": {
+          "name": "qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_batch_inventory_session_balances_session": {
+          "name": "idx_batch_inventory_session_balances_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "custody_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_batch_inventory_session_balances_line": {
+          "name": "idx_batch_inventory_session_balances_line",
+          "columns": [
+            {
+              "expression": "shipment_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "batch_inventory_session_balances_session_id_batch_inventory_sessions_id_fk": {
+          "name": "batch_inventory_session_balances_session_id_batch_inventory_sessions_id_fk",
+          "tableFrom": "batch_inventory_session_balances",
+          "tableTo": "batch_inventory_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "batch_inventory_session_balances_sku_id_skus_id_fk": {
+          "name": "batch_inventory_session_balances_sku_id_skus_id_fk",
+          "tableFrom": "batch_inventory_session_balances",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "batch_inventory_session_balances_source_location_id_locations_id_fk": {
+          "name": "batch_inventory_session_balances_source_location_id_locations_id_fk",
+          "tableFrom": "batch_inventory_session_balances",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "source_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "batch_inventory_session_balances_shipment_line_id_shipment_lines_id_fk": {
+          "name": "batch_inventory_session_balances_shipment_line_id_shipment_lines_id_fk",
+          "tableFrom": "batch_inventory_session_balances",
+          "tableTo": "shipment_lines",
+          "columnsFrom": [
+            "shipment_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_batch_inventory_session_balance_grain": {
+          "name": "uq_batch_inventory_session_balance_grain",
+          "nullsNotDistinct": true,
+          "columns": [
+            "session_id",
+            "sku_id",
+            "source_location_id",
+            "custody_type",
+            "custody_ref",
+            "shipment_line_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_batch_inventory_session_balances_qty": {
+          "name": "ck_batch_inventory_session_balances_qty",
+          "value": "\"batch_inventory_session_balances\".\"qty\" >= 0"
+        },
+        "ck_batch_inventory_session_balances_version": {
+          "name": "ck_batch_inventory_session_balances_version",
+          "value": "\"batch_inventory_session_balances\".\"version\" > 0"
+        },
+        "ck_batch_inventory_session_balances_custody": {
+          "name": "ck_batch_inventory_session_balances_custody",
+          "value": "(\n        (\"batch_inventory_session_balances\".\"custody_type\" = 'AT_SOURCE' AND \"batch_inventory_session_balances\".\"source_location_id\" IS NOT NULL AND \"batch_inventory_session_balances\".\"custody_ref\" IS NULL AND \"batch_inventory_session_balances\".\"shipment_line_id\" IS NULL)\n        OR (\"batch_inventory_session_balances\".\"custody_type\" = 'BULK_CART' AND \"batch_inventory_session_balances\".\"source_location_id\" IS NOT NULL AND \"batch_inventory_session_balances\".\"custody_ref\" IS NOT NULL AND \"batch_inventory_session_balances\".\"shipment_line_id\" IS NULL)\n        OR (\"batch_inventory_session_balances\".\"custody_type\" IN ('WORKER', 'TOTE', 'SORTING', 'PACKING', 'PACKED') AND \"batch_inventory_session_balances\".\"source_location_id\" IS NOT NULL AND \"batch_inventory_session_balances\".\"custody_ref\" IS NOT NULL AND \"batch_inventory_session_balances\".\"shipment_line_id\" IS NOT NULL)\n        OR (\"batch_inventory_session_balances\".\"custody_type\" IN ('RETURN_PENDING', 'SETTLED') AND \"batch_inventory_session_balances\".\"source_location_id\" IS NOT NULL AND \"batch_inventory_session_balances\".\"custody_ref\" IS NULL AND \"batch_inventory_session_balances\".\"shipment_line_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.batch_inventory_session_events": {
+      "name": "batch_inventory_session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_custody_type": {
+          "name": "from_custody_type",
+          "type": "batch_inventory_custody_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_custody_ref": {
+          "name": "from_custody_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_source_location_id": {
+          "name": "from_source_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_shipment_line_id": {
+          "name": "from_shipment_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_custody_type": {
+          "name": "to_custody_type",
+          "type": "batch_inventory_custody_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_custody_ref": {
+          "name": "to_custody_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_source_location_id": {
+          "name": "to_source_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_shipment_line_id": {
+          "name": "to_shipment_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_batch_inventory_session_events_from_location": {
+          "name": "idx_batch_inventory_session_events_from_location",
+          "columns": [
+            {
+              "expression": "from_source_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_batch_inventory_session_events_to_location": {
+          "name": "idx_batch_inventory_session_events_to_location",
+          "columns": [
+            {
+              "expression": "to_source_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_batch_inventory_session_events_from_line": {
+          "name": "idx_batch_inventory_session_events_from_line",
+          "columns": [
+            {
+              "expression": "from_shipment_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_batch_inventory_session_events_to_line": {
+          "name": "idx_batch_inventory_session_events_to_line",
+          "columns": [
+            {
+              "expression": "to_shipment_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "batch_inventory_session_events_session_id_batch_inventory_sessions_id_fk": {
+          "name": "batch_inventory_session_events_session_id_batch_inventory_sessions_id_fk",
+          "tableFrom": "batch_inventory_session_events",
+          "tableTo": "batch_inventory_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "batch_inventory_session_events_sku_id_skus_id_fk": {
+          "name": "batch_inventory_session_events_sku_id_skus_id_fk",
+          "tableFrom": "batch_inventory_session_events",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "batch_inventory_session_events_from_source_location_id_locations_id_fk": {
+          "name": "batch_inventory_session_events_from_source_location_id_locations_id_fk",
+          "tableFrom": "batch_inventory_session_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "from_source_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "batch_inventory_session_events_from_shipment_line_id_shipment_lines_id_fk": {
+          "name": "batch_inventory_session_events_from_shipment_line_id_shipment_lines_id_fk",
+          "tableFrom": "batch_inventory_session_events",
+          "tableTo": "shipment_lines",
+          "columnsFrom": [
+            "from_shipment_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "batch_inventory_session_events_to_source_location_id_locations_id_fk": {
+          "name": "batch_inventory_session_events_to_source_location_id_locations_id_fk",
+          "tableFrom": "batch_inventory_session_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "to_source_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "batch_inventory_session_events_to_shipment_line_id_shipment_lines_id_fk": {
+          "name": "batch_inventory_session_events_to_shipment_line_id_shipment_lines_id_fk",
+          "tableFrom": "batch_inventory_session_events",
+          "tableTo": "shipment_lines",
+          "columnsFrom": [
+            "to_shipment_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_batch_inventory_session_event_idempotency": {
+          "name": "uq_batch_inventory_session_event_idempotency",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_batch_inventory_session_events_qty_positive": {
+          "name": "ck_batch_inventory_session_events_qty_positive",
+          "value": "\"batch_inventory_session_events\".\"quantity\" > 0"
+        },
+        "ck_batch_inventory_session_events_sides": {
+          "name": "ck_batch_inventory_session_events_sides",
+          "value": "\"batch_inventory_session_events\".\"from_custody_type\" IS NOT NULL OR \"batch_inventory_session_events\".\"to_custody_type\" IS NOT NULL"
+        },
+        "ck_batch_inventory_session_events_from_grain": {
+          "name": "ck_batch_inventory_session_events_from_grain",
+          "value": "(\n        (\"batch_inventory_session_events\".\"from_custody_type\" IS NULL AND \"batch_inventory_session_events\".\"from_source_location_id\" IS NULL AND \"batch_inventory_session_events\".\"from_custody_ref\" IS NULL AND \"batch_inventory_session_events\".\"from_shipment_line_id\" IS NULL)\n        OR (\"batch_inventory_session_events\".\"from_custody_type\" IS NOT NULL AND (\n          (\"batch_inventory_session_events\".\"from_custody_type\" = 'AT_SOURCE' AND \"batch_inventory_session_events\".\"from_source_location_id\" IS NOT NULL AND \"batch_inventory_session_events\".\"from_custody_ref\" IS NULL AND \"batch_inventory_session_events\".\"from_shipment_line_id\" IS NULL)\n          OR (\"batch_inventory_session_events\".\"from_custody_type\" = 'BULK_CART' AND \"batch_inventory_session_events\".\"from_source_location_id\" IS NOT NULL AND \"batch_inventory_session_events\".\"from_custody_ref\" IS NOT NULL AND \"batch_inventory_session_events\".\"from_shipment_line_id\" IS NULL)\n          OR (\"batch_inventory_session_events\".\"from_custody_type\" IN ('WORKER', 'TOTE', 'SORTING', 'PACKING', 'PACKED') AND \"batch_inventory_session_events\".\"from_source_location_id\" IS NOT NULL AND \"batch_inventory_session_events\".\"from_custody_ref\" IS NOT NULL AND \"batch_inventory_session_events\".\"from_shipment_line_id\" IS NOT NULL)\n          OR (\"batch_inventory_session_events\".\"from_custody_type\" IN ('RETURN_PENDING', 'SETTLED') AND \"batch_inventory_session_events\".\"from_source_location_id\" IS NOT NULL AND \"batch_inventory_session_events\".\"from_custody_ref\" IS NULL AND \"batch_inventory_session_events\".\"from_shipment_line_id\" IS NOT NULL)\n        ))\n      )"
+        },
+        "ck_batch_inventory_session_events_to_grain": {
+          "name": "ck_batch_inventory_session_events_to_grain",
+          "value": "(\n        (\"batch_inventory_session_events\".\"to_custody_type\" IS NULL AND \"batch_inventory_session_events\".\"to_source_location_id\" IS NULL AND \"batch_inventory_session_events\".\"to_custody_ref\" IS NULL AND \"batch_inventory_session_events\".\"to_shipment_line_id\" IS NULL)\n        OR (\"batch_inventory_session_events\".\"to_custody_type\" IS NOT NULL AND (\n          (\"batch_inventory_session_events\".\"to_custody_type\" = 'AT_SOURCE' AND \"batch_inventory_session_events\".\"to_source_location_id\" IS NOT NULL AND \"batch_inventory_session_events\".\"to_custody_ref\" IS NULL AND \"batch_inventory_session_events\".\"to_shipment_line_id\" IS NULL)\n          OR (\"batch_inventory_session_events\".\"to_custody_type\" = 'BULK_CART' AND \"batch_inventory_session_events\".\"to_source_location_id\" IS NOT NULL AND \"batch_inventory_session_events\".\"to_custody_ref\" IS NOT NULL AND \"batch_inventory_session_events\".\"to_shipment_line_id\" IS NULL)\n          OR (\"batch_inventory_session_events\".\"to_custody_type\" IN ('WORKER', 'TOTE', 'SORTING', 'PACKING', 'PACKED') AND \"batch_inventory_session_events\".\"to_source_location_id\" IS NOT NULL AND \"batch_inventory_session_events\".\"to_custody_ref\" IS NOT NULL AND \"batch_inventory_session_events\".\"to_shipment_line_id\" IS NOT NULL)\n          OR (\"batch_inventory_session_events\".\"to_custody_type\" IN ('RETURN_PENDING', 'SETTLED') AND \"batch_inventory_session_events\".\"to_source_location_id\" IS NOT NULL AND \"batch_inventory_session_events\".\"to_custody_ref\" IS NULL AND \"batch_inventory_session_events\".\"to_shipment_line_id\" IS NOT NULL)\n        ))\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.batch_inventory_sessions": {
+      "name": "batch_inventory_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "batch_inventory_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "handed_in_qty": {
+          "name": "handed_in_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "settled_qty": {
+          "name": "settled_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "returned_qty": {
+          "name": "returned_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "shortage_qty": {
+          "name": "shortage_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recovery_reason": {
+          "name": "recovery_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_batch_inventory_sessions_active_batch": {
+          "name": "uq_batch_inventory_sessions_active_batch",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"batch_inventory_sessions\".\"status\" IN ('active', 'recovery_required')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_batch_inventory_sessions_status": {
+          "name": "idx_batch_inventory_sessions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "batch_inventory_sessions_batch_id_outbound_batches_id_fk": {
+          "name": "batch_inventory_sessions_batch_id_outbound_batches_id_fk",
+          "tableFrom": "batch_inventory_sessions",
+          "tableTo": "outbound_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_batch_inventory_sessions_version_positive": {
+          "name": "ck_batch_inventory_sessions_version_positive",
+          "value": "\"batch_inventory_sessions\".\"version\" > 0"
+        },
+        "ck_batch_inventory_sessions_quantities": {
+          "name": "ck_batch_inventory_sessions_quantities",
+          "value": "\"batch_inventory_sessions\".\"handed_in_qty\" >= 0 AND \"batch_inventory_sessions\".\"settled_qty\" >= 0 AND \"batch_inventory_sessions\".\"returned_qty\" >= 0 AND \"batch_inventory_sessions\".\"shortage_qty\" >= 0"
+        },
+        "ck_batch_inventory_sessions_settlement": {
+          "name": "ck_batch_inventory_sessions_settlement",
+          "value": "\"batch_inventory_sessions\".\"settled_qty\" + \"batch_inventory_sessions\".\"returned_qty\" + \"batch_inventory_sessions\".\"shortage_qty\" <= \"batch_inventory_sessions\".\"handed_in_qty\""
+        },
+        "ck_batch_inventory_sessions_recovery": {
+          "name": "ck_batch_inventory_sessions_recovery",
+          "value": "\"batch_inventory_sessions\".\"status\" <> 'recovery_required' OR \"batch_inventory_sessions\".\"recovery_reason\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.business_links": {
+      "name": "business_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_external_ref": {
+          "name": "source_external_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_external_ref": {
+          "name": "target_external_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relation_name": {
+          "name": "relation_name",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_business_links_source_id": {
+          "name": "idx_business_links_source_id",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_business_links_source_external_ref": {
+          "name": "idx_business_links_source_external_ref",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_external_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_business_links_target_id": {
+          "name": "idx_business_links_target_id",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_business_links_target_external_ref": {
+          "name": "idx_business_links_target_external_ref",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_external_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_business_links_relation_name": {
+          "name": "idx_business_links_relation_name",
+          "columns": [
+            {
+              "expression": "relation_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_business_links_occurred_at": {
+          "name": "idx_business_links_occurred_at",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "business_links_source_ref_required": {
+          "name": "business_links_source_ref_required",
+          "value": "\"business_links\".\"source_id\" IS NOT NULL OR \"business_links\".\"source_external_ref\" IS NOT NULL"
+        },
+        "business_links_target_ref_required": {
+          "name": "business_links_target_ref_required",
+          "value": "\"business_links\".\"target_id\" IS NOT NULL OR \"business_links\".\"target_external_ref\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_profiles": {
+      "name": "delivery_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_delivery_days": {
+          "name": "avg_delivery_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_snapshot": {
+          "name": "sender_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_address_snapshot": {
+          "name": "origin_address_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "return_address_snapshot": {
+          "name": "return_address_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carrier_account_ref": {
+          "name": "carrier_account_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_fulfillment_modes": {
+          "name": "supported_fulfillment_modes",
+          "type": "fulfillment_mode[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handling_flags": {
+          "name": "handling_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispatch_attempt_sources": {
+      "name": "dispatch_attempt_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dispatch_attempt_id": {
+          "name": "dispatch_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_line_id": {
+          "name": "shipment_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_location_id": {
+          "name": "source_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qty": {
+          "name": "qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_event_id": {
+          "name": "stock_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_dispatch_attempt_sources_stock_event": {
+          "name": "uq_dispatch_attempt_sources_stock_event",
+          "columns": [
+            {
+              "expression": "stock_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispatch_attempt_sources\".\"stock_event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dispatch_attempt_sources_line": {
+          "name": "idx_dispatch_attempt_sources_line",
+          "columns": [
+            {
+              "expression": "shipment_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispatch_attempt_sources_dispatch_attempt_id_dispatch_attempts_id_fk": {
+          "name": "dispatch_attempt_sources_dispatch_attempt_id_dispatch_attempts_id_fk",
+          "tableFrom": "dispatch_attempt_sources",
+          "tableTo": "dispatch_attempts",
+          "columnsFrom": [
+            "dispatch_attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dispatch_attempt_sources_shipment_line_id_shipment_lines_id_fk": {
+          "name": "dispatch_attempt_sources_shipment_line_id_shipment_lines_id_fk",
+          "tableFrom": "dispatch_attempt_sources",
+          "tableTo": "shipment_lines",
+          "columnsFrom": [
+            "shipment_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dispatch_attempt_sources_source_location_id_locations_id_fk": {
+          "name": "dispatch_attempt_sources_source_location_id_locations_id_fk",
+          "tableFrom": "dispatch_attempt_sources",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "source_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dispatch_attempt_sources_stock_event_id_stock_events_id_fk": {
+          "name": "dispatch_attempt_sources_stock_event_id_stock_events_id_fk",
+          "tableFrom": "dispatch_attempt_sources",
+          "tableTo": "stock_events",
+          "columnsFrom": [
+            "stock_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_dispatch_attempt_sources_grain": {
+          "name": "uq_dispatch_attempt_sources_grain",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dispatch_attempt_id",
+            "shipment_line_id",
+            "source_location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_dispatch_attempt_sources_qty_positive": {
+          "name": "ck_dispatch_attempt_sources_qty_positive",
+          "value": "\"dispatch_attempt_sources\".\"qty\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.dispatch_attempts": {
+      "name": "dispatch_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_no": {
+          "name": "attempt_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dispatch_attempt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waybill_id": {
+          "name": "waybill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_journal_id": {
+          "name": "stock_journal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reversal_journal_id": {
+          "name": "reversal_journal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carrier_accepted_at": {
+          "name": "carrier_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recalled_at": {
+          "name": "recalled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recovery_code": {
+          "name": "recovery_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_dispatch_attempts_stock_journal": {
+          "name": "uq_dispatch_attempts_stock_journal",
+          "columns": [
+            {
+              "expression": "stock_journal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispatch_attempts\".\"stock_journal_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_dispatch_attempts_reversal_journal": {
+          "name": "uq_dispatch_attempts_reversal_journal",
+          "columns": [
+            {
+              "expression": "reversal_journal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispatch_attempts\".\"reversal_journal_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dispatch_attempts_shipment_status": {
+          "name": "idx_dispatch_attempts_shipment_status",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispatch_attempts_shipment_id_shipments_id_fk": {
+          "name": "dispatch_attempts_shipment_id_shipments_id_fk",
+          "tableFrom": "dispatch_attempts",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dispatch_attempts_waybill_id_waybills_id_fk": {
+          "name": "dispatch_attempts_waybill_id_waybills_id_fk",
+          "tableFrom": "dispatch_attempts",
+          "tableTo": "waybills",
+          "columnsFrom": [
+            "waybill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dispatch_attempts_stock_journal_id_stock_journals_id_fk": {
+          "name": "dispatch_attempts_stock_journal_id_stock_journals_id_fk",
+          "tableFrom": "dispatch_attempts",
+          "tableTo": "stock_journals",
+          "columnsFrom": [
+            "stock_journal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dispatch_attempts_reversal_journal_id_stock_journals_id_fk": {
+          "name": "dispatch_attempts_reversal_journal_id_stock_journals_id_fk",
+          "tableFrom": "dispatch_attempts",
+          "tableTo": "stock_journals",
+          "columnsFrom": [
+            "reversal_journal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_dispatch_attempts_shipment_attempt": {
+          "name": "uq_dispatch_attempts_shipment_attempt",
+          "nullsNotDistinct": false,
+          "columns": [
+            "shipment_id",
+            "attempt_no"
+          ]
+        },
+        "uq_dispatch_attempts_idempotency": {
+          "name": "uq_dispatch_attempts_idempotency",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_dispatch_attempts_attempt_no_positive": {
+          "name": "ck_dispatch_attempts_attempt_no_positive",
+          "value": "\"dispatch_attempts\".\"attempt_no\" > 0"
+        },
+        "ck_dispatch_attempts_dispatched_at": {
+          "name": "ck_dispatch_attempts_dispatched_at",
+          "value": "\"dispatch_attempts\".\"status\" NOT IN ('dispatched', 'recalled') OR (\"dispatch_attempts\".\"dispatched_at\" IS NOT NULL AND \"dispatch_attempts\".\"stock_journal_id\" IS NOT NULL)"
+        },
+        "ck_dispatch_attempts_recalled_at": {
+          "name": "ck_dispatch_attempts_recalled_at",
+          "value": "\"dispatch_attempts\".\"status\" <> 'recalled' OR (\"dispatch_attempts\".\"recalled_at\" IS NOT NULL AND \"dispatch_attempts\".\"reversal_journal_id\" IS NOT NULL)"
+        },
+        "ck_dispatch_attempts_distinct_journals": {
+          "name": "ck_dispatch_attempts_distinct_journals",
+          "value": "\"dispatch_attempts\".\"stock_journal_id\" IS NULL OR \"dispatch_attempts\".\"reversal_journal_id\" IS NULL OR \"dispatch_attempts\".\"stock_journal_id\" <> \"dispatch_attempts\".\"reversal_journal_id\""
+        },
+        "ck_dispatch_attempts_recall_chronology": {
+          "name": "ck_dispatch_attempts_recall_chronology",
+          "value": "\"dispatch_attempts\".\"status\" <> 'recalled' OR \"dispatch_attempts\".\"recalled_at\" >= \"dispatch_attempts\".\"dispatched_at\""
+        },
+        "ck_dispatch_attempts_recall_carrier": {
+          "name": "ck_dispatch_attempts_recall_carrier",
+          "value": "\"dispatch_attempts\".\"status\" <> 'recalled' OR \"dispatch_attempts\".\"carrier_accepted_at\" IS NULL"
+        },
+        "ck_dispatch_attempts_carrier_acceptance": {
+          "name": "ck_dispatch_attempts_carrier_acceptance",
+          "value": "\"dispatch_attempts\".\"carrier_accepted_at\" IS NULL OR (\"dispatch_attempts\".\"dispatched_at\" IS NOT NULL AND \"dispatch_attempts\".\"carrier_accepted_at\" >= \"dispatch_attempts\".\"dispatched_at\")"
+        },
+        "ck_dispatch_attempts_recovery_code": {
+          "name": "ck_dispatch_attempts_recovery_code",
+          "value": "\"dispatch_attempts\".\"status\" <> 'recovery_required' OR \"dispatch_attempts\".\"recovery_code\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.exchange_request_items": {
+      "name": "exchange_request_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "exchange_request_id": {
+          "name": "exchange_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_order_line_id": {
+          "name": "sales_order_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "desired_variant_id": {
+          "name": "desired_variant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_exchange_request_items_request": {
+          "name": "idx_exchange_request_items_request",
+          "columns": [
+            {
+              "expression": "exchange_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_exchange_request_items_order_line": {
+          "name": "idx_exchange_request_items_order_line",
+          "columns": [
+            {
+              "expression": "sales_order_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exchange_request_items_exchange_request_id_exchange_requests_id_fk": {
+          "name": "exchange_request_items_exchange_request_id_exchange_requests_id_fk",
+          "tableFrom": "exchange_request_items",
+          "tableTo": "exchange_requests",
+          "columnsFrom": [
+            "exchange_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exchange_requests": {
+      "name": "exchange_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "exchange_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "exchange_reason_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_detail": {
+          "name": "reason_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_exchange_requests_sales_order": {
+          "name": "idx_exchange_requests_sales_order",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_exchange_requests_status": {
+          "name": "idx_exchange_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_exchange_requests_customer": {
+          "name": "idx_exchange_requests_customer",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exchange_requests_sales_order_id_sales_orders_id_fk": {
+          "name": "exchange_requests_sales_order_id_sales_orders_id_fk",
+          "tableFrom": "exchange_requests",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "sales_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fulfillment_command_requests": {
+      "name": "fulfillment_command_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "command_type": {
+          "name": "command_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "fulfillment_command_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_snapshot": {
+          "name": "response_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_fulfillment_command_status": {
+          "name": "idx_fulfillment_command_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fulfillment_command_operation": {
+          "name": "idx_fulfillment_command_operation",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fulfillment_command_attempt": {
+          "name": "idx_fulfillment_command_attempt",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fulfillment_command_requests_attempt_id_dispatch_attempts_id_fk": {
+          "name": "fulfillment_command_requests_attempt_id_dispatch_attempts_id_fk",
+          "tableFrom": "fulfillment_command_requests",
+          "tableTo": "dispatch_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_fulfillment_command_idempotency": {
+          "name": "uq_fulfillment_command_idempotency",
+          "nullsNotDistinct": false,
+          "columns": [
+            "command_type",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_fulfillment_command_request_hash": {
+          "name": "ck_fulfillment_command_request_hash",
+          "value": "length(\"fulfillment_command_requests\".\"request_hash\") = 64"
+        },
+        "ck_fulfillment_command_completion": {
+          "name": "ck_fulfillment_command_completion",
+          "value": "\"fulfillment_command_requests\".\"status\" <> 'completed' OR (\"fulfillment_command_requests\".\"completed_at\" IS NOT NULL AND \"fulfillment_command_requests\".\"response_snapshot\" IS NOT NULL)"
+        },
+        "ck_fulfillment_command_failure": {
+          "name": "ck_fulfillment_command_failure",
+          "value": "\"fulfillment_command_requests\".\"status\" <> 'failed' OR \"fulfillment_command_requests\".\"last_error\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fulfillment_order_creation_backlogs": {
+      "name": "fulfillment_order_creation_backlogs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fulfillment_order_id": {
+          "name": "fulfillment_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "fulfillment_order_creation_backlog_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "waiting_variant_ids": {
+          "name": "waiting_variant_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_details": {
+          "name": "failure_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fo_creation_backlogs_status_next_attempt": {
+          "name": "idx_fo_creation_backlogs_status_next_attempt",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fo_creation_backlogs_fulfillment_order": {
+          "name": "idx_fo_creation_backlogs_fulfillment_order",
+          "columns": [
+            {
+              "expression": "fulfillment_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fo_creation_backlogs_waiting_variant_ids": {
+          "name": "idx_fo_creation_backlogs_waiting_variant_ids",
+          "columns": [
+            {
+              "expression": "waiting_variant_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fulfillment_order_creation_backlogs_sales_order_id_sales_orders_id_fk": {
+          "name": "fulfillment_order_creation_backlogs_sales_order_id_sales_orders_id_fk",
+          "tableFrom": "fulfillment_order_creation_backlogs",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "sales_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fulfillment_order_creation_backlogs_fulfillment_order_id_fulfillment_orders_id_fk": {
+          "name": "fulfillment_order_creation_backlogs_fulfillment_order_id_fulfillment_orders_id_fk",
+          "tableFrom": "fulfillment_order_creation_backlogs",
+          "tableTo": "fulfillment_orders",
+          "columnsFrom": [
+            "fulfillment_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fulfillment_order_creation_backlogs_sales_order_id_unique": {
+          "name": "fulfillment_order_creation_backlogs_sales_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sales_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fulfillment_order_items": {
+      "name": "fulfillment_order_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fulfillment_order_id": {
+          "name": "fulfillment_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_order_line_id": {
+          "name": "sales_order_line_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mapping_snapshot_id": {
+          "name": "mapping_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qty": {
+          "name": "qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reserved_qty": {
+          "name": "reserved_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "picked_qty": {
+          "name": "picked_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "shipped_qty": {
+          "name": "shipped_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "canceled_qty": {
+          "name": "canceled_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fulfillment_order_items_fo": {
+          "name": "idx_fulfillment_order_items_fo",
+          "columns": [
+            {
+              "expression": "fulfillment_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fulfillment_order_items_so": {
+          "name": "idx_fulfillment_order_items_so",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fulfillment_order_items_sku": {
+          "name": "idx_fulfillment_order_items_sku",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fulfillment_order_items_variant": {
+          "name": "idx_fulfillment_order_items_variant",
+          "columns": [
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fulfillment_order_items_fulfillment_order_id_fulfillment_orders_id_fk": {
+          "name": "fulfillment_order_items_fulfillment_order_id_fulfillment_orders_id_fk",
+          "tableFrom": "fulfillment_order_items",
+          "tableTo": "fulfillment_orders",
+          "columnsFrom": [
+            "fulfillment_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fulfillment_order_items_mapping_snapshot_id_product_sku_mapping_snapshots_id_fk": {
+          "name": "fulfillment_order_items_mapping_snapshot_id_product_sku_mapping_snapshots_id_fk",
+          "tableFrom": "fulfillment_order_items",
+          "tableTo": "product_sku_mapping_snapshots",
+          "columnsFrom": [
+            "mapping_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fulfillment_order_items_sku_id_skus_id_fk": {
+          "name": "fulfillment_order_items_sku_id_skus_id_fk",
+          "tableFrom": "fulfillment_order_items",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_fulfillment_order_items_qty_positive": {
+          "name": "ck_fulfillment_order_items_qty_positive",
+          "value": "\"fulfillment_order_items\".\"qty\" > 0"
+        },
+        "ck_fulfillment_order_items_progress_nonnegative": {
+          "name": "ck_fulfillment_order_items_progress_nonnegative",
+          "value": "\"fulfillment_order_items\".\"reserved_qty\" >= 0 AND \"fulfillment_order_items\".\"picked_qty\" >= 0 AND \"fulfillment_order_items\".\"shipped_qty\" >= 0 AND \"fulfillment_order_items\".\"canceled_qty\" >= 0"
+        },
+        "ck_fulfillment_order_items_settled_within_qty": {
+          "name": "ck_fulfillment_order_items_settled_within_qty",
+          "value": "\"fulfillment_order_items\".\"shipped_qty\" + \"fulfillment_order_items\".\"canceled_qty\" <= \"fulfillment_order_items\".\"qty\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fulfillment_orders": {
+      "name": "fulfillment_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "fulfillment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "direct_ship_status": {
+          "name": "direct_ship_status",
+          "type": "direct_ship_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fulfillment_mode": {
+          "name": "fulfillment_mode",
+          "type": "fulfillment_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "task_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "total_items": {
+          "name": "total_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_qty": {
+          "name": "total_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_reserved_qty": {
+          "name": "total_reserved_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reservation_failure_reason": {
+          "name": "reservation_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reservation_failure_details": {
+          "name": "reservation_failure_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocated_at": {
+          "name": "allocated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipped_at": {
+          "name": "shipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_address": {
+          "name": "shipping_address",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_no": {
+          "name": "label_no",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_fulfillment_orders_sales_order": {
+          "name": "uq_fulfillment_orders_sales_order",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"fulfillment_orders\".\"sales_order_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fulfillment_orders_sales_order_id_sales_orders_id_fk": {
+          "name": "fulfillment_orders_sales_order_id_sales_orders_id_fk",
+          "tableFrom": "fulfillment_orders",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "sales_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fulfillment_orders_warehouse_id_warehouses_id_fk": {
+          "name": "fulfillment_orders_warehouse_id_warehouses_id_fk",
+          "tableFrom": "fulfillment_orders",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fulfillment_orders_owner_id_holders_id_fk": {
+          "name": "fulfillment_orders_owner_id_holders_id_fk",
+          "tableFrom": "fulfillment_orders",
+          "tableTo": "holders",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.holders": {
+      "name": "holders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_our_asset": {
+          "name": "is_our_asset",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.holidays": {
+      "name": "holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_plan_items": {
+      "name": "inbound_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_qty": {
+          "name": "expected_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_qty": {
+          "name": "received_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "inbound_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_inbound_plan_items_plan": {
+          "name": "idx_inbound_plan_items_plan",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbound_plan_items_sku": {
+          "name": "idx_inbound_plan_items_sku",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbound_plan_items_plan_id_inbound_plans_id_fk": {
+          "name": "inbound_plan_items_plan_id_inbound_plans_id_fk",
+          "tableFrom": "inbound_plan_items",
+          "tableTo": "inbound_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbound_plan_items_sku_id_skus_id_fk": {
+          "name": "inbound_plan_items_sku_id_skus_id_fk",
+          "tableFrom": "inbound_plan_items",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_plans": {
+      "name": "inbound_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "expected_date": {
+          "name": "expected_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "plan_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'destination'"
+        },
+        "parent_plan_id": {
+          "name": "parent_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_purchase_order_id": {
+          "name": "linked_purchase_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_warehouse_id": {
+          "name": "destination_warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requires_transfer": {
+          "name": "requires_transfer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "inbound_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_inbound_plans_wh_date": {
+          "name": "idx_inbound_plans_wh_date",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expected_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbound_plans_destination": {
+          "name": "idx_inbound_plans_destination",
+          "columns": [
+            {
+              "expression": "destination_warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expected_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbound_plans_warehouse_type_status": {
+          "name": "idx_inbound_plans_warehouse_type_status",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbound_plans_parent": {
+          "name": "idx_inbound_plans_parent",
+          "columns": [
+            {
+              "expression": "parent_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbound_plans_purchase_order": {
+          "name": "idx_inbound_plans_purchase_order",
+          "columns": [
+            {
+              "expression": "linked_purchase_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbound_plans_warehouse_id_warehouses_id_fk": {
+          "name": "inbound_plans_warehouse_id_warehouses_id_fk",
+          "tableFrom": "inbound_plans",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbound_plans_parent_plan_id_inbound_plans_id_fk": {
+          "name": "inbound_plans_parent_plan_id_inbound_plans_id_fk",
+          "tableFrom": "inbound_plans",
+          "tableTo": "inbound_plans",
+          "columnsFrom": [
+            "parent_plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inbound_plans_linked_purchase_order_id_purchase_orders_id_fk": {
+          "name": "inbound_plans_linked_purchase_order_id_purchase_orders_id_fk",
+          "tableFrom": "inbound_plans",
+          "tableTo": "purchase_orders",
+          "columnsFrom": [
+            "linked_purchase_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inbound_plans_destination_warehouse_id_warehouses_id_fk": {
+          "name": "inbound_plans_destination_warehouse_id_warehouses_id_fk",
+          "tableFrom": "inbound_plans",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "destination_warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_receipt_lines": {
+      "name": "inbound_receipt_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "receipt_id": {
+          "name": "receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_location_id": {
+          "name": "origin_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "returned_qty": {
+          "name": "returned_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "canceled_qty": {
+          "name": "canceled_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "putaway_from_origin_qty": {
+          "name": "putaway_from_origin_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "plan_item_id": {
+          "name": "plan_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_inbound_lines_receipt": {
+          "name": "idx_inbound_lines_receipt",
+          "columns": [
+            {
+              "expression": "receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbound_lines_sku": {
+          "name": "idx_inbound_lines_sku",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbound_receipt_lines_receipt_id_inbound_receipts_id_fk": {
+          "name": "inbound_receipt_lines_receipt_id_inbound_receipts_id_fk",
+          "tableFrom": "inbound_receipt_lines",
+          "tableTo": "inbound_receipts",
+          "columnsFrom": [
+            "receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbound_receipt_lines_sku_id_skus_id_fk": {
+          "name": "inbound_receipt_lines_sku_id_skus_id_fk",
+          "tableFrom": "inbound_receipt_lines",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "inbound_receipt_lines_origin_location_id_locations_id_fk": {
+          "name": "inbound_receipt_lines_origin_location_id_locations_id_fk",
+          "tableFrom": "inbound_receipt_lines",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "origin_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_receipt_lines_event_id_stock_events_id_fk": {
+          "name": "inbound_receipt_lines_event_id_stock_events_id_fk",
+          "tableFrom": "inbound_receipt_lines",
+          "tableTo": "stock_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_receipt_lines_plan_item_id_inbound_plan_items_id_fk": {
+          "name": "inbound_receipt_lines_plan_item_id_inbound_plan_items_id_fk",
+          "tableFrom": "inbound_receipt_lines",
+          "tableTo": "inbound_plan_items",
+          "columnsFrom": [
+            "plan_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_receipts": {
+      "name": "inbound_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "method": {
+          "name": "method",
+          "type": "inbound_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "inbound_receipt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "total_quantity": {
+          "name": "total_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "journal_id": {
+          "name": "journal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_inbound_receipts_wh_time": {
+          "name": "idx_inbound_receipts_wh_time",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbound_receipts_warehouse_id_warehouses_id_fk": {
+          "name": "inbound_receipts_warehouse_id_warehouses_id_fk",
+          "tableFrom": "inbound_receipts",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbound_receipts_location_id_locations_id_fk": {
+          "name": "inbound_receipts_location_id_locations_id_fk",
+          "tableFrom": "inbound_receipts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_receipts_journal_id_stock_journals_id_fk": {
+          "name": "inbound_receipts_journal_id_stock_journals_id_fk",
+          "tableFrom": "inbound_receipts",
+          "tableTo": "stock_journals",
+          "columnsFrom": [
+            "journal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_work_logs": {
+      "name": "inbound_work_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "inbound_work_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "receipt_id": {
+          "name": "receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_item_id": {
+          "name": "plan_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_location_id": {
+          "name": "from_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_location_id": {
+          "name": "to_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "inbound_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_inbound_work_time": {
+          "name": "idx_inbound_work_time",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbound_work_logs_receipt_id_inbound_receipts_id_fk": {
+          "name": "inbound_work_logs_receipt_id_inbound_receipts_id_fk",
+          "tableFrom": "inbound_work_logs",
+          "tableTo": "inbound_receipts",
+          "columnsFrom": [
+            "receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_work_logs_line_id_inbound_receipt_lines_id_fk": {
+          "name": "inbound_work_logs_line_id_inbound_receipt_lines_id_fk",
+          "tableFrom": "inbound_work_logs",
+          "tableTo": "inbound_receipt_lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_work_logs_plan_item_id_inbound_plan_items_id_fk": {
+          "name": "inbound_work_logs_plan_item_id_inbound_plan_items_id_fk",
+          "tableFrom": "inbound_work_logs",
+          "tableTo": "inbound_plan_items",
+          "columnsFrom": [
+            "plan_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_work_logs_sku_id_skus_id_fk": {
+          "name": "inbound_work_logs_sku_id_skus_id_fk",
+          "tableFrom": "inbound_work_logs",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_work_logs_warehouse_id_warehouses_id_fk": {
+          "name": "inbound_work_logs_warehouse_id_warehouses_id_fk",
+          "tableFrom": "inbound_work_logs",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_work_logs_from_location_id_locations_id_fk": {
+          "name": "inbound_work_logs_from_location_id_locations_id_fk",
+          "tableFrom": "inbound_work_logs",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "from_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_work_logs_to_location_id_locations_id_fk": {
+          "name": "inbound_work_logs_to_location_id_locations_id_fk",
+          "tableFrom": "inbound_work_logs",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "to_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_work_logs_event_id_stock_events_id_fk": {
+          "name": "inbound_work_logs_event_id_stock_events_id_fk",
+          "tableFrom": "inbound_work_logs",
+          "tableTo": "stock_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inspection_issues": {
+      "name": "inspection_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "foi_id": {
+          "name": "foi_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "qty": {
+          "name": "qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inspector_user_id": {
+          "name": "inspector_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_inspection_issues_foi": {
+          "name": "idx_inspection_issues_foi",
+          "columns": [
+            {
+              "expression": "foi_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inspection_issues_shipment": {
+          "name": "idx_inspection_issues_shipment",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inspection_issues_foi_id_fulfillment_order_items_id_fk": {
+          "name": "inspection_issues_foi_id_fulfillment_order_items_id_fk",
+          "tableFrom": "inspection_issues",
+          "tableTo": "fulfillment_order_items",
+          "columnsFrom": [
+            "foi_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inspection_issues_shipment_id_shipments_id_fk": {
+          "name": "inspection_issues_shipment_id_shipments_id_fk",
+          "tableFrom": "inspection_issues",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_idempotency_requests": {
+      "name": "inventory_idempotency_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_inv_idem_requests_endpoint_key": {
+          "name": "uq_inv_idem_requests_endpoint_key",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inv_idem_requests_created_at": {
+          "name": "idx_inv_idem_requests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_columns": {
+      "name": "location_columns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_name": {
+          "name": "column_name",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_columns_warehouse_name": {
+          "name": "idx_columns_warehouse_name",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "column_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_columns_warehouse_id_warehouses_id_fk": {
+          "name": "location_columns_warehouse_id_warehouses_id_fk",
+          "tableFrom": "location_columns",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_columns_warehouse_id_column_name_unique": {
+          "name": "location_columns_warehouse_id_column_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "warehouse_id",
+            "column_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_racks": {
+      "name": "location_racks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rack_number": {
+          "name": "rack_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_bin_start": {
+          "name": "default_bin_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_bin_end": {
+          "name": "default_bin_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "auto_generate_bins": {
+          "name": "auto_generate_bins",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "physical_width": {
+          "name": "physical_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "physical_height": {
+          "name": "physical_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_racks_column_number": {
+          "name": "idx_racks_column_number",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rack_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_racks_column_id_location_columns_id_fk": {
+          "name": "location_racks_column_id_location_columns_id_fk",
+          "tableFrom": "location_racks",
+          "tableTo": "location_columns",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_racks_column_id_rack_number_unique": {
+          "name": "location_racks_column_id_rack_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "column_id",
+            "rack_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "location_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rack_id": {
+          "name": "rack_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bin_identifier": {
+          "name": "bin_identifier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_limit": {
+          "name": "capacity_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fifo_rank": {
+          "name": "fifo_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_expiry_separated": {
+          "name": "is_expiry_separated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "system_role": {
+          "name": "system_role",
+          "type": "system_location_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_locations_warehouse_type": {
+          "name": "idx_locations_warehouse_type",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_locations_rack_bin": {
+          "name": "idx_locations_rack_bin",
+          "columns": [
+            {
+              "expression": "rack_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bin_identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_warehouse_id_warehouses_id_fk": {
+          "name": "locations_warehouse_id_warehouses_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "locations_rack_id_location_racks_id_fk": {
+          "name": "locations_rack_id_location_racks_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "location_racks",
+          "columnsFrom": [
+            "rack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "locations_warehouse_id_code_unique": {
+          "name": "locations_warehouse_id_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "warehouse_id",
+            "code"
+          ]
+        },
+        "locations_warehouse_id_system_role_unique": {
+          "name": "locations_warehouse_id_system_role_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "warehouse_id",
+            "system_role"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_locations_type": {
+          "name": "ck_locations_type",
+          "value": "(\n        (location_type = 'standard' AND rack_id IS NOT NULL AND bin_identifier IS NOT NULL)\n        OR \n        (location_type = 'zone' AND rack_id IS NULL AND bin_identifier IS NULL)\n    )"
+        },
+        "ck_locations_system_role": {
+          "name": "ck_locations_system_role",
+          "value": "( (is_system = true AND system_role IS NOT NULL) OR (is_system = false AND system_role IS NULL) )"
+        },
+        "ck_locations_system_zone": {
+          "name": "ck_locations_system_zone",
+          "value": "( is_system = false OR location_type = 'zone' )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.merge_groups": {
+      "name": "merge_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_email": {
+          "name": "customer_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipping_address_hash": {
+          "name": "shipping_address_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_shipping_fee": {
+          "name": "total_shipping_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "order_count": {
+          "name": "order_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movement_job_lines": {
+      "name": "movement_job_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_location_id": {
+          "name": "from_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_location_id": {
+          "name": "to_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_movement_lines_job": {
+          "name": "idx_movement_lines_job",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_movement_lines_sku": {
+          "name": "idx_movement_lines_sku",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "movement_job_lines_job_id_movement_jobs_id_fk": {
+          "name": "movement_job_lines_job_id_movement_jobs_id_fk",
+          "tableFrom": "movement_job_lines",
+          "tableTo": "movement_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "movement_job_lines_sku_id_skus_id_fk": {
+          "name": "movement_job_lines_sku_id_skus_id_fk",
+          "tableFrom": "movement_job_lines",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "movement_job_lines_from_location_id_locations_id_fk": {
+          "name": "movement_job_lines_from_location_id_locations_id_fk",
+          "tableFrom": "movement_job_lines",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "from_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "movement_job_lines_to_location_id_locations_id_fk": {
+          "name": "movement_job_lines_to_location_id_locations_id_fk",
+          "tableFrom": "movement_job_lines",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "to_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "movement_job_lines_event_id_stock_events_id_fk": {
+          "name": "movement_job_lines_event_id_stock_events_id_fk",
+          "tableFrom": "movement_job_lines",
+          "tableTo": "stock_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movement_jobs": {
+      "name": "movement_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_quantity": {
+          "name": "total_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "journal_id": {
+          "name": "journal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_movement_jobs_wh_time": {
+          "name": "idx_movement_jobs_wh_time",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "movement_jobs_warehouse_id_warehouses_id_fk": {
+          "name": "movement_jobs_warehouse_id_warehouses_id_fk",
+          "tableFrom": "movement_jobs",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "movement_jobs_journal_id_stock_journals_id_fk": {
+          "name": "movement_jobs_journal_id_stock_journals_id_fk",
+          "tableFrom": "movement_jobs",
+          "tableTo": "stock_journals",
+          "columnsFrom": [
+            "journal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movement_work_logs": {
+      "name": "movement_work_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MOVE'"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_location_id": {
+          "name": "from_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_location_id": {
+          "name": "to_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_movement_work_time": {
+          "name": "idx_movement_work_time",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "movement_work_logs_job_id_movement_jobs_id_fk": {
+          "name": "movement_work_logs_job_id_movement_jobs_id_fk",
+          "tableFrom": "movement_work_logs",
+          "tableTo": "movement_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "movement_work_logs_line_id_movement_job_lines_id_fk": {
+          "name": "movement_work_logs_line_id_movement_job_lines_id_fk",
+          "tableFrom": "movement_work_logs",
+          "tableTo": "movement_job_lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "movement_work_logs_sku_id_skus_id_fk": {
+          "name": "movement_work_logs_sku_id_skus_id_fk",
+          "tableFrom": "movement_work_logs",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "movement_work_logs_warehouse_id_warehouses_id_fk": {
+          "name": "movement_work_logs_warehouse_id_warehouses_id_fk",
+          "tableFrom": "movement_work_logs",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "movement_work_logs_from_location_id_locations_id_fk": {
+          "name": "movement_work_logs_from_location_id_locations_id_fk",
+          "tableFrom": "movement_work_logs",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "from_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "movement_work_logs_to_location_id_locations_id_fk": {
+          "name": "movement_work_logs_to_location_id_locations_id_fk",
+          "tableFrom": "movement_work_logs",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "to_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "movement_work_logs_event_id_stock_events_id_fk": {
+          "name": "movement_work_logs_event_id_stock_events_id_fk",
+          "tableFrom": "movement_work_logs",
+          "tableTo": "stock_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_events": {
+      "name": "order_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type_order",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_events_order_id_sales_orders_id_fk": {
+          "name": "order_events_order_id_sales_orders_id_fk",
+          "tableFrom": "order_events",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_events_event_id_unique": {
+          "name": "order_events_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outbound_batch_work_items": {
+      "name": "outbound_batch_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "outbound_batch_work_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "picker_id": {
+          "name": "picker_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picker_claimed_at": {
+          "name": "picker_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picker_released_at": {
+          "name": "picker_released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "packer_id": {
+          "name": "packer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "packer_claimed_at": {
+          "name": "packer_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "packer_released_at": {
+          "name": "packer_released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handed_off_at": {
+          "name": "handed_off_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_version": {
+          "name": "lease_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recovery_reason": {
+          "name": "recovery_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waiting_operation_id": {
+          "name": "waiting_operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_outbound_work_item_active_shipment": {
+          "name": "uq_outbound_work_item_active_shipment",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"outbound_batch_work_items\".\"status\" NOT IN ('completed', 'excluded')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outbound_work_items_batch_status": {
+          "name": "idx_outbound_work_items_batch_status",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outbound_work_items_waiting_operation": {
+          "name": "idx_outbound_work_items_waiting_operation",
+          "columns": [
+            {
+              "expression": "waiting_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outbound_batch_work_items_batch_id_outbound_batches_id_fk": {
+          "name": "outbound_batch_work_items_batch_id_outbound_batches_id_fk",
+          "tableFrom": "outbound_batch_work_items",
+          "tableTo": "outbound_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "outbound_batch_work_items_shipment_id_shipments_id_fk": {
+          "name": "outbound_batch_work_items_shipment_id_shipments_id_fk",
+          "tableFrom": "outbound_batch_work_items",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "outbound_batch_work_items_waiting_operation_id_shipment_operations_id_fk": {
+          "name": "outbound_batch_work_items_waiting_operation_id_shipment_operations_id_fk",
+          "tableFrom": "outbound_batch_work_items",
+          "tableTo": "shipment_operations",
+          "columnsFrom": [
+            "waiting_operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_outbound_work_items_lease_version": {
+          "name": "ck_outbound_work_items_lease_version",
+          "value": "\"outbound_batch_work_items\".\"lease_version\" >= 0"
+        },
+        "ck_outbound_work_items_exclusion": {
+          "name": "ck_outbound_work_items_exclusion",
+          "value": "\"outbound_batch_work_items\".\"status\" <> 'excluded' OR \"outbound_batch_work_items\".\"exclusion_reason\" IS NOT NULL"
+        },
+        "ck_outbound_work_items_recovery": {
+          "name": "ck_outbound_work_items_recovery",
+          "value": "\"outbound_batch_work_items\".\"status\" <> 'short_pick_recovery' OR \"outbound_batch_work_items\".\"recovery_reason\" IS NOT NULL"
+        },
+        "ck_outbound_work_items_completion": {
+          "name": "ck_outbound_work_items_completion",
+          "value": "\"outbound_batch_work_items\".\"status\" <> 'completed' OR \"outbound_batch_work_items\".\"completed_at\" IS NOT NULL"
+        },
+        "ck_outbound_work_items_picker_release": {
+          "name": "ck_outbound_work_items_picker_release",
+          "value": "\"outbound_batch_work_items\".\"picker_released_at\" IS NULL OR (\"outbound_batch_work_items\".\"picker_claimed_at\" IS NOT NULL AND \"outbound_batch_work_items\".\"picker_released_at\" >= \"outbound_batch_work_items\".\"picker_claimed_at\")"
+        },
+        "ck_outbound_work_items_packer_release": {
+          "name": "ck_outbound_work_items_packer_release",
+          "value": "\"outbound_batch_work_items\".\"packer_released_at\" IS NULL OR (\"outbound_batch_work_items\".\"packer_claimed_at\" IS NOT NULL AND \"outbound_batch_work_items\".\"packer_released_at\" >= \"outbound_batch_work_items\".\"packer_claimed_at\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.outbound_batches": {
+      "name": "outbound_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "batch_number": {
+          "name": "batch_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "batch_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "picking_method": {
+          "name": "picking_method",
+          "type": "picking_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cart_capacity": {
+          "name": "cart_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_picking_at": {
+          "name": "scheduled_picking_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_outbound_batches_warehouse_status": {
+          "name": "idx_outbound_batches_warehouse_status",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outbound_batches_number": {
+          "name": "idx_outbound_batches_number",
+          "columns": [
+            {
+              "expression": "batch_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outbound_batches_warehouse_id_warehouses_id_fk": {
+          "name": "outbound_batches_warehouse_id_warehouses_id_fk",
+          "tableFrom": "outbound_batches",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "outbound_batches_batch_number_unique": {
+          "name": "outbound_batches_batch_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "batch_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outbox_events": {
+      "name": "outbox_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_type": {
+          "name": "aggregate_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partition_key": {
+          "name": "partition_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "outbox_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_outbox_status_next": {
+          "name": "idx_outbox_status_next",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outbox_topic_status_next": {
+          "name": "idx_outbox_topic_status_next",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_outbox_topic_event_idempotency": {
+          "name": "uq_outbox_topic_event_idempotency",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.picking_plan_members": {
+      "name": "picking_plan_members",
+      "schema": "",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_version": {
+          "name": "reservation_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retire_reason": {
+          "name": "retire_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_by_operation_id": {
+          "name": "retired_by_operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_by_operation_type": {
+          "name": "retired_by_operation_type",
+          "type": "shipment_operation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_picking_plan_members_shipment": {
+          "name": "idx_picking_plan_members_shipment",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_picking_plan_members_active_shipment": {
+          "name": "idx_picking_plan_members_active_shipment",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"picking_plan_members\".\"retired_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "picking_plan_members_plan_id_picking_plans_id_fk": {
+          "name": "picking_plan_members_plan_id_picking_plans_id_fk",
+          "tableFrom": "picking_plan_members",
+          "tableTo": "picking_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "picking_plan_members_shipment_id_shipments_id_fk": {
+          "name": "picking_plan_members_shipment_id_shipments_id_fk",
+          "tableFrom": "picking_plan_members",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fk_picking_plan_member_retirement_operation": {
+          "name": "fk_picking_plan_member_retirement_operation",
+          "tableFrom": "picking_plan_members",
+          "tableTo": "shipment_operations",
+          "columnsFrom": [
+            "retired_by_operation_id",
+            "retired_by_operation_type"
+          ],
+          "columnsTo": [
+            "id",
+            "type"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "picking_plan_members_plan_id_shipment_id_pk": {
+          "name": "picking_plan_members_plan_id_shipment_id_pk",
+          "columns": [
+            "plan_id",
+            "shipment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_picking_plan_member_versions": {
+          "name": "ck_picking_plan_member_versions",
+          "value": "\"picking_plan_members\".\"manifest_version\" > 0 AND \"picking_plan_members\".\"reservation_version\" > 0"
+        },
+        "ck_picking_plan_member_retirement": {
+          "name": "ck_picking_plan_member_retirement",
+          "value": "(\n        \"picking_plan_members\".\"retired_at\" IS NULL\n        AND \"picking_plan_members\".\"retire_reason\" IS NULL\n        AND \"picking_plan_members\".\"retired_by_operation_id\" IS NULL\n        AND \"picking_plan_members\".\"retired_by_operation_type\" IS NULL\n      ) OR (\n        \"picking_plan_members\".\"retired_at\" IS NOT NULL\n        AND \"picking_plan_members\".\"retire_reason\" IS NOT NULL\n        AND length(btrim(\"picking_plan_members\".\"retire_reason\")) > 0\n        AND \"picking_plan_members\".\"retired_by_operation_id\" IS NOT NULL\n        AND \"picking_plan_members\".\"retired_by_operation_type\" IS NOT NULL\n        AND \"picking_plan_members\".\"retired_by_operation_type\" = 'short_pick'\n        AND \"picking_plan_members\".\"retired_at\" >= \"picking_plan_members\".\"created_at\"\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.picking_plans": {
+      "name": "picking_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "picking_strategy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "picking_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invalidated_at": {
+          "name": "invalidated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invalidation_reason": {
+          "name": "invalidation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_picking_plans_batch_status": {
+          "name": "idx_picking_plans_batch_status",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "picking_plans_batch_id_outbound_batches_id_fk": {
+          "name": "picking_plans_batch_id_outbound_batches_id_fk",
+          "tableFrom": "picking_plans",
+          "tableTo": "outbound_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_picking_plans_batch_version": {
+          "name": "uq_picking_plans_batch_version",
+          "nullsNotDistinct": false,
+          "columns": [
+            "batch_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_picking_plans_version_positive": {
+          "name": "ck_picking_plans_version_positive",
+          "value": "\"picking_plans\".\"version\" > 0"
+        },
+        "ck_picking_plans_invalidation": {
+          "name": "ck_picking_plans_invalidation",
+          "value": "\"picking_plans\".\"status\" <> 'invalidated' OR (\"picking_plans\".\"invalidated_at\" IS NOT NULL AND \"picking_plans\".\"invalidation_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.picking_source_allocations": {
+      "name": "picking_source_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_line_id": {
+          "name": "shipment_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_location_id": {
+          "name": "source_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qty": {
+          "name": "qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_stock_version": {
+          "name": "source_stock_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_picking_source_allocations_line": {
+          "name": "idx_picking_source_allocations_line",
+          "columns": [
+            {
+              "expression": "shipment_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "picking_source_allocations_plan_id_picking_plans_id_fk": {
+          "name": "picking_source_allocations_plan_id_picking_plans_id_fk",
+          "tableFrom": "picking_source_allocations",
+          "tableTo": "picking_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "picking_source_allocations_shipment_line_id_shipment_lines_id_fk": {
+          "name": "picking_source_allocations_shipment_line_id_shipment_lines_id_fk",
+          "tableFrom": "picking_source_allocations",
+          "tableTo": "shipment_lines",
+          "columnsFrom": [
+            "shipment_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "picking_source_allocations_source_location_id_locations_id_fk": {
+          "name": "picking_source_allocations_source_location_id_locations_id_fk",
+          "tableFrom": "picking_source_allocations",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "source_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_picking_source_allocations_grain": {
+          "name": "uq_picking_source_allocations_grain",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plan_id",
+            "shipment_line_id",
+            "source_location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_picking_source_allocations_qty_positive": {
+          "name": "ck_picking_source_allocations_qty_positive",
+          "value": "\"picking_source_allocations\".\"qty\" > 0"
+        },
+        "ck_picking_source_allocations_stock_version": {
+          "name": "ck_picking_source_allocations_stock_version",
+          "value": "\"picking_source_allocations\".\"source_stock_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.product_matchings": {
+      "name": "product_matchings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku_group_id": {
+          "name": "sku_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "matching_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "matching_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "matching_strategy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_resolved": {
+          "name": "is_resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pre_stock_sellable": {
+          "name": "pre_stock_sellable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "always_sellable_zero_stock": {
+          "name": "always_sellable_zero_stock",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_product_matchings_master_id": {
+          "name": "idx_product_matchings_master_id",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_matchings_sku_group_id_sku_groups_id_fk": {
+          "name": "product_matchings_sku_group_id_sku_groups_id_fk",
+          "tableFrom": "product_matchings",
+          "tableTo": "sku_groups",
+          "columnsFrom": [
+            "sku_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "product_matchings_variant_id_unique": {
+          "name": "product_matchings_variant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_sellable_quantity_projections": {
+      "name": "product_sellable_quantity_projections",
+      "schema": "",
+      "columns": {
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matching_id": {
+          "name": "matching_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sellable_quantity": {
+          "name": "sellable_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stock_bound_quantity": {
+          "name": "stock_bound_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_sellable": {
+          "name": "is_sellable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_product_sellable_qty_sellable": {
+          "name": "idx_product_sellable_qty_sellable",
+          "columns": [
+            {
+              "expression": "is_sellable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_product_sellable_qty_updated_at": {
+          "name": "idx_product_sellable_qty_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_sku_mapping_items": {
+      "name": "product_sku_mapping_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mapping_id": {
+          "name": "mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qty_per_product": {
+          "name": "qty_per_product",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_product_sku_mapping_items_mapping": {
+          "name": "idx_product_sku_mapping_items_mapping",
+          "columns": [
+            {
+              "expression": "mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_product_sku_mapping_items_mapping_variant": {
+          "name": "uq_product_sku_mapping_items_mapping_variant",
+          "columns": [
+            {
+              "expression": "mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_sku_mapping_items_mapping_id_product_sku_mappings_id_fk": {
+          "name": "product_sku_mapping_items_mapping_id_product_sku_mappings_id_fk",
+          "tableFrom": "product_sku_mapping_items",
+          "tableTo": "product_sku_mappings",
+          "columnsFrom": [
+            "mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_sku_mapping_items_sku_id_skus_id_fk": {
+          "name": "product_sku_mapping_items_sku_id_skus_id_fk",
+          "tableFrom": "product_sku_mapping_items",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_sku_mapping_snapshots": {
+      "name": "product_sku_mapping_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_data": {
+          "name": "snapshot_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mapping_id": {
+          "name": "mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_product_sku_mapping_snapshots_product": {
+          "name": "idx_product_sku_mapping_snapshots_product",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_sku_mapping_snapshots_warehouse_id_warehouses_id_fk": {
+          "name": "product_sku_mapping_snapshots_warehouse_id_warehouses_id_fk",
+          "tableFrom": "product_sku_mapping_snapshots",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "product_sku_mapping_snapshots_sku_id_skus_id_fk": {
+          "name": "product_sku_mapping_snapshots_sku_id_skus_id_fk",
+          "tableFrom": "product_sku_mapping_snapshots",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "product_sku_mapping_snapshots_mapping_id_product_sku_mappings_id_fk": {
+          "name": "product_sku_mapping_snapshots_mapping_id_product_sku_mappings_id_fk",
+          "tableFrom": "product_sku_mapping_snapshots",
+          "tableTo": "product_sku_mappings",
+          "columnsFrom": [
+            "mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_sku_mappings": {
+      "name": "product_sku_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_product_sku_mappings_product_warehouse": {
+          "name": "idx_product_sku_mappings_product_warehouse",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_product_sku_mappings_active": {
+          "name": "idx_product_sku_mappings_active",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_sku_mappings_warehouse_id_warehouses_id_fk": {
+          "name": "product_sku_mappings_warehouse_id_warehouses_id_fk",
+          "tableFrom": "product_sku_mappings",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_variant_sku_links": {
+      "name": "product_variant_sku_links",
+      "schema": "",
+      "columns": {
+        "product_matching_id": {
+          "name": "product_matching_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_variant_sku_links_product_matching_id_product_matchings_id_fk": {
+          "name": "product_variant_sku_links_product_matching_id_product_matchings_id_fk",
+          "tableFrom": "product_variant_sku_links",
+          "tableTo": "product_matchings",
+          "columnsFrom": [
+            "product_matching_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_variant_sku_links_sku_id_skus_id_fk": {
+          "name": "product_variant_sku_links_sku_id_skus_id_fk",
+          "tableFrom": "product_variant_sku_links",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "product_variant_sku_links_product_matching_id_sku_id_pk": {
+          "name": "product_variant_sku_links_product_matching_id_sku_id_pk",
+          "columns": [
+            "product_matching_id",
+            "sku_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_order_cart": {
+      "name": "purchase_order_cart",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "po_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_order_cart_sku_id_skus_id_fk": {
+          "name": "purchase_order_cart_sku_id_skus_id_fk",
+          "tableFrom": "purchase_order_cart",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "purchase_order_cart_supplier_id_suppliers_id_fk": {
+          "name": "purchase_order_cart_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_order_cart",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_order_lines": {
+      "name": "purchase_order_lines",
+      "schema": "",
+      "columns": {
+        "po_id": {
+          "name": "po_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_order_lines_po_id_purchase_orders_id_fk": {
+          "name": "purchase_order_lines_po_id_purchase_orders_id_fk",
+          "tableFrom": "purchase_order_lines",
+          "tableTo": "purchase_orders",
+          "columnsFrom": [
+            "po_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "purchase_order_lines_sku_id_skus_id_fk": {
+          "name": "purchase_order_lines_sku_id_skus_id_fk",
+          "tableFrom": "purchase_order_lines",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "purchase_order_lines_po_id_sku_id_pk": {
+          "name": "purchase_order_lines_po_id_sku_id_pk",
+          "columns": [
+            "po_id",
+            "sku_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "po_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_arrival": {
+          "name": "expected_arrival",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "po_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "source_warehouse_id": {
+          "name": "source_warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_warehouse_id": {
+          "name": "destination_warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requires_transfer": {
+          "name": "requires_transfer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "audit_status": {
+          "name": "audit_status",
+          "type": "po_audit_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submitted_for_audit_at": {
+          "name": "submitted_for_audit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_for_audit_by": {
+          "name": "submitted_for_audit_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audited_at": {
+          "name": "audited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audited_by": {
+          "name": "audited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_notes": {
+          "name": "audit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_source_warehouse_id_warehouses_id_fk": {
+          "name": "purchase_orders_source_warehouse_id_warehouses_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "source_warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_destination_warehouse_id_warehouses_id_fk": {
+          "name": "purchase_orders_destination_warehouse_id_warehouses_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "destination_warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.return_items": {
+      "name": "return_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "return_id": {
+          "name": "return_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_quantity": {
+          "name": "requested_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_quantity": {
+          "name": "received_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "qc_passed_quantity": {
+          "name": "qc_passed_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "qc_failed_quantity": {
+          "name": "qc_failed_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "restocked_quantity": {
+          "name": "restocked_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "disposed_quantity": {
+          "name": "disposed_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qc_status": {
+          "name": "qc_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "qc_reason": {
+          "name": "qc_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "return_items_return_idx": {
+          "name": "return_items_return_idx",
+          "columns": [
+            {
+              "expression": "return_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "return_items_sku_idx": {
+          "name": "return_items_sku_idx",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "return_items_qc_status_idx": {
+          "name": "return_items_qc_status_idx",
+          "columns": [
+            {
+              "expression": "qc_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "return_items_return_id_returns_id_fk": {
+          "name": "return_items_return_id_returns_id_fk",
+          "tableFrom": "return_items",
+          "tableTo": "returns",
+          "columnsFrom": [
+            "return_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "return_items_sku_id_skus_id_fk": {
+          "name": "return_items_sku_id_skus_id_fk",
+          "tableFrom": "return_items",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "return_items_location_id_locations_id_fk": {
+          "name": "return_items_location_id_locations_id_fk",
+          "tableFrom": "return_items",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.return_refund_attempts": {
+      "name": "return_refund_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "return_request_id": {
+          "name": "return_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_number": {
+          "name": "attempt_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "return_refund_attempt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "wallet_outcome": {
+          "name": "wallet_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_return_refund_attempt_pending": {
+          "name": "uq_return_refund_attempt_pending",
+          "columns": [
+            {
+              "expression": "return_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"return_refund_attempts\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_return_refund_attempts_request": {
+          "name": "idx_return_refund_attempts_request",
+          "columns": [
+            {
+              "expression": "return_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "return_refund_attempts_return_request_id_return_requests_id_fk": {
+          "name": "return_refund_attempts_return_request_id_return_requests_id_fk",
+          "tableFrom": "return_refund_attempts",
+          "tableTo": "return_requests",
+          "columnsFrom": [
+            "return_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_return_refund_attempt_number": {
+          "name": "uq_return_refund_attempt_number",
+          "nullsNotDistinct": false,
+          "columns": [
+            "return_request_id",
+            "attempt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.return_request_items": {
+      "name": "return_request_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "return_request_id": {
+          "name": "return_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_order_line_id": {
+          "name": "sales_order_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_line_id": {
+          "name": "shipment_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempt_id": {
+          "name": "dispatch_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "return_reason_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_return_request_items_request": {
+          "name": "idx_return_request_items_request",
+          "columns": [
+            {
+              "expression": "return_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_return_request_items_order_line": {
+          "name": "idx_return_request_items_order_line",
+          "columns": [
+            {
+              "expression": "sales_order_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_return_request_items_shipment_line": {
+          "name": "idx_return_request_items_shipment_line",
+          "columns": [
+            {
+              "expression": "shipment_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_return_request_items_dispatch_attempt": {
+          "name": "idx_return_request_items_dispatch_attempt",
+          "columns": [
+            {
+              "expression": "dispatch_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "return_request_items_return_request_id_return_requests_id_fk": {
+          "name": "return_request_items_return_request_id_return_requests_id_fk",
+          "tableFrom": "return_request_items",
+          "tableTo": "return_requests",
+          "columnsFrom": [
+            "return_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "return_request_items_shipment_line_id_shipment_lines_id_fk": {
+          "name": "return_request_items_shipment_line_id_shipment_lines_id_fk",
+          "tableFrom": "return_request_items",
+          "tableTo": "shipment_lines",
+          "columnsFrom": [
+            "shipment_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "return_request_items_dispatch_attempt_id_dispatch_attempts_id_fk": {
+          "name": "return_request_items_dispatch_attempt_id_dispatch_attempts_id_fk",
+          "tableFrom": "return_request_items",
+          "tableTo": "dispatch_attempts",
+          "columnsFrom": [
+            "dispatch_attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_return_request_items_quantity_positive": {
+          "name": "ck_return_request_items_quantity_positive",
+          "value": "\"return_request_items\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.return_requests": {
+      "name": "return_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "return_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "return_reason_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_detail": {
+          "name": "reason_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "return_address": {
+          "name": "return_address",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collected_at": {
+          "name": "collected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_return_requests_sales_order": {
+          "name": "idx_return_requests_sales_order",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_return_requests_status": {
+          "name": "idx_return_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_return_requests_customer": {
+          "name": "idx_return_requests_customer",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "return_requests_sales_order_id_sales_orders_id_fk": {
+          "name": "return_requests_sales_order_id_sales_orders_id_fk",
+          "tableFrom": "return_requests",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "sales_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.returns": {
+      "name": "returns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "return_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "return_reason": {
+          "name": "return_reason",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qc_inspected_at": {
+          "name": "qc_inspected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qc_inspected_by": {
+          "name": "qc_inspected_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qc_notes": {
+          "name": "qc_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restock_quantity": {
+          "name": "restock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispose_quantity": {
+          "name": "dispose_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "returns_warehouse_idx": {
+          "name": "returns_warehouse_idx",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "returns_status_idx": {
+          "name": "returns_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "returns_order_idx": {
+          "name": "returns_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "returns_order_id_sales_orders_id_fk": {
+          "name": "returns_order_id_sales_orders_id_fk",
+          "tableFrom": "returns",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "returns_shipment_id_shipments_id_fk": {
+          "name": "returns_shipment_id_shipments_id_fk",
+          "tableFrom": "returns",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "returns_warehouse_id_warehouses_id_fk": {
+          "name": "returns_warehouse_id_warehouses_id_fk",
+          "tableFrom": "returns",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sales_order_amendments": {
+      "name": "sales_order_amendments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amendment_kind": {
+          "name": "amendment_kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approved'"
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deltas": {
+          "name": "deltas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sales_order_amendments_sales_order_id": {
+          "name": "idx_sales_order_amendments_sales_order_id",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_order_amendments_kind": {
+          "name": "idx_sales_order_amendments_kind",
+          "columns": [
+            {
+              "expression": "amendment_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_order_amendments_occurred_at": {
+          "name": "idx_sales_order_amendments_occurred_at",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sales_order_amendments_sales_order_id_sales_orders_id_fk": {
+          "name": "sales_order_amendments_sales_order_id_sales_orders_id_fk",
+          "tableFrom": "sales_order_amendments",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "sales_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sales_order_amendments_kind_check": {
+          "name": "sales_order_amendments_kind_check",
+          "value": "\"sales_order_amendments\".\"amendment_kind\" IN ('commercial', 'fulfillment_only')"
+        },
+        "sales_order_amendments_decision_check": {
+          "name": "sales_order_amendments_decision_check",
+          "value": "\"sales_order_amendments\".\"decision\" IN ('approved', 'rejected', 'pending')"
+        },
+        "sales_order_amendments_deltas_array_check": {
+          "name": "sales_order_amendments_deltas_array_check",
+          "value": "jsonb_typeof(\"sales_order_amendments\".\"deltas\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sales_order_cancellations": {
+      "name": "sales_order_cancellations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancellation_scope": {
+          "name": "cancellation_scope",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'applied'"
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_detail": {
+          "name": "reason_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by": {
+          "name": "cancelled_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sales_order_cancellations_sales_order_id": {
+          "name": "idx_sales_order_cancellations_sales_order_id",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_order_cancellations_scope": {
+          "name": "idx_sales_order_cancellations_scope",
+          "columns": [
+            {
+              "expression": "cancellation_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_order_cancellations_occurred_at": {
+          "name": "idx_sales_order_cancellations_occurred_at",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_sales_order_full_cancellation": {
+          "name": "uniq_sales_order_full_cancellation",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sales_order_cancellations\".\"cancellation_scope\" = 'full'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sales_order_cancellations_sales_order_id_sales_orders_id_fk": {
+          "name": "sales_order_cancellations_sales_order_id_sales_orders_id_fk",
+          "tableFrom": "sales_order_cancellations",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "sales_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sales_order_cancellations_scope_check": {
+          "name": "sales_order_cancellations_scope_check",
+          "value": "\"sales_order_cancellations\".\"cancellation_scope\" IN ('full', 'partial')"
+        },
+        "sales_order_cancellations_status_check": {
+          "name": "sales_order_cancellations_status_check",
+          "value": "\"sales_order_cancellations\".\"status\" IN ('applied')"
+        },
+        "sales_order_cancellations_effects_array_check": {
+          "name": "sales_order_cancellations_effects_array_check",
+          "value": "jsonb_typeof(\"sales_order_cancellations\".\"effects\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sales_order_lines": {
+      "name": "sales_order_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_matching_id": {
+          "name": "product_matching_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mapping_snapshot_id": {
+          "name": "mapping_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fulfillment_kind": {
+          "name": "fulfillment_kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_shipping": {
+          "name": "requires_shipping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_order_item_id": {
+          "name": "channel_order_item_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_product_id": {
+          "name": "channel_product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "order_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "suggested_quantity": {
+          "name": "suggested_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unavailable_sku_ids": {
+          "name": "unavailable_sku_ids",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deducted_at": {
+          "name": "deducted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sales_order_lines_sales_order_id": {
+          "name": "idx_sales_order_lines_sales_order_id",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_order_lines_snapshot": {
+          "name": "idx_sales_order_lines_snapshot",
+          "columns": [
+            {
+              "expression": "mapping_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_order_lines_variant": {
+          "name": "idx_sales_order_lines_variant",
+          "columns": [
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_order_lines_channel_order_item": {
+          "name": "idx_sales_order_lines_channel_order_item",
+          "columns": [
+            {
+              "expression": "channel_order_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_order_lines_channel_product": {
+          "name": "idx_sales_order_lines_channel_product",
+          "columns": [
+            {
+              "expression": "channel_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_sales_order_lines_order_channel_item": {
+          "name": "uq_sales_order_lines_order_channel_item",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_order_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sales_order_lines\".\"channel_order_item_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sales_order_lines_sales_order_id_sales_orders_id_fk": {
+          "name": "sales_order_lines_sales_order_id_sales_orders_id_fk",
+          "tableFrom": "sales_order_lines",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "sales_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sales_order_lines_product_matching_id_product_matchings_id_fk": {
+          "name": "sales_order_lines_product_matching_id_product_matchings_id_fk",
+          "tableFrom": "sales_order_lines",
+          "tableTo": "product_matchings",
+          "columnsFrom": [
+            "product_matching_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sales_order_lines_mapping_snapshot_id_product_sku_mapping_snapshots_id_fk": {
+          "name": "sales_order_lines_mapping_snapshot_id_product_sku_mapping_snapshots_id_fk",
+          "tableFrom": "sales_order_lines",
+          "tableTo": "product_sku_mapping_snapshots",
+          "columnsFrom": [
+            "mapping_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sales_orders": {
+      "name": "sales_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_order_id": {
+          "name": "channel_order_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_channel": {
+          "name": "sales_channel",
+          "type": "sales_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_email": {
+          "name": "customer_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_phone": {
+          "name": "customer_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_address": {
+          "name": "shipping_address",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipping_address_hash": {
+          "name": "shipping_address_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_fee": {
+          "name": "shipping_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "merge_group_id": {
+          "name": "merge_group_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_merged": {
+          "name": "is_merged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_intent_id": {
+          "name": "wallet_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sales_orders_order_date": {
+          "name": "idx_sales_orders_order_date",
+          "columns": [
+            {
+              "expression": "order_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sales_orders_sales_channel_channel_order_id_unique": {
+          "name": "sales_orders_sales_channel_channel_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sales_channel",
+            "channel_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sales_variant_policies": {
+      "name": "sales_variant_policies",
+      "schema": "",
+      "columns": {
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inventory_management": {
+          "name": "inventory_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pre_stock_sellable": {
+          "name": "pre_stock_sellable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "always_sellable_zero_stock": {
+          "name": "always_sellable_zero_stock",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "availability_override": {
+          "name": "availability_override",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "setting_key",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_warehouse_id_warehouses_id_fk": {
+          "name": "settings_warehouse_id_warehouses_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shipment_lines": {
+      "name": "shipment_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fulfillment_order_item_id": {
+          "name": "fulfillment_order_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qty": {
+          "name": "qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reserved_qty": {
+          "name": "reserved_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "inspected_qty": {
+          "name": "inspected_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "line_version": {
+          "name": "line_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_from_line_id": {
+          "name": "created_from_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forced": {
+          "name": "forced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_shipment_lines_shipment": {
+          "name": "idx_shipment_lines_shipment",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_shipment_lines_created_from_line": {
+          "name": "idx_shipment_lines_created_from_line",
+          "columns": [
+            {
+              "expression": "created_from_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shipment_lines_shipment_id_shipments_id_fk": {
+          "name": "shipment_lines_shipment_id_shipments_id_fk",
+          "tableFrom": "shipment_lines",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shipment_lines_fulfillment_order_item_id_fulfillment_order_items_id_fk": {
+          "name": "shipment_lines_fulfillment_order_item_id_fulfillment_order_items_id_fk",
+          "tableFrom": "shipment_lines",
+          "tableTo": "fulfillment_order_items",
+          "columnsFrom": [
+            "fulfillment_order_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "shipment_lines_sku_id_skus_id_fk": {
+          "name": "shipment_lines_sku_id_skus_id_fk",
+          "tableFrom": "shipment_lines",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "shipment_lines_created_from_line_id_shipment_lines_id_fk": {
+          "name": "shipment_lines_created_from_line_id_shipment_lines_id_fk",
+          "tableFrom": "shipment_lines",
+          "tableTo": "shipment_lines",
+          "columnsFrom": [
+            "created_from_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_shipment_lines_shipment_foi": {
+          "name": "uq_shipment_lines_shipment_foi",
+          "nullsNotDistinct": false,
+          "columns": [
+            "shipment_id",
+            "fulfillment_order_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_shipment_lines_qty_positive": {
+          "name": "ck_shipment_lines_qty_positive",
+          "value": "\"shipment_lines\".\"qty\" > 0"
+        },
+        "ck_shipment_lines_inspected_range": {
+          "name": "ck_shipment_lines_inspected_range",
+          "value": "\"shipment_lines\".\"inspected_qty\" >= 0 AND \"shipment_lines\".\"inspected_qty\" <= \"shipment_lines\".\"qty\""
+        },
+        "ck_shipment_lines_reserved_range": {
+          "name": "ck_shipment_lines_reserved_range",
+          "value": "\"shipment_lines\".\"reserved_qty\" >= 0 AND \"shipment_lines\".\"reserved_qty\" <= \"shipment_lines\".\"qty\""
+        },
+        "ck_shipment_lines_line_version_positive": {
+          "name": "ck_shipment_lines_line_version_positive",
+          "value": "\"shipment_lines\".\"line_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.shipment_operation_members": {
+      "name": "shipment_operation_members",
+      "schema": "",
+      "columns": {
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "shipment_operation_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_manifest_version": {
+          "name": "before_manifest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_manifest_version": {
+          "name": "after_manifest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before_manifest_snapshot": {
+          "name": "before_manifest_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_manifest_snapshot": {
+          "name": "after_manifest_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_shipment_operation_members_shipment": {
+          "name": "idx_shipment_operation_members_shipment",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shipment_operation_members_operation_id_shipment_operations_id_fk": {
+          "name": "shipment_operation_members_operation_id_shipment_operations_id_fk",
+          "tableFrom": "shipment_operation_members",
+          "tableTo": "shipment_operations",
+          "columnsFrom": [
+            "operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "shipment_operation_members_shipment_id_shipments_id_fk": {
+          "name": "shipment_operation_members_shipment_id_shipments_id_fk",
+          "tableFrom": "shipment_operation_members",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "shipment_operation_members_operation_id_shipment_id_role_pk": {
+          "name": "shipment_operation_members_operation_id_shipment_id_role_pk",
+          "columns": [
+            "operation_id",
+            "shipment_id",
+            "role"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_shipment_operation_member_versions": {
+          "name": "ck_shipment_operation_member_versions",
+          "value": "(\"shipment_operation_members\".\"before_manifest_version\" IS NULL OR \"shipment_operation_members\".\"before_manifest_version\" > 0)\n        AND (\"shipment_operation_members\".\"after_manifest_version\" IS NULL OR \"shipment_operation_members\".\"after_manifest_version\" > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.shipment_operations": {
+      "name": "shipment_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "shipment_operation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "shipment_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "operator_id": {
+          "name": "operator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cs_case_id": {
+          "name": "cs_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_manifest_snapshot": {
+          "name": "before_manifest_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_manifest_snapshot": {
+          "name": "after_manifest_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_shipment_operation_status": {
+          "name": "idx_shipment_operation_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_shipment_operation_idempotency": {
+          "name": "uq_shipment_operation_idempotency",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "idempotency_key"
+          ]
+        },
+        "uq_shipment_operations_id_type": {
+          "name": "uq_shipment_operations_id_type",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_shipment_operation_request_hash": {
+          "name": "ck_shipment_operation_request_hash",
+          "value": "length(\"shipment_operations\".\"request_hash\") = 64"
+        },
+        "ck_shipment_operation_completion": {
+          "name": "ck_shipment_operation_completion",
+          "value": "\"shipment_operations\".\"status\" <> 'completed' OR \"shipment_operations\".\"completed_at\" IS NOT NULL"
+        },
+        "ck_shipment_operation_error_context": {
+          "name": "ck_shipment_operation_error_context",
+          "value": "\"shipment_operations\".\"status\" NOT IN ('failed', 'recovery_required') OR \"shipment_operations\".\"last_error\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.shipment_tote_assignments": {
+      "name": "shipment_tote_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tote_id": {
+          "name": "tote_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_shipment_tote_assignments_active_tote": {
+          "name": "uq_shipment_tote_assignments_active_tote",
+          "columns": [
+            {
+              "expression": "tote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"shipment_tote_assignments\".\"released_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_shipment_tote_assignments_active_pair": {
+          "name": "uq_shipment_tote_assignments_active_pair",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"shipment_tote_assignments\".\"released_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_shipment_tote_assignments_shipment": {
+          "name": "idx_shipment_tote_assignments_shipment",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shipment_tote_assignments_shipment_id_shipments_id_fk": {
+          "name": "shipment_tote_assignments_shipment_id_shipments_id_fk",
+          "tableFrom": "shipment_tote_assignments",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "shipment_tote_assignments_tote_id_totes_id_fk": {
+          "name": "shipment_tote_assignments_tote_id_totes_id_fk",
+          "tableFrom": "shipment_tote_assignments",
+          "tableTo": "totes",
+          "columnsFrom": [
+            "tote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_shipment_tote_assignments_release": {
+          "name": "ck_shipment_tote_assignments_release",
+          "value": "\"shipment_tote_assignments\".\"released_at\" IS NULL OR \"shipment_tote_assignments\".\"released_at\" >= \"shipment_tote_assignments\".\"assigned_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.shipment_tracking": {
+      "name": "shipment_tracking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispatch_attempt_id": {
+          "name": "dispatch_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "shipment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_shipment_tracking_attempt": {
+          "name": "idx_shipment_tracking_attempt",
+          "columns": [
+            {
+              "expression": "dispatch_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_shipment_tracking_provider_event": {
+          "name": "uq_shipment_tracking_provider_event",
+          "columns": [
+            {
+              "expression": "dispatch_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"shipment_tracking\".\"provider_event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shipment_tracking_shipment_id_shipments_id_fk": {
+          "name": "shipment_tracking_shipment_id_shipments_id_fk",
+          "tableFrom": "shipment_tracking",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shipment_tracking_dispatch_attempt_id_dispatch_attempts_id_fk": {
+          "name": "shipment_tracking_dispatch_attempt_id_dispatch_attempts_id_fk",
+          "tableFrom": "shipment_tracking",
+          "tableTo": "dispatch_attempts",
+          "columnsFrom": [
+            "dispatch_attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shipments": {
+      "name": "shipments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_for_fulfillment_order_id": {
+          "name": "opened_for_fulfillment_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "shipment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "shipping_profile_id": {
+          "name": "shipping_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_snapshot": {
+          "name": "recipient_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reservation_version": {
+          "name": "reservation_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "opened_by": {
+          "name": "opened_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "planned_at": {
+          "name": "planned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipped_at": {
+          "name": "shipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recovery_code": {
+          "name": "recovery_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_shipments_opened_for_fo": {
+          "name": "idx_shipments_opened_for_fo",
+          "columns": [
+            {
+              "expression": "opened_for_fulfillment_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_shipments_shipping_profile": {
+          "name": "idx_shipments_shipping_profile",
+          "columns": [
+            {
+              "expression": "shipping_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_shipments_warehouse_status": {
+          "name": "idx_shipments_warehouse_status",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shipments_warehouse_id_warehouses_id_fk": {
+          "name": "shipments_warehouse_id_warehouses_id_fk",
+          "tableFrom": "shipments",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "shipments_opened_for_fulfillment_order_id_fulfillment_orders_id_fk": {
+          "name": "shipments_opened_for_fulfillment_order_id_fulfillment_orders_id_fk",
+          "tableFrom": "shipments",
+          "tableTo": "fulfillment_orders",
+          "columnsFrom": [
+            "opened_for_fulfillment_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "shipments_shipping_profile_id_delivery_profiles_id_fk": {
+          "name": "shipments_shipping_profile_id_delivery_profiles_id_fk",
+          "tableFrom": "shipments",
+          "tableTo": "delivery_profiles",
+          "columnsFrom": [
+            "shipping_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_shipments_manifest_version_positive": {
+          "name": "ck_shipments_manifest_version_positive",
+          "value": "\"shipments\".\"manifest_version\" > 0"
+        },
+        "ck_shipments_reservation_version_positive": {
+          "name": "ck_shipments_reservation_version_positive",
+          "value": "\"shipments\".\"reservation_version\" > 0"
+        },
+        "ck_shipments_recovery_code": {
+          "name": "ck_shipments_recovery_code",
+          "value": "\"shipments\".\"status\"::text <> 'recovery_required' OR \"shipments\".\"recovery_code\" IS NOT NULL"
+        },
+        "ck_shipments_superseded_at": {
+          "name": "ck_shipments_superseded_at",
+          "value": "\"shipments\".\"status\"::text <> 'superseded' OR \"shipments\".\"superseded_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sku_barcodes": {
+      "name": "sku_barcodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "barcode": {
+          "name": "barcode",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "packing_unit": {
+          "name": "packing_unit",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sku_barcodes_sku_id_skus_id_fk": {
+          "name": "sku_barcodes_sku_id_skus_id_fk",
+          "tableFrom": "sku_barcodes",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sku_barcodes_barcode_unique": {
+          "name": "sku_barcodes_barcode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "barcode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sku_categories": {
+      "name": "sku_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sku_categories_sku_id_skus_id_fk": {
+          "name": "sku_categories_sku_id_skus_id_fk",
+          "tableFrom": "sku_categories",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sku_categories_category_id_categories_id_fk": {
+          "name": "sku_categories_category_id_categories_id_fk",
+          "tableFrom": "sku_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sku_groups": {
+      "name": "sku_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sku_groups_code": {
+          "name": "idx_sku_groups_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sku_groups_name": {
+          "name": "idx_sku_groups_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sku_groups_code_unique": {
+          "name": "sku_groups_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sku_images": {
+      "name": "sku_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sku_images_sku_id": {
+          "name": "idx_sku_images_sku_id",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sku_images_primary": {
+          "name": "idx_sku_images_primary",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sku_images_sort": {
+          "name": "idx_sku_images_sort",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sku_images_sku_id_skus_id_fk": {
+          "name": "sku_images_sku_id_skus_id_fk",
+          "tableFrom": "sku_images",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sku_location_movements": {
+      "name": "sku_location_movements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "barcode": {
+          "name": "barcode",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_location_id": {
+          "name": "from_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_location_id": {
+          "name": "to_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "moved_by": {
+          "name": "moved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "movement_timestamp": {
+          "name": "movement_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_movement_sku": {
+          "name": "idx_movement_sku",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_movement_barcode": {
+          "name": "idx_movement_barcode",
+          "columns": [
+            {
+              "expression": "barcode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_movement_timestamp": {
+          "name": "idx_movement_timestamp",
+          "columns": [
+            {
+              "expression": "movement_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sku_location_movements_sku_id_skus_id_fk": {
+          "name": "sku_location_movements_sku_id_skus_id_fk",
+          "tableFrom": "sku_location_movements",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sku_location_movements_from_location_id_locations_id_fk": {
+          "name": "sku_location_movements_from_location_id_locations_id_fk",
+          "tableFrom": "sku_location_movements",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "from_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sku_location_movements_to_location_id_locations_id_fk": {
+          "name": "sku_location_movements_to_location_id_locations_id_fk",
+          "tableFrom": "sku_location_movements",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "to_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sku_managers": {
+      "name": "sku_managers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "designer_id": {
+          "name": "designer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_manager_id": {
+          "name": "purchase_manager_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_manager_id": {
+          "name": "registration_manager_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sku_managers_sku_id_skus_id_fk": {
+          "name": "sku_managers_sku_id_skus_id_fk",
+          "tableFrom": "sku_managers",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sku_managers_sku_id_unique": {
+          "name": "sku_managers_sku_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sku_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sku_suppliers": {
+      "name": "sku_suppliers",
+      "schema": "",
+      "columns": {
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_sku": {
+          "name": "supplier_sku",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sku_suppliers_sku_id_skus_id_fk": {
+          "name": "sku_suppliers_sku_id_skus_id_fk",
+          "tableFrom": "sku_suppliers",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sku_suppliers_supplier_id_suppliers_id_fk": {
+          "name": "sku_suppliers_supplier_id_suppliers_id_fk",
+          "tableFrom": "sku_suppliers",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sku_suppliers_sku_id_supplier_id_pk": {
+          "name": "sku_suppliers_sku_id_supplier_id_pk",
+          "columns": [
+            "sku_id",
+            "supplier_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skus": {
+      "name": "skus",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "holder_id": {
+          "name": "holder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'019d0001-0000-7000-a000-000000000001'"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "option_key": {
+          "name": "option_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_type": {
+          "name": "stock_type",
+          "type": "stock_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'physical'"
+        },
+        "delivery_profile_id": {
+          "name": "delivery_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_1m": {
+          "name": "sale_1m",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_3m": {
+          "name": "sale_3m",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safety_stock": {
+          "name": "safety_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "business_product_name": {
+          "name": "business_product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_declaration_number": {
+          "name": "import_declaration_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logistics_partner_id": {
+          "name": "logistics_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer_star": {
+          "name": "manufacturer_star",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_weight": {
+          "name": "product_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dimension_width": {
+          "name": "dimension_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dimension_height": {
+          "name": "dimension_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dimension_depth": {
+          "name": "dimension_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_material": {
+          "name": "product_material",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "korean_name": {
+          "name": "korean_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_discount_quantity": {
+          "name": "max_discount_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "packaging_importer_name": {
+          "name": "packaging_importer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_description": {
+          "name": "product_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moq": {
+          "name": "moq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo2": {
+          "name": "memo2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo3": {
+          "name": "memo3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_image_url": {
+          "name": "main_image_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_date_management": {
+          "name": "expiry_date_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiry_start_date": {
+          "name": "expiry_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_end_date": {
+          "name": "expiry_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturing_date_management": {
+          "name": "manufacturing_date_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_general_inventory": {
+          "name": "is_general_inventory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "validity_start_date": {
+          "name": "validity_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validity_end_date": {
+          "name": "validity_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_location_id": {
+          "name": "primary_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_location_id": {
+          "name": "secondary_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_group_code": {
+          "name": "variant_group_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skus_safety_stock": {
+          "name": "idx_skus_safety_stock",
+          "columns": [
+            {
+              "expression": "safety_stock",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skus_variant_group": {
+          "name": "idx_skus_variant_group",
+          "columns": [
+            {
+              "expression": "variant_group_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skus_primary_location": {
+          "name": "idx_skus_primary_location",
+          "columns": [
+            {
+              "expression": "primary_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skus_weight": {
+          "name": "idx_skus_weight",
+          "columns": [
+            {
+              "expression": "product_weight",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skus_moq": {
+          "name": "idx_skus_moq",
+          "columns": [
+            {
+              "expression": "moq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skus_group_id": {
+          "name": "idx_skus_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skus_holder_id_holders_id_fk": {
+          "name": "skus_holder_id_holders_id_fk",
+          "tableFrom": "skus",
+          "tableTo": "holders",
+          "columnsFrom": [
+            "holder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skus_group_id_sku_groups_id_fk": {
+          "name": "skus_group_id_sku_groups_id_fk",
+          "tableFrom": "skus",
+          "tableTo": "sku_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "skus_delivery_profile_id_delivery_profiles_id_fk": {
+          "name": "skus_delivery_profile_id_delivery_profiles_id_fk",
+          "tableFrom": "skus",
+          "tableTo": "delivery_profiles",
+          "columnsFrom": [
+            "delivery_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "skus_logistics_partner_id_suppliers_id_fk": {
+          "name": "skus_logistics_partner_id_suppliers_id_fk",
+          "tableFrom": "skus",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "logistics_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "skus_primary_location_id_locations_id_fk": {
+          "name": "skus_primary_location_id_locations_id_fk",
+          "tableFrom": "skus",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "primary_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "skus_secondary_location_id_locations_id_fk": {
+          "name": "skus_secondary_location_id_locations_id_fk",
+          "tableFrom": "skus",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "secondary_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skus_code_unique": {
+          "name": "skus_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stock_events": {
+      "name": "stock_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "journal_id": {
+          "name": "journal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_warehouse_id": {
+          "name": "from_warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_location_id": {
+          "name": "from_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_warehouse_id": {
+          "name": "to_warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_location_id": {
+          "name": "to_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_state": {
+          "name": "from_state",
+          "type": "stock_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_state": {
+          "name": "to_state",
+          "type": "stock_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transition_type": {
+          "name": "transition_type",
+          "type": "transition_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_status": {
+          "name": "event_status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'POSTED'"
+        },
+        "reversal_of_event_id": {
+          "name": "reversal_of_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_by_event_id": {
+          "name": "voided_by_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_stock_events_grain_time": {
+          "name": "ix_stock_events_grain_time",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_stock_events_reversal_of_event": {
+          "name": "uq_stock_events_reversal_of_event",
+          "columns": [
+            {
+              "expression": "reversal_of_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stock_events\".\"reversal_of_event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stock_events_journal_id_stock_journals_id_fk": {
+          "name": "stock_events_journal_id_stock_journals_id_fk",
+          "tableFrom": "stock_events",
+          "tableTo": "stock_journals",
+          "columnsFrom": [
+            "journal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_events_sku_id_skus_id_fk": {
+          "name": "stock_events_sku_id_skus_id_fk",
+          "tableFrom": "stock_events",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_events_from_warehouse_id_warehouses_id_fk": {
+          "name": "stock_events_from_warehouse_id_warehouses_id_fk",
+          "tableFrom": "stock_events",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "from_warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_events_from_location_id_locations_id_fk": {
+          "name": "stock_events_from_location_id_locations_id_fk",
+          "tableFrom": "stock_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "from_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stock_events_to_warehouse_id_warehouses_id_fk": {
+          "name": "stock_events_to_warehouse_id_warehouses_id_fk",
+          "tableFrom": "stock_events",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "to_warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_events_to_location_id_locations_id_fk": {
+          "name": "stock_events_to_location_id_locations_id_fk",
+          "tableFrom": "stock_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "to_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stock_events_idempotency_key_unique": {
+          "name": "stock_events_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_events_qty_positive": {
+          "name": "ck_events_qty_positive",
+          "value": "\"stock_events\".\"quantity\" > 0"
+        },
+        "ck_events_states_diff": {
+          "name": "ck_events_states_diff",
+          "value": "(\"stock_events\".\"from_state\" is distinct from \"stock_events\".\"to_state\") \n          OR (\"stock_events\".\"from_location_id\" is distinct from \"stock_events\".\"to_location_id\")\n          OR (\"stock_events\".\"from_warehouse_id\" is distinct from \"stock_events\".\"to_warehouse_id\")"
+        },
+        "ck_events_side_present": {
+          "name": "ck_events_side_present",
+          "value": "(\"stock_events\".\"from_state\" is not null) or (\"stock_events\".\"to_state\" is not null)"
+        },
+        "ck_events_fromloc_has_wh": {
+          "name": "ck_events_fromloc_has_wh",
+          "value": "(\"stock_events\".\"from_location_id\" is null) or (\"stock_events\".\"from_warehouse_id\" is not null)"
+        },
+        "ck_events_toloc_has_wh": {
+          "name": "ck_events_toloc_has_wh",
+          "value": "(\"stock_events\".\"to_location_id\" is null) or (\"stock_events\".\"to_warehouse_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.stock_journals": {
+      "name": "stock_journals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stock_journals_idempotency_key_unique": {
+          "name": "stock_journals_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stock_ledgers": {
+      "name": "stock_ledgers",
+      "schema": "",
+      "columns": {
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_state": {
+          "name": "stock_state",
+          "type": "stock_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qty": {
+          "name": "qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ix_ledgers_lookup": {
+          "name": "ix_ledgers_lookup",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stock_ledgers_sku_id_skus_id_fk": {
+          "name": "stock_ledgers_sku_id_skus_id_fk",
+          "tableFrom": "stock_ledgers",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stock_ledgers_warehouse_id_warehouses_id_fk": {
+          "name": "stock_ledgers_warehouse_id_warehouses_id_fk",
+          "tableFrom": "stock_ledgers",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_ledgers_location_id_locations_id_fk": {
+          "name": "stock_ledgers_location_id_locations_id_fk",
+          "tableFrom": "stock_ledgers",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stock_ledgers_sku_id_warehouse_id_location_id_stock_state_pk": {
+          "name": "stock_ledgers_sku_id_warehouse_id_location_id_stock_state_pk",
+          "columns": [
+            "sku_id",
+            "warehouse_id",
+            "location_id",
+            "stock_state"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_ledgers_non_negative": {
+          "name": "ck_ledgers_non_negative",
+          "value": "\"stock_ledgers\".\"qty\" >= 0"
+        },
+        "ck_stock_ledgers_version_positive": {
+          "name": "ck_stock_ledgers_version_positive",
+          "value": "\"stock_ledgers\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.stock_reservations": {
+      "name": "stock_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fulfillment_order_item_id": {
+          "name": "fulfillment_order_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipment_line_id": {
+          "name": "shipment_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "reservation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "timeout_at": {
+          "name": "timeout_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_reason": {
+          "name": "state_reason",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invalidated_at": {
+          "name": "invalidated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stock_reservations_target_idx": {
+          "name": "stock_reservations_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stock_reservations_sku_warehouse_idx": {
+          "name": "stock_reservations_sku_warehouse_idx",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stock_reservations_status_idx": {
+          "name": "stock_reservations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stock_reservations_shipment_line": {
+          "name": "idx_stock_reservations_shipment_line",
+          "columns": [
+            {
+              "expression": "shipment_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stock_reservations_requested_at": {
+          "name": "idx_stock_reservations_requested_at",
+          "columns": [
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stock_reservations_fulfillment_order_item_id_fulfillment_order_items_id_fk": {
+          "name": "stock_reservations_fulfillment_order_item_id_fulfillment_order_items_id_fk",
+          "tableFrom": "stock_reservations",
+          "tableTo": "fulfillment_order_items",
+          "columnsFrom": [
+            "fulfillment_order_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stock_reservations_shipment_line_id_shipment_lines_id_fk": {
+          "name": "stock_reservations_shipment_line_id_shipment_lines_id_fk",
+          "tableFrom": "stock_reservations",
+          "tableTo": "shipment_lines",
+          "columnsFrom": [
+            "shipment_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stock_reservations_sku_id_skus_id_fk": {
+          "name": "stock_reservations_sku_id_skus_id_fk",
+          "tableFrom": "stock_reservations",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stock_reservations_warehouse_id_warehouses_id_fk": {
+          "name": "stock_reservations_warehouse_id_warehouses_id_fk",
+          "tableFrom": "stock_reservations",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_stock_reservations_quantity_positive": {
+          "name": "ck_stock_reservations_quantity_positive",
+          "value": "\"stock_reservations\".\"quantity\" > 0"
+        },
+        "ck_stock_reservations_invalidation": {
+          "name": "ck_stock_reservations_invalidation",
+          "value": "\"stock_reservations\".\"invalidated_at\" IS NULL OR \"stock_reservations\".\"state_reason\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.stocktaking_adjustments": {
+      "name": "stocktaking_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_event_id": {
+          "name": "stock_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adjustment_quantity": {
+          "name": "adjustment_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adjustment_type": {
+          "name": "adjustment_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "applied_by": {
+          "name": "applied_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_adjustment_session": {
+          "name": "idx_adjustment_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_adjustment_line": {
+          "name": "idx_adjustment_line",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stocktaking_adjustments_session_id_stocktaking_sessions_id_fk": {
+          "name": "stocktaking_adjustments_session_id_stocktaking_sessions_id_fk",
+          "tableFrom": "stocktaking_adjustments",
+          "tableTo": "stocktaking_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stocktaking_adjustments_line_id_stocktaking_lines_id_fk": {
+          "name": "stocktaking_adjustments_line_id_stocktaking_lines_id_fk",
+          "tableFrom": "stocktaking_adjustments",
+          "tableTo": "stocktaking_lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stocktaking_adjustments_stock_event_id_stock_events_id_fk": {
+          "name": "stocktaking_adjustments_stock_event_id_stock_events_id_fk",
+          "tableFrom": "stocktaking_adjustments",
+          "tableTo": "stock_events",
+          "columnsFrom": [
+            "stock_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_stocktaking_adjustment_line": {
+          "name": "uq_stocktaking_adjustment_line",
+          "nullsNotDistinct": false,
+          "columns": [
+            "line_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stocktaking_lines": {
+      "name": "stocktaking_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_quantity": {
+          "name": "expected_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counted_quantity": {
+          "name": "counted_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variance": {
+          "name": "variance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scanned_barcode": {
+          "name": "scanned_barcode",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "counted_at": {
+          "name": "counted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counted_by": {
+          "name": "counted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_stocktaking_line_session": {
+          "name": "idx_stocktaking_line_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stocktaking_line_sku": {
+          "name": "idx_stocktaking_line_sku",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stocktaking_line_location": {
+          "name": "idx_stocktaking_line_location",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stocktaking_lines_session_id_stocktaking_sessions_id_fk": {
+          "name": "stocktaking_lines_session_id_stocktaking_sessions_id_fk",
+          "tableFrom": "stocktaking_lines",
+          "tableTo": "stocktaking_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stocktaking_lines_sku_id_skus_id_fk": {
+          "name": "stocktaking_lines_sku_id_skus_id_fk",
+          "tableFrom": "stocktaking_lines",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stocktaking_lines_location_id_locations_id_fk": {
+          "name": "stocktaking_lines_location_id_locations_id_fk",
+          "tableFrom": "stocktaking_lines",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_stocktaking_line_session_sku_location": {
+          "name": "uq_stocktaking_line_session_sku_location",
+          "nullsNotDistinct": true,
+          "columns": [
+            "session_id",
+            "sku_id",
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stocktaking_sessions": {
+      "name": "stocktaking_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_name": {
+          "name": "session_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stocktaking_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_by": {
+          "name": "started_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stocktaking_sessions_warehouse_id_warehouses_id_fk": {
+          "name": "stocktaking_sessions_warehouse_id_warehouses_id_fk",
+          "tableFrom": "stocktaking_sessions",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_categories": {
+      "name": "supplier_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "supplier_categories_name_unique": {
+          "name": "supplier_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_category_mappings": {
+      "name": "supplier_category_mappings",
+      "schema": "",
+      "columns": {
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "supplier_category_mappings_supplier_id_suppliers_id_fk": {
+          "name": "supplier_category_mappings_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_category_mappings",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "supplier_category_mappings_category_id_supplier_categories_id_fk": {
+          "name": "supplier_category_mappings_category_id_supplier_categories_id_fk",
+          "tableFrom": "supplier_category_mappings",
+          "tableTo": "supplier_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "supplier_category_mappings_supplier_id_category_id_pk": {
+          "name": "supplier_category_mappings_supplier_id_category_id_pk",
+          "columns": [
+            "supplier_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fax": {
+          "name": "fax",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zipcode": {
+          "name": "zipcode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address1": {
+          "name": "address1",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address2": {
+          "name": "address2",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_reg_no": {
+          "name": "business_reg_no",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ceo_name": {
+          "name": "ceo_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_direct_delivery": {
+          "name": "is_direct_delivery",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order_cutoff_time": {
+          "name": "order_cutoff_time",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_name": {
+          "name": "bank_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_account_no": {
+          "name": "bank_account_no",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_account_holder": {
+          "name": "bank_account_holder",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_manager_id": {
+          "name": "purchase_manager_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_warehouse_id": {
+          "name": "default_warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "suppliers_default_warehouse_id_warehouses_id_fk": {
+          "name": "suppliers_default_warehouse_id_warehouses_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "default_warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.totes": {
+      "name": "totes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "barcode": {
+          "name": "barcode",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tote_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_totes_warehouse_status": {
+          "name": "idx_totes_warehouse_status",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "totes_warehouse_id_warehouses_id_fk": {
+          "name": "totes_warehouse_id_warehouses_id_fk",
+          "tableFrom": "totes",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_totes_barcode": {
+          "name": "uq_totes_barcode",
+          "nullsNotDistinct": false,
+          "columns": [
+            "barcode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_totes_version_positive": {
+          "name": "ck_totes_version_positive",
+          "value": "\"totes\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.warehouses": {
+      "name": "warehouses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "warehouse_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'domestic'"
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_picking_strategies": {
+          "name": "supported_picking_strategies",
+          "type": "picking_strategy[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waybills": {
+      "name": "waybills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "waybill_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "carrier": {
+          "name": "carrier",
+          "type": "carrier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "waybill_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tracking_no": {
+          "name": "tracking_no",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cust_ord_no": {
+          "name": "cust_ord_no",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_data": {
+          "name": "label_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_hash": {
+          "name": "recipient_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_waybills_shipment": {
+          "name": "idx_waybills_shipment",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_waybills_status": {
+          "name": "idx_waybills_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_waybills_tracking_no": {
+          "name": "idx_waybills_tracking_no",
+          "columns": [
+            {
+              "expression": "tracking_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_waybills_shipment_active": {
+          "name": "uq_waybills_shipment_active",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"waybills\".\"status\" NOT IN ('voided', 'failed', 'abandoned')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_waybills_tracking_live": {
+          "name": "uq_waybills_tracking_live",
+          "columns": [
+            {
+              "expression": "tracking_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"waybills\".\"tracking_no\" IS NOT NULL AND \"waybills\".\"status\" NOT IN ('voided', 'failed', 'abandoned')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "waybills_shipment_id_shipments_id_fk": {
+          "name": "waybills_shipment_id_shipments_id_fk",
+          "tableFrom": "waybills",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_waybills_tracking_present": {
+          "name": "ck_waybills_tracking_present",
+          "value": "\"waybills\".\"status\" NOT IN ('allocated', 'registered', 'used') OR \"waybills\".\"tracking_no\" IS NOT NULL"
+        },
+        "ck_waybills_manual_status": {
+          "name": "ck_waybills_manual_status",
+          "value": "\"waybills\".\"source\" <> 'manual' OR \"waybills\".\"status\" IN ('registered', 'used', 'voided')"
+        },
+        "ck_waybills_attempts": {
+          "name": "ck_waybills_attempts",
+          "value": "\"waybills\".\"attempts\" >= 0"
+        },
+        "ck_waybills_recipient_hash": {
+          "name": "ck_waybills_recipient_hash",
+          "value": "length(\"waybills\".\"recipient_hash\") = 64"
+        },
+        "ck_waybills_manifest_version": {
+          "name": "ck_waybills_manifest_version",
+          "value": "\"waybills\".\"manifest_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.digital_asset_file_versions": {
+      "name": "digital_asset_file_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_note": {
+          "name": "release_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "released_by": {
+          "name": "released_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_dafv_asset": {
+          "name": "idx_dafv_asset",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_dafv_asset_version": {
+          "name": "uniq_dafv_asset_version",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "digital_asset_file_versions_asset_id_digital_assets_id_fk": {
+          "name": "digital_asset_file_versions_asset_id_digital_assets_id_fk",
+          "tableFrom": "digital_asset_file_versions",
+          "tableTo": "digital_assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.digital_asset_ownerships": {
+      "name": "digital_asset_ownerships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "exercised_at": {
+          "name": "exercised_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_dao_customer": {
+          "name": "idx_dao_customer",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dao_asset": {
+          "name": "idx_dao_asset",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dao_order": {
+          "name": "idx_dao_order",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_dao_customer_asset_order": {
+          "name": "uniq_dao_customer_asset_order",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "digital_asset_ownerships_asset_id_digital_assets_id_fk": {
+          "name": "digital_asset_ownerships_asset_id_digital_assets_id_fk",
+          "tableFrom": "digital_asset_ownerships",
+          "tableTo": "digital_assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.digital_assets": {
+      "name": "digital_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_file_version_id": {
+          "name": "current_file_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_digital_assets_name": {
+          "name": "idx_digital_assets_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_digital_assets_created_at": {
+          "name": "idx_digital_assets_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_digital_assets_deleted_at": {
+          "name": "idx_digital_assets_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "digital_assets_current_file_version_id_digital_asset_file_versions_id_fk": {
+          "name": "digital_assets_current_file_version_id_digital_asset_file_versions_id_fk",
+          "tableFrom": "digital_assets",
+          "tableTo": "digital_asset_file_versions",
+          "columnsFrom": [
+            "current_file_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_variant_digital_asset_links": {
+      "name": "product_variant_digital_asset_links",
+      "schema": "",
+      "columns": {
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pvdal_variant": {
+          "name": "idx_pvdal_variant",
+          "columns": [
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pvdal_asset": {
+          "name": "idx_pvdal_asset",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_variant_digital_asset_links_asset_id_digital_assets_id_fk": {
+          "name": "product_variant_digital_asset_links_asset_id_digital_assets_id_fk",
+          "tableFrom": "product_variant_digital_asset_links",
+          "tableTo": "digital_assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "product_variant_digital_asset_links_variant_id_asset_id_pk": {
+          "name": "product_variant_digital_asset_links_variant_id_asset_id_pk",
+          "columns": [
+            "variant_id",
+            "asset_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cs_case_comment_attachments": {
+      "name": "cs_case_comment_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cs_case_id": {
+          "name": "cs_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cs_attachment_case_id": {
+          "name": "idx_cs_attachment_case_id",
+          "columns": [
+            {
+              "expression": "cs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cs_attachment_comment_id": {
+          "name": "idx_cs_attachment_comment_id",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cs_case_comment_mentions": {
+      "name": "cs_case_comment_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentioned_user_id": {
+          "name": "mentioned_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cs_mention_user": {
+          "name": "idx_cs_mention_user",
+          "columns": [
+            {
+              "expression": "mentioned_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_cs_comment_mention": {
+          "name": "uq_cs_comment_mention",
+          "nullsNotDistinct": false,
+          "columns": [
+            "comment_id",
+            "mentioned_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cs_case_comments": {
+      "name": "cs_case_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cs_case_id": {
+          "name": "cs_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cs_case_comments_case_id": {
+          "name": "idx_cs_case_comments_case_id",
+          "columns": [
+            {
+              "expression": "cs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cs_case_events": {
+      "name": "cs_case_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cs_case_id": {
+          "name": "cs_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(48)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cs_case_events_case_id": {
+          "name": "idx_cs_case_events_case_id",
+          "columns": [
+            {
+              "expression": "cs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cs_case_labels": {
+      "name": "cs_case_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cs_case_id": {
+          "name": "cs_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cs_case_labels_case_id": {
+          "name": "idx_cs_case_labels_case_id",
+          "columns": [
+            {
+              "expression": "cs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_cs_case_label": {
+          "name": "uq_cs_case_label",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cs_case_id",
+            "label_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cs_cases": {
+      "name": "cs_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_channel": {
+          "name": "source_channel",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'kakao'"
+        },
+        "external_thread_ref": {
+          "name": "external_thread_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cs_cases_status": {
+          "name": "idx_cs_cases_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cs_cases_customer_id": {
+          "name": "idx_cs_cases_customer_id",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cs_cases_assigned_to": {
+          "name": "idx_cs_cases_assigned_to",
+          "columns": [
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cs_cases_source_channel": {
+          "name": "idx_cs_cases_source_channel",
+          "columns": [
+            {
+              "expression": "source_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cs_cases_created_at": {
+          "name": "idx_cs_cases_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cs_labels": {
+      "name": "cs_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#888888'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_cs_labels_name": {
+          "name": "uq_cs_labels_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "event.outbox_events": {
+      "name": "outbox_events",
+      "schema": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_type": {
+          "name": "aggregate_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "outbox_status_idx": {
+          "name": "outbox_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_processing_started_idx": {
+          "name": "outbox_processing_started_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processing_started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_topic_idx": {
+          "name": "outbox_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "event.event_resource_links": {
+      "name": "event_resource_links",
+      "schema": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(26)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "erl_chain_idx": {
+          "name": "erl_chain_idx",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "erl_resource_idx": {
+          "name": "erl_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "erl_event_idx": {
+          "name": "erl_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.role_scope_mapping": {
+      "name": "role_scope_mapping",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_scope_unique_idx": {
+          "name": "role_scope_unique_idx",
+          "columns": [
+            {
+              "expression": "role_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_scope_mapping_scope_id_scopes_id_fk": {
+          "name": "role_scope_mapping_scope_id_scopes_id_fk",
+          "tableFrom": "role_scope_mapping",
+          "tableTo": "scopes",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.scopes": {
+      "name": "scopes",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microservice_name": {
+          "name": "microservice_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scopes_key_unique": {
+          "name": "scopes_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.product_master_version_approval_status": {
+      "name": "product_master_version_approval_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.product_master_version_status": {
+      "name": "product_master_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "inactive",
+        "active"
+      ]
+    },
+    "public.pricing_rule_layer": {
+      "name": "pricing_rule_layer",
+      "schema": "public",
+      "values": [
+        "base_price",
+        "membership_price",
+        "tiered_price"
+      ]
+    },
+    "public.pricing_rule_operation_type": {
+      "name": "pricing_rule_operation_type",
+      "schema": "public",
+      "values": [
+        "offset",
+        "scale",
+        "override"
+      ]
+    },
+    "public.pricing_rule_scope_type": {
+      "name": "pricing_rule_scope_type",
+      "schema": "public",
+      "values": [
+        "all_variants",
+        "with_option",
+        "variants"
+      ]
+    },
+    "public.product_import_item_status": {
+      "name": "product_import_item_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "failed"
+      ]
+    },
+    "public.product_import_session_status": {
+      "name": "product_import_session_status",
+      "schema": "public",
+      "values": [
+        "completed",
+        "archived"
+      ]
+    },
+    "public.audit_event_type": {
+      "name": "audit_event_type",
+      "schema": "public",
+      "values": [
+        "USER_LOGIN",
+        "USER_LOGOUT",
+        "USER_ACTION",
+        "STOCK_CREATED",
+        "STOCK_UPDATED",
+        "STOCK_DELETED",
+        "STOCK_RESERVED",
+        "STOCK_UNRESERVED",
+        "STOCK_MOVED",
+        "ORDER_CREATED",
+        "ORDER_CONFIRMED",
+        "ORDER_CANCELLED",
+        "ORDER_MERGED",
+        "FULFILLMENT_CREATED",
+        "FULFILLMENT_READY",
+        "FULFILLMENT_SHIPPED",
+        "SKU_CREATED",
+        "SKU_UPDATED",
+        "SKU_DELETED",
+        "PRODUCT_MATCHED",
+        "PRODUCT_MATCHING_RESOLVED",
+        "SYSTEM_STARTUP",
+        "SYSTEM_ERROR",
+        "SYSTEM_WARNING",
+        "CONFIG_CHANGED",
+        "POLICY_CHANGED"
+      ]
+    },
+    "public.audit_severity": {
+      "name": "audit_severity",
+      "schema": "public",
+      "values": [
+        "INFO",
+        "WARN",
+        "ERROR",
+        "CRITICAL"
+      ]
+    },
+    "public.batch_inventory_custody_type": {
+      "name": "batch_inventory_custody_type",
+      "schema": "public",
+      "values": [
+        "AT_SOURCE",
+        "WORKER",
+        "BULK_CART",
+        "TOTE",
+        "SORTING",
+        "PACKING",
+        "PACKED",
+        "RETURN_PENDING",
+        "SETTLED"
+      ]
+    },
+    "public.batch_inventory_session_status": {
+      "name": "batch_inventory_session_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "settled",
+        "recovery_required",
+        "canceled"
+      ]
+    },
+    "public.batch_status": {
+      "name": "batch_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "picking",
+        "completed",
+        "canceled"
+      ]
+    },
+    "public.carrier": {
+      "name": "carrier",
+      "schema": "public",
+      "values": [
+        "CJ",
+        "HANJIN",
+        "LOTTE",
+        "LOGEN",
+        "KDEXP",
+        "CJGLS"
+      ]
+    },
+    "public.direct_ship_status": {
+      "name": "direct_ship_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "forwarded",
+        "completed",
+        "canceled"
+      ]
+    },
+    "public.dispatch_attempt_status": {
+      "name": "dispatch_attempt_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "dispatched",
+        "recalled",
+        "recovery_required"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "POSTED",
+        "VOIDED"
+      ]
+    },
+    "public.event_type_order": {
+      "name": "event_type_order",
+      "schema": "public",
+      "values": [
+        "ORDER_CREATED",
+        "ORDER_CONFIRMED",
+        "ORDER_MODIFIED",
+        "ORDER_CANCELLED",
+        "ORDER_REFUND_CREATED"
+      ]
+    },
+    "public.exchange_reason_code": {
+      "name": "exchange_reason_code",
+      "schema": "public",
+      "values": [
+        "defective",
+        "not_as_described",
+        "change_of_mind",
+        "wrong_item",
+        "damaged_in_shipping",
+        "other"
+      ]
+    },
+    "public.exchange_request_status": {
+      "name": "exchange_request_status",
+      "schema": "public",
+      "values": [
+        "requested",
+        "approved",
+        "rejected",
+        "collection_pending",
+        "collected",
+        "inspected",
+        "refund_pending",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.fulfillment_command_request_status": {
+      "name": "fulfillment_command_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.fulfillment_mode": {
+      "name": "fulfillment_mode",
+      "schema": "public",
+      "values": [
+        "in_house",
+        "3pl",
+        "drop_ship"
+      ]
+    },
+    "public.fulfillment_order_creation_backlog_status": {
+      "name": "fulfillment_order_creation_backlog_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "awaiting_matching",
+        "completed",
+        "not_required",
+        "failed"
+      ]
+    },
+    "public.fulfillment_status": {
+      "name": "fulfillment_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "partially_reserved",
+        "ready",
+        "processing",
+        "shipped",
+        "partially_shipped",
+        "completed",
+        "canceled",
+        "recovery_required"
+      ]
+    },
+    "public.inbound_method": {
+      "name": "inbound_method",
+      "schema": "public",
+      "values": [
+        "individual",
+        "simple",
+        "simple_fullscan",
+        "planned"
+      ]
+    },
+    "public.inbound_receipt_status": {
+      "name": "inbound_receipt_status",
+      "schema": "public",
+      "values": [
+        "posted",
+        "voided"
+      ]
+    },
+    "public.inbound_status": {
+      "name": "inbound_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "applied",
+        "receiving",
+        "confirmed"
+      ]
+    },
+    "public.inbound_work_type": {
+      "name": "inbound_work_type",
+      "schema": "public",
+      "values": [
+        "INBOUND",
+        "PUTAWAY",
+        "RETURN",
+        "CANCEL"
+      ]
+    },
+    "public.location_type": {
+      "name": "location_type",
+      "schema": "public",
+      "values": [
+        "standard",
+        "zone"
+      ]
+    },
+    "public.matching_priority": {
+      "name": "matching_priority",
+      "schema": "public",
+      "values": [
+        "normal",
+        "high"
+      ]
+    },
+    "public.matching_status": {
+      "name": "matching_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "matched",
+        "ignored"
+      ]
+    },
+    "public.matching_strategy": {
+      "name": "matching_strategy",
+      "schema": "public",
+      "values": [
+        "void",
+        "variant"
+      ]
+    },
+    "public.order_item_status": {
+      "name": "order_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "matched",
+        "stock_deducted",
+        "stock_unavailable",
+        "cancelled"
+      ]
+    },
+    "public.order_status": {
+      "name": "order_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "processing",
+        "shipped",
+        "delivered",
+        "cancelled",
+        "timeout"
+      ]
+    },
+    "public.outbound_batch_work_item_status": {
+      "name": "outbound_batch_work_item_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "picking",
+        "ready_to_pack",
+        "packing",
+        "completed",
+        "short_pick_recovery",
+        "excluded"
+      ]
+    },
+    "public.outbox_status": {
+      "name": "outbox_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "published",
+        "failed"
+      ]
+    },
+    "public.picking_method": {
+      "name": "picking_method",
+      "schema": "public",
+      "values": [
+        "individual",
+        "total_picking"
+      ]
+    },
+    "public.picking_plan_status": {
+      "name": "picking_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "invalidated",
+        "completed",
+        "canceled"
+      ]
+    },
+    "public.picking_strategy": {
+      "name": "picking_strategy",
+      "schema": "public",
+      "values": [
+        "discrete",
+        "aggregate_then_sort",
+        "pick_to_tote"
+      ]
+    },
+    "public.plan_type": {
+      "name": "plan_type",
+      "schema": "public",
+      "values": [
+        "source",
+        "destination"
+      ]
+    },
+    "public.po_audit_status": {
+      "name": "po_audit_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending_audit",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.po_status": {
+      "name": "po_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "confirmed",
+        "received"
+      ]
+    },
+    "public.po_type": {
+      "name": "po_type",
+      "schema": "public",
+      "values": [
+        "domestic",
+        "foreign"
+      ]
+    },
+    "public.reservation_status": {
+      "name": "reservation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "released",
+        "active"
+      ]
+    },
+    "public.return_reason_code": {
+      "name": "return_reason_code",
+      "schema": "public",
+      "values": [
+        "defective",
+        "not_as_described",
+        "change_of_mind",
+        "wrong_item",
+        "damaged_in_shipping",
+        "other"
+      ]
+    },
+    "public.return_refund_attempt_status": {
+      "name": "return_refund_attempt_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "succeeded",
+        "failed"
+      ]
+    },
+    "public.return_request_status": {
+      "name": "return_request_status",
+      "schema": "public",
+      "values": [
+        "requested",
+        "approved",
+        "rejected",
+        "collection_pending",
+        "collected",
+        "inspected",
+        "refund_pending",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.return_status": {
+      "name": "return_status",
+      "schema": "public",
+      "values": [
+        "requested",
+        "received",
+        "qc_passed",
+        "qc_failed",
+        "disposed"
+      ]
+    },
+    "public.sales_channel": {
+      "name": "sales_channel",
+      "schema": "public",
+      "values": [
+        "medusa",
+        "naver",
+        "coupang",
+        "3pl"
+      ]
+    },
+    "public.setting_key": {
+      "name": "setting_key",
+      "schema": "public",
+      "values": [
+        "use_sub_barcode",
+        "use_expiry_separation"
+      ]
+    },
+    "public.shipment_operation_member_role": {
+      "name": "shipment_operation_member_role",
+      "schema": "public",
+      "values": [
+        "source",
+        "target"
+      ]
+    },
+    "public.shipment_operation_status": {
+      "name": "shipment_operation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "failed",
+        "recovery_required"
+      ]
+    },
+    "public.shipment_operation_type": {
+      "name": "shipment_operation_type",
+      "schema": "public",
+      "values": [
+        "split",
+        "consolidate",
+        "recipient_revision",
+        "cancel",
+        "reopen",
+        "plan",
+        "replan",
+        "short_pick",
+        "recall"
+      ]
+    },
+    "public.shipment_status": {
+      "name": "shipment_status",
+      "schema": "public",
+      "values": [
+        "shipped",
+        "in_transit",
+        "delivered",
+        "failed",
+        "canceled",
+        "draft",
+        "planned",
+        "superseded",
+        "recovery_required"
+      ]
+    },
+    "public.source_type": {
+      "name": "source_type",
+      "schema": "public",
+      "values": [
+        "direct",
+        "in_house",
+        "overseas"
+      ]
+    },
+    "public.stock_state": {
+      "name": "stock_state",
+      "schema": "public",
+      "values": [
+        "ON_HAND",
+        "DEFECTIVE",
+        "IN_TRANSFER"
+      ]
+    },
+    "public.stock_type": {
+      "name": "stock_type",
+      "schema": "public",
+      "values": [
+        "physical",
+        "infinite",
+        "drop_shipped",
+        "consignment"
+      ]
+    },
+    "public.stocktaking_status": {
+      "name": "stocktaking_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "in_progress",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.system_location_role": {
+      "name": "system_location_role",
+      "schema": "public",
+      "values": [
+        "inbound_default",
+        "return_default",
+        "outbound_rework"
+      ]
+    },
+    "public.task_priority": {
+      "name": "task_priority",
+      "schema": "public",
+      "values": [
+        "normal",
+        "high",
+        "urgent"
+      ]
+    },
+    "public.task_status": {
+      "name": "task_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "picking",
+        "packed",
+        "shipped",
+        "canceled"
+      ]
+    },
+    "public.tote_status": {
+      "name": "tote_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "in_use",
+        "damaged",
+        "retired"
+      ]
+    },
+    "public.transition_type": {
+      "name": "transition_type",
+      "schema": "public",
+      "values": [
+        "RECEIVE",
+        "SHIP",
+        "MOVE",
+        "MARK_DEFECT",
+        "REWORK_GOOD",
+        "SCRAP",
+        "ADJUST_UP",
+        "ADJUST_DOWN"
+      ]
+    },
+    "public.unavailable_reason": {
+      "name": "unavailable_reason",
+      "schema": "public",
+      "values": [
+        "pb",
+        "foreign",
+        "low_margin"
+      ]
+    },
+    "public.warehouse_type": {
+      "name": "warehouse_type",
+      "schema": "public",
+      "values": [
+        "domestic",
+        "overseas",
+        "bonded",
+        "return"
+      ]
+    },
+    "public.waybill_source": {
+      "name": "waybill_source",
+      "schema": "public",
+      "values": [
+        "carrier",
+        "manual"
+      ]
+    },
+    "public.waybill_status": {
+      "name": "waybill_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "allocated",
+        "registered",
+        "used",
+        "voided",
+        "failed",
+        "abandoned"
+      ]
+    }
+  },
+  "schemas": {
+    "event": "event",
+    "auth": "auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.stock_summary_view": {
+      "columns": {
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_name": {
+          "name": "sku_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warehouse_name": {
+          "name": "warehouse_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_hand_qty": {
+          "name": "on_hand_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "defective_qty": {
+          "name": "defective_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "in_transfer_qty": {
+          "name": "in_transfer_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reserved_qty": {
+          "name": "reserved_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_qty": {
+          "name": "available_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "inbound_pending_qty": {
+          "name": "inbound_pending_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "on_order_qty": {
+          "name": "on_order_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transfer_pending_qty": {
+          "name": "transfer_pending_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "projected_available_qty": {
+          "name": "projected_available_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_calculated_at": {
+          "name": "last_calculated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "\n    SELECT\n        s.id as sku_id,\n        w.id as warehouse_id,\n        s.name as sku_name,\n        w.name as warehouse_name,\n\n        -- 물리적 재고\n        COALESCE(on_hand.qty, 0) as on_hand_qty,\n        COALESCE(defective.qty, 0) as defective_qty,\n        COALESCE(in_transfer.qty, 0) as in_transfer_qty,\n\n        -- 예약 상태\n        COALESCE(reserved.qty, 0) as reserved_qty,\n        COALESCE(on_hand.qty, 0) - COALESCE(reserved.qty, 0) - COALESCE(transit_out.qty, 0) as available_qty,\n\n        -- 예정 상태\n        COALESCE(inbound_pending.qty, 0) as inbound_pending_qty,\n        0 as on_order_qty,\n        COALESCE(transit_out.qty, 0) as transfer_pending_qty,\n\n        -- 계산된 전망\n        COALESCE(on_hand.qty, 0) - COALESCE(reserved.qty, 0) + COALESCE(inbound_pending.qty, 0) as projected_available_qty,\n\n        NOW() as last_calculated_at\n\n    FROM skus s\n    CROSS JOIN warehouses w\n    LEFT JOIN (\n        SELECT sku_id, warehouse_id, SUM(qty) as qty\n        FROM stock_ledgers\n        WHERE stock_state = 'ON_HAND'\n        GROUP BY sku_id, warehouse_id\n    ) on_hand ON s.id = on_hand.sku_id AND w.id = on_hand.warehouse_id\n    LEFT JOIN (\n        SELECT sku_id, warehouse_id, SUM(qty) as qty\n        FROM stock_ledgers\n        WHERE stock_state = 'DEFECTIVE'\n        GROUP BY sku_id, warehouse_id\n    ) defective ON s.id = defective.sku_id AND w.id = defective.warehouse_id\n    LEFT JOIN (\n        SELECT sku_id, warehouse_id, SUM(qty) as qty\n        FROM stock_ledgers\n        WHERE stock_state = 'IN_TRANSFER'\n        GROUP BY sku_id, warehouse_id\n    ) in_transfer ON s.id = in_transfer.sku_id AND w.id = in_transfer.warehouse_id\n    LEFT JOIN (\n        SELECT sku_id, warehouse_id, SUM(quantity) as qty\n        FROM stock_reservations\n        WHERE status = 'confirmed'\n        GROUP BY sku_id, warehouse_id\n    ) reserved ON s.id = reserved.sku_id AND w.id = reserved.warehouse_id\n    LEFT JOIN (\n        SELECT ipi.sku_id, ip.destination_warehouse_id, SUM(ipi.expected_qty - ipi.received_qty) as qty\n        FROM inbound_plan_items ipi\n        INNER JOIN inbound_plans ip ON ipi.plan_id = ip.id\n        WHERE ipi.status = 'pending'\n        GROUP BY ipi.sku_id, ip.destination_warehouse_id\n    ) inbound_pending ON s.id = inbound_pending.sku_id AND w.id = inbound_pending.destination_warehouse_id\n    LEFT JOIN (\n        SELECT ipi.sku_id, ip.warehouse_id, SUM(ipi.expected_qty - ipi.received_qty) as qty\n        FROM inbound_plan_items ipi\n        INNER JOIN inbound_plans ip ON ipi.plan_id = ip.id\n        WHERE ipi.status = 'pending' AND ip.requires_transfer = true AND ip.warehouse_id != ip.destination_warehouse_id\n        GROUP BY ipi.sku_id, ip.warehouse_id\n    ) transit_out ON s.id = transit_out.sku_id AND w.id = transit_out.warehouse_id\n",
+      "name": "stock_summary_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/core/drizzle/meta/_journal.json
+++ b/apps/core/drizzle/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1784290811317,
       "tag": "20260717122011_drop-invoices",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1784702981671,
+      "tag": "20260722064941_add-order-list-perf-indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/core/src/modules/catalog/core/products/services/product-variants.service.ts
+++ b/apps/core/src/modules/catalog/core/products/services/product-variants.service.ts
@@ -607,6 +607,7 @@ export class ProductVariantsService {
       masterId: string;
       masterName: string;
       optionLabel?: string;
+      thumbnail?: string | null;
     }[]
   > {
     if (!ids.length) return [];
@@ -620,6 +621,7 @@ export class ProductVariantsService {
         masterId: productMasterVariants.masterId,
         versionId: productMasterVariants.versionId,
         masterName: productMasterVersions.name,
+        thumbnail: productMasterVersions.thumbnail, // 마스터 버전 대표 썸네일(파일 ID)
       })
       .from(productVariants)
       .innerJoin(productMasterVariants, eq(productMasterVariants.variantId, productVariants.id))
@@ -683,6 +685,7 @@ export class ProductVariantsService {
       masterId: row.masterId,
       masterName: row.masterName,
       optionLabel: optionMap.get(row.variantId)?.join(', '),
+      thumbnail: row.thumbnail ?? null,
     }));
   }
 

--- a/apps/core/src/modules/inventory/schema/inventory.schema.ts
+++ b/apps/core/src/modules/inventory/schema/inventory.schema.ts
@@ -1142,6 +1142,7 @@ export const salesOrders = pgTable(
   },
   (t) => ({
     uniqueChannelOrder: unique().on(t.salesChannel, t.channelOrderId), // 채널별 주문 ID 유니크
+    idxOrderDate: index('idx_sales_orders_order_date').on(t.orderDate), // 주문내역/통계의 주 기간필터
   }),
 );
 
@@ -1183,6 +1184,7 @@ export const salesOrderLines = pgTable(
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => ({
+    idxSalesOrderId: index('idx_sales_order_lines_sales_order_id').on(t.salesOrderId), // EXISTS/조인 주문별 라인 조회
     idxMappingSnapshot: index('idx_sales_order_lines_snapshot').on(t.mappingSnapshotId),
     idxVariant: index('idx_sales_order_lines_variant').on(t.variantId),
     idxChannelOrderItem: index('idx_sales_order_lines_channel_order_item').on(t.channelOrderItemId),

--- a/apps/core/src/modules/sales-order/dto/sales-order-filter.dto.ts
+++ b/apps/core/src/modules/sales-order/dto/sales-order-filter.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsEnum, IsDateString, IsInt, Min } from 'class-validator';
+import { IsOptional, IsEnum, IsDateString, IsInt, Min, IsIn, IsString, IsBoolean } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { orderStatusEnum, salesChannelEnum } from '../schema/sales-order.schema';
 
@@ -8,6 +8,24 @@ type OrderStatusEnum = (typeof orderStatusValues)[number];
 
 const salesChannelValues = salesChannelEnum.enumValues;
 type SalesChannelEnum = (typeof salesChannelValues)[number];
+
+// 구분 필터 — 재고/매칭 상태 파생 (어드민 주문내역 화면 '구분')
+export const ORDER_TYPE_GROUPS = [
+  'all', // 전체
+  'pending', // 주문 미확정
+  'ready', // 완전출고 (모든 라인 재고차감)
+  'partial', // 부분출고 (일부 라인만 재고차감)
+  'hold', // 출고불가 (재고부족 라인 존재)
+  'unmatched', // 매칭안됨 (미매칭 라인 존재)
+  'direct', // 직배송 (drop_ship FO 존재)
+] as const;
+export type OrderTypeGroup = (typeof ORDER_TYPE_GROUPS)[number];
+
+export const ORDER_KEYWORD_TYPES = ['all', 'orderNo', 'receiver', 'phone', 'product'] as const;
+export type OrderKeywordType = (typeof ORDER_KEYWORD_TYPES)[number];
+
+const toBool = ({ value }: { value: unknown }) =>
+  value === true || value === 'true' || value === '1';
 
 export class SalesOrderFilterDto {
   @ApiPropertyOptional({ description: '조회 시작일 (YYYY-MM-DD)' })
@@ -25,10 +43,37 @@ export class SalesOrderFilterDto {
   @IsEnum(salesChannelValues)
   channel?: SalesChannelEnum;
 
-  @ApiPropertyOptional({ description: '주문 상태', enum: orderStatusValues })
+  @ApiPropertyOptional({ description: '주문 상태(단일)', enum: orderStatusValues })
   @IsOptional()
   @IsEnum(orderStatusValues)
   status?: OrderStatusEnum;
+
+  @ApiPropertyOptional({ description: '구분 (재고/매칭 상태)', enum: ORDER_TYPE_GROUPS })
+  @IsOptional()
+  @IsIn(ORDER_TYPE_GROUPS)
+  typeGroup?: OrderTypeGroup;
+
+  @ApiPropertyOptional({ description: "취소/타임아웃 제외 (typeGroup='all'일 때)" })
+  @IsOptional()
+  @Transform(toBool)
+  @IsBoolean()
+  excludeTerminal?: boolean;
+
+  @ApiPropertyOptional({ description: '환불 실패/수동처리 주문만' })
+  @IsOptional()
+  @Transform(toBool)
+  @IsBoolean()
+  refundIssueOnly?: boolean;
+
+  @ApiPropertyOptional({ description: '키워드' })
+  @IsOptional()
+  @IsString()
+  keyword?: string;
+
+  @ApiPropertyOptional({ description: '키워드 검색 대상', enum: ORDER_KEYWORD_TYPES })
+  @IsOptional()
+  @IsIn(ORDER_KEYWORD_TYPES)
+  keywordType?: OrderKeywordType;
 
   @ApiPropertyOptional({ description: '조회할 최대 개수', default: 20 })
   @IsOptional()

--- a/apps/core/src/modules/sales-order/services/sales-orders.list.integration.spec.ts
+++ b/apps/core/src/modules/sales-order/services/sales-orders.list.integration.spec.ts
@@ -1,0 +1,251 @@
+import { randomUUID } from 'crypto';
+import * as postgres from 'postgres';
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { DbTx, wmsSchema, wmsTables } from '../../inventory/schema/inventory.schema';
+import { makeDb, makeDbService, inRollbackTx } from '../../fulfillment/services/__support__';
+import { SalesOrdersService } from './sales-orders.service';
+import type { SalesOrderFilterDto } from '../dto/sales-order-filter.dto';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+
+// list() 는 this.db.run(fn, tx) 만 쓰므로 나머지 의존성은 미사용 → 빈 목으로 충분.
+function makeService(db: PostgresJsDatabase<typeof wmsSchema>): SalesOrdersService {
+  const noop = {} as never;
+  return new SalesOrdersService(makeDbService(db), noop, noop, noop, noop, noop, noop);
+}
+
+async function insertOrder(
+  tx: DbTx,
+  o: Partial<{
+    status: 'pending' | 'confirmed' | 'cancelled' | 'timeout';
+    orderDate: Date;
+    channelOrderId: string;
+    customerName: string | null;
+    customerPhone: string | null;
+    salesChannel: 'medusa' | 'naver' | 'coupang' | '3pl';
+    shippingAddress: unknown;
+  }> = {},
+): Promise<string> {
+  const [so] = await tx
+    .insert(wmsTables.salesOrders)
+    .values({
+      channelOrderId: o.channelOrderId ?? `IT-${randomUUID().slice(0, 12)}`,
+      salesChannel: o.salesChannel ?? 'medusa',
+      status: o.status ?? 'confirmed',
+      shippingAddress: o.shippingAddress ?? { recipientName: 'RCPT', phone: '01000000000' },
+      customerName: o.customerName ?? null,
+      customerPhone: o.customerPhone ?? null,
+      orderDate: o.orderDate ?? new Date(),
+    })
+    .returning();
+  return so.id;
+}
+
+async function insertLine(
+  tx: DbTx,
+  salesOrderId: string,
+  l: Partial<{
+    status: 'pending' | 'matched' | 'stock_deducted' | 'stock_unavailable' | 'cancelled';
+    productMatchingId: string | null;
+    productName: string;
+  }> = {},
+): Promise<void> {
+  await tx.insert(wmsTables.salesOrderLines).values({
+    salesOrderId,
+    variantId: randomUUID(),
+    productName: l.productName ?? 'IT Product',
+    quantity: 1,
+    unitPrice: 1000,
+    status: l.status ?? 'pending',
+    productMatchingId: l.productMatchingId ?? null,
+  });
+}
+
+async function insertRefundLink(
+  tx: DbTx,
+  salesOrderId: string,
+  refundStatus: string,
+  createdAt: Date,
+  extraMeta: Record<string, unknown> = {},
+): Promise<string> {
+  const [row] = await tx
+    .insert(wmsTables.businessLinks)
+    .values({
+      sourceType: 'sales_order',
+      sourceId: salesOrderId,
+      targetType: 'wallet_refund',
+      targetId: randomUUID(),
+      relationName: 'cancellation_linked_wallet_refund',
+      metadata: { refundStatus, ...extraMeta },
+      occurredAt: createdAt,
+      createdAt,
+    })
+    .returning();
+  return row.id;
+}
+
+describeIfDb('SalesOrdersService.list — server-side filters (DB integration, rollback-only)', () => {
+  jest.setTimeout(120_000);
+  let client: postgres.Sql;
+  let db: PostgresJsDatabase<typeof wmsSchema>;
+
+  beforeAll(() => {
+    ({ sql: client, db } = makeDb(DATABASE_URL as string));
+  });
+  afterAll(async () => {
+    await client.end();
+  });
+
+  const run = (fn: (tx: DbTx, svc: SalesOrdersService, tag: string) => Promise<void>) =>
+    inRollbackTx(db, async (tx) => {
+      // 이 테스트가 만든 주문만 조회하도록 유니크 채널 접두사로 격리
+      const tag = `TAG-${randomUUID().slice(0, 8)}`;
+      await fn(tx, makeService(db), tag);
+    });
+
+  const listByKeyword = (svc: SalesOrdersService, tx: DbTx, extra: Partial<SalesOrderFilterDto>) =>
+    svc.list({ limit: 100, offset: 0, keyword: undefined, ...extra } as SalesOrderFilterDto, tx);
+
+  it('KST 달력일 경계로 필터한다 (00:30 KST 포함, 익일 00:30 제외)', async () => {
+    await run(async (tx, svc, tag) => {
+      // KST 2026-07-22 00:30 == UTC 2026-07-21 15:30
+      const inDay = await insertOrder(tx, {
+        channelOrderId: `${tag}-in`,
+        orderDate: new Date('2026-07-21T15:30:00.000Z'),
+      });
+      // KST 2026-07-23 00:30 == UTC 2026-07-22 15:30 (다음날)
+      await insertOrder(tx, {
+        channelOrderId: `${tag}-out`,
+        orderDate: new Date('2026-07-22T15:30:00.000Z'),
+      });
+
+      const res = await listByKeyword(svc, tx, {
+        startDate: '2026-07-22',
+        endDate: '2026-07-22',
+        keyword: tag,
+      });
+      const ids = res.data.map((d: { id: string }) => d.id);
+      expect(ids).toContain(inDay);
+      expect(res.data).toHaveLength(1);
+    });
+  });
+
+  it('typeGroup: ready / partial / hold 를 라인 상태로 구분한다', async () => {
+    await run(async (tx, svc, tag) => {
+      const ready = await insertOrder(tx, { channelOrderId: `${tag}-ready` });
+      await insertLine(tx, ready, { status: 'stock_deducted' });
+      await insertLine(tx, ready, { status: 'stock_deducted' });
+
+      const partial = await insertOrder(tx, { channelOrderId: `${tag}-partial` });
+      await insertLine(tx, partial, { status: 'stock_deducted' });
+      await insertLine(tx, partial, { status: 'pending' });
+
+      const hold = await insertOrder(tx, { channelOrderId: `${tag}-hold` });
+      await insertLine(tx, hold, { status: 'stock_unavailable' });
+
+      const readyRes = await listByKeyword(svc, tx, { keyword: tag, typeGroup: 'ready' });
+      expect(readyRes.data.map((d: { id: string }) => d.id)).toEqual([ready]);
+
+      const partialRes = await listByKeyword(svc, tx, { keyword: tag, typeGroup: 'partial' });
+      expect(partialRes.data.map((d: { id: string }) => d.id)).toEqual([partial]);
+
+      const holdRes = await listByKeyword(svc, tx, { keyword: tag, typeGroup: 'hold' });
+      expect(holdRes.data.map((d: { id: string }) => d.id)).toEqual([hold]);
+    });
+  });
+
+  it('typeGroup: unmatched 는 미매칭 라인이 있는 주문만', async () => {
+    await run(async (tx, svc, tag) => {
+      const [matching] = await tx
+        .insert(wmsTables.productMatchings)
+        .values({ variantId: randomUUID(), status: 'matched', strategy: 'variant', isResolved: true })
+        .returning();
+
+      const unmatched = await insertOrder(tx, { channelOrderId: `${tag}-unmatched` });
+      await insertLine(tx, unmatched, { productMatchingId: null });
+
+      const matched = await insertOrder(tx, { channelOrderId: `${tag}-matched` });
+      await insertLine(tx, matched, { productMatchingId: matching.id });
+
+      const res = await listByKeyword(svc, tx, { keyword: tag, typeGroup: 'unmatched' });
+      expect(res.data.map((d: { id: string }) => d.id)).toEqual([unmatched]);
+    });
+  });
+
+  it('keyword: 상품명 / 수령자 / 주문번호 대상별 검색', async () => {
+    await run(async (tx, svc, tag) => {
+      const byProduct = await insertOrder(tx, { channelOrderId: `${tag}-p` });
+      await insertLine(tx, byProduct, { productName: `${tag}-바나나킥` });
+
+      const byReceiver = await insertOrder(tx, {
+        channelOrderId: `${tag}-r`,
+        shippingAddress: { recipientName: `${tag}-홍길동`, phone: '01011112222' },
+      });
+      await insertLine(tx, byReceiver, {});
+
+      const productRes = await listByKeyword(svc, tx, {
+        keyword: `${tag}-바나나킥`,
+        keywordType: 'product',
+      });
+      expect(productRes.data.map((d: { id: string }) => d.id)).toEqual([byProduct]);
+
+      const receiverRes = await listByKeyword(svc, tx, {
+        keyword: `${tag}-홍길동`,
+        keywordType: 'receiver',
+      });
+      expect(receiverRes.data.map((d: { id: string }) => d.id)).toEqual([byReceiver]);
+
+      const orderNoRes = await listByKeyword(svc, tx, {
+        keyword: `${tag}-p`,
+        keywordType: 'orderNo',
+      });
+      expect(orderNoRes.data.map((d: { id: string }) => d.id)).toEqual([byProduct]);
+    });
+  });
+
+  it('refundIssueOnly: 어드민 화면과 동일 규칙 (미완료 manual_pending 또는 최신 failed; 정식 종결만 제외)', async () => {
+    await run(async (tx, svc, tag) => {
+      // ① 최신이 manual_pending → 포함
+      const pending = await insertOrder(tx, { channelOrderId: `${tag}-pending`, status: 'cancelled' });
+      await insertRefundLink(tx, pending, 'failed', new Date('2026-01-01T00:00:00Z'));
+      await insertRefundLink(tx, pending, 'manual_pending', new Date('2026-01-02T00:00:00Z'));
+
+      // ② manual_pending 을 완결(completedRefundLinkId 로 종결)한 succeeded → 제외
+      const completed = await insertOrder(tx, { channelOrderId: `${tag}-completed`, status: 'cancelled' });
+      const mpLinkId = await insertRefundLink(tx, completed, 'manual_pending', new Date('2026-01-01T00:00:00Z'));
+      await insertRefundLink(tx, completed, 'succeeded', new Date('2026-01-03T00:00:00Z'), {
+        completedRefundLinkId: mpLinkId,
+      });
+
+      // ③ 미완료 manual_pending + 뒤에 '무관한' succeeded(다른 링크를 완결) → 여전히 미처리라 포함
+      const unrelated = await insertOrder(tx, { channelOrderId: `${tag}-unrelated`, status: 'cancelled' });
+      await insertRefundLink(tx, unrelated, 'manual_pending', new Date('2026-01-01T00:00:00Z'));
+      await insertRefundLink(tx, unrelated, 'succeeded', new Date('2026-01-03T00:00:00Z'), {
+        completedRefundLinkId: randomUUID(), // 이 주문의 manual_pending 을 가리키지 않음
+      });
+
+      // ④ failed(t1) 후 무관 succeeded(t2, 최신) → 최신이 failed 아님·미완료 mp 없음 → 제외
+      const retried = await insertOrder(tx, { channelOrderId: `${tag}-retried`, status: 'cancelled' });
+      await insertRefundLink(tx, retried, 'failed', new Date('2026-01-01T00:00:00Z'));
+      await insertRefundLink(tx, retried, 'succeeded', new Date('2026-01-02T00:00:00Z'));
+
+      const res = await listByKeyword(svc, tx, { keyword: tag, refundIssueOnly: true });
+      expect(res.data.map((d: { id: string }) => d.id).sort()).toEqual([pending, unrelated].sort());
+    });
+  });
+
+  it('total 은 주문 수, lineTotal 은 라인 수 를 반환한다', async () => {
+    await run(async (tx, svc, tag) => {
+      const o1 = await insertOrder(tx, { channelOrderId: `${tag}-1` });
+      await insertLine(tx, o1, {});
+      await insertLine(tx, o1, {});
+      const o2 = await insertOrder(tx, { channelOrderId: `${tag}-2` });
+      await insertLine(tx, o2, {});
+
+      const res = await listByKeyword(svc, tx, { keyword: tag });
+      expect(res.total).toBe(2);
+      expect(res.lineTotal).toBe(3);
+    });
+  });
+});

--- a/apps/core/src/modules/sales-order/services/sales-orders.service.ts
+++ b/apps/core/src/modules/sales-order/services/sales-orders.service.ts
@@ -11,8 +11,11 @@ import { InjectTypedDb } from '@app/db/decorators';
 import { wmsTables, wmsSchema, DbTx } from '../../inventory/schema/inventory.schema';
 import {
   eq,
+  ne,
+  gt,
   asc,
   inArray,
+  notInArray,
   desc,
   and,
   or,
@@ -20,10 +23,15 @@ import {
   lte,
   count,
   sql,
+  ilike,
+  isNull,
   isNotNull,
+  exists,
+  notExists,
   type InferInsertModel,
   type SQL,
 } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
 import { PoliciesService } from './policies.service';
 import { OutboxService } from '../../inventory/shared/outbox/outbox.service';
 import { ReservationLifecycleService } from '../../inventory/shared/services/reservation-lifecycle.service';
@@ -38,6 +46,7 @@ import { ORDER_EVENTS } from '../common/events';
 import { CreateSalesOrderDto } from '../dto/create-sales-order.dto';
 import { UpdateSalesOrderDto } from '../dto/update-sales-order.dto';
 import { SalesOrderFilterDto } from '../dto/sales-order-filter.dto';
+import { kstDayStart, kstDayEndInclusive, kstTodayRange } from '../utils/kst-date.util';
 import { BusinessLinkReferenceDto, CreateBusinessLinkDto } from '../dto/create-business-link.dto';
 import { CancelSalesOrderDto } from '../dto/cancel-sales-order.dto';
 import { AddressDto } from '../dto/address.dto';
@@ -780,46 +789,235 @@ export class SalesOrdersService {
 
   async list(params: SalesOrderFilterDto, tx?: DbTx) {
     return this.db.run(async (trx) => {
+      const S = wmsTables;
+
+      // ── 상관 서브쿼리 헬퍼: 현재 주문의 라인 존재/부재 조건 ──
+      const lineExists = (cond?: SQL) =>
+        exists(
+          trx
+            .select({ x: sql`1` })
+            .from(S.salesOrderLines)
+            .where(
+              cond
+                ? and(eq(S.salesOrderLines.salesOrderId, S.salesOrders.id), cond)
+                : eq(S.salesOrderLines.salesOrderId, S.salesOrders.id),
+            ),
+        );
+      const lineNotExists = (cond: SQL) =>
+        notExists(
+          trx
+            .select({ x: sql`1` })
+            .from(S.salesOrderLines)
+            .where(and(eq(S.salesOrderLines.salesOrderId, S.salesOrders.id), cond)),
+        );
+
       const conditions: SQL[] = [];
 
       if (params.startDate) {
-        conditions.push(gte(wmsTables.salesOrders.orderDate, new Date(params.startDate)));
+        // KST 달력일 00:00 부터 (order_date 는 UTC 저장)
+        conditions.push(gte(S.salesOrders.orderDate, kstDayStart(params.startDate)));
       }
       if (params.endDate) {
-        const end = new Date(params.endDate);
-        end.setHours(23, 59, 59, 999);
-        conditions.push(lte(wmsTables.salesOrders.orderDate, end));
+        // KST 달력일 23:59:59.999 까지 (inclusive)
+        conditions.push(lte(S.salesOrders.orderDate, kstDayEndInclusive(params.endDate)));
       }
       if (params.channel) {
-        conditions.push(eq(wmsTables.salesOrders.salesChannel, params.channel));
+        conditions.push(eq(S.salesOrders.salesChannel, params.channel));
       }
       if (params.status) {
-        conditions.push(eq(wmsTables.salesOrders.status, params.status));
+        conditions.push(eq(S.salesOrders.status, params.status));
+      }
+
+      // ── 구분(typeGroup): 재고/매칭 상태 파생 (주문 단위) ──
+      switch (params.typeGroup) {
+        case 'pending':
+          conditions.push(eq(S.salesOrders.status, 'pending'));
+          break;
+        case 'ready': // 완전출고: 라인 존재 + 모든 라인 stock_deducted
+          conditions.push(lineExists());
+          conditions.push(lineNotExists(ne(S.salesOrderLines.status, 'stock_deducted')));
+          break;
+        case 'partial': // 부분출고: 일부만 stock_deducted
+          conditions.push(lineExists(eq(S.salesOrderLines.status, 'stock_deducted')));
+          conditions.push(lineExists(ne(S.salesOrderLines.status, 'stock_deducted')));
+          break;
+        case 'hold': // 출고불가: 재고부족 라인 존재
+          conditions.push(lineExists(eq(S.salesOrderLines.status, 'stock_unavailable')));
+          break;
+        case 'unmatched': // 매칭안됨: 미매칭 라인 존재
+          conditions.push(lineExists(isNull(S.salesOrderLines.productMatchingId)));
+          break;
+        case 'direct': // 직배송: drop_ship FO 존재
+          conditions.push(
+            exists(
+              trx
+                .select({ x: sql`1` })
+                .from(S.fulfillmentOrders)
+                .where(
+                  and(
+                    eq(S.fulfillmentOrders.salesOrderId, S.salesOrders.id),
+                    eq(S.fulfillmentOrders.fulfillmentMode, 'drop_ship'),
+                  ),
+                ),
+            ),
+          );
+          break;
+        case 'all':
+        default:
+          if (params.excludeTerminal) {
+            conditions.push(notInArray(S.salesOrders.status, ['cancelled', 'timeout']));
+          }
+          break;
+      }
+
+      // ── 환불 실패/수동처리만 ──
+      // 어드민 주문내역 화면(use-order-rows)의 refundStatus 도출과 동일 규칙:
+      //   effectiveLink = (미완료 manual_pending 링크) ?? (최신 링크)
+      //   이 링크가 failed/manual_pending 이면 이슈. → 아래 두 조건의 OR 로 정확히 재현.
+      //   ① 미완료 manual_pending 링크 존재 (뒤에 무관한 succeeded 가 생겨도 여전히 미처리로 노출)
+      //   ② 최신 링크가 failed
+      // 링크 앵커: sourceType='sales_order', sourceId=SO (store-sales-orders 와 동일).
+      if (params.refundIssueOnly) {
+        conditions.push(eq(S.salesOrders.status, 'cancelled'));
+        const REFUND_RELATION = 'cancellation_linked_wallet_refund';
+        const mp = alias(S.businessLinks, 'refund_mp'); // manual_pending 후보
+        const completion = alias(S.businessLinks, 'refund_completion'); // mp 를 종결한 succeeded
+        const failedLink = alias(S.businessLinks, 'refund_failed'); // failed 후보
+        const laterLink = alias(S.businessLinks, 'refund_later'); // failedLink 이후 링크
+
+        // ① 아직 종결되지 않은 manual_pending 링크
+        const uncompletedManualPending = exists(
+          trx
+            .select({ x: sql`1` })
+            .from(mp)
+            .where(
+              and(
+                eq(mp.sourceType, SALES_ORDER_REF_TYPE),
+                eq(mp.sourceId, S.salesOrders.id),
+                eq(mp.relationName, REFUND_RELATION),
+                sql`${mp.metadata}->>'refundStatus' = 'manual_pending'`,
+                notExists(
+                  trx
+                    .select({ x: sql`1` })
+                    .from(completion)
+                    .where(
+                      and(
+                        eq(completion.relationName, REFUND_RELATION),
+                        sql`${completion.metadata}->>'refundStatus' = 'succeeded'`,
+                        sql`${completion.metadata}->>'completedRefundLinkId' = ${mp.id}::text`,
+                      ),
+                    ),
+                ),
+              ),
+            ),
+        );
+
+        // ② 최신 링크가 failed
+        const latestIsFailed = exists(
+          trx
+            .select({ x: sql`1` })
+            .from(failedLink)
+            .where(
+              and(
+                eq(failedLink.sourceType, SALES_ORDER_REF_TYPE),
+                eq(failedLink.sourceId, S.salesOrders.id),
+                eq(failedLink.relationName, REFUND_RELATION),
+                sql`${failedLink.metadata}->>'refundStatus' = 'failed'`,
+                notExists(
+                  trx
+                    .select({ x: sql`1` })
+                    .from(laterLink)
+                    .where(
+                      and(
+                        eq(laterLink.sourceType, SALES_ORDER_REF_TYPE),
+                        eq(laterLink.sourceId, S.salesOrders.id),
+                        eq(laterLink.relationName, REFUND_RELATION),
+                        gt(laterLink.createdAt, failedLink.createdAt),
+                      ),
+                    ),
+                ),
+              ),
+            ),
+        );
+
+        conditions.push(or(uncompletedManualPending, latestIsFailed)!);
+      }
+
+      // ── 키워드 검색 ──
+      if (params.keyword && params.keyword.trim()) {
+        const kw = `%${params.keyword.trim()}%`;
+        const orderNoCond = or(
+          ilike(S.salesOrders.channelOrderId, kw),
+          sql`${S.salesOrders.id}::text ILIKE ${kw}`,
+        )!;
+        const receiverCond = or(
+          sql`${S.salesOrders.shippingAddress}->>'recipientName' ILIKE ${kw}`,
+          ilike(S.salesOrders.customerName, kw),
+        )!;
+        const phoneCond = or(
+          ilike(S.salesOrders.customerPhone, kw),
+          sql`${S.salesOrders.shippingAddress}->>'phone' ILIKE ${kw}`,
+        )!;
+        const productCond = lineExists(ilike(S.salesOrderLines.productName, kw));
+        switch (params.keywordType) {
+          case 'orderNo':
+            conditions.push(orderNoCond);
+            break;
+          case 'receiver':
+            conditions.push(receiverCond);
+            break;
+          case 'phone':
+            conditions.push(phoneCond);
+            break;
+          case 'product':
+            conditions.push(productCond);
+            break;
+          case 'all':
+          default:
+            conditions.push(or(orderNoCond, receiverCond, phoneCond, productCond)!);
+            break;
+        }
       }
 
       const where = conditions.length > 0 ? and(...conditions) : undefined;
       const limit = params.limit ?? 20;
       const offset = params.offset ?? 0;
 
-      const [{ total }] = await trx.select({ total: count() }).from(wmsTables.salesOrders).where(where);
+      // 주문 수 + 라인 수(집계) 병렬
+      const [[{ total }], [{ lineTotal }]] = await Promise.all([
+        trx.select({ total: count() }).from(S.salesOrders).where(where),
+        trx
+          .select({ lineTotal: count() })
+          .from(S.salesOrderLines)
+          .innerJoin(S.salesOrders, eq(S.salesOrders.id, S.salesOrderLines.salesOrderId))
+          .where(where),
+      ]);
 
       const orders = await trx
         .select()
-        .from(wmsTables.salesOrders)
+        .from(S.salesOrders)
         .where(where)
         .limit(limit)
         .offset(offset)
-        .orderBy(desc(wmsTables.salesOrders.createdAt));
+        // createdAt 동률(대량수입) 시 offset 페이지 경계에서 행이 밀리는 것 방지 — id 2차정렬
+        .orderBy(desc(S.salesOrders.createdAt), desc(S.salesOrders.id));
 
       if (orders.length === 0) {
-        return { data: [], total, page: Math.floor(offset / limit) + 1, limit, totalPages: Math.ceil(total / limit) };
+        return {
+          data: [],
+          total,
+          lineTotal,
+          page: Math.floor(offset / limit) + 1,
+          limit,
+          totalPages: Math.ceil(total / limit),
+        };
       }
 
       const orderIds = orders.map((o) => o.id);
       const lines = await trx
         .select()
-        .from(wmsTables.salesOrderLines)
-        .where(inArray(wmsTables.salesOrderLines.salesOrderId, orderIds));
+        .from(S.salesOrderLines)
+        .where(inArray(S.salesOrderLines.salesOrderId, orderIds));
 
       const linesByOrderId = new Map<string, typeof lines>();
       for (const line of lines) {
@@ -834,21 +1032,22 @@ export class SalesOrdersService {
         lines: linesByOrderId.get(order.id) || [],
       }));
 
-      return { data, total, page: Math.floor(offset / limit) + 1, limit, totalPages: Math.ceil(total / limit) };
+      return {
+        data,
+        total,
+        lineTotal,
+        page: Math.floor(offset / limit) + 1,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      };
     }, tx);
   }
 
   async getStats() {
     const db = this.db.db;
 
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const todayEnd = new Date();
-    todayEnd.setHours(23, 59, 59, 999);
-
-    const fourteenDaysAgo = new Date();
-    fourteenDaysAgo.setDate(fourteenDaysAgo.getDate() - 13);
-    fourteenDaysAgo.setHours(0, 0, 0, 0);
+    // KST 달력일 기준 오늘/최근 14일 경계 (서버 TZ 무관)
+    const { start: today, end: todayEnd, backStart: fourteenDaysAgo } = kstTodayRange(13);
 
     const [todayResult] = await db
       .select({ cnt: count() })

--- a/apps/core/src/modules/sales-order/utils/kst-date.util.spec.ts
+++ b/apps/core/src/modules/sales-order/utils/kst-date.util.spec.ts
@@ -1,0 +1,27 @@
+import { kstDayStart, kstDayEndInclusive, kstTodayRange } from './kst-date.util';
+
+describe('kst-date.util', () => {
+  it('KST 달력일 시작을 UTC-9h instant 로 변환한다', () => {
+    expect(kstDayStart('2026-07-22').toISOString()).toBe('2026-07-21T15:00:00.000Z');
+  });
+
+  it('KST 달력일 종료(inclusive)를 UTC 로 변환한다', () => {
+    expect(kstDayEndInclusive('2026-07-22').toISOString()).toBe('2026-07-22T14:59:59.999Z');
+  });
+
+  it('KST 00:30 주문은 그 날짜 범위에 포함된다', () => {
+    const order = new Date('2026-07-22T00:30:00+09:00');
+    expect(order >= kstDayStart('2026-07-22')).toBe(true);
+    expect(order <= kstDayEndInclusive('2026-07-22')).toBe(true);
+  });
+
+  it('kstTodayRange 는 서버 TZ 와 무관하게 KST 달력일 경계를 낸다', () => {
+    // now = 2026-07-22T01:00:00Z (= 10:00 KST) 로 고정
+    jest.useFakeTimers().setSystemTime(new Date('2026-07-22T01:00:00Z'));
+    const { start, end, backStart } = kstTodayRange(13);
+    expect(start.toISOString()).toBe('2026-07-21T15:00:00.000Z');
+    expect(end.toISOString()).toBe('2026-07-22T14:59:59.999Z');
+    expect(backStart.toISOString()).toBe('2026-07-08T15:00:00.000Z');
+    jest.useRealTimers();
+  });
+});

--- a/apps/core/src/modules/sales-order/utils/kst-date.util.ts
+++ b/apps/core/src/modules/sales-order/utils/kst-date.util.ts
@@ -1,0 +1,36 @@
+// 주문 일자 필터/통계는 한국(KST, UTC+9) 달력일 기준이어야 한다.
+// order_date 는 timestamptz(UTC 저장)이므로, KST 달력일 경계를 UTC instant 로 변환한다.
+// 서버 프로세스 TZ 에 의존하지 않도록 오프셋을 명시적으로 다룬다.
+
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+/** `YYYY-MM-DD`(KST 달력일)의 00:00:00.000 KST 를 UTC Date 로 변환. */
+export function kstDayStart(dateStr: string): Date {
+  return new Date(`${dateStr}T00:00:00.000+09:00`);
+}
+
+/** `YYYY-MM-DD`(KST 달력일)의 23:59:59.999 KST 를 UTC Date 로 변환 (inclusive 상한). */
+export function kstDayEndInclusive(dateStr: string): Date {
+  return new Date(`${dateStr}T23:59:59.999+09:00`);
+}
+
+/**
+ * 현재 시각을 KST 달력일 기준으로 오늘 경계 및 N일 전 시작점을 UTC Date 로 반환.
+ * @param daysBack backStart = (오늘 - daysBack)일의 KST 00:00
+ */
+export function kstTodayRange(daysBack = 0): {
+  start: Date;
+  end: Date;
+  backStart: Date;
+} {
+  // UTC getter 가 KST 벽시계를 읽도록 오프셋만큼 앞당긴 시각.
+  const nowKstWall = new Date(Date.now() + KST_OFFSET_MS);
+  const y = nowKstWall.getUTCFullYear();
+  const m = nowKstWall.getUTCMonth();
+  const d = nowKstWall.getUTCDate();
+  return {
+    start: new Date(Date.UTC(y, m, d, 0, 0, 0, 0) - KST_OFFSET_MS),
+    end: new Date(Date.UTC(y, m, d, 23, 59, 59, 999) - KST_OFFSET_MS),
+    backStart: new Date(Date.UTC(y, m, d - daysBack, 0, 0, 0, 0) - KST_OFFSET_MS),
+  };
+}

--- a/docs/runbooks/order-list-perf-indexes.md
+++ b/docs/runbooks/order-list-perf-indexes.md
@@ -1,0 +1,39 @@
+# 주문 목록/대시보드 성능 인덱스 — 라이브 무중단 적용 런북
+
+마이그레이션 `apps/core/drizzle/20260722064941_add-order-list-perf-indexes.sql` 는 주문내역/대시보드
+서버 필터의 핫패스 인덱스 2개를 추가한다.
+
+- `idx_sales_orders_order_date` (`sales_orders.order_date`) — 기간 필터·통계
+- `idx_sales_order_lines_sales_order_id` (`sales_order_lines.sales_order_id`) — 구분(EXISTS)·라인 집계
+
+## 왜 런북이 필요한가
+
+두 테이블은 **고객 결제/주문 생성이 쓰는** 테이블이다. 일반 `CREATE INDEX` 는 빌드 동안 테이블에
+**쓰기 락**을 걸어 그 사이 들어오는 주문 INSERT 를 대기시킨다(테이블이 크면 결제 지연/타임아웃).
+따라서 라이브에서는 **`CREATE INDEX CONCURRENTLY`(쓰기 락 없음)로 먼저 만든 뒤** 정규 마이그레이션을
+돌린다. 정규 마이그레이션은 `CREATE INDEX IF NOT EXISTS` 라 이미 존재하면 즉시 no-op 이다.
+
+> 인덱스는 순수 성능용(unique/NOT NULL 아님)이라 빌드가 어떤 주문 데이터도 거부하지 않으며,
+> 실패해도 주문 생성에는 영향이 없다(쿼리만 느려질 뿐).
+
+## 라이브 적용 순서
+
+1. **CONCURRENTLY 로 인덱스 선생성** (트랜잭션 밖에서, 락 없음 — psql autocommit 로 각 문장 개별 실행):
+
+   ```bash
+   psql "$LIVE_CORE_DATABASE_URL" -c 'CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_sales_order_lines_sales_order_id" ON "sales_order_lines" USING btree ("sales_order_id");'
+   psql "$LIVE_CORE_DATABASE_URL" -c 'CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_sales_orders_order_date" ON "sales_orders" USING btree ("order_date");'
+   ```
+
+   - `CREATE INDEX CONCURRENTLY` 는 트랜잭션 블록 안에서 실행 불가 → **`drizzle-kit migrate` 로 실행 금지**, 위처럼 psql 단문으로.
+   - 실패(`INVALID` 인덱스 잔여) 시: `DROP INDEX CONCURRENTLY IF EXISTS "<name>";` 후 재시도.
+
+2. **정규 배포 절차의 `db:migrate` 실행** — 위에서 이미 만들었으므로 `IF NOT EXISTS` 가 no-op 처리.
+
+3. **배포 순서**: 새 admin-web 은 서버측 필터(typeGroup/keyword/refundIssueOnly/lineTotal)를 기대하므로
+   **core 배포가 admin-web 보다 먼저이거나 동시**여야 한다. (autodeploy 없음 — 수동.)
+
+## 작은/신규/로컬 DB
+
+굳이 CONCURRENTLY 를 먼저 안 돌려도 된다. `db:migrate` 의 `CREATE INDEX IF NOT EXISTS` 가
+직접 생성한다(작은 테이블은 락 시간이 짧아 무방).


### PR DESCRIPTION
- 일자 기준을 KST 달력일(00:00~24:00) 경계로 수정 — 목록 list()·통계 getStats() (kst-date.util)
- 구분/키워드/환불이슈/취소제외 필터와 페이지네이션을 백엔드 list() 로 이관 (correlated EXISTS, 환불이슈는 어드민 화면과 동일 규칙, total·lineTotal 반환, id 2차정렬)
- 주문내역 화면을 서버 페이지네이션으로 재작성 (클라 필터/슬라이스 제거, keepPreviousData)
- 총 주문/상품 라인 수 분리 표시, 오래된 주문 "상품 정보 없음" 해결(목록 lines 폴백)
- 상품 이미지: /variants/batch(findByIds) 에 마스터 썸네일 추가 → 주문내역 표에 표시
- 성능 인덱스 추가 (sales_orders.order_date, sales_order_lines.sales_order_id) IF NOT EXISTS 마이그레이션 + 라이브 무중단 CONCURRENTLY 런북(docs/runbooks)
- 통합/단위 테스트 추가 (list 서버필터 6종, KST util)