### PR TITLE
[core] 채널 주문 식별자로 취소 대상 SalesOrder 해석

### DIFF
--- a/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.spec.ts
@@ -84,6 +84,8 @@ describe('OrderPollerOrchestrator', () => {
         aggregateId: '11111111-1111-4111-8111-111111111111',
         payload: expect.objectContaining({
           orderId: '11111111-1111-4111-8111-111111111111',
+          externalOrderId: 'medusa_order_1',
+          salesChannel: 'medusa',
         }),
       }),
     ]);
@@ -178,6 +180,8 @@ describe('OrderPollerOrchestrator', () => {
         aggregateId: '11111111-1111-4111-8111-111111111111',
         payload: expect.objectContaining({
           orderId: '11111111-1111-4111-8111-111111111111',
+          externalOrderId: 'medusa_order_1',
+          salesChannel: 'medusa',
           reason: 'ADMIN_CANCEL',
         }),
       }),

--- a/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.ts
+++ b/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.ts
@@ -429,8 +429,14 @@ export class OrderPollerOrchestrator {
     }
 
     const payload = {
-      orderId: mapping[0].wmsOrderId,
       ...item.payload,
+      orderId: mapping[0].wmsOrderId,
+      ...(item.eventType === 'OrderCancelled'
+        ? {
+            externalOrderId: item.externalOrderId,
+            salesChannel: provider.channel,
+          }
+        : {}),
     };
     const lifecycleResourceId = `${item.externalOrderId}:${item.eventKey}`;
     const newHash = this.pollingHashService.computeHash({

--- a/apps/channel-adapter/src/services/order-event.publisher.spec.ts
+++ b/apps/channel-adapter/src/services/order-event.publisher.spec.ts
@@ -1,4 +1,4 @@
-import { ORDER_STREAM, type OrderCreatedPayload } from '@packages/event-contracts/streams';
+import { ORDER_STREAM, type OrderCancelledPayload, type OrderCreatedPayload } from '@packages/event-contracts/streams';
 import type { InternalOrderEvent } from '../types';
 import type { InboxService } from './inbox.service';
 import type { ChannelListingClient } from './clients/channel-listing.client';
@@ -114,5 +114,25 @@ describe('OrderEventPublisher external line identity', () => {
     });
     expect(channelListingClient.lookupByChannelCode).not.toHaveBeenCalled();
     expect(inboxService.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('publishes cancellation with the channel identity needed to resolve the Core order', async () => {
+    const { publisher, inboxService } = makePublisher();
+
+    await publisher.publishOrderCancelled(
+      'naver_smartstore',
+      orderEvent({
+        internalOrderId: 'channel-adapter-generated-id',
+        externalOrderId: 'naver-order-1',
+      }),
+    );
+
+    const payload = inboxService.enqueue.mock.calls[0][0].payload as unknown as OrderCancelledPayload;
+    expect(ORDER_STREAM.events.OrderCancelled.schema!.parse(payload)).toEqual(payload);
+    expect(payload).toMatchObject({
+      orderId: 'channel-adapter-generated-id',
+      externalOrderId: 'naver-order-1',
+      salesChannel: 'naver',
+    });
   });
 });

--- a/apps/channel-adapter/src/services/order-event.publisher.ts
+++ b/apps/channel-adapter/src/services/order-event.publisher.ts
@@ -227,6 +227,8 @@ export class OrderEventPublisher {
 
     const payload: OrderCancelledPayload = {
       orderId: orderEvent.internalOrderId ?? orderEvent.externalOrderId,
+      externalOrderId: orderEvent.externalOrderId,
+      salesChannel,
       reason: this.mapCancelReason(reason),
       reasonDetail: orderEvent.reason,
       cancelledBy: cancelledBy === 'customer' ? 'CUSTOMER' : 'ADMIN',

--- a/apps/core/src/modules/sales-order/consumers/order-events.consumer.spec.ts
+++ b/apps/core/src/modules/sales-order/consumers/order-events.consumer.spec.ts
@@ -247,6 +247,7 @@ describe('OrderEventsConsumer', () => {
 
     await consumer.handleOrderCancelled(payload, cancelledEnvelope);
 
+    expect(mocks.salesOrders.findByChannelOrderId).not.toHaveBeenCalled();
     expect(mocks.salesOrders.cancel).toHaveBeenCalledWith(
       payload.orderId,
       expect.objectContaining({
@@ -263,6 +264,47 @@ describe('OrderEventsConsumer', () => {
     );
     expect(mocks.backlog.closeOpenForSalesOrder).not.toHaveBeenCalled();
     expect(mocks.library.revokeOwnershipsForOrder).not.toHaveBeenCalled();
+  });
+
+  it('resolves OrderCancelled by channel identity when the producer ID is not the Core order ID', async () => {
+    const mocks = makeMocks();
+    const consumer = makeConsumer(mocks);
+    const payload = {
+      orderId: 'channel-adapter-generated-id',
+      externalOrderId: 'order_01KWK34YTFTE12ZW5AK91EDPNX',
+      salesChannel: 'medusa',
+      reason: 'ADMIN_CANCEL',
+      cancelledBy: 'medusa',
+      cancelledAt: '2026-07-03T05:41:00.000Z',
+      refundRequired: false,
+    } as OrderCancelledPayload;
+    const cancelledEnvelope = {
+      messageId: 'cancel-msg-external-1',
+      correlationId: 'corr-1',
+    } as MessageEnvelope<OrderCancelledPayload>;
+    mocks.salesOrders.getOne.mockResolvedValue(undefined as any);
+    mocks.salesOrders.findByChannelOrderId.mockResolvedValue({ id: 'core-sales-order-id' } as any);
+
+    await consumer.handleOrderCancelled(payload, cancelledEnvelope);
+
+    expect(mocks.salesOrders.findByChannelOrderId).toHaveBeenCalledWith(
+      'medusa',
+      'order_01KWK34YTFTE12ZW5AK91EDPNX',
+      mocks.fakeTx,
+    );
+    expect(mocks.salesOrders.cancel).toHaveBeenCalledWith(
+      'core-sales-order-id',
+      expect.objectContaining({
+        reasonCode: 'ADMIN_CANCEL',
+        metadata: expect.objectContaining({ sourceEventId: 'cancel-msg-external-1' }),
+      }),
+      mocks.fakeTx,
+    );
+    expect(mocks.txInserts[0].values).toMatchObject({
+      eventId: 'cancel-msg-external-1',
+      orderId: 'core-sales-order-id',
+      eventType: 'ORDER_CANCELLED',
+    });
   });
 
   it('OrderCancelled 대상 SalesOrder 가 없으면 throw 로 실패를 표면화한다 (필터가 non-retryable 로 분류 → 즉시 DLQ)', async () => {

--- a/apps/core/src/modules/sales-order/consumers/order-events.consumer.ts
+++ b/apps/core/src/modules/sales-order/consumers/order-events.consumer.ts
@@ -132,14 +132,21 @@ export class OrderEventsConsumer {
 
     try {
       await this.dbService.run(async (tx) => {
-        const salesOrder = await this.salesOrdersService.getOne(payload.orderId, tx);
+        const salesOrderById = await this.salesOrdersService.getOne(payload.orderId, tx);
+        const salesOrder =
+          salesOrderById ??
+          (payload.salesChannel && payload.externalOrderId
+            ? await this.salesOrdersService.findByChannelOrderId(payload.salesChannel, payload.externalOrderId, tx)
+            : null);
         if (!salesOrder) {
           throw new NotFoundException(`Sales order ${payload.orderId} not found for OrderCancelled`);
         }
 
+        const salesOrderId = salesOrder.id;
+
         const alreadyProcessed = await this.checkAndRecordEvent(
           envelope.messageId,
-          payload.orderId,
+          salesOrderId,
           'ORDER_CANCELLED',
           payload,
           tx,
@@ -147,7 +154,7 @@ export class OrderEventsConsumer {
         if (alreadyProcessed) return;
 
         await this.salesOrdersService.cancel(
-          payload.orderId,
+          salesOrderId,
           {
             reasonCode: payload.reason,
             reasonDetail: payload.reasonDetail,
@@ -163,7 +170,7 @@ export class OrderEventsConsumer {
           tx,
         );
 
-        this.logger.log(`[OrderCancelled] Cancelled sales order: ${payload.orderId}, reason: ${payload.reason}`);
+        this.logger.log(`[OrderCancelled] Cancelled sales order: ${salesOrderId}, reason: ${payload.reason}`);
       });
     } catch (error) {
       this.logger.error(`[OrderCancelled] Failed to process: ${payload.orderId}`, error.stack);

--- a/packages/event-contracts/streams/orders.stream.ts
+++ b/packages/event-contracts/streams/orders.stream.ts
@@ -106,6 +106,10 @@ export interface OrderModifiedPayload {
  */
 export interface OrderCancelledPayload {
   orderId: string;
+  /** 외부 채널의 주문 식별자. orderId가 Core PK와 다를 때 주문을 해석하는 데 사용한다. */
+  externalOrderId?: string;
+  /** externalOrderId의 네임스페이스. 채널 간 주문번호 충돌을 막기 위해 함께 전달한다. */
+  salesChannel?: SalesChannel;
   reason: 'CUSTOMER_REQUEST' | 'OUT_OF_STOCK' | 'PAYMENT_FAILED' | 'ADMIN_CANCEL' | 'TIMEOUT';
   reasonDetail?: string;
   cancelledBy: string;
@@ -254,6 +258,8 @@ const OrderModifiedSchema = z.object({
 
 const OrderCancelledSchema = z.object({
   orderId: z.string().min(1),
+  externalOrderId: z.string().min(1).optional(),
+  salesChannel: z.enum(['medusa', 'naver', 'coupang', '3pl']).optional(),
   reason: z.enum(['CUSTOMER_REQUEST', 'OUT_OF_STOCK', 'PAYMENT_FAILED', 'ADMIN_CANCEL', 'TIMEOUT']),
   reasonDetail: z.string().optional(),
   cancelledBy: z.string().min(1),


### PR DESCRIPTION
## Summary

- extend `OrderCancelled` with the external order ID and its sales-channel namespace
- include that identity from both polled Medusa lifecycle events and direct channel cancellation events
- resolve the real Core `sales_orders.id` before recording and executing a cancellation

## Root cause

Channel Adapter generates an ID for `OrderCreated`, but Core creates `sales_orders` with its own database-generated ID. The cancellation consumer treated the producer ID as the Core primary key, so `getOne(payload.orderId)` could not find the order even though the Medusa cancellation event was published successfully.

## Impact

Medusa, Naver, and Coupang cancellation events can now fall back to the unambiguous `(salesChannel, externalOrderId)` identity. Events that already contain the real Core ID keep using the existing direct lookup path. No database migration or environment change is required.

## Validation

- `npx jest --runInBand --no-cache --runTestsByPath "apps/core/src/modules/sales-order/consumers/order-events.consumer.spec.ts" "apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.spec.ts" "apps/channel-adapter/src/services/order-event.publisher.spec.ts"` (41 tests passed)
- `npm run build:channel-adapter`
- `npm run build:core`
- `git diff --check`

Closes #495
