### PR TITLE
[storefront] 멤버십 결제 이름 변경

### DIFF
--- a/web/almondyoung-storefront/src/app/[countryCode]/(mypage)/mypage/membership/subscribe/payment/components.tsx
+++ b/web/almondyoung-storefront/src/app/[countryCode]/(mypage)/mypage/membership/subscribe/payment/components.tsx
@@ -373,14 +373,14 @@ export function MembershipForm({
                       <PlanOption
                         selected={field.value === "monthly"}
                         onSelect={() => field.onChange("monthly")}
-                        title="월간 구독"
+                        title="월간 결제"
                         price={`${monthlyPlan.plan.price.toLocaleString()}원`}
                         unit="/ 월"
                       />
                       <PlanOption
                         selected={field.value === "yearly"}
                         onSelect={() => field.onChange("yearly")}
-                        title="연간 구독"
+                        title="연간 결제"
                         price={`${yearlyPlan.plan.price.toLocaleString()}원`}
                         unit="/ 연"
                         badge="2달 무료"
@@ -673,7 +673,7 @@ export function MembershipForm({
               <span className="text-sm text-gray-600">
                 {hasPrice
                   ? `${
-                      subscriptionType === "monthly" ? "월간 구독" : "연간 구독"
+                      subscriptionType === "monthly" ? "월간 결제" : "연간 결제"
                     } · ${
                       billingMode === "recurring"
                         ? "정기결제 (매월 자동결제)"
@@ -1000,8 +1000,8 @@ function TermsAndConditions({
                 이용하려면 재결제가 필요합니다.
               </li>
               <li>
-                결제 금액: 월간 구독 {monthlyPrice.toLocaleString()}원 / 연간
-                구독 {yearlyPrice.toLocaleString()}원
+                결제 금액: 월간 결제 {monthlyPrice.toLocaleString()}원 / 연간
+                결제 {yearlyPrice.toLocaleString()}원
               </li>
             </>
           )}


### PR DESCRIPTION
## 변경 사항

- 멤버십 결제 선택 카드의 `월간 구독`/`연간 구독`을 `월간 결제`/`연간 결제`로 변경했습니다.
- 선택 요약과 이용약관의 결제 금액 안내에도 같은 명칭을 적용했습니다.
- 다른 화면의 실제 구독 상태 문구는 변경하지 않았습니다.

## 영향

멤버십 결제 화면의 용어가 결제 행위 중심으로 일관되게 표시됩니다.

## 검증

- `git diff --check` (passed)
- 결제 화면에서 기존 `월간 구독`/`연간 구독` 문자열이 남지 않은 것을 확인했습니다.

## 참고

- Storefront 전체 `tsc --noEmit`은 기존의 관련 없는 타입 오류로 실패했으며, 수정 파일은 진단 목록에 포함되지 않았습니다.
- 파일 대상 ESLint는 루트와 Storefront의 ESLint 플러그인 버전 충돌로 규칙 로딩 단계에서 중단됐습니다.

Closes #522
