### PR TITLE
[channel-adapter] 비활성 버전 재고 이벤트 재시도 노이즈 제거

### DIFF
--- a/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts
+++ b/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts
@@ -30,11 +30,7 @@ describe('PimMedusaSyncService.handleProductSellableQuantityChanged', () => {
     const storefrontRevalidate = {
       revalidateProduct: jest.fn().mockResolvedValue(undefined),
     };
-    const service = new PimMedusaSyncService(
-      medusaClient as any,
-      mappingRepo as any,
-      storefrontRevalidate as any,
-    );
+    const service = new PimMedusaSyncService(medusaClient as any, mappingRepo as any, storefrontRevalidate as any);
 
     return { service, medusaClient, mappingRepo, storefrontRevalidate };
   }
@@ -81,7 +77,24 @@ describe('PimMedusaSyncService.handleProductSellableQuantityChanged', () => {
     expect(medusaClient.applyProductSellableQuantityProjection).not.toHaveBeenCalled();
   });
 
-  it('throws when the event lacks masterId because channel-adapter must not guess product identity', async () => {
+  it('skips an inactive-version event without masterId because no Medusa product can exist for it', async () => {
+    const { service, medusaClient, mappingRepo } = createService();
+
+    await expect(
+      service.handleProductSellableQuantityChanged({
+        ...payload,
+        masterId: null,
+        versionId: null,
+        reason: 'NOT_ACTIVE_VERSION',
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mappingRepo.findByPimMasterId).not.toHaveBeenCalled();
+    expect(medusaClient.findProductByHandle).not.toHaveBeenCalled();
+    expect(medusaClient.applyProductSellableQuantityProjection).not.toHaveBeenCalled();
+  });
+
+  it('throws when another event lacks masterId because channel-adapter must not guess product identity', async () => {
     const { service, medusaClient } = createService();
 
     await expect(
@@ -106,11 +119,7 @@ describe('PimMedusaSyncService.handleProductMasterDeleted', () => {
     const storefrontRevalidate = {
       revalidateProduct: jest.fn().mockResolvedValue(undefined),
     };
-    const service = new PimMedusaSyncService(
-      medusaClient as any,
-      mappingRepo as any,
-      storefrontRevalidate as any,
-    );
+    const service = new PimMedusaSyncService(medusaClient as any, mappingRepo as any, storefrontRevalidate as any);
 
     return { service, medusaClient, mappingRepo, storefrontRevalidate };
   }
@@ -174,11 +183,7 @@ describe('PimMedusaSyncService.syncPriceLists (replace semantics)', () => {
     };
     const mappingRepo = { findByPimMasterId: jest.fn(), update: jest.fn() };
     const storefrontRevalidate = { revalidateProduct: jest.fn() };
-    const service = new PimMedusaSyncService(
-      medusaClient as any,
-      mappingRepo as any,
-      storefrontRevalidate as any,
-    );
+    const service = new PimMedusaSyncService(medusaClient as any, mappingRepo as any, storefrontRevalidate as any);
     return { service, medusaClient, calls };
   }
 

--- a/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts
+++ b/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts
@@ -500,6 +500,13 @@ export class PimMedusaSyncService {
 
   async handleProductSellableQuantityChanged(payload: ProductSellableQuantityChangedPayload): Promise<void> {
     if (!payload.masterId) {
+      if (payload.reason === 'NOT_ACTIVE_VERSION') {
+        this.logger.debug(
+          `Skipping ProductSellableQuantityChanged for inactive variant ${payload.variantId}; no active master exists`,
+        );
+        return;
+      }
+
       throw new Error(
         `ProductSellableQuantityChanged missing masterId for variant ${payload.variantId}; cannot resolve Medusa product`,
       );


### PR DESCRIPTION
## 변경 사항

- `ProductSellableQuantityChanged` 이벤트가 `reason=NOT_ACTIVE_VERSION`, `masterId=null`이면 Medusa 조회 없이 정상 종료합니다.
- 그 밖의 `masterId` 누락 이벤트는 기존처럼 실패시켜 잘못된 이벤트를 숨기지 않습니다.
- 비활성 버전 이벤트가 외부 호출을 하지 않는 회귀 테스트를 추가했습니다.

## 원인 및 영향

활성 상품 버전이 없는 변이는 producer 계약상 `masterId=null`로 발행될 수 있지만, consumer가 이를 항상 예외로 처리해 inbox 재시도와 실패 노이즈가 누적됐습니다. 정상적인 비활성 버전 이벤트만 acknowledge하여 불필요한 재시도를 제거합니다.

## 검증

- `npx jest apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts --runInBand --no-cache` (9 tests passed)
- `npm run build:channel-adapter` (passed)

## 참고

- 수정 파일 대상 ESLint는 같은 파일의 기존 `any` 및 `require-await` 진단으로 전체 성공하지 않았으며, 새 분기에서는 추가 진단이 발생하지 않았습니다.

Closes #513
