### PR TITLE
[storefront] 멤버십 결제 콜백을 실제 상태 확인 후 판정

### DIFF
--- a/web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/callback/callback-status.spec.ts
+++ b/web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/callback/callback-status.spec.ts
@@ -1,0 +1,23 @@
+import { shouldRejectCallbackStatus } from "./callback-status"
+
+describe("shouldRejectCallbackStatus", () => {
+  it.each([null, "failed", "cancelled"])(
+    "allows membership confirmation when URL status is %p",
+    (status) => {
+      expect(shouldRejectCallbackStatus(status, "membership")).toBe(false)
+    }
+  )
+
+  it.each([null, "failed", "cancelled"])(
+    "keeps rejecting a non-membership callback when URL status is %p",
+    (status) => {
+      expect(shouldRejectCallbackStatus(status, "one_time")).toBe(true)
+    }
+  )
+
+  it("accepts a succeeded callback for every payment mode", () => {
+    expect(shouldRejectCallbackStatus("succeeded", "membership")).toBe(false)
+    expect(shouldRejectCallbackStatus("succeeded", "one_time")).toBe(false)
+    expect(shouldRejectCallbackStatus("succeeded", null)).toBe(false)
+  })
+})

--- a/web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/callback/callback-status.ts
+++ b/web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/callback/callback-status.ts
@@ -1,0 +1,4 @@
+export const shouldRejectCallbackStatus = (
+  status: string | null,
+  mode: string | null
+) => mode !== "membership" && status !== "succeeded"

--- a/web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/callback/page.tsx
+++ b/web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/callback/page.tsx
@@ -10,6 +10,7 @@ import {
   removePendingPaymentMode,
 } from "@/lib/utils/checkout-intent-map"
 import { processPaymentCallback, revalidateMembershipSuccess } from "./actions"
+import { shouldRejectCallbackStatus } from "./callback-status"
 
 const getErrorMessage = (err: unknown, fallback: string) =>
   err instanceof Error && err.message ? err.message : fallback
@@ -56,7 +57,7 @@ export default function CallbackPage() {
         cartIdFromQuery ||
         (paymentIntentId ? getCheckoutCartByIntent(paymentIntentId) : null)
 
-      if (status !== "succeeded") {
+      if (shouldRejectCallbackStatus(status, mode)) {
         clearPendingPayment(paymentIntentId)
         replace(failUrl("PAYMENT_FAILED", t("paymentFailed"), mode))
         return


### PR DESCRIPTION
## 변경 사항

- 멤버십 콜백은 URL `status` 값과 무관하게 `confirm-checkout-intent`로 실제 결제/구독 상태를 먼저 확인하도록 변경했습니다.
- 일반 체크아웃은 기존처럼 `status=succeeded`가 아니면 실패 처리합니다.
- URL status와 결제 mode 조합별 조기 실패 조건을 순수 함수로 분리하고 회귀 테스트를 추가했습니다.

## 원인 및 영향

기존 콜백은 실제 상태 확인 전에 URL `status`만으로 실패를 확정했습니다. 따라서 Toss 결제와 멤버십 활성화가 성공했더라도 콜백 URL에 status가 누락되면 `PAYMENT_FAILED` 화면이 노출됐습니다.

멤버십 경로에서는 idempotent confirm 응답(`2xx` 또는 기존과 동일한 `409`)을 기준으로 성공을 판정하므로, 성공 결제를 실패로 보여주는 false-negative를 방지합니다.

## 검증

- `npx jest --runInBand --no-cache --roots 'web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/callback' --runTestsByPath 'web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/callback/callback-status.spec.ts'` (7 tests passed)
- 새 helper/spec 파일 Prettier 검사 통과
- Storefront `tsc --noEmit` 결과 이번 callback 파일 진단 0건

## 참고

- Storefront 전체 타입 검사는 기존의 관련 없는 진단 66건 때문에 여전히 실패합니다.

Closes #504
