### PR TITLE
feat(warehouse-app): 재고 이동(로케이션↔로케이션) — 현장 앱 + 로케이션 내용물 조회 API

### DIFF
--- a/apps/core/src/modules/inventory/stock-projection/controllers/stock-projection.controller.ts
+++ b/apps/core/src/modules/inventory/stock-projection/controllers/stock-projection.controller.ts
@@ -6,6 +6,7 @@ import { CurrentStockDto } from '../dto/current-stock.dto';
 import { GetStockQueryDto } from '../dto/get-stock-query.dto';
 import { GetStockSummaryListQueryDto, StockSummaryListItemDto } from '../dto/stock-summary-list.dto';
 import { SkuStockSummaryDto } from '../dto/sku-stock-summary.dto';
+import { LocationContentsDto } from '../dto/location-contents.dto';
 import { StockProjectionService } from '../services/stock-projection.service';
 
 @ApiTags('Inventory')
@@ -66,6 +67,14 @@ export class StockProjectionController {
   @ApiParam({ name: 'warehouseId', description: '창고 ID' })
   async getStockBySkuAndWarehouse(@Param('skuId') skuId: string, @Param('warehouseId') warehouseId: string) {
     return this.stockProjection.getBySkuAndWarehouse(skuId, warehouseId);
+  }
+
+  @Get('/stocks/location/:locationId')
+  @ApiOperation({ summary: '로케이션 내용물 조회 (SKU·상태·수량)' })
+  @ApiParam({ name: 'locationId', description: '로케이션 ID' })
+  @ApiResponse({ status: 200, type: LocationContentsDto })
+  async getLocationContents(@Param('locationId') locationId: string): Promise<LocationContentsDto> {
+    return this.stockProjection.getLocationContents(locationId);
   }
 
   @Get('/stocks/history')

--- a/apps/core/src/modules/inventory/stock-projection/dto/location-contents.dto.ts
+++ b/apps/core/src/modules/inventory/stock-projection/dto/location-contents.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class LocationContentItemDto {
+  @ApiProperty()
+  skuId: string;
+
+  @ApiProperty()
+  skuCode: string;
+
+  @ApiProperty()
+  skuName: string;
+
+  @ApiProperty({ description: 'ON_HAND | DEFECTIVE | IN_TRANSFER' })
+  stockState: string;
+
+  @ApiProperty()
+  quantity: number;
+}
+
+export class LocationContentsDto {
+  @ApiProperty()
+  locationId: string;
+
+  @ApiProperty()
+  locationCode: string;
+
+  @ApiProperty()
+  warehouseId: string;
+
+  @ApiProperty({ type: [LocationContentItemDto] })
+  items: LocationContentItemDto[];
+}

--- a/apps/core/src/modules/inventory/stock-projection/services/stock-projection-by-location.integration.spec.ts
+++ b/apps/core/src/modules/inventory/stock-projection/services/stock-projection-by-location.integration.spec.ts
@@ -2,6 +2,7 @@ import * as postgres from 'postgres';
 import { drizzle, PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { sql as dsql } from 'drizzle-orm';
 import { randomUUID } from 'crypto';
+import { NotFoundError } from '@app/shared';
 import { DbService } from '@app/db';
 import { wmsTables, wmsSchema, DbTx } from '../../schema/inventory.schema';
 import { StockProjectionReader } from './stock-projection.reader';
@@ -13,63 +14,67 @@ const DATABASE_URL = process.env.DATABASE_URL;
 const describeIfDb = DATABASE_URL ? describe : describe.skip;
 class Rollback extends Error {}
 
+// 이 파일의 두 describeIfDb 블록(by-location / getLocationContents)이 공유하는 셋업.
+// 모듈 스코프에 둬야 두 블록에서 동일한 reader/inRollbackTx/seedEntities 를 재사용할 수 있다.
+jest.setTimeout(120_000);
+let sql: postgres.Sql;
+let db: PostgresJsDatabase<typeof wmsSchema>;
+let reader: StockProjectionReader;
+
+beforeAll(() => {
+  if (!DATABASE_URL) return;
+  sql = postgres(DATABASE_URL, { max: 1 });
+  db = drizzle(sql, { schema: wmsSchema });
+  const dbService = {
+    db,
+    run: async (fn: (t: DbTx) => Promise<unknown>, t?: DbTx) => (t ? fn(t) : db.transaction(fn)),
+  } as unknown as DbService<typeof wmsSchema>;
+  const outbox = new OutboxService(dbService);
+  const sellable = new ProductSellableQuantityService(dbService as never, outbox);
+  const eventStore = new StockEventStore(dbService, sellable);
+  reader = new StockProjectionReader(dbService, eventStore);
+});
+afterAll(async () => {
+  if (!DATABASE_URL) return;
+  await sql.end();
+});
+
+async function inRollbackTx(fn: (tx: DbTx) => Promise<void>) {
+  await expect(
+    db.transaction(async (tx) => {
+      await fn(tx);
+      throw new Rollback();
+    }),
+  ).rejects.toThrow(Rollback);
+}
+
+// 엔티티(창고/보유자/SKU/로케이션)만 시딩한다. 원장 행은 각 테스트가 필요한 모양대로 얹는다.
+async function seedEntities(tx: DbTx) {
+  const [warehouse] = await tx
+    .insert(wmsTables.warehouses)
+    .values({ name: `it-wh-${randomUUID().slice(0, 8)}` })
+    .returning();
+  const [holder] = await tx
+    .insert(wmsTables.holders)
+    .values({ name: `it-h-${randomUUID().slice(0, 8)}` })
+    .returning();
+  const [sku] = await tx
+    .insert(wmsTables.skus)
+    .values({ name: 'it-sku', code: `IT-${randomUUID()}`, holderId: holder.id })
+    .returning();
+  // 코드 역순으로 삽입해 정렬이 실제로 적용되는지 본다.
+  const [locB] = await tx
+    .insert(wmsTables.locations)
+    .values({ warehouseId: warehouse.id, code: `IT-LOC-B-${randomUUID().slice(0, 8)}`, locationType: 'zone' })
+    .returning();
+  const [locA] = await tx
+    .insert(wmsTables.locations)
+    .values({ warehouseId: warehouse.id, code: `IT-LOC-A-${randomUUID().slice(0, 8)}`, locationType: 'zone' })
+    .returning();
+  return { warehouse, sku, locA, locB };
+}
+
 describeIfDb('stock projection by-location (DB integration, rollback-only)', () => {
-  jest.setTimeout(120_000);
-  let sql: postgres.Sql;
-  let db: PostgresJsDatabase<typeof wmsSchema>;
-  let reader: StockProjectionReader;
-
-  beforeAll(() => {
-    sql = postgres(DATABASE_URL as string, { max: 1 });
-    db = drizzle(sql, { schema: wmsSchema });
-    const dbService = {
-      db,
-      run: async (fn: (t: DbTx) => Promise<unknown>, t?: DbTx) => (t ? fn(t) : db.transaction(fn)),
-    } as unknown as DbService<typeof wmsSchema>;
-    const outbox = new OutboxService(dbService);
-    const sellable = new ProductSellableQuantityService(dbService as never, outbox);
-    const eventStore = new StockEventStore(dbService, sellable);
-    reader = new StockProjectionReader(dbService, eventStore);
-  });
-  afterAll(async () => {
-    await sql.end();
-  });
-
-  async function inRollbackTx(fn: (tx: DbTx) => Promise<void>) {
-    await expect(
-      db.transaction(async (tx) => {
-        await fn(tx);
-        throw new Rollback();
-      }),
-    ).rejects.toThrow(Rollback);
-  }
-
-  // 엔티티(창고/보유자/SKU/로케이션)만 시딩한다. 원장 행은 각 테스트가 필요한 모양대로 얹는다.
-  async function seedEntities(tx: DbTx) {
-    const [warehouse] = await tx
-      .insert(wmsTables.warehouses)
-      .values({ name: `it-wh-${randomUUID().slice(0, 8)}` })
-      .returning();
-    const [holder] = await tx
-      .insert(wmsTables.holders)
-      .values({ name: `it-h-${randomUUID().slice(0, 8)}` })
-      .returning();
-    const [sku] = await tx
-      .insert(wmsTables.skus)
-      .values({ name: 'it-sku', code: `IT-${randomUUID()}`, holderId: holder.id })
-      .returning();
-    // 코드 역순으로 삽입해 정렬이 실제로 적용되는지 본다.
-    const [locB] = await tx
-      .insert(wmsTables.locations)
-      .values({ warehouseId: warehouse.id, code: `IT-LOC-B-${randomUUID().slice(0, 8)}`, locationType: 'zone' })
-      .returning();
-    const [locA] = await tx
-      .insert(wmsTables.locations)
-      .values({ warehouseId: warehouse.id, code: `IT-LOC-A-${randomUUID().slice(0, 8)}`, locationType: 'zone' })
-      .returning();
-    return { warehouse, sku, locA, locB };
-  }
-
   it('details 각 행에 locationCode 를 동반하고 위치 코드 오름차순으로 정렬한다', async () => {
     await inRollbackTx(async (tx) => {
       const { warehouse, sku, locA, locB } = await seedEntities(tx);
@@ -131,6 +136,71 @@ describeIfDb('stock projection by-location (DB integration, rollback-only)', () 
       expect(result.details[2].locationId).toBe(locB.id);
       expect(result.details[2].stockState).toBe('ON_HAND');
       expect(result.details[2].quantity).toBe(7);
+    });
+  });
+});
+
+describeIfDb('getLocationContents (DB integration, rollback-only)', () => {
+  it('로케이션 내용물을 skuCode 오름차순으로, 조인된 코드·이름과 함께 반환한다', async () => {
+    await inRollbackTx(async (tx) => {
+      const { warehouse, locA } = await seedEntities(tx);
+      const [holderX] = await tx
+        .insert(wmsTables.holders)
+        .values({ name: `it-hx-${randomUUID().slice(0, 8)}` })
+        .returning();
+      // 4번째 문자 'A' < 'Z' 라 접미 uuid 와 무관하게 skuLo.code < skuHi.code 가 확정된다.
+      const [skuLo] = await tx
+        .insert(wmsTables.skus)
+        .values({ name: 'lo', code: `IT-A-${randomUUID()}`, holderId: holderX.id })
+        .returning();
+      const [skuHi] = await tx
+        .insert(wmsTables.skus)
+        .values({ name: 'hi', code: `IT-Z-${randomUUID()}`, holderId: holderX.id })
+        .returning();
+      // 기대 출력과 반대 순서로 삽입해 정렬이 실제로 적용되는지 본다.
+      await tx.insert(wmsTables.stockLedgers).values([
+        { skuId: skuHi.id, warehouseId: warehouse.id, locationId: locA.id, stockState: 'ON_HAND', qty: 4 },
+        { skuId: skuLo.id, warehouseId: warehouse.id, locationId: locA.id, stockState: 'ON_HAND', qty: 9 },
+      ]);
+
+      const result = await reader.getLocationContents(locA.id, tx);
+
+      expect(result.locationId).toBe(locA.id);
+      expect(result.locationCode).toBe(locA.code);
+      expect(result.warehouseId).toBe(warehouse.id);
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].skuId).toBe(skuLo.id);
+      expect(result.items[0].skuCode).toBe(skuLo.code);
+      expect(result.items[0].skuName).toBe('lo');
+      expect(result.items[0].quantity).toBe(9);
+      expect(result.items[1].skuId).toBe(skuHi.id);
+    });
+  });
+
+  it('없는 로케이션은 NotFoundError 를 던진다', async () => {
+    await inRollbackTx(async (tx) => {
+      await expect(reader.getLocationContents(randomUUID(), tx)).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  it('재고가 없는 로케이션은 빈 items 를 준다', async () => {
+    await inRollbackTx(async (tx) => {
+      const { locB } = await seedEntities(tx);
+      const result = await reader.getLocationContents(locB.id, tx);
+      expect(result.items).toEqual([]);
+    });
+  });
+
+  it('ON_HAND 가 아닌 상태(DEFECTIVE)도 필터 없이 함께 반환한다', async () => {
+    await inRollbackTx(async (tx) => {
+      const { warehouse, sku, locA } = await seedEntities(tx);
+      await tx.insert(wmsTables.stockLedgers).values([
+        { skuId: sku.id, warehouseId: warehouse.id, locationId: locA.id, stockState: 'ON_HAND', qty: 5 },
+        { skuId: sku.id, warehouseId: warehouse.id, locationId: locA.id, stockState: 'DEFECTIVE', qty: 1 },
+      ]);
+      const result = await reader.getLocationContents(locA.id, tx);
+      expect(result.items).toHaveLength(2);
+      expect(result.items.map((i) => i.stockState).sort()).toEqual(['DEFECTIVE', 'ON_HAND']);
     });
   });
 });

--- a/apps/core/src/modules/inventory/stock-projection/services/stock-projection.reader.ts
+++ b/apps/core/src/modules/inventory/stock-projection/services/stock-projection.reader.ts
@@ -9,6 +9,7 @@ import { GetStockSummaryListQueryDto, StockSummaryListItemDto } from '../dto/sto
 import { CurrentStockDto } from '../dto/current-stock.dto';
 import { SkuStockSummaryDto } from '../dto/sku-stock-summary.dto';
 import { PaginatedResponseDto } from '../../shared/dto';
+import { LocationContentsDto } from '../dto/location-contents.dto';
 
 @Injectable()
 export class StockProjectionReader {
@@ -202,6 +203,44 @@ export class StockProjectionReader {
         : null,
       details,
     };
+  }
+
+  async getLocationContents(locationId: string, tx?: DbTx): Promise<LocationContentsDto> {
+    return this.dbService.run(async (trx) => {
+      const [location] = await trx
+        .select({
+          id: wmsTables.locations.id,
+          code: wmsTables.locations.code,
+          warehouseId: wmsTables.locations.warehouseId,
+        })
+        .from(wmsTables.locations)
+        .where(eq(wmsTables.locations.id, locationId))
+        .limit(1);
+
+      if (!location) {
+        throw new NotFoundError(`Location not found: ${locationId}`);
+      }
+
+      const items = await trx
+        .select({
+          skuId: wmsTables.stockLedgers.skuId,
+          skuCode: wmsTables.skus.code,
+          skuName: wmsTables.skus.name,
+          stockState: wmsTables.stockLedgers.stockState,
+          quantity: wmsTables.stockLedgers.qty,
+        })
+        .from(wmsTables.stockLedgers)
+        .innerJoin(wmsTables.skus, eq(wmsTables.stockLedgers.skuId, wmsTables.skus.id))
+        .where(eq(wmsTables.stockLedgers.locationId, locationId))
+        .orderBy(wmsTables.skus.code, wmsTables.stockLedgers.stockState);
+
+      return {
+        locationId: location.id,
+        locationCode: location.code,
+        warehouseId: location.warehouseId,
+        items,
+      };
+    }, tx);
   }
 
   getHistory(skuId: string, warehouseId?: string, startDate?: string, endDate?: string) {

--- a/apps/core/src/modules/inventory/stock-projection/services/stock-projection.service.ts
+++ b/apps/core/src/modules/inventory/stock-projection/services/stock-projection.service.ts
@@ -28,6 +28,10 @@ export class StockProjectionService {
     return this.reader.getBySkuAndWarehouse(skuId, warehouseId, tx);
   }
 
+  getLocationContents(locationId: string, tx?: DbTx) {
+    return this.reader.getLocationContents(locationId, tx);
+  }
+
   getHistory(skuId: string, warehouseId?: string, startDate?: string, endDate?: string) {
     return this.reader.getHistory(skuId, warehouseId, startDate, endDate);
   }

--- a/docs/superpowers/plans/2026-07-25-warehouse-app-movement.md
+++ b/docs/superpowers/plans/2026-07-25-warehouse-app-movement.md
@@ -1,0 +1,1332 @@
+# 재고 이동(로케이션↔로케이션) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 물류 현장 앱의 `/movement` 스텁을 로케이션 우선 재고 이동 워크플로우로 교체하고, 이를 뒷받침할 로케이션 내용물 조회 엔드포인트를 백엔드에 추가한다.
+
+**Architecture:** 이동 자체는 기존 `POST /movement/move`(동일 창고 배치, 라인 1개)를 재사용한다. 유일한 백엔드 공백인 "로케이션 내용물 조회"는 `GET /inventory/stocks/location/:locationId` additive read 로 채운다. 프론트는 출발지 스캔 → 내용물(ON_HAND) → 품목별 단건 이동 + 직전 도착지 재사용의 화면 내 상태기계이며, Phase 1 의 훅/컴포넌트/테스트 패턴을 그대로 복제한다.
+
+**Tech Stack:** NestJS + Drizzle ORM(postgres.js) (apps/core) · React 19 + TanStack Query/Router + Tailwind + Vitest/Testing Library (native/warehouse-app, Tauri 웹뷰).
+
+## Global Constraints
+
+- 상위 스펙: `docs/superpowers/specs/2026-07-25-warehouse-app-movement-design.md` — 결정/문구/범위의 단일 출처.
+- 백엔드는 **전부 additive** — 스키마 변경 0 · 마이그레이션 0 · 기존 응답 필드 제거 0.
+- 백엔드 inventory 규칙(CLAUDE.md): `trx.select().from().innerJoin().where().orderBy()`(Drizzle 연산자), `db.query.*`·`with` 관계·`any`/`as` 금지, `@InjectTypedDb<typeof wmsSchema>()`, `dbService.run(fn, tx)` 단일 러너. 서비스는 `@app/shared` 도메인 예외(`NotFoundError`)를 던지고 컨트롤러는 try/catch 하지 않는다. 중첩 DTO 는 별도 클래스, `@ApiProperty({ type: 'object' })` 금지.
+- 프론트 데이터훅 규약(Phase 1): react-query key = 파라미터 튜플, `api.request<T>({ path })`, URL 상태 없이 로컬 `useState`, mutation 성공 시 관련 key 무효화.
+- 이동 = `ON_HAND → ON_HAND` 고정. 화면은 ON_HAND 행만 이동 대상으로 노출.
+- 검증 게이트: `nest build core` exit 0 · `npm test`(warehouse-app vitest) 전량 green · oxlint 신규 error 0(변경 파일 스코프). 백엔드 통합 스펙은 `DATABASE_URL` 있을 때만 실행(없으면 auto-skip, Phase 1 과 동일 취급).
+- 작업 디렉터리: 백엔드 명령은 리포 루트, 프론트 명령은 `native/warehouse-app`.
+
+---
+
+### Task 1: 백엔드 — 로케이션 내용물 조회 엔드포인트
+
+**Files:**
+- Create: `apps/core/src/modules/inventory/stock-projection/dto/location-contents.dto.ts`
+- Modify: `apps/core/src/modules/inventory/stock-projection/services/stock-projection.reader.ts` (import + `getLocationContents` 메서드 추가, reader.ts:205 `getBySkuAndWarehouse` 뒤)
+- Modify: `apps/core/src/modules/inventory/stock-projection/services/stock-projection.service.ts` (delegation 추가)
+- Modify: `apps/core/src/modules/inventory/stock-projection/controllers/stock-projection.controller.ts` (route + import 추가)
+- Test: `apps/core/src/modules/inventory/stock-projection/services/stock-projection-by-location.integration.spec.ts` (기존 파일에 describe 추가)
+
+**Interfaces:**
+- Produces:
+  - `class LocationContentItemDto { skuId: string; skuCode: string; skuName: string; stockState: string; quantity: number }`
+  - `class LocationContentsDto { locationId: string; locationCode: string; warehouseId: string; items: LocationContentItemDto[] }`
+  - `StockProjectionReader.getLocationContents(locationId: string, tx?: DbTx): Promise<LocationContentsDto>`
+  - `StockProjectionService.getLocationContents(locationId: string, tx?: DbTx)`
+  - HTTP `GET /inventory/stocks/location/:locationId` → `LocationContentsDto`
+- Consumes: `wmsTables.locations`(`id`·`code`·`warehouseId` 모두 notNull), `wmsTables.stockLedgers`(`skuId`·`locationId`·`stockState`·`qty`), `wmsTables.skus`(`code`·`name` notNull), `NotFoundError`(`@app/shared`), `DbTx`/`wmsTables`(inventory.schema), `dbService.run`.
+
+- [ ] **Step 1: DTO 파일 작성**
+
+Create `apps/core/src/modules/inventory/stock-projection/dto/location-contents.dto.ts`:
+
+```ts
+import { ApiProperty } from '@nestjs/swagger';
+
+export class LocationContentItemDto {
+  @ApiProperty()
+  skuId: string;
+
+  @ApiProperty()
+  skuCode: string;
+
+  @ApiProperty()
+  skuName: string;
+
+  @ApiProperty({ description: 'ON_HAND | DEFECTIVE | IN_TRANSFER' })
+  stockState: string;
+
+  @ApiProperty()
+  quantity: number;
+}
+
+export class LocationContentsDto {
+  @ApiProperty()
+  locationId: string;
+
+  @ApiProperty()
+  locationCode: string;
+
+  @ApiProperty()
+  warehouseId: string;
+
+  @ApiProperty({ type: [LocationContentItemDto] })
+  items: LocationContentItemDto[];
+}
+```
+
+- [ ] **Step 2: 통합 스펙 작성 (실패 대신 auto-skip; DATABASE_URL 있으면 실행)**
+
+기존 `stock-projection-by-location.integration.spec.ts` 상단 import 에 `NotFoundError` 를 추가한다:
+
+```ts
+import { NotFoundError } from '@app/shared';
+```
+
+그리고 파일 맨 끝(마지막 `});` 다음 줄, describeIfDb 블록 안이 아니라 새 describeIfDb 블록으로) 아래 describe 를 추가한다. `describeIfDb`·`inRollbackTx`·`seedEntities`·`reader`·`randomUUID`·`wmsTables` 는 파일 상단에 이미 있으므로 재사용한다:
+
+```ts
+describeIfDb('getLocationContents (DB integration, rollback-only)', () => {
+  it('로케이션 내용물을 skuCode 오름차순으로, 조인된 코드·이름과 함께 반환한다', async () => {
+    await inRollbackTx(async (tx) => {
+      const { warehouse, locA } = await seedEntities(tx);
+      const [holderX] = await tx
+        .insert(wmsTables.holders)
+        .values({ name: `it-hx-${randomUUID().slice(0, 8)}` })
+        .returning();
+      // 4번째 문자 'A' < 'Z' 라 접미 uuid 와 무관하게 skuLo.code < skuHi.code 가 확정된다.
+      const [skuLo] = await tx
+        .insert(wmsTables.skus)
+        .values({ name: 'lo', code: `IT-A-${randomUUID()}`, holderId: holderX.id })
+        .returning();
+      const [skuHi] = await tx
+        .insert(wmsTables.skus)
+        .values({ name: 'hi', code: `IT-Z-${randomUUID()}`, holderId: holderX.id })
+        .returning();
+      // 기대 출력과 반대 순서로 삽입해 정렬이 실제로 적용되는지 본다.
+      await tx.insert(wmsTables.stockLedgers).values([
+        { skuId: skuHi.id, warehouseId: warehouse.id, locationId: locA.id, stockState: 'ON_HAND', qty: 4 },
+        { skuId: skuLo.id, warehouseId: warehouse.id, locationId: locA.id, stockState: 'ON_HAND', qty: 9 },
+      ]);
+
+      const result = await reader.getLocationContents(locA.id, tx);
+
+      expect(result.locationId).toBe(locA.id);
+      expect(result.locationCode).toBe(locA.code);
+      expect(result.warehouseId).toBe(warehouse.id);
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].skuId).toBe(skuLo.id);
+      expect(result.items[0].skuCode).toBe(skuLo.code);
+      expect(result.items[0].skuName).toBe('lo');
+      expect(result.items[0].quantity).toBe(9);
+      expect(result.items[1].skuId).toBe(skuHi.id);
+    });
+  });
+
+  it('없는 로케이션은 NotFoundError 를 던진다', async () => {
+    await inRollbackTx(async (tx) => {
+      await expect(reader.getLocationContents(randomUUID(), tx)).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  it('재고가 없는 로케이션은 빈 items 를 준다', async () => {
+    await inRollbackTx(async (tx) => {
+      const { locB } = await seedEntities(tx);
+      const result = await reader.getLocationContents(locB.id, tx);
+      expect(result.items).toEqual([]);
+    });
+  });
+
+  it('ON_HAND 가 아닌 상태(DEFECTIVE)도 필터 없이 함께 반환한다', async () => {
+    await inRollbackTx(async (tx) => {
+      const { warehouse, sku, locA } = await seedEntities(tx);
+      await tx.insert(wmsTables.stockLedgers).values([
+        { skuId: sku.id, warehouseId: warehouse.id, locationId: locA.id, stockState: 'ON_HAND', qty: 5 },
+        { skuId: sku.id, warehouseId: warehouse.id, locationId: locA.id, stockState: 'DEFECTIVE', qty: 1 },
+      ]);
+      const result = await reader.getLocationContents(locA.id, tx);
+      expect(result.items).toHaveLength(2);
+      expect(result.items.map((i) => i.stockState).sort()).toEqual(['DEFECTIVE', 'ON_HAND']);
+    });
+  });
+});
+```
+
+- [ ] **Step 3: reader 에 `getLocationContents` 구현**
+
+`stock-projection.reader.ts` 상단 import 에 DTO 를 추가한다:
+
+```ts
+import { LocationContentsDto } from '../dto/location-contents.dto';
+```
+
+`getBySkuAndWarehouse` 메서드(reader.ts:205 `}` 로 끝남) 바로 뒤에 추가한다:
+
+```ts
+  async getLocationContents(locationId: string, tx?: DbTx): Promise<LocationContentsDto> {
+    return this.dbService.run(async (trx) => {
+      const [location] = await trx
+        .select({
+          id: wmsTables.locations.id,
+          code: wmsTables.locations.code,
+          warehouseId: wmsTables.locations.warehouseId,
+        })
+        .from(wmsTables.locations)
+        .where(eq(wmsTables.locations.id, locationId))
+        .limit(1);
+
+      if (!location) {
+        throw new NotFoundError(`Location not found: ${locationId}`);
+      }
+
+      const items = await trx
+        .select({
+          skuId: wmsTables.stockLedgers.skuId,
+          skuCode: wmsTables.skus.code,
+          skuName: wmsTables.skus.name,
+          stockState: wmsTables.stockLedgers.stockState,
+          quantity: wmsTables.stockLedgers.qty,
+        })
+        .from(wmsTables.stockLedgers)
+        .innerJoin(wmsTables.skus, eq(wmsTables.stockLedgers.skuId, wmsTables.skus.id))
+        .where(eq(wmsTables.stockLedgers.locationId, locationId))
+        .orderBy(wmsTables.skus.code, wmsTables.stockLedgers.stockState);
+
+      return {
+        locationId: location.id,
+        locationCode: location.code,
+        warehouseId: location.warehouseId,
+        items,
+      };
+    }, tx);
+  }
+```
+
+(`eq`·`NotFoundError` 는 reader.ts 상단에 이미 import 되어 있다 — reader.ts:2,3. 확인만.)
+
+- [ ] **Step 4: service delegation 추가**
+
+`stock-projection.service.ts` 의 `getBySkuAndWarehouse` delegation(service.ts:27-29) 바로 뒤에 추가한다:
+
+```ts
+  getLocationContents(locationId: string, tx?: DbTx) {
+    return this.reader.getLocationContents(locationId, tx);
+  }
+```
+
+- [ ] **Step 5: controller route 추가**
+
+`stock-projection.controller.ts` 상단 import 에 DTO 를 추가한다:
+
+```ts
+import { LocationContentsDto } from '../dto/location-contents.dto';
+```
+
+`getStockBySkuAndWarehouse` 핸들러(controller.ts:63-69) 바로 뒤에 추가한다:
+
+```ts
+  @Get('/stocks/location/:locationId')
+  @ApiOperation({ summary: '로케이션 내용물 조회 (SKU·상태·수량)' })
+  @ApiParam({ name: 'locationId', description: '로케이션 ID' })
+  @ApiResponse({ status: 200, type: LocationContentsDto })
+  async getLocationContents(@Param('locationId') locationId: string): Promise<LocationContentsDto> {
+    return this.stockProjection.getLocationContents(locationId);
+  }
+```
+
+(`@Get`·`@Param`·`@ApiOperation`·`@ApiParam`·`@ApiResponse` 는 controller.ts 상단에 이미 import 되어 있다.)
+
+- [ ] **Step 6: 빌드로 검증**
+
+Run(리포 루트): `npx nest build core`
+Expected: exit 0, 타입 에러 없음.
+
+- [ ] **Step 7: 통합 스펙 실행(있으면) + 심볼 확인**
+
+Run: `DATABASE_URL 이 설정돼 있으면` → `npx jest --testPathPattern=stock-projection-by-location`
+Expected: getLocationContents describe 4개 PASS. `DATABASE_URL` 미설정이면 `describe.skip` 으로 auto-skip — 이는 정상(Phase 1 과 동일). 이 경우 검증은 Step 6 빌드가 담당.
+
+- [ ] **Step 8: 커밋**
+
+```bash
+git add apps/core/src/modules/inventory/stock-projection/
+git commit -m "feat(inventory): GET /inventory/stocks/location/:locationId 로케이션 내용물 조회"
+```
+
+---
+
+### Task 2: 프론트 — movement 타입 + `useLocationContents` 훅
+
+**Files:**
+- Create: `native/warehouse-app/src/domains/movement/types.ts`
+- Create: `native/warehouse-app/src/domains/movement/useLocationContents.ts`
+- Test: `native/warehouse-app/src/domains/movement/useLocationContents.test.tsx`
+
+**Interfaces:**
+- Produces:
+  - `interface LocationContentItem { skuId: string; skuCode: string; skuName: string; stockState: string; quantity: number }`
+  - `interface LocationContents { locationId: string; locationCode: string; warehouseId: string; items: LocationContentItem[] }`
+  - `interface MoveInput { warehouseId: string; skuId: string; fromLocationId: string; toLocationId: string; quantity: number; reason?: string; idempotencyKey: string }`
+  - `useLocationContents(locationId: string | undefined)` → react-query result of `LocationContents`, query key `['location-contents', locationId]`, `enabled` when locationId truthy.
+- Consumes: `useApiClient()`(`api.request<T>({ path })`), `useQuery`.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+Create `native/warehouse-app/src/domains/movement/useLocationContents.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SessionProvider } from '../../app/session-context';
+import { ApiClientProvider } from '../../core/data/ApiClientProvider';
+import type { ApiClient } from '../../core/data/httpClient';
+import type { Session } from '../../core/auth/session';
+import { useLocationContents } from './useLocationContents';
+
+const session = {
+  bootstrap: async () => {},
+  isAuthenticated: () => true,
+  getAccessToken: async () => 'tok',
+  login: async () => {},
+  logout: async () => {},
+  subscribe: () => () => {},
+} satisfies Session;
+
+function wrapperWith(client: ApiClient) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <SessionProvider session={session}>
+      <QueryClientProvider client={qc}>
+        <ApiClientProvider client={client}>{children}</ApiClientProvider>
+      </QueryClientProvider>
+    </SessionProvider>
+  );
+}
+
+describe('useLocationContents', () => {
+  it('locationId 로 GET 경로를 만들고 응답을 준다', async () => {
+    const request = vi.fn(async (_o: { path: string }) => ({
+      locationId: 'l-1',
+      locationCode: 'A-01-02',
+      warehouseId: 'w-1',
+      items: [{ skuId: 's1', skuCode: 'C1', skuName: '상품1', stockState: 'ON_HAND', quantity: 12 }],
+    }));
+    const client: ApiClient = { request: request as unknown as ApiClient['request'] };
+    const { result } = renderHook(() => useLocationContents('l-1'), { wrapper: wrapperWith(client) });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(request.mock.calls[0][0].path).toBe('/inventory/stocks/location/l-1');
+    expect(result.current.data?.items[0].skuCode).toBe('C1');
+  });
+
+  it('locationId 가 없으면 요청하지 않는다', () => {
+    const request = vi.fn(async () => ({}));
+    const client: ApiClient = { request: request as unknown as ApiClient['request'] };
+    renderHook(() => useLocationContents(undefined), { wrapper: wrapperWith(client) });
+    expect(request).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run(native/warehouse-app): `npm test -- useLocationContents`
+Expected: FAIL — `Cannot find module './useLocationContents'` (또는 types).
+
+- [ ] **Step 3: 타입 파일 작성**
+
+Create `native/warehouse-app/src/domains/movement/types.ts`:
+
+```ts
+/** GET /inventory/stocks/location/:locationId 의 items[] 한 행. */
+export interface LocationContentItem {
+  skuId: string;
+  skuCode: string;
+  skuName: string;
+  /** ON_HAND | DEFECTIVE | IN_TRANSFER. 이동 대상은 ON_HAND 뿐이다. */
+  stockState: string;
+  quantity: number;
+}
+
+/** GET /inventory/stocks/location/:locationId 응답. */
+export interface LocationContents {
+  locationId: string;
+  locationCode: string;
+  warehouseId: string;
+  items: LocationContentItem[];
+}
+
+/** MovementScreen → useMoveStock 입력. 라인 1개 MoveBatchDto 로 조립된다. */
+export interface MoveInput {
+  warehouseId: string;
+  skuId: string;
+  fromLocationId: string;
+  toLocationId: string;
+  quantity: number;
+  /** 선택 사유. MoveLineDto.memo 로 전달된다. */
+  reason?: string;
+  /** (c) 시트 진입 시 1회 생성, 재시도에 재사용. */
+  idempotencyKey: string;
+}
+```
+
+- [ ] **Step 4: 훅 작성**
+
+Create `native/warehouse-app/src/domains/movement/useLocationContents.ts`:
+
+```ts
+import { useQuery } from '@tanstack/react-query';
+import { useApiClient } from '../../core/data/ApiClientProvider';
+import type { LocationContents } from './types';
+
+/** GET /inventory/stocks/location/:locationId — 로케이션 내용물(SKU·상태·수량). */
+export function useLocationContents(locationId: string | undefined) {
+  const api = useApiClient();
+  return useQuery({
+    queryKey: ['location-contents', locationId],
+    enabled: Boolean(locationId),
+    queryFn: () => api.request<LocationContents>({ path: `/inventory/stocks/location/${locationId}` }),
+  });
+}
+```
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run(native/warehouse-app): `npm test -- useLocationContents`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add native/warehouse-app/src/domains/movement/types.ts \
+        native/warehouse-app/src/domains/movement/useLocationContents.ts \
+        native/warehouse-app/src/domains/movement/useLocationContents.test.tsx
+git commit -m "feat(warehouse-app): useLocationContents 훅 + movement 타입"
+```
+
+---
+
+### Task 3: 프론트 — `useMoveStock` 훅
+
+**Files:**
+- Create: `native/warehouse-app/src/domains/movement/useMoveStock.ts`
+- Test: `native/warehouse-app/src/domains/movement/useMoveStock.test.tsx`
+
+**Interfaces:**
+- Produces:
+  - `MOVE_REASONS: readonly ['재배치', '통합', '분산', '기타']`
+  - `useMoveStock()` → mutation of `MoveInput`. POST `/movement/move`, body = `{ warehouseId, idempotencyKey, lines: [{ skuId, fromLocationId, toLocationId, quantity, memo: reason }] }`, `idempotencyKey` 헤더 동반. 성공 시 `location-contents`·`sku-warehouse-stock`·`sku-stock-summary` 무효화.
+- Consumes: `MoveInput`(Task 2), `useApiClient`, `useMutation`/`useQueryClient`.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+Create `native/warehouse-app/src/domains/movement/useMoveStock.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SessionProvider } from '../../app/session-context';
+import { ApiClientProvider } from '../../core/data/ApiClientProvider';
+import type { ApiClient } from '../../core/data/httpClient';
+import type { Session } from '../../core/auth/session';
+import { useMoveStock } from './useMoveStock';
+
+const session = {
+  bootstrap: async () => {},
+  isAuthenticated: () => true,
+  getAccessToken: async () => 'tok',
+  login: async () => {},
+  logout: async () => {},
+  subscribe: () => () => {},
+} satisfies Session;
+
+function harness() {
+  const request = vi.fn(
+    async (_o: { path: string; method?: string; body?: unknown; idempotencyKey?: string }) => ({})
+  );
+  const client: ApiClient = { request: request as unknown as ApiClient['request'] };
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const invalidate = vi.spyOn(qc, 'invalidateQueries');
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <SessionProvider session={session}>
+      <QueryClientProvider client={qc}>
+        <ApiClientProvider client={client}>{children}</ApiClientProvider>
+      </QueryClientProvider>
+    </SessionProvider>
+  );
+  return { request, invalidate, wrapper };
+}
+
+describe('useMoveStock', () => {
+  it('라인 1개 배치와 멱등 헤더를 보내고 캐시를 무효화한다', async () => {
+    const { request, invalidate, wrapper } = harness();
+    const { result } = renderHook(() => useMoveStock(), { wrapper });
+
+    await result.current.mutateAsync({
+      warehouseId: 'w-1',
+      skuId: 's1',
+      fromLocationId: 'l-1',
+      toLocationId: 'l-2',
+      quantity: 5,
+      reason: '재배치',
+      idempotencyKey: 'k1',
+    });
+
+    const call = request.mock.calls[0][0];
+    expect(call.path).toBe('/movement/move');
+    expect(call.method).toBe('POST');
+    expect(call.idempotencyKey).toBe('k1');
+    expect(call.body).toEqual({
+      warehouseId: 'w-1',
+      idempotencyKey: 'k1',
+      lines: [
+        { skuId: 's1', fromLocationId: 'l-1', toLocationId: 'l-2', quantity: 5, memo: '재배치' },
+      ],
+    });
+
+    await waitFor(() => expect(invalidate).toHaveBeenCalled());
+    const keys = invalidate.mock.calls.map((c) => JSON.stringify(c[0]));
+    expect(keys.some((k) => k.includes('location-contents'))).toBe(true);
+    expect(keys.some((k) => k.includes('sku-warehouse-stock'))).toBe(true);
+    expect(keys.some((k) => k.includes('sku-stock-summary'))).toBe(true);
+  });
+
+  it('사유가 없으면 memo 를 보내지 않는다', async () => {
+    const { request, wrapper } = harness();
+    const { result } = renderHook(() => useMoveStock(), { wrapper });
+
+    await result.current.mutateAsync({
+      warehouseId: 'w-1',
+      skuId: 's1',
+      fromLocationId: 'l-1',
+      toLocationId: 'l-2',
+      quantity: 3,
+      idempotencyKey: 'k2',
+    });
+
+    const call = request.mock.calls[0][0] as { body: { lines: Array<{ memo?: string }> } };
+    expect(call.body.lines[0].memo).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run(native/warehouse-app): `npm test -- useMoveStock`
+Expected: FAIL — `Cannot find module './useMoveStock'`.
+
+- [ ] **Step 3: 훅 작성**
+
+Create `native/warehouse-app/src/domains/movement/useMoveStock.ts`:
+
+```ts
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useApiClient } from '../../core/data/ApiClientProvider';
+import type { MoveInput } from './types';
+
+export const MOVE_REASONS = ['재배치', '통합', '분산', '기타'] as const;
+
+/**
+ * POST /movement/move — 동일 창고 라인 1개 배치 이동.
+ * 서버가 출발지 ON_HAND 부족(400)·동일 로케이션 금지·창고 소속을 검증한다.
+ */
+export function useMoveStock() {
+  const api = useApiClient();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: MoveInput) =>
+      api.request<unknown>({
+        method: 'POST',
+        path: '/movement/move',
+        body: {
+          warehouseId: input.warehouseId,
+          idempotencyKey: input.idempotencyKey,
+          lines: [
+            {
+              skuId: input.skuId,
+              fromLocationId: input.fromLocationId,
+              toLocationId: input.toLocationId,
+              quantity: input.quantity,
+              memo: input.reason,
+            },
+          ],
+        },
+        idempotencyKey: input.idempotencyKey,
+      }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['location-contents'] });
+      void qc.invalidateQueries({ queryKey: ['sku-warehouse-stock'] });
+      void qc.invalidateQueries({ queryKey: ['sku-stock-summary'] });
+    },
+  });
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run(native/warehouse-app): `npm test -- useMoveStock`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add native/warehouse-app/src/domains/movement/useMoveStock.ts \
+        native/warehouse-app/src/domains/movement/useMoveStock.test.tsx
+git commit -m "feat(warehouse-app): useMoveStock 훅 (라인 1개 배치 이동)"
+```
+
+---
+
+### Task 4: 프론트 — `errorMessage` 에 movement 문맥 추가
+
+**Files:**
+- Modify: `native/warehouse-app/src/core/data/errorMessage.ts` (`ErrorContext` union + `CONTEXTUAL`)
+- Test: `native/warehouse-app/src/core/data/errorMessage.test.ts` (케이스 추가)
+
+**Interfaces:**
+- Produces: `ErrorContext` 에 `'movement'` 추가. `errorMessage(e, 'movement')` 는 400 → `'출발지 재고가 부족해요. 다시 확인해 주세요.'`.
+- Consumes: 없음.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`errorMessage.test.ts` 의 `describe('errorMessage with context', …)` 블록 안, `'실사 문맥의 400 …'` it 블록(test.ts:40-44) 바로 뒤에 추가한다:
+
+```ts
+  it('이동 문맥의 400 은 출발지 부족을 짚어준다', () => {
+    expect(errorMessage(new Error('POST /movement/move → 400'), 'movement')).toBe(
+      '출발지 재고가 부족해요. 다시 확인해 주세요.'
+    );
+  });
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run(native/warehouse-app): `npm test -- errorMessage`
+Expected: FAIL — `'movement'` 인자가 타입에 없어 tsc/실행 에러, 또는 기대 문자열 불일치.
+
+- [ ] **Step 3: 구현 — union + 매핑 추가**
+
+`errorMessage.ts` 의 `ErrorContext` 타입(errorMessage.ts:4)을 교체한다:
+
+```ts
+export type ErrorContext = 'barcode' | 'location' | 'stocktaking' | 'movement';
+```
+
+그리고 `CONTEXTUAL` 상수(errorMessage.ts:6-10)에 `movement` 항목을 추가한다:
+
+```ts
+const CONTEXTUAL: Record<ErrorContext, Partial<Record<number, string>>> = {
+  barcode: { 404: '등록되지 않은 바코드예요.' },
+  location: { 404: '로케이션을 찾을 수 없어요.' },
+  stocktaking: { 400: '실사가 진행 중이 아니에요. 세션 상태를 확인해 주세요.' },
+  movement: { 400: '출발지 재고가 부족해요. 다시 확인해 주세요.' },
+};
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run(native/warehouse-app): `npm test -- errorMessage`
+Expected: PASS (기존 + 신규 케이스).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add native/warehouse-app/src/core/data/errorMessage.ts \
+        native/warehouse-app/src/core/data/errorMessage.test.ts
+git commit -m "feat(warehouse-app): errorMessage movement 문맥(400 출발지 부족)"
+```
+
+---
+
+### Task 5: 프론트 — MovementScreen + 라우트 배선
+
+**Files:**
+- Create: `native/warehouse-app/src/domains/movement/MovementScreen.tsx`
+- Create: `native/warehouse-app/src/app/routes/MovementRoute.tsx`
+- Modify: `native/warehouse-app/src/app/routeTree.tsx` (`/movement` 플레이스홀더 → `MovementRoute`)
+- Test: `native/warehouse-app/src/domains/movement/MovementScreen.test.tsx`
+
+**Interfaces:**
+- Produces: `MovementScreen()` React 컴포넌트(props 없음), `MovementRoute()` 래퍼.
+- Consumes: `useLocationContents`(Task 2), `useMoveStock`·`MOVE_REASONS`(Task 3), `errorMessage(_, 'movement'|'location')`(Task 4), `LocationContentItem`(Task 2), `useWarehouse`, `useLocationSearch`, `useScanner`, `NumberPad`, `ConfirmDialog`, `ScreenHeader`, `Button`, `WarehousePicker`, `cn`.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+Create `native/warehouse-app/src/domains/movement/MovementScreen.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  RouterProvider,
+  Outlet,
+} from '@tanstack/react-router';
+import { SessionProvider } from '../../app/session-context';
+import { WarehouseProvider } from '../../app/warehouse-context';
+import { createMemoryPrefs } from '../../core/data/devicePrefs';
+import { ApiClientProvider } from '../../core/data/ApiClientProvider';
+import { ScanProvider } from '../../core/hardware/scan/ScanProvider';
+import type { ApiClient } from '../../core/data/httpClient';
+import type { Session } from '../../core/auth/session';
+import { MovementScreen } from './MovementScreen';
+
+const session = {
+  bootstrap: async () => {},
+  isAuthenticated: () => true,
+  getAccessToken: async () => 'tok',
+  login: async () => {},
+  logout: async () => {},
+  subscribe: () => () => {},
+} satisfies Session;
+
+const CONTENTS = {
+  locationId: 'l-src',
+  locationCode: 'A-01-02',
+  warehouseId: 'w-1',
+  items: [
+    { skuId: 's1', skuCode: 'CT-001', skuName: '코튼셔츠', stockState: 'ON_HAND', quantity: 12 },
+    { skuId: 's2', skuCode: 'DF-002', skuName: '불량품', stockState: 'DEFECTIVE', quantity: 2 },
+  ],
+};
+
+function makeClient(calls: Array<{ path: string; method?: string; body?: unknown }>): ApiClient {
+  return {
+    request: (async (opts: { path: string; method?: string; body?: unknown }) => {
+      calls.push({ path: opts.path, method: opts.method, body: opts.body });
+      if (opts.path.startsWith('/locations/warehouses/')) {
+        if (opts.path.includes('A-01')) {
+          return { items: [{ id: 'l-src', code: 'A-01-02', displayName: 'A-01-02' }], total: 1 };
+        }
+        if (opts.path.includes('B-05')) {
+          return { items: [{ id: 'l-dst', code: 'B-05-03', displayName: 'B-05-03' }], total: 1 };
+        }
+        return { items: [], total: 0 };
+      }
+      if (opts.path === '/inventory/stocks/location/l-src') return CONTENTS;
+      if (opts.path === '/movement/move') return {};
+      throw new Error(`GET ${opts.path} → 404`);
+    }) as unknown as ApiClient['request'],
+  };
+}
+
+function renderScreen(client: ApiClient, withWarehouse = true) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const prefs = createMemoryPrefs(
+    withWarehouse ? { 'almondwms.warehouse': JSON.stringify({ id: 'w-1', name: '본창고' }) } : {}
+  );
+  const rootRoute = createRootRoute({ component: Outlet });
+  const index = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <MovementScreen />,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([index]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  });
+  const wrap = ({ children }: { children: ReactNode }) => (
+    <SessionProvider session={session}>
+      <QueryClientProvider client={qc}>
+        <ApiClientProvider client={client}>
+          <ScanProvider>
+            <WarehouseProvider prefs={prefs}>{children}</WarehouseProvider>
+          </ScanProvider>
+        </ApiClientProvider>
+      </QueryClientProvider>
+    </SessionProvider>
+  );
+  return render(<RouterProvider router={router as never} />, { wrapper: wrap });
+}
+
+// 출발지 A-01-02 를 골라 내용물 모드로 진입시키는 공통 절차.
+async function pickSource() {
+  await userEvent.type(await screen.findByLabelText('출발 로케이션 검색'), 'A-01');
+  await userEvent.click(await screen.findByRole('button', { name: /A-01-02/ }));
+}
+
+describe('MovementScreen', () => {
+  it('창고 미설정이면 창고 선택을 안내한다', async () => {
+    renderScreen(makeClient([]), false);
+    expect(await screen.findByText('창고를 먼저 선택해 주세요.')).toBeInTheDocument();
+  });
+
+  it('출발지를 고르면 ON_HAND 품목만 보여준다(불량품 제외)', async () => {
+    renderScreen(makeClient([]));
+    await pickSource();
+    expect(await screen.findByText('코튼셔츠')).toBeInTheDocument();
+    expect(screen.queryByText('불량품')).not.toBeInTheDocument();
+  });
+
+  it('품목·대상지·수량을 갖추면 확인 후 이동을 보낸다', async () => {
+    const calls: Array<{ path: string; method?: string; body?: unknown }> = [];
+    renderScreen(makeClient(calls));
+    await pickSource();
+
+    await userEvent.click(await screen.findByRole('button', { name: '이동' }));
+    // 대상지 선택
+    await userEvent.type(await screen.findByLabelText('대상 로케이션 검색'), 'B-05');
+    await userEvent.click(await screen.findByRole('button', { name: /B-05-03/ }));
+    // 이동 실행
+    await userEvent.click(screen.getByRole('button', { name: '이동하기' }));
+    const dialog = await screen.findByRole('dialog', { name: '재고 이동' });
+    await userEvent.click(within(dialog).getByRole('button', { name: '이동' }));
+
+    const move = calls.find((c) => c.path === '/movement/move');
+    expect(move?.method).toBe('POST');
+    expect(move?.body).toMatchObject({
+      warehouseId: 'w-1',
+      lines: [{ skuId: 's1', fromLocationId: 'l-src', toLocationId: 'l-dst', quantity: 12 }],
+    });
+  });
+
+  it('이동 성공 후 시트를 닫고 재오픈 시 직전 대상지 칩을 보여준다', async () => {
+    renderScreen(makeClient([]));
+    await pickSource();
+
+    await userEvent.click(await screen.findByRole('button', { name: '이동' }));
+    await userEvent.type(await screen.findByLabelText('대상 로케이션 검색'), 'B-05');
+    await userEvent.click(await screen.findByRole('button', { name: /B-05-03/ }));
+    await userEvent.click(screen.getByRole('button', { name: '이동하기' }));
+    const dialog = await screen.findByRole('dialog', { name: '재고 이동' });
+    await userEvent.click(within(dialog).getByRole('button', { name: '이동' }));
+
+    // 시트가 닫힌다(품목 이동 다이얼로그 사라짐).
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: '품목 이동' })).not.toBeInTheDocument()
+    );
+    // 재오픈 → 직전 대상지 칩.
+    await userEvent.click(await screen.findByRole('button', { name: '이동' }));
+    expect(await screen.findByRole('button', { name: '직전 대상지 B-05-03 사용' })).toBeInTheDocument();
+  });
+
+  it('대상 로케이션 목록에서 출발지는 제외된다', async () => {
+    renderScreen(makeClient([]));
+    await pickSource();
+    await userEvent.click(await screen.findByRole('button', { name: '이동' }));
+
+    // 대상지 검색에 출발지 코드를 넣어도(같은 l-src) 목록에서 걸러진다.
+    await userEvent.type(await screen.findByLabelText('대상 로케이션 검색'), 'A-01');
+    await waitFor(() => {
+      const sheet = screen.getByRole('dialog', { name: '품목 이동' });
+      expect(within(sheet).queryByRole('button', { name: /A-01-02/ })).not.toBeInTheDocument();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run(native/warehouse-app): `npm test -- MovementScreen`
+Expected: FAIL — `Cannot find module './MovementScreen'`.
+
+- [ ] **Step 3: MovementScreen 작성**
+
+Create `native/warehouse-app/src/domains/movement/MovementScreen.tsx`:
+
+```tsx
+import { useEffect, useRef, useState } from 'react';
+import { useWarehouse } from '../../app/warehouse-context';
+import { errorMessage } from '../../core/data/errorMessage';
+import { Button } from '../../core/design/Button';
+import { ScreenHeader } from '../../core/design/ScreenHeader';
+import { NumberPad } from '../../core/design/NumberPad';
+import { ConfirmDialog } from '../../core/design/ConfirmDialog';
+import { cn } from '../../core/design/cn';
+import { useScanner } from '../../core/hardware/scan/useScanner';
+import { useLocationSearch } from '../warehouse/useLocationSearch';
+import { WarehousePicker } from '../warehouse/WarehousePicker';
+import { useLocationContents } from './useLocationContents';
+import { useMoveStock, MOVE_REASONS } from './useMoveStock';
+import type { LocationContentItem } from './types';
+
+const OTHER = '기타';
+
+interface LocationRef {
+  id: string;
+  code: string;
+}
+
+export function MovementScreen() {
+  const { warehouseId, isSet } = useWarehouse();
+
+  // (a) 출발지
+  const [source, setSource] = useState<LocationRef | null>(null);
+  const [sourceTerm, setSourceTerm] = useState('');
+  // (c) 품목 이동 시트
+  const [activeItem, setActiveItem] = useState<LocationContentItem | null>(null);
+  const [dest, setDest] = useState<LocationRef | null>(null);
+  const [destTerm, setDestTerm] = useState('');
+  const [qty, setQty] = useState(0);
+  const [reason, setReason] = useState<string | null>(null);
+  const [otherReason, setOtherReason] = useState('');
+  const [lastDest, setLastDest] = useState<LocationRef | null>(null);
+  const [confirming, setConfirming] = useState(false);
+  const [idempotencyKey, setIdempotencyKey] = useState(() => crypto.randomUUID());
+
+  const contents = useLocationContents(source?.id);
+  const sourceSearch = useLocationSearch(warehouseId, source ? '' : sourceTerm);
+  const destSearch = useLocationSearch(warehouseId, !activeItem || dest ? '' : destTerm);
+  const move = useMoveStock();
+
+  // 스캔은 모드에 따라 라우팅된다: 시트가 열려 있고 대상지 미정이면 대상지로,
+  // 아니면 출발지 대기 중일 때 출발지로. 내용물 모드(출발지 선택됨·시트 닫힘)의
+  // 스캔은 무시한다 — 품목은 탭으로 고른다.
+  useScanner((e) => {
+    if (activeItem) {
+      if (!dest) setDestTerm(e.code);
+      return;
+    }
+    if (!source) setSourceTerm(e.code);
+  });
+
+  // 출발지: 스캔/입력이 코드와 정확히 일치하는 단건이면 자동 선택.
+  useEffect(() => {
+    if (source) return;
+    const term = sourceTerm.trim();
+    if (!term) return;
+    const exact = (sourceSearch.data?.items ?? []).filter((i) => i.code === term);
+    if (exact.length === 1) {
+      setSource({ id: exact[0].id, code: exact[0].code });
+      setSourceTerm('');
+    }
+  }, [sourceSearch.data, sourceTerm, source]);
+
+  // 대상지: 출발지를 제외한 뒤 코드 완전일치 단건이면 자동 선택.
+  useEffect(() => {
+    if (!activeItem || dest) return;
+    const term = destTerm.trim();
+    if (!term) return;
+    const exact = (destSearch.data?.items ?? [])
+      .filter((i) => i.id !== source?.id)
+      .filter((i) => i.code === term);
+    if (exact.length === 1) {
+      setDest({ id: exact[0].id, code: exact[0].code });
+      setDestTerm('');
+    }
+  }, [destSearch.data, destTerm, activeItem, dest, source]);
+
+  // 멱등키 회전: payload(품목·출발·대상·수량)가 바뀌면 새 키를 발급한다.
+  // "요청은 커밋됐는데 응답만 유실" 뒤 값을 고쳐 재제출하면 옛 payload 를
+  // 같은 키로 replay 하는 사고를 막는다. 값이 안 바뀐 재시도는 같은 키를 유지.
+  const keyPayloadRef = useRef({ skuId: '', from: '', to: '', qty: 0 });
+  useEffect(() => {
+    if (!activeItem || !source) return;
+    const next = { skuId: activeItem.skuId, from: source.id, to: dest?.id ?? '', qty };
+    const prev = keyPayloadRef.current;
+    if (prev.skuId === next.skuId && prev.from === next.from && prev.to === next.to && prev.qty === next.qty) {
+      return;
+    }
+    keyPayloadRef.current = next;
+    setIdempotencyKey(crypto.randomUUID());
+  }, [activeItem, source, dest, qty]);
+
+  function openSheet(item: LocationContentItem) {
+    if (!source) return;
+    setActiveItem(item);
+    setDest(null);
+    setDestTerm('');
+    setQty(item.quantity);
+    setReason(null);
+    setOtherReason('');
+    keyPayloadRef.current = { skuId: item.skuId, from: source.id, to: '', qty: item.quantity };
+    setIdempotencyKey(crypto.randomUUID());
+  }
+
+  function closeSheet() {
+    setActiveItem(null);
+    setDest(null);
+    setDestTerm('');
+    setQty(0);
+    setReason(null);
+    setOtherReason('');
+  }
+
+  const movable = (contents.data?.items ?? []).filter(
+    (i) => i.stockState === 'ON_HAND' && i.quantity > 0
+  );
+  const effectiveReason = reason === OTHER ? otherReason.trim() : reason ?? '';
+  const canSubmit =
+    Boolean(activeItem) &&
+    Boolean(source) &&
+    Boolean(dest) &&
+    dest?.id !== source?.id &&
+    qty >= 1 &&
+    qty <= (activeItem?.quantity ?? 0);
+
+  if (!isSet) {
+    return (
+      <div className="space-y-4">
+        <ScreenHeader title="재고 이동" backTo="/" />
+        <div className="space-y-3 rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4">
+          <p className="text-sm text-gray-600">창고를 먼저 선택해 주세요.</p>
+          <WarehousePicker />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <ScreenHeader title="재고 이동" backTo="/" />
+
+      {!source ? (
+        <section className="space-y-2">
+          <h2 className="text-sm font-semibold text-gray-700">출발 로케이션</h2>
+          <label htmlFor="src-search" className="sr-only">
+            출발 로케이션 검색
+          </label>
+          <input
+            id="src-search"
+            aria-label="출발 로케이션 검색"
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            placeholder="출발 로케이션 바코드를 스캔하거나 코드를 입력하세요"
+            value={sourceTerm}
+            onChange={(e) => setSourceTerm(e.target.value)}
+          />
+          {sourceSearch.isError ? (
+            <p role="alert" className="text-sm text-red-600">
+              {errorMessage(sourceSearch.error, 'location')}
+            </p>
+          ) : null}
+          <ul className="space-y-1">
+            {(sourceSearch.data?.items ?? []).map((loc) => (
+              <li key={loc.id}>
+                <button
+                  type="button"
+                  className="w-full rounded-md border border-gray-200 bg-white p-3 text-left active:bg-gray-50"
+                  onClick={() => {
+                    setSource({ id: loc.id, code: loc.code });
+                    setSourceTerm('');
+                  }}
+                >
+                  {loc.code}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : (
+        <>
+          <div className="flex items-center gap-3 rounded-lg border border-blue-500 bg-blue-50 p-3">
+            <span className="text-xs text-gray-500">출발</span>
+            <span className="flex-1 font-medium text-gray-800">{source.code}</span>
+            <button
+              type="button"
+              className="text-xs text-blue-700 underline"
+              onClick={() => {
+                setSource(null);
+                closeSheet();
+              }}
+            >
+              변경
+            </button>
+          </div>
+
+          <section className="space-y-2">
+            <h2 className="text-sm font-semibold text-gray-700">이동할 품목</h2>
+            {contents.isError ? (
+              <p role="alert" className="text-sm text-red-600">
+                {errorMessage(contents.error, 'location')}
+              </p>
+            ) : contents.isLoading ? (
+              <p className="text-sm text-gray-500">불러오는 중…</p>
+            ) : movable.length === 0 ? (
+              <p className="text-sm text-gray-500">이 로케이션에는 이동할 재고가 없어요.</p>
+            ) : (
+              <ul className="space-y-2">
+                {movable.map((item) => (
+                  <li
+                    key={`${item.skuId}-${item.stockState}`}
+                    className="flex items-center gap-3 rounded-lg border border-gray-200 bg-white p-3"
+                  >
+                    <span className="flex-1">
+                      <span className="block font-medium text-gray-800">{item.skuName}</span>
+                      <span className="block font-mono text-xs text-gray-500">{item.skuCode}</span>
+                    </span>
+                    <span className="text-lg font-semibold text-gray-900">{item.quantity}</span>
+                    <Button className="px-3 py-1.5 text-xs" onClick={() => openSheet(item)}>
+                      이동
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </>
+      )}
+
+      {activeItem && source ? (
+        <div
+          className="fixed inset-0 z-40 flex items-end justify-center bg-black/40 p-4 sm:items-center"
+          role="dialog"
+          aria-modal="true"
+          aria-label="품목 이동"
+        >
+          <div className="max-h-[90vh] w-full max-w-sm space-y-4 overflow-y-auto rounded-xl bg-white p-5 shadow-lg">
+            <div>
+              <div className="font-semibold text-gray-800">{activeItem.skuName}</div>
+              <div className="font-mono text-xs text-gray-500">{activeItem.skuCode}</div>
+              <div className="mt-1 text-xs text-gray-500">
+                출발 {source.code} · 현재 ON_HAND {activeItem.quantity}
+              </div>
+            </div>
+
+            <section className="space-y-2">
+              <h3 className="text-sm font-semibold text-gray-700">이동 수량</h3>
+              <div
+                className={cn(
+                  'rounded-lg border p-2 text-center text-2xl font-semibold',
+                  qty >= 1 && qty <= activeItem.quantity
+                    ? 'border-blue-500 bg-blue-50 text-blue-700'
+                    : 'border-gray-200 bg-white text-gray-400'
+                )}
+              >
+                {qty}
+              </div>
+              <NumberPad value={qty} onChange={setQty} />
+              {qty > activeItem.quantity ? (
+                <p className="text-xs text-red-600">현재 수량({activeItem.quantity})을 초과할 수 없어요.</p>
+              ) : null}
+            </section>
+
+            <section className="space-y-2">
+              <h3 className="text-sm font-semibold text-gray-700">대상 로케이션</h3>
+              {dest ? (
+                <div className="flex items-center gap-3 rounded-lg border border-blue-500 bg-blue-50 p-3">
+                  <span className="flex-1 font-medium text-gray-800">{dest.code}</span>
+                  <button
+                    type="button"
+                    className="text-xs text-blue-700 underline"
+                    onClick={() => setDest(null)}
+                  >
+                    변경
+                  </button>
+                </div>
+              ) : (
+                <>
+                  {lastDest && lastDest.id !== source.id ? (
+                    <button
+                      type="button"
+                      className="w-full rounded-md border border-blue-300 bg-blue-50 p-2 text-sm text-blue-700"
+                      onClick={() => setDest(lastDest)}
+                    >
+                      직전 대상지 {lastDest.code} 사용
+                    </button>
+                  ) : null}
+                  <label htmlFor="dest-search" className="sr-only">
+                    대상 로케이션 검색
+                  </label>
+                  <input
+                    id="dest-search"
+                    aria-label="대상 로케이션 검색"
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                    placeholder="대상 로케이션 바코드를 스캔하거나 코드를 입력하세요"
+                    value={destTerm}
+                    onChange={(e) => setDestTerm(e.target.value)}
+                  />
+                  {destSearch.isError ? (
+                    <p role="alert" className="text-sm text-red-600">
+                      {errorMessage(destSearch.error, 'location')}
+                    </p>
+                  ) : null}
+                  <ul className="space-y-1">
+                    {(destSearch.data?.items ?? [])
+                      .filter((i) => i.id !== source.id)
+                      .map((loc) => (
+                        <li key={loc.id}>
+                          <button
+                            type="button"
+                            className="w-full rounded-md border border-gray-200 bg-white p-3 text-left active:bg-gray-50"
+                            onClick={() => setDest({ id: loc.id, code: loc.code })}
+                          >
+                            {loc.code}
+                          </button>
+                        </li>
+                      ))}
+                  </ul>
+                </>
+              )}
+            </section>
+
+            <section className="space-y-2">
+              <h3 className="text-sm font-semibold text-gray-700">
+                사유 <span className="text-xs font-normal text-gray-400">(선택)</span>
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {MOVE_REASONS.map((r) => (
+                  <button
+                    key={r}
+                    type="button"
+                    onClick={() => setReason(reason === r ? null : r)}
+                    className={cn(
+                      'rounded-full border px-3 py-1.5 text-sm',
+                      reason === r
+                        ? 'border-blue-500 bg-blue-50 text-blue-700'
+                        : 'border-gray-300 bg-white text-gray-700'
+                    )}
+                  >
+                    {r}
+                  </button>
+                ))}
+              </div>
+              {reason === OTHER ? (
+                <input
+                  aria-label="사유 직접 입력"
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                  placeholder="사유를 입력하세요"
+                  value={otherReason}
+                  onChange={(e) => setOtherReason(e.target.value)}
+                />
+              ) : null}
+            </section>
+
+            {move.isError ? (
+              <p role="alert" className="text-sm text-red-600">
+                {errorMessage(move.error, 'movement')}
+              </p>
+            ) : null}
+
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                className="flex-1 border border-gray-300 bg-white text-gray-800 hover:bg-gray-50"
+                onClick={closeSheet}
+              >
+                취소
+              </Button>
+              <Button
+                type="button"
+                className="flex-1"
+                disabled={!canSubmit || move.isPending}
+                onClick={() => setConfirming(true)}
+              >
+                이동하기
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      <ConfirmDialog
+        open={confirming}
+        title="재고 이동"
+        message={`${source?.code ?? ''} → ${dest?.code ?? ''}, ${activeItem?.skuName ?? '상품'} ${qty}개 이동합니다.`}
+        confirmLabel="이동"
+        onCancel={() => setConfirming(false)}
+        onConfirm={() => {
+          setConfirming(false);
+          if (!activeItem || !source || !dest || !warehouseId) return;
+          move.mutate(
+            {
+              warehouseId,
+              skuId: activeItem.skuId,
+              fromLocationId: source.id,
+              toLocationId: dest.id,
+              quantity: qty,
+              reason: effectiveReason || undefined,
+              idempotencyKey,
+            },
+            {
+              onSuccess: () => {
+                setLastDest(dest);
+                setIdempotencyKey(crypto.randomUUID());
+                closeSheet();
+              },
+            }
+          );
+        }}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: MovementRoute 래퍼 작성**
+
+Create `native/warehouse-app/src/app/routes/MovementRoute.tsx`:
+
+```tsx
+import { MovementScreen } from '../../domains/movement/MovementScreen';
+
+export function MovementRoute() {
+  return <MovementScreen />;
+}
+```
+
+- [ ] **Step 5: routeTree 배선 교체**
+
+`native/warehouse-app/src/app/routeTree.tsx` 의 import 블록(routeTree.tsx:19 뒤)에 추가:
+
+```ts
+import { MovementRoute } from './routes/MovementRoute';
+```
+
+그리고 `movementRoute` 정의(routeTree.tsx:96-100)의 `component` 를 교체한다:
+
+```ts
+const movementRoute = createRoute({
+  getParentRoute: () => authedRoute,
+  path: '/movement',
+  component: MovementRoute,
+});
+```
+
+(`PlaceholderScreen` import 는 `shipments`·`inbound`·`picking`·`packing` 라우트가 계속 쓰므로 그대로 둔다. `movementRoute` 는 이미 `routeTree.addChildren` 에 등록돼 있어 등록부는 변경 없음.)
+
+- [ ] **Step 6: 화면 테스트 통과 확인**
+
+Run(native/warehouse-app): `npm test -- MovementScreen`
+Expected: PASS (5 tests).
+
+- [ ] **Step 7: 라우터 회귀 확인 + 전량 테스트 + 빌드/린트**
+
+Run(native/warehouse-app):
+```bash
+npm test
+```
+Expected: 전량 green(198 기존 + 신규). `router.test.tsx`·`router.handheld.test.tsx` 가 `/movement` 해석을 계속 통과하는지 포함.
+
+Run(native/warehouse-app):
+```bash
+npx tsc -p tsconfig.app.json --noEmit
+npx oxlint src/domains/movement src/app/routes/MovementRoute.tsx src/app/routeTree.tsx src/core/data/errorMessage.ts
+```
+Expected: tsc 에러 0, oxlint 변경 파일 신규 error 0.
+
+- [ ] **Step 8: 커밋**
+
+```bash
+git add native/warehouse-app/src/domains/movement/MovementScreen.tsx \
+        native/warehouse-app/src/domains/movement/MovementScreen.test.tsx \
+        native/warehouse-app/src/app/routes/MovementRoute.tsx \
+        native/warehouse-app/src/app/routeTree.tsx
+git commit -m "feat(warehouse-app): 재고 이동 화면(MovementScreen) + /movement 배선"
+```
+
+---
+
+## 검증 체크리스트 (전 태스크 완료 후)
+
+- [ ] `npx nest build core` exit 0 (Task 1)
+- [ ] `npm test`(warehouse-app) 전량 green
+- [ ] `npx tsc -p tsconfig.app.json --noEmit`(warehouse-app) 에러 0
+- [ ] oxlint 변경 파일 신규 error 0
+- [ ] `GET /inventory/stocks/location/:locationId` 통합 스펙: DATABASE_URL 있으면 실행해 green, 없으면 ⏸(auto-skip)
+- [ ] 기기 수동 스모크(선택, 라이브): HID 리더로 출발지→품목→대상지 스캔 1회전 후 admin-web 에서 원장 반영(출발 −N/대상 +N, 총량 불변) 확인
+
+## 후속(이 플랜 밖, 스펙 §2 비목표)
+
+- 장바구니 일괄 이동(라인별 도착지 카트), 상품 우선 진입(SkuDetail `[이동]`), 이동 이력 탭, DEFECTIVE 이동, 다중 작업자 충돌 UI.

--- a/docs/superpowers/specs/2026-07-25-warehouse-app-movement-design.md
+++ b/docs/superpowers/specs/2026-07-25-warehouse-app-movement-design.md
@@ -1,0 +1,249 @@
+# 물류 현장 앱 — 재고 이동(로케이션↔로케이션) 설계 스펙
+
+- 날짜: 2026-07-25
+- 대상: `native/warehouse-app` (프론트) + `apps/core` (읽기 엔드포인트 1개 추가)
+- 브랜치: `feat/warehouse-app-movement`
+- 상태: 설계 승인됨 (구현 전) — 브레인스토밍 산출물
+- 상위 문서:
+  - `docs/superpowers/specs/2026-07-20-warehouse-native-app-design.md` (마스터 설계)
+  - `docs/superpowers/specs/2026-07-22-warehouse-app-page-structure-design.md` (IA/페이지 골격) — `/movement` = "이동 (로케이션↔로케이션)", 스캔=로케이션
+  - `docs/superpowers/specs/2026-07-23-warehouse-app-phase1-adjust-stocktaking-design.md` (Phase 1) — 이동을 명시적으로 이연("별도 세션으로 미룬다"). 본 문서가 그 후속
+  - `docs/superpowers/specs/2026-07-10-inter-warehouse-movement-retirement-design.md` — **창고간** 이동은 은퇴됨. 본 문서는 **동일창고** 로케이션↔로케이션 이동
+
+## 1. 배경 / 현재 상태
+
+Phase 1(재고 상세·조정 & 실사)까지 끝나, `native/warehouse-app`은 재고조회·상세·조정·실사가 실 배선돼 있다. `/movement`만 아직 `PlaceholderScreen` 스텁("후속 Phase에서 구현됩니다")이다.
+
+이동에는 두 개념이 있고 본 작업은 후자만 다룬다:
+
+- **창고간 이동** — `inter-warehouse-movement-retirement` 스펙에서 **은퇴**(하드 삭제). 안전 경로는 `POST /inventory/transfers`(admin-web 전용). 현장 앱 범위 밖.
+- **동일창고 로케이션↔로케이션 이동** — `POST /movement/move`(`MovementService.moveImmediately`)가 담당. admin-web `move-dialog`가 이미 라이브로 쓰는 정상 경로. **본 작업이 현장 앱에 얹는 대상.**
+
+## 2. 범위
+
+### 목표
+1. `/movement` 스텁 → 실 워크플로우 화면으로 교체 (핸드헬드)
+2. **로케이션 우선 흐름**: 출발지 스캔 → 내용물 조회 → 품목 선택 → 대상지 스캔 → 이동
+3. **품목별 단건 이동** + **직전 도착지 재사용** 단축
+4. 백엔드 **읽기 엔드포인트 1개 추가**: `GET /inventory/stocks/location/:locationId` (로케이션 내용물) — additive
+
+### 비목표 (후속)
+- **장바구니 일괄 이동**(라인별 도착지 카트, `MoveBatchDto.lines[]` N개) — 빈 통째 재배치 빈도 계측 후 승격. v1은 라인 1개 배치
+- **상품 우선 진입**(SkuDetail의 per-location `[이동]` 버튼) — 로케이션 우선과 패러다임 혼재 회피. `/movement` 타일 단일 진입
+- 이동 이력 탭(`GET /movement/history`), 다중 작업자 동시 이동 충돌 UI, 오프라인 큐
+- DEFECTIVE 등 비-ON_HAND 상태 이동 (`moveImmediately`는 `ON_HAND→ON_HAND` 고정)
+
+## 3. 백엔드 사전 조사 결과 (실측)
+
+### 3.1 이미 있는 것 — 이동 엔드포인트 (무변경)
+
+`POST /movement/move` (`MovementController.moveImmediately` → `MovementService.moveImmediately`), 요청 `MoveBatchDto`:
+
+```jsonc
+{
+  "warehouseId": "…",                 // UUID, 필수
+  "idempotencyKey": "…",              // 필수, non-empty, ≤90
+  "occurredAt": "…",                  // ISO, optional
+  "actorId": "…",                     // UUID, optional
+  "memo": "…",                        // optional (배치 메모)
+  "lines": [                          // 최소 1개
+    { "skuId": "…", "fromLocationId": "…", "toLocationId": "…",
+      "quantity": 12, "memo": "…" }   // quantity ≥ 1, memo optional
+  ]
+}
+```
+
+서버 측 검증(`movement.service.ts`)이 이미 하는 것:
+- `lines` 필수, 각 라인 `from ≠ to`, 두 로케이션 모두 `warehouseId` 소속, SKU 존재, `quantity > 0`
+- **출발지 ON_HAND 부족 → 400** (`insufficient quantity at from location`) — `stock_ledgers`의 `(sku, warehouse, fromLocation, ON_HAND)` 잔량 확인
+- `stock_availability_lock`으로 동시성 직렬화, `movement.move:<idempotencyKey>:<i>` 라인 접미 멱등키 부여, 원장은 `ON_HAND→ON_HAND` `MOVE` 이벤트
+
+응답 `MovementJobWithLinesDto`(job + lines). **이동 자체는 백엔드 무변경.**
+
+### 3.2 없는 것 (공백 1개)
+
+**로케이션 내용물 조회 엔드포인트 부재.** `stock-projection.controller`에는 SKU 우선 조회만 있다:
+- `GET /inventory/stocks/sku/:skuId/warehouse/:warehouseId` — SKU를 고정하고 위치별 분포 반환 (역방향)
+
+"주어진 로케이션에 어떤 SKU가 몇 개 있나"의 엔드포인트가 없어 **로케이션 우선 흐름을 지원할 수 없다.** → §4에서 추가.
+
+### 3.3 로케이션 코드→id 해석 (기존 재사용)
+
+- `GET /locations/warehouses/:warehouseId?search=<코드|이름>` (`LocationQueryDto.search`) — Phase 1 조정 화면이 대상지 해석에 이미 쓴다. 이동의 출발지·대상지 양쪽에 재사용.
+
+## 4. 백엔드 변경 (apps/core) — additive 1개
+
+**스키마 변경 0 · 마이그레이션 0 · 기존 응답 필드 제거 0.**
+
+### 4.1 `GET /inventory/stocks/location/:locationId` (신규)
+
+`StockProjectionController` + `StockProjectionService.getLocationContents()` + `StockProjectionReader.getLocationContents()`. 기존 `getBySkuAndWarehouse`(reader.ts:163)의 `select().innerJoin()...orderBy()` 패턴 복제.
+
+```jsonc
+{
+  "locationId": "…",
+  "locationCode": "A-01-02",
+  "warehouseId": "…",
+  "items": [
+    { "skuId": "…", "skuCode": "SKU-1", "skuName": "…", "stockState": "ON_HAND",   "quantity": 12 },
+    { "skuId": "…", "skuCode": "SKU-2", "skuName": "…", "stockState": "ON_HAND",   "quantity": 3  },
+    { "skuId": "…", "skuCode": "SKU-3", "skuName": "…", "stockState": "DEFECTIVE", "quantity": 1  }
+  ]
+}
+```
+
+- 쿼리: `stock_ledgers ⨝ skus(innerJoin) ⨝ locations(innerJoin)`, `where stock_ledgers.location_id = :locationId`
+- 정렬: `skus.code ASC, stock_ledgers.stock_state ASC`
+- 로케이션 없으면 `NotFoundError` → 404 (locations 조회로 먼저 확인해 `locationCode`·`warehouseId`를 얻고, 없으면 404)
+- **필터 안 함**(Phase 1 §4.2 컨벤션 — 서버가 행 집합을 줄이지 않는다): `quantity = 0` 제외와 "ON_HAND만 이동 가능" 판정은 프론트가. 응답은 `stockState`를 정직하게 포함
+- `stock_ledgers.location_id`는 NOT NULL·복합 PK 일부 → 위치 없는 재고 행은 존재 불가. innerJoin이 안전
+- 소비자 0개 신규 read — 확장 위험 없음. 이동 외 재고 실측·입고 적치 등에서 재사용 여지
+
+### 4.2 코드 규약
+
+CLAUDE.md inventory 규칙 준수: `trx.select().from().innerJoin().where().orderBy()`(Drizzle 연산자), `db.query.*`·`with` 관계·`any`/`as` 금지, `@InjectTypedDb<typeof inventorySchema>()`, `dbService.run(fn, tx)` 단일 러너, 중첩 DTO는 별도 클래스. 서비스는 `@app/shared`의 `NotFoundError`를 던지고 컨트롤러는 try/catch하지 않는다. 응답 DTO는 `LocationContentsDto` + 중첩 `LocationContentItemDto`로 정의(`@ApiProperty({ type: 'object' })` 금지).
+
+## 5. 창고 컨텍스트
+
+이동은 `warehouseId`가 필수다. Phase 1의 기기별 고정 창고(`useWarehouse()`)를 그대로 쓴다.
+
+- 로케이션 검색(`useLocationSearch`)이 `warehouseId` 스코프이므로 출발·대상지 해석이 자동으로 현재 창고로 한정됨
+- **미설정 가드**: `/movement` 진입 시 창고 미설정이면 화면 대신 "창고를 먼저 선택하세요" 인라인 카드 + `WarehousePicker` (조정 화면 §5와 동일 처리, 라우터 리디렉트 아님)
+
+## 6. 화면 설계 — `MovementScreen` (`/movement`)
+
+`/movement` 스텁 → `MovementRoute`(`AdjustStockRoute` 형태 래퍼) → `MovementScreen`. 플랫 라우트 1개(서브라우트 없음 — "워크플로우 내부 스캔" IA 원칙). 화면 내 **상태기계**로 모드 전환(SessionCountScreen 형태).
+
+### (a) 출발지 대기 모드
+- 큰 프롬프트 "출발 로케이션을 스캔하세요" + 수동 코드 입력 폴백
+- `useScanner`/입력 → `term` → `useLocationSearch(warehouseId, term)`로 코드→id 해석
+  - 코드 완전일치 1건 → 자동 선택 → (b)
+  - 여러 건 → 목록에서 탭 → (b)
+  - 0건 → "로케이션을 찾을 수 없습니다" (`errorMessage`)
+- (조정 화면의 로케이션 해석과 동형)
+
+### (b) 내용물 모드 (출발지 확정)
+- 상단: 출발 로케이션 칩 `[A-01-02]` + `[변경]`→(a)
+- `useLocationContents(fromLocationId)` → **ON_HAND & quantity > 0** 행만 이동 대상으로 렌더 (`SKU X · 12ea [이동]`)
+- 비-ON_HAND(DEFECTIVE 등)는 이번 범위 밖 — 렌더 제외
+- 비어 있으면 "이 로케이션에는 이동할 재고가 없습니다"
+- 품목 `[이동]` 탭 → (c)
+
+### (c) 품목 이동 시트 (한 품목 선택)
+- 헤더: 상품명·코드 · `출발 A-01-02` · `현재 ON_HAND 12`
+- **수량**: `NumberPad`, 기본값 = 전량(해당 품목 ON_HAND), 범위 `1..onHand`. `0` 및 `onHand 초과`는 프론트가 먼저 차단(백엔드 400과 별개)
+- **대상지**:
+  - `[직전 대상지 A-05-03 사용]` 칩 — 직전 성공 이동이 있으면 노출(스캔 생략)
+  - 또는 스캔/검색 (`useLocationSearch`, 조정과 동일). **대상지 = 출발지 선택 차단**(같은 로케이션 필터·경고)
+- **사유(memo)**: 선택 입력. 접이식 프리셋 칩(`재배치 · 통합 · 분산 · 기타`, 기타 시 자유 입력). 미선택 시 memo 없이 전송. (이동은 물리 재배치라 조정과 달리 사유 비필수 — 백엔드 `memo` optional)
+- `[이동하기]` → `ConfirmDialog`("A-01-02 → A-05-03, `<상품>` 12개 이동") → `POST /movement/move`(라인 1개)
+  - 성공: 직전 대상지 `{destId, destCode}` 기억, 시트 닫고 (b) 내용물 재조회(옮긴 품목 감소/소멸 반영)
+  - 실패: 시트 유지, `errorMessage` 표시
+
+**직전 도착지 재사용**: 성공한 이동의 대상지를 화면 상태로 보관. 다음 (c)에서 칩으로 재선택(스캔 없이). 출발지를 바꿔도 유지(같은 목적지로 여러 빈 정리), 화면 이탈 시 소멸.
+
+## 7. 프론트 구조
+
+```
+src/domains/movement/
+  types.ts                 # LocationContents, LocationContentItem, MoveInput
+  useLocationContents.ts   # GET /inventory/stocks/location/:locationId
+  useMoveStock.ts          # POST /movement/move (라인 1개 배치)
+  MovementScreen.tsx       # (a)(b)(c) 상태기계
+  (+ 각 *.test.tsx)
+src/app/routes/
+  MovementRoute.tsx        # <MovementScreen /> 래퍼
+src/app/routeTree.tsx      # /movement 스텁 → MovementRoute 교체
+```
+
+**재사용(신규 훅 없음)**: `useLocationSearch`(warehouse) — 출발지 해석 + 대상지 선택 양쪽. `useScanner`, `NumberPad`, `ConfirmDialog`, `ScreenHeader`, `Button`, `WarehousePicker`, `errorMessage`, `useWarehouse`.
+
+**훅 규약**(Phase 1 그대로 — react-query key = 파라미터 튜플, `api.request<T>`, URL 상태 없이 로컬 `useState`):
+
+```ts
+// useLocationContents.ts
+export function useLocationContents(locationId: string | undefined) {
+  const api = useApiClient();
+  return useQuery({
+    queryKey: ['location-contents', locationId],
+    queryFn: () => api.request<LocationContents>({ path: `/inventory/stocks/location/${locationId}` }),
+    enabled: Boolean(locationId),
+  });
+}
+
+// useMoveStock.ts — MoveInput을 라인 1개 MoveBatchDto로 조립
+export function useMoveStock() {
+  const api = useApiClient(); const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: MoveInput) =>
+      api.request<unknown>({
+        method: 'POST', path: '/movement/move',
+        body: {
+          warehouseId: input.warehouseId,
+          idempotencyKey: input.idempotencyKey,
+          lines: [{ skuId: input.skuId, fromLocationId: input.fromLocationId,
+                    toLocationId: input.toLocationId, quantity: input.quantity,
+                    memo: input.reason }],
+        },
+        idempotencyKey: input.idempotencyKey,
+      }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['location-contents'] });   // 출발·대상 양쪽
+      void qc.invalidateQueries({ queryKey: ['sku-warehouse-stock'] });
+      void qc.invalidateQueries({ queryKey: ['sku-stock-summary'] });
+    },
+  });
+}
+```
+
+- `MoveInput` = `{warehouseId, skuId, fromLocationId, toLocationId, quantity, reason?, idempotencyKey}`
+- `location-contents` 전체 무효화 → 출발지(감소)·대상지(증가) 다음 조회 시 갱신. 낙관적 갱신 안 씀(서버가 진실)
+
+## 8. 에러 처리 · 멱등성
+
+**에러 매핑**(`errorMessage`, 호출 지점이 문맥 제공):
+- 400 출발지 부족 → "출발지 재고가 부족합니다" (프론트가 `수량 ≤ ON_HAND`로 먼저 막지만, 조회~이동 사이 타 작업자가 뺐을 때의 백엔드 방어)
+- 404 로케이션 없음 → "로케이션을 찾을 수 없습니다" (출발지 해석·대상지 선택 공통)
+- 400 동일 로케이션 → 프론트가 대상지=출발지 선택 차단(발생 방지) + 방어 "출발지와 대상지가 같습니다"
+- 409 → "다른 사람이 먼저 변경했습니다" + `createApiClient` 409 1회 재시도 유지
+
+**멱등성**(조정 화면 규율 이식):
+- (c) 시트 진입 시 `crypto.randomUUID()` 1회 → 상태 보관
+- payload(`skuId·fromLocationId·toLocationId·quantity`) 변경 시 키 회전 — "요청 커밋됐는데 응답만 유실" 후 값 수정 재제출 시 옛 payload replay 차단
+- **성공 시에만** 키 회전(실패 후 재시도는 같은 키 재사용). `movement.move:<key>:0` 라인 접미는 백엔드 부여
+- 모든 이동 버튼 `isPending` 동안 비활성 — 더블탭 1차 방어
+
+## 9. 테스트 전략
+
+**프론트 (vitest + Testing Library, 가짜 트랜스포트)** — 기존 패턴 계승:
+- 훅 유닛: `useLocationContents`(키·경로·`enabled` 게이트), `useMoveStock`(라인 1개 조립·`memo` 전달·무효화 3종)
+- 순수 유닛: 수량 경계(`0` 금지·`ON_HAND 초과` 차단·기본값=전량), 출발지 해석 분기(0/1/다건), 직전 대상지 재사용 칩, 창고 미설정 가드, 대상지=출발지 차단
+- 화면: (a)→(b)→(c) 전환, 이동 성공 후 시트 닫힘 + 내용물 재조회, 성공 후 직전 대상지 칩 노출, ON_HAND만 이동 대상 노출
+
+**백엔드 (통합 스펙)** — `stock-projection-by-location.integration.spec.ts` 패턴:
+- `getLocationContents` — `skus`·`locations` 조인, `skuCode` 정렬, ON_HAND/DEFECTIVE 혼재 시 전 행 반환, 없는 로케이션 404, 빈 로케이션 `items: []`
+
+**기기 수동 스모크** — HID 리더로 출발지→품목→대상지 스캔 1회전, admin-web에서 원장 반영(출발 −N/대상 +N, 총량 불변) 확인.
+
+**검증 게이트**: `nest build core` exit 0 · oxlint 신규 error 0(변경 파일 스코프) · vitest 전량 green · 신규 통합 스펙 green(dev DB 복구 시 ⏸).
+
+## 10. 리스크 / 주의
+
+| 리스크 | 대응 |
+|---|---|
+| 조회~이동 사이 타 작업자가 출발지 재고를 뺌 | 백엔드가 이동 시 ON_HAND 재확인 → 400. 프론트는 그 메시지 표시 + 내용물 무효화로 재조회 |
+| 직전 대상지 칩이 다른 창고/무효 로케이션을 가리킴 | 창고 고정이라 창고간 오지정 불가. 화면 이탈 시 소멸. 이동 시 백엔드가 창고 소속 재검증 |
+| 라인 1개 배치의 오버헤드 | `moveImmediately`는 배치 API지만 라인 1개도 정상. 멱등키가 job 단위 dedupe |
+| 내용물 조회가 큰 로케이션에서 무거움 | v1 페이지네이션 없음(로케이션 단위라 행 수 제한적). 계측 후 필요 시 후속 |
+| 잘못된 창고 고정 상태로 이동 | 상단 바 창고명 상시 노출 + 이동 확인 다이얼로그에 로케이션 코드 명시 |
+
+## 11. 주요 결정 로그
+
+| 결정 | 선택 | 근거 |
+|---|---|---|
+| 진입 흐름 | 로케이션 우선 | IA "이동=로케이션" 부합. 스캔 종류 일관, 빈 재배치 동선 자연스러움 |
+| 이동 단위 | 품목별 단건 + 직전 대상지 재사용 | 다중 도착지를 기본 지원(각 이동이 자기 도착지), 원자·멱등 경계 명확, 조정 화면과 동형. 카트는 계측 후 승격 |
+| 백엔드 손대기 | 로케이션 내용물 read 1개 (additive) | 이동 자체는 기존 `POST /movement/move` 재사용. 공백은 로케이션 우선 조회뿐 |
+| 사유(memo) | 선택 입력 | 백엔드 `memo` optional. 스캔 핫패스에 매 이동 사유 강제는 과함. 이동은 물리 재배치 |
+| 진입점 | `/movement` 타일 단일 | SkuDetail의 `[이동]`(상품 우선)은 패러다임 혼재 → 이연 |
+| 창고 컨텍스트 | Phase 1 기기별 고정 재사용 | 신규 개념 불필요 |

--- a/native/warehouse-app/src/app/routeTree.tsx
+++ b/native/warehouse-app/src/app/routeTree.tsx
@@ -17,6 +17,7 @@ import { AdjustStockRoute } from './routes/AdjustStockRoute';
 import { StocktakingRoute } from './routes/StocktakingRoute';
 import { StocktakingSessionRoute } from './routes/StocktakingSessionRoute';
 import { StocktakingVariancesRoute } from './routes/StocktakingVariancesRoute';
+import { MovementRoute } from './routes/MovementRoute';
 
 export interface RouterContext {
   session: Session;
@@ -96,7 +97,7 @@ const stocktakingVariancesRoute = createRoute({
 const movementRoute = createRoute({
   getParentRoute: () => authedRoute,
   path: '/movement',
-  component: () => <PlaceholderScreen title="이동" note="후속 Phase에서 구현됩니다." />,
+  component: MovementRoute,
 });
 const inboundRoute = createRoute({
   getParentRoute: () => authedRoute,

--- a/native/warehouse-app/src/app/routes/MovementRoute.tsx
+++ b/native/warehouse-app/src/app/routes/MovementRoute.tsx
@@ -1,0 +1,5 @@
+import { MovementScreen } from '../../domains/movement/MovementScreen';
+
+export function MovementRoute() {
+  return <MovementScreen />;
+}

--- a/native/warehouse-app/src/core/data/errorMessage.test.ts
+++ b/native/warehouse-app/src/core/data/errorMessage.test.ts
@@ -43,6 +43,12 @@ describe('errorMessage with context', () => {
     );
   });
 
+  it('이동 문맥의 400 은 출발지 부족을 짚어준다', () => {
+    expect(errorMessage(new Error('POST /movement/move → 400'), 'movement')).toBe(
+      '출발지 재고가 부족해요. 다시 확인해 주세요.'
+    );
+  });
+
   it('문맥이 없으면 기존 문구를 유지한다', () => {
     expect(errorMessage(new Error('GET /x → 404'))).toBe('찾을 수 없어요.');
     expect(errorMessage(new Error('GET /x → 400'))).toBe('요청이 올바르지 않아요.');

--- a/native/warehouse-app/src/core/data/errorMessage.ts
+++ b/native/warehouse-app/src/core/data/errorMessage.ts
@@ -1,12 +1,13 @@
 import { ConflictError } from './httpClient';
 
 /** 같은 상태 코드라도 화면 문맥에 따라 현장에 필요한 문구가 다르다. */
-export type ErrorContext = 'barcode' | 'location' | 'stocktaking';
+export type ErrorContext = 'barcode' | 'location' | 'stocktaking' | 'movement';
 
 const CONTEXTUAL: Record<ErrorContext, Partial<Record<number, string>>> = {
   barcode: { 404: '등록되지 않은 바코드예요.' },
   location: { 404: '로케이션을 찾을 수 없어요.' },
   stocktaking: { 400: '실사가 진행 중이 아니에요. 세션 상태를 확인해 주세요.' },
+  movement: { 400: '출발지 재고가 부족해요. 다시 확인해 주세요.' },
 };
 
 export function errorMessage(error: unknown, context?: ErrorContext): string {

--- a/native/warehouse-app/src/domains/movement/MovementScreen.test.tsx
+++ b/native/warehouse-app/src/domains/movement/MovementScreen.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import type { ReactNode } from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  createRouter,
+  createRootRoute,
+  createRoute,
+  createMemoryHistory,
+  RouterProvider,
+  Outlet,
+} from '@tanstack/react-router';
+import { SessionProvider } from '../../app/session-context';
+import { WarehouseProvider } from '../../app/warehouse-context';
+import { createMemoryPrefs } from '../../core/data/devicePrefs';
+import { ApiClientProvider } from '../../core/data/ApiClientProvider';
+import { ScanProvider } from '../../core/hardware/scan/ScanProvider';
+import type { ApiClient } from '../../core/data/httpClient';
+import type { Session } from '../../core/auth/session';
+import { MovementScreen } from './MovementScreen';
+
+const session = {
+  bootstrap: async () => {},
+  isAuthenticated: () => true,
+  getAccessToken: async () => 'tok',
+  login: async () => {},
+  logout: async () => {},
+  subscribe: () => () => {},
+} satisfies Session;
+
+const CONTENTS = {
+  locationId: 'l-src',
+  locationCode: 'A-01-02',
+  warehouseId: 'w-1',
+  items: [
+    { skuId: 's1', skuCode: 'CT-001', skuName: '코튼셔츠', stockState: 'ON_HAND', quantity: 12 },
+    { skuId: 's2', skuCode: 'DF-002', skuName: '불량품', stockState: 'DEFECTIVE', quantity: 2 },
+  ],
+};
+
+function makeClient(calls: Array<{ path: string; method?: string; body?: unknown }>): ApiClient {
+  return {
+    request: (async (opts: { path: string; method?: string; body?: unknown }) => {
+      calls.push({ path: opts.path, method: opts.method, body: opts.body });
+      if (opts.path.startsWith('/locations/warehouses/')) {
+        if (opts.path.includes('A-01')) {
+          return { items: [{ id: 'l-src', code: 'A-01-02', displayName: 'A-01-02' }], total: 1 };
+        }
+        if (opts.path.includes('B-05')) {
+          return { items: [{ id: 'l-dst', code: 'B-05-03', displayName: 'B-05-03' }], total: 1 };
+        }
+        return { items: [], total: 0 };
+      }
+      if (opts.path === '/inventory/stocks/location/l-src') return CONTENTS;
+      if (opts.path === '/movement/move') return {};
+      throw new Error(`GET ${opts.path} → 404`);
+    }) as unknown as ApiClient['request'],
+  };
+}
+
+function renderScreen(client: ApiClient, withWarehouse = true) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const prefs = createMemoryPrefs(
+    withWarehouse ? { 'almondwms.warehouse': JSON.stringify({ id: 'w-1', name: '본창고' }) } : {}
+  );
+  const rootRoute = createRootRoute({ component: Outlet });
+  const index = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <MovementScreen />,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([index]),
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  });
+  const wrap = ({ children }: { children: ReactNode }) => (
+    <SessionProvider session={session}>
+      <QueryClientProvider client={qc}>
+        <ApiClientProvider client={client}>
+          <ScanProvider>
+            <WarehouseProvider prefs={prefs}>{children}</WarehouseProvider>
+          </ScanProvider>
+        </ApiClientProvider>
+      </QueryClientProvider>
+    </SessionProvider>
+  );
+  return render(<RouterProvider router={router as never} />, { wrapper: wrap });
+}
+
+// 출발지 A-01-02 를 골라 내용물 모드로 진입시키는 공통 절차.
+async function pickSource() {
+  await userEvent.type(await screen.findByLabelText('출발 로케이션 검색'), 'A-01');
+  await userEvent.click(await screen.findByRole('button', { name: /A-01-02/ }));
+}
+
+describe('MovementScreen', () => {
+  it('창고 미설정이면 창고 선택을 안내한다', async () => {
+    renderScreen(makeClient([]), false);
+    expect(await screen.findByText('창고를 먼저 선택해 주세요.')).toBeInTheDocument();
+  });
+
+  it('출발지를 고르면 ON_HAND 품목만 보여준다(불량품 제외)', async () => {
+    renderScreen(makeClient([]));
+    await pickSource();
+    expect(await screen.findByText('코튼셔츠')).toBeInTheDocument();
+    expect(screen.queryByText('불량품')).not.toBeInTheDocument();
+  });
+
+  it('품목·대상지·수량을 갖추면 확인 후 이동을 보낸다', async () => {
+    const calls: Array<{ path: string; method?: string; body?: unknown }> = [];
+    renderScreen(makeClient(calls));
+    await pickSource();
+
+    await userEvent.click(await screen.findByRole('button', { name: '이동' }));
+    // 대상지 선택
+    await userEvent.type(await screen.findByLabelText('대상 로케이션 검색'), 'B-05');
+    await userEvent.click(await screen.findByRole('button', { name: /B-05-03/ }));
+    // 이동 실행
+    await userEvent.click(screen.getByRole('button', { name: '이동하기' }));
+    const dialog = await screen.findByRole('dialog', { name: '재고 이동' });
+    await userEvent.click(within(dialog).getByRole('button', { name: '이동' }));
+
+    const move = calls.find((c) => c.path === '/movement/move');
+    expect(move?.method).toBe('POST');
+    expect(move?.body).toMatchObject({
+      warehouseId: 'w-1',
+      lines: [{ skuId: 's1', fromLocationId: 'l-src', toLocationId: 'l-dst', quantity: 12 }],
+    });
+  });
+
+  it('이동 성공 후 시트를 닫고 재오픈 시 직전 대상지 칩을 보여준다', async () => {
+    renderScreen(makeClient([]));
+    await pickSource();
+
+    await userEvent.click(await screen.findByRole('button', { name: '이동' }));
+    await userEvent.type(await screen.findByLabelText('대상 로케이션 검색'), 'B-05');
+    await userEvent.click(await screen.findByRole('button', { name: /B-05-03/ }));
+    await userEvent.click(screen.getByRole('button', { name: '이동하기' }));
+    const dialog = await screen.findByRole('dialog', { name: '재고 이동' });
+    await userEvent.click(within(dialog).getByRole('button', { name: '이동' }));
+
+    // 시트가 닫힌다(품목 이동 다이얼로그 사라짐).
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: '품목 이동' })).not.toBeInTheDocument()
+    );
+    // 재오픈 → 직전 대상지 칩.
+    await userEvent.click(await screen.findByRole('button', { name: '이동' }));
+    expect(await screen.findByRole('button', { name: '직전 대상지 B-05-03 사용' })).toBeInTheDocument();
+  });
+
+  it('대상 로케이션 목록에서 출발지는 제외된다', async () => {
+    renderScreen(makeClient([]));
+    await pickSource();
+    await userEvent.click(await screen.findByRole('button', { name: '이동' }));
+
+    // 대상지 검색에 출발지 코드를 넣어도(같은 l-src) 목록에서 걸러진다.
+    await userEvent.type(await screen.findByLabelText('대상 로케이션 검색'), 'A-01');
+    await waitFor(() => {
+      const sheet = screen.getByRole('dialog', { name: '품목 이동' });
+      expect(within(sheet).queryByRole('button', { name: /A-01-02/ })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/native/warehouse-app/src/domains/movement/MovementScreen.test.tsx
+++ b/native/warehouse-app/src/domains/movement/MovementScreen.test.tsx
@@ -161,4 +161,67 @@ describe('MovementScreen', () => {
       expect(within(sheet).queryByRole('button', { name: /A-01-02/ })).not.toBeInTheDocument();
     });
   });
+
+  it('quantity 0 인 ON_HAND 행은 이동 목록에서 제외된다', async () => {
+    const contents = {
+      locationId: 'l-src',
+      locationCode: 'A-01-02',
+      warehouseId: 'w-1',
+      items: [
+        { skuId: 's1', skuCode: 'CT-001', skuName: '코튼셔츠', stockState: 'ON_HAND', quantity: 12 },
+        { skuId: 's3', skuCode: 'ZR-000', skuName: '영수량품', stockState: 'ON_HAND', quantity: 0 },
+      ],
+    };
+    const client: ApiClient = {
+      request: (async (opts: { path: string; method?: string; body?: unknown }) => {
+        if (opts.path.startsWith('/locations/warehouses/')) {
+          if (opts.path.includes('A-01')) {
+            return { items: [{ id: 'l-src', code: 'A-01-02', displayName: 'A-01-02' }], total: 1 };
+          }
+          return { items: [], total: 0 };
+        }
+        if (opts.path === '/inventory/stocks/location/l-src') return contents;
+        throw new Error(`GET ${opts.path} → 404`);
+      }) as unknown as ApiClient['request'],
+    };
+    renderScreen(client);
+    await pickSource();
+    expect(await screen.findByText('코튼셔츠')).toBeInTheDocument();
+    expect(screen.queryByText('영수량품')).not.toBeInTheDocument();
+  });
+
+  it('수량을 0 으로 지우면 이동하기가 비활성이다', async () => {
+    renderScreen(makeClient([]));
+    await pickSource();
+
+    await userEvent.click(await screen.findByRole('button', { name: '이동' }));
+    await userEvent.type(await screen.findByLabelText('대상 로케이션 검색'), 'B-05');
+    await userEvent.click(await screen.findByRole('button', { name: /B-05-03/ }));
+
+    const sheet = screen.getByRole('dialog', { name: '품목 이동' });
+    const backspace = within(sheet).getByRole('button', { name: '지우기' });
+    // 12 → 1 → 0
+    await userEvent.click(backspace);
+    await userEvent.click(backspace);
+
+    await waitFor(() => {
+      expect(within(sheet).getByRole('button', { name: '이동하기' })).toBeDisabled();
+    });
+  });
+
+  it('현재 수량을 초과하면 이동하기가 비활성이고 경고를 보여준다', async () => {
+    renderScreen(makeClient([]));
+    await pickSource();
+
+    await userEvent.click(await screen.findByRole('button', { name: '이동' }));
+    await userEvent.type(await screen.findByLabelText('대상 로케이션 검색'), 'B-05');
+    await userEvent.click(await screen.findByRole('button', { name: /B-05-03/ }));
+
+    const sheet = screen.getByRole('dialog', { name: '품목 이동' });
+    // 12 → 123 (초과)
+    await userEvent.click(within(sheet).getByRole('button', { name: '3' }));
+
+    expect(await within(sheet).findByText('현재 수량(12)을 초과할 수 없어요.')).toBeInTheDocument();
+    expect(within(sheet).getByRole('button', { name: '이동하기' })).toBeDisabled();
+  });
 });

--- a/native/warehouse-app/src/domains/movement/MovementScreen.tsx
+++ b/native/warehouse-app/src/domains/movement/MovementScreen.tsx
@@ -1,0 +1,415 @@
+import { useEffect, useRef, useState } from 'react';
+import { useWarehouse } from '../../app/warehouse-context';
+import { errorMessage } from '../../core/data/errorMessage';
+import { Button } from '../../core/design/Button';
+import { ScreenHeader } from '../../core/design/ScreenHeader';
+import { NumberPad } from '../../core/design/NumberPad';
+import { ConfirmDialog } from '../../core/design/ConfirmDialog';
+import { cn } from '../../core/design/cn';
+import { useScanner } from '../../core/hardware/scan/useScanner';
+import { useLocationSearch } from '../warehouse/useLocationSearch';
+import { WarehousePicker } from '../warehouse/WarehousePicker';
+import { useLocationContents } from './useLocationContents';
+import { useMoveStock, MOVE_REASONS } from './useMoveStock';
+import type { LocationContentItem } from './types';
+
+const OTHER = '기타';
+
+interface LocationRef {
+  id: string;
+  code: string;
+}
+
+export function MovementScreen() {
+  const { warehouseId, isSet } = useWarehouse();
+
+  // (a) 출발지
+  const [source, setSource] = useState<LocationRef | null>(null);
+  const [sourceTerm, setSourceTerm] = useState('');
+  // (c) 품목 이동 시트
+  const [activeItem, setActiveItem] = useState<LocationContentItem | null>(null);
+  const [dest, setDest] = useState<LocationRef | null>(null);
+  const [destTerm, setDestTerm] = useState('');
+  const [qty, setQty] = useState(0);
+  const [reason, setReason] = useState<string | null>(null);
+  const [otherReason, setOtherReason] = useState('');
+  const [lastDest, setLastDest] = useState<LocationRef | null>(null);
+  const [confirming, setConfirming] = useState(false);
+  const [idempotencyKey, setIdempotencyKey] = useState(() => crypto.randomUUID());
+
+  const contents = useLocationContents(source?.id);
+  const sourceSearch = useLocationSearch(warehouseId, source ? '' : sourceTerm);
+  const destSearch = useLocationSearch(warehouseId, !activeItem || dest ? '' : destTerm);
+  const move = useMoveStock();
+
+  // 스캔은 모드에 따라 라우팅된다: 시트가 열려 있고 대상지 미정이면 대상지로,
+  // 아니면 출발지 대기 중일 때 출발지로. 내용물 모드(출발지 선택됨·시트 닫힘)의
+  // 스캔은 무시한다 — 품목은 탭으로 고른다.
+  useScanner((e) => {
+    if (activeItem) {
+      if (!dest) setDestTerm(e.code);
+      return;
+    }
+    if (!source) setSourceTerm(e.code);
+  });
+
+  // 출발지: 스캔/입력이 코드와 정확히 일치하는 단건이면 자동 선택.
+  useEffect(() => {
+    if (source) return;
+    const term = sourceTerm.trim();
+    if (!term) return;
+    const exact = (sourceSearch.data?.items ?? []).filter((i) => i.code === term);
+    if (exact.length === 1) {
+      setSource({ id: exact[0].id, code: exact[0].code });
+      setSourceTerm('');
+    }
+  }, [sourceSearch.data, sourceTerm, source]);
+
+  // 대상지: 출발지를 제외한 뒤 코드 완전일치 단건이면 자동 선택.
+  useEffect(() => {
+    if (!activeItem || dest) return;
+    const term = destTerm.trim();
+    if (!term) return;
+    const exact = (destSearch.data?.items ?? [])
+      .filter((i) => i.id !== source?.id)
+      .filter((i) => i.code === term);
+    if (exact.length === 1) {
+      setDest({ id: exact[0].id, code: exact[0].code });
+      setDestTerm('');
+    }
+  }, [destSearch.data, destTerm, activeItem, dest, source]);
+
+  // 멱등키 회전: payload(품목·출발·대상·수량)가 바뀌면 새 키를 발급한다.
+  // "요청은 커밋됐는데 응답만 유실" 뒤 값을 고쳐 재제출하면 옛 payload 를
+  // 같은 키로 replay 하는 사고를 막는다. 값이 안 바뀐 재시도는 같은 키를 유지.
+  const keyPayloadRef = useRef({ skuId: '', from: '', to: '', qty: 0 });
+  useEffect(() => {
+    if (!activeItem || !source) return;
+    const next = { skuId: activeItem.skuId, from: source.id, to: dest?.id ?? '', qty };
+    const prev = keyPayloadRef.current;
+    if (prev.skuId === next.skuId && prev.from === next.from && prev.to === next.to && prev.qty === next.qty) {
+      return;
+    }
+    keyPayloadRef.current = next;
+    setIdempotencyKey(crypto.randomUUID());
+  }, [activeItem, source, dest, qty]);
+
+  function openSheet(item: LocationContentItem) {
+    if (!source) return;
+    setActiveItem(item);
+    setDest(null);
+    setDestTerm('');
+    setQty(item.quantity);
+    setReason(null);
+    setOtherReason('');
+    keyPayloadRef.current = { skuId: item.skuId, from: source.id, to: '', qty: item.quantity };
+    setIdempotencyKey(crypto.randomUUID());
+  }
+
+  function closeSheet() {
+    setActiveItem(null);
+    setDest(null);
+    setDestTerm('');
+    setQty(0);
+    setReason(null);
+    setOtherReason('');
+  }
+
+  const movable = (contents.data?.items ?? []).filter(
+    (i) => i.stockState === 'ON_HAND' && i.quantity > 0
+  );
+  const effectiveReason = reason === OTHER ? otherReason.trim() : reason ?? '';
+  const canSubmit =
+    Boolean(activeItem) &&
+    Boolean(source) &&
+    Boolean(dest) &&
+    dest?.id !== source?.id &&
+    qty >= 1 &&
+    qty <= (activeItem?.quantity ?? 0);
+
+  if (!isSet) {
+    return (
+      <div className="space-y-4">
+        <ScreenHeader title="재고 이동" backTo="/" />
+        <div className="space-y-3 rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4">
+          <p className="text-sm text-gray-600">창고를 먼저 선택해 주세요.</p>
+          <WarehousePicker />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <ScreenHeader title="재고 이동" backTo="/" />
+
+      {!source ? (
+        <section className="space-y-2">
+          <h2 className="text-sm font-semibold text-gray-700">출발 로케이션</h2>
+          <label htmlFor="src-search" className="sr-only">
+            출발 로케이션 검색
+          </label>
+          <input
+            id="src-search"
+            aria-label="출발 로케이션 검색"
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+            placeholder="출발 로케이션 바코드를 스캔하거나 코드를 입력하세요"
+            value={sourceTerm}
+            onChange={(e) => setSourceTerm(e.target.value)}
+          />
+          {sourceSearch.isError ? (
+            <p role="alert" className="text-sm text-red-600">
+              {errorMessage(sourceSearch.error, 'location')}
+            </p>
+          ) : null}
+          <ul className="space-y-1">
+            {(sourceSearch.data?.items ?? []).map((loc) => (
+              <li key={loc.id}>
+                <button
+                  type="button"
+                  className="w-full rounded-md border border-gray-200 bg-white p-3 text-left active:bg-gray-50"
+                  onClick={() => {
+                    setSource({ id: loc.id, code: loc.code });
+                    setSourceTerm('');
+                  }}
+                >
+                  {loc.code}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : (
+        <>
+          <div className="flex items-center gap-3 rounded-lg border border-blue-500 bg-blue-50 p-3">
+            <span className="text-xs text-gray-500">출발</span>
+            <span className="flex-1 font-medium text-gray-800">{source.code}</span>
+            <button
+              type="button"
+              className="text-xs text-blue-700 underline"
+              onClick={() => {
+                setSource(null);
+                closeSheet();
+              }}
+            >
+              변경
+            </button>
+          </div>
+
+          <section className="space-y-2">
+            <h2 className="text-sm font-semibold text-gray-700">이동할 품목</h2>
+            {contents.isError ? (
+              <p role="alert" className="text-sm text-red-600">
+                {errorMessage(contents.error, 'location')}
+              </p>
+            ) : contents.isLoading ? (
+              <p className="text-sm text-gray-500">불러오는 중…</p>
+            ) : movable.length === 0 ? (
+              <p className="text-sm text-gray-500">이 로케이션에는 이동할 재고가 없어요.</p>
+            ) : (
+              <ul className="space-y-2">
+                {movable.map((item) => (
+                  <li
+                    key={`${item.skuId}-${item.stockState}`}
+                    className="flex items-center gap-3 rounded-lg border border-gray-200 bg-white p-3"
+                  >
+                    <span className="flex-1">
+                      <span className="block font-medium text-gray-800">{item.skuName}</span>
+                      <span className="block font-mono text-xs text-gray-500">{item.skuCode}</span>
+                    </span>
+                    <span className="text-lg font-semibold text-gray-900">{item.quantity}</span>
+                    <Button className="px-3 py-1.5 text-xs" onClick={() => openSheet(item)}>
+                      이동
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </>
+      )}
+
+      {activeItem && source ? (
+        <div
+          className="fixed inset-0 z-40 flex items-end justify-center bg-black/40 p-4 sm:items-center"
+          role="dialog"
+          aria-modal="true"
+          aria-label="품목 이동"
+        >
+          <div className="max-h-[90vh] w-full max-w-sm space-y-4 overflow-y-auto rounded-xl bg-white p-5 shadow-lg">
+            <div>
+              <div className="font-semibold text-gray-800">{activeItem.skuName}</div>
+              <div className="font-mono text-xs text-gray-500">{activeItem.skuCode}</div>
+              <div className="mt-1 text-xs text-gray-500">
+                출발 {source.code} · 현재 ON_HAND {activeItem.quantity}
+              </div>
+            </div>
+
+            <section className="space-y-2">
+              <h3 className="text-sm font-semibold text-gray-700">이동 수량</h3>
+              <div
+                className={cn(
+                  'rounded-lg border p-2 text-center text-2xl font-semibold',
+                  qty >= 1 && qty <= activeItem.quantity
+                    ? 'border-blue-500 bg-blue-50 text-blue-700'
+                    : 'border-gray-200 bg-white text-gray-400'
+                )}
+              >
+                {qty}
+              </div>
+              <NumberPad value={qty} onChange={setQty} />
+              {qty > activeItem.quantity ? (
+                <p className="text-xs text-red-600">현재 수량({activeItem.quantity})을 초과할 수 없어요.</p>
+              ) : null}
+            </section>
+
+            <section className="space-y-2">
+              <h3 className="text-sm font-semibold text-gray-700">대상 로케이션</h3>
+              {dest ? (
+                <div className="flex items-center gap-3 rounded-lg border border-blue-500 bg-blue-50 p-3">
+                  <span className="flex-1 font-medium text-gray-800">{dest.code}</span>
+                  <button
+                    type="button"
+                    className="text-xs text-blue-700 underline"
+                    onClick={() => setDest(null)}
+                  >
+                    변경
+                  </button>
+                </div>
+              ) : (
+                <>
+                  {lastDest && lastDest.id !== source.id ? (
+                    <button
+                      type="button"
+                      className="w-full rounded-md border border-blue-300 bg-blue-50 p-2 text-sm text-blue-700"
+                      onClick={() => setDest(lastDest)}
+                    >
+                      직전 대상지 {lastDest.code} 사용
+                    </button>
+                  ) : null}
+                  <label htmlFor="dest-search" className="sr-only">
+                    대상 로케이션 검색
+                  </label>
+                  <input
+                    id="dest-search"
+                    aria-label="대상 로케이션 검색"
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                    placeholder="대상 로케이션 바코드를 스캔하거나 코드를 입력하세요"
+                    value={destTerm}
+                    onChange={(e) => setDestTerm(e.target.value)}
+                  />
+                  {destSearch.isError ? (
+                    <p role="alert" className="text-sm text-red-600">
+                      {errorMessage(destSearch.error, 'location')}
+                    </p>
+                  ) : null}
+                  <ul className="space-y-1">
+                    {(destSearch.data?.items ?? [])
+                      .filter((i) => i.id !== source.id)
+                      .map((loc) => (
+                        <li key={loc.id}>
+                          <button
+                            type="button"
+                            className="w-full rounded-md border border-gray-200 bg-white p-3 text-left active:bg-gray-50"
+                            onClick={() => setDest({ id: loc.id, code: loc.code })}
+                          >
+                            {loc.code}
+                          </button>
+                        </li>
+                      ))}
+                  </ul>
+                </>
+              )}
+            </section>
+
+            <section className="space-y-2">
+              <h3 className="text-sm font-semibold text-gray-700">
+                사유 <span className="text-xs font-normal text-gray-400">(선택)</span>
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {MOVE_REASONS.map((r) => (
+                  <button
+                    key={r}
+                    type="button"
+                    onClick={() => setReason(reason === r ? null : r)}
+                    className={cn(
+                      'rounded-full border px-3 py-1.5 text-sm',
+                      reason === r
+                        ? 'border-blue-500 bg-blue-50 text-blue-700'
+                        : 'border-gray-300 bg-white text-gray-700'
+                    )}
+                  >
+                    {r}
+                  </button>
+                ))}
+              </div>
+              {reason === OTHER ? (
+                <input
+                  aria-label="사유 직접 입력"
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+                  placeholder="사유를 입력하세요"
+                  value={otherReason}
+                  onChange={(e) => setOtherReason(e.target.value)}
+                />
+              ) : null}
+            </section>
+
+            {move.isError ? (
+              <p role="alert" className="text-sm text-red-600">
+                {errorMessage(move.error, 'movement')}
+              </p>
+            ) : null}
+
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                className="flex-1 border border-gray-300 bg-white text-gray-800 hover:bg-gray-50"
+                onClick={closeSheet}
+              >
+                취소
+              </Button>
+              <Button
+                type="button"
+                className="flex-1"
+                disabled={!canSubmit || move.isPending}
+                onClick={() => setConfirming(true)}
+              >
+                이동하기
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      <ConfirmDialog
+        open={confirming}
+        title="재고 이동"
+        message={`${source?.code ?? ''} → ${dest?.code ?? ''}, ${activeItem?.skuName ?? '상품'} ${qty}개 이동합니다.`}
+        confirmLabel="이동"
+        onCancel={() => setConfirming(false)}
+        onConfirm={() => {
+          setConfirming(false);
+          if (!activeItem || !source || !dest || !warehouseId) return;
+          move.mutate(
+            {
+              warehouseId,
+              skuId: activeItem.skuId,
+              fromLocationId: source.id,
+              toLocationId: dest.id,
+              quantity: qty,
+              reason: effectiveReason || undefined,
+              idempotencyKey,
+            },
+            {
+              onSuccess: () => {
+                setLastDest(dest);
+                setIdempotencyKey(crypto.randomUUID());
+                closeSheet();
+              },
+            }
+          );
+        }}
+      />
+    </div>
+  );
+}

--- a/native/warehouse-app/src/domains/movement/types.ts
+++ b/native/warehouse-app/src/domains/movement/types.ts
@@ -1,0 +1,30 @@
+/** GET /inventory/stocks/location/:locationId 의 items[] 한 행. */
+export interface LocationContentItem {
+  skuId: string;
+  skuCode: string;
+  skuName: string;
+  /** ON_HAND | DEFECTIVE | IN_TRANSFER. 이동 대상은 ON_HAND 뿐이다. */
+  stockState: string;
+  quantity: number;
+}
+
+/** GET /inventory/stocks/location/:locationId 응답. */
+export interface LocationContents {
+  locationId: string;
+  locationCode: string;
+  warehouseId: string;
+  items: LocationContentItem[];
+}
+
+/** MovementScreen → useMoveStock 입력. 라인 1개 MoveBatchDto 로 조립된다. */
+export interface MoveInput {
+  warehouseId: string;
+  skuId: string;
+  fromLocationId: string;
+  toLocationId: string;
+  quantity: number;
+  /** 선택 사유. MoveLineDto.memo 로 전달된다. */
+  reason?: string;
+  /** (c) 시트 진입 시 1회 생성, 재시도에 재사용. */
+  idempotencyKey: string;
+}

--- a/native/warehouse-app/src/domains/movement/useLocationContents.test.tsx
+++ b/native/warehouse-app/src/domains/movement/useLocationContents.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SessionProvider } from '../../app/session-context';
+import { ApiClientProvider } from '../../core/data/ApiClientProvider';
+import type { ApiClient } from '../../core/data/httpClient';
+import type { Session } from '../../core/auth/session';
+import { useLocationContents } from './useLocationContents';
+
+const session = {
+  bootstrap: async () => {},
+  isAuthenticated: () => true,
+  getAccessToken: async () => 'tok',
+  login: async () => {},
+  logout: async () => {},
+  subscribe: () => () => {},
+} satisfies Session;
+
+function wrapperWith(client: ApiClient) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <SessionProvider session={session}>
+      <QueryClientProvider client={qc}>
+        <ApiClientProvider client={client}>{children}</ApiClientProvider>
+      </QueryClientProvider>
+    </SessionProvider>
+  );
+}
+
+describe('useLocationContents', () => {
+  it('locationId 로 GET 경로를 만들고 응답을 준다', async () => {
+    const request = vi.fn(async (_o: { path: string }) => ({
+      locationId: 'l-1',
+      locationCode: 'A-01-02',
+      warehouseId: 'w-1',
+      items: [{ skuId: 's1', skuCode: 'C1', skuName: '상품1', stockState: 'ON_HAND', quantity: 12 }],
+    }));
+    const client: ApiClient = { request: request as unknown as ApiClient['request'] };
+    const { result } = renderHook(() => useLocationContents('l-1'), { wrapper: wrapperWith(client) });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(request.mock.calls[0][0].path).toBe('/inventory/stocks/location/l-1');
+    expect(result.current.data?.items[0].skuCode).toBe('C1');
+  });
+
+  it('locationId 가 없으면 요청하지 않는다', () => {
+    const request = vi.fn(async () => ({}));
+    const client: ApiClient = { request: request as unknown as ApiClient['request'] };
+    renderHook(() => useLocationContents(undefined), { wrapper: wrapperWith(client) });
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/native/warehouse-app/src/domains/movement/useLocationContents.ts
+++ b/native/warehouse-app/src/domains/movement/useLocationContents.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { useApiClient } from '../../core/data/ApiClientProvider';
+import type { LocationContents } from './types';
+
+/** GET /inventory/stocks/location/:locationId — 로케이션 내용물(SKU·상태·수량). */
+export function useLocationContents(locationId: string | undefined) {
+  const api = useApiClient();
+  return useQuery({
+    queryKey: ['location-contents', locationId],
+    enabled: Boolean(locationId),
+    queryFn: () => api.request<LocationContents>({ path: `/inventory/stocks/location/${locationId}` }),
+  });
+}

--- a/native/warehouse-app/src/domains/movement/useMoveStock.test.tsx
+++ b/native/warehouse-app/src/domains/movement/useMoveStock.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SessionProvider } from '../../app/session-context';
+import { ApiClientProvider } from '../../core/data/ApiClientProvider';
+import type { ApiClient } from '../../core/data/httpClient';
+import type { Session } from '../../core/auth/session';
+import { useMoveStock } from './useMoveStock';
+
+const session = {
+  bootstrap: async () => {},
+  isAuthenticated: () => true,
+  getAccessToken: async () => 'tok',
+  login: async () => {},
+  logout: async () => {},
+  subscribe: () => () => {},
+} satisfies Session;
+
+function harness() {
+  const request = vi.fn(
+    async (_o: { path: string; method?: string; body?: unknown; idempotencyKey?: string }) => ({})
+  );
+  const client: ApiClient = { request: request as unknown as ApiClient['request'] };
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const invalidate = vi.spyOn(qc, 'invalidateQueries');
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <SessionProvider session={session}>
+      <QueryClientProvider client={qc}>
+        <ApiClientProvider client={client}>{children}</ApiClientProvider>
+      </QueryClientProvider>
+    </SessionProvider>
+  );
+  return { request, invalidate, wrapper };
+}
+
+describe('useMoveStock', () => {
+  it('라인 1개 배치와 멱등 헤더를 보내고 캐시를 무효화한다', async () => {
+    const { request, invalidate, wrapper } = harness();
+    const { result } = renderHook(() => useMoveStock(), { wrapper });
+
+    await result.current.mutateAsync({
+      warehouseId: 'w-1',
+      skuId: 's1',
+      fromLocationId: 'l-1',
+      toLocationId: 'l-2',
+      quantity: 5,
+      reason: '재배치',
+      idempotencyKey: 'k1',
+    });
+
+    const call = request.mock.calls[0][0];
+    expect(call.path).toBe('/movement/move');
+    expect(call.method).toBe('POST');
+    expect(call.idempotencyKey).toBe('k1');
+    expect(call.body).toEqual({
+      warehouseId: 'w-1',
+      idempotencyKey: 'k1',
+      lines: [
+        { skuId: 's1', fromLocationId: 'l-1', toLocationId: 'l-2', quantity: 5, memo: '재배치' },
+      ],
+    });
+
+    await waitFor(() => expect(invalidate).toHaveBeenCalled());
+    const keys = invalidate.mock.calls.map((c) => JSON.stringify(c[0]));
+    expect(keys.some((k) => k.includes('location-contents'))).toBe(true);
+    expect(keys.some((k) => k.includes('sku-warehouse-stock'))).toBe(true);
+    expect(keys.some((k) => k.includes('sku-stock-summary'))).toBe(true);
+  });
+
+  it('사유가 없으면 memo 를 보내지 않는다', async () => {
+    const { request, wrapper } = harness();
+    const { result } = renderHook(() => useMoveStock(), { wrapper });
+
+    await result.current.mutateAsync({
+      warehouseId: 'w-1',
+      skuId: 's1',
+      fromLocationId: 'l-1',
+      toLocationId: 'l-2',
+      quantity: 3,
+      idempotencyKey: 'k2',
+    });
+
+    const call = request.mock.calls[0][0] as { body: { lines: Array<{ memo?: string }> } };
+    expect(call.body.lines[0].memo).toBeUndefined();
+  });
+});

--- a/native/warehouse-app/src/domains/movement/useMoveStock.ts
+++ b/native/warehouse-app/src/domains/movement/useMoveStock.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useApiClient } from '../../core/data/ApiClientProvider';
+import type { MoveInput } from './types';
+
+export const MOVE_REASONS = ['재배치', '통합', '분산', '기타'] as const;
+
+/**
+ * POST /movement/move — 동일 창고 라인 1개 배치 이동.
+ * 서버가 출발지 ON_HAND 부족(400)·동일 로케이션 금지·창고 소속을 검증한다.
+ */
+export function useMoveStock() {
+  const api = useApiClient();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: MoveInput) =>
+      api.request<unknown>({
+        method: 'POST',
+        path: '/movement/move',
+        body: {
+          warehouseId: input.warehouseId,
+          idempotencyKey: input.idempotencyKey,
+          lines: [
+            {
+              skuId: input.skuId,
+              fromLocationId: input.fromLocationId,
+              toLocationId: input.toLocationId,
+              quantity: input.quantity,
+              memo: input.reason,
+            },
+          ],
+        },
+        idempotencyKey: input.idempotencyKey,
+      }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['location-contents'] });
+      void qc.invalidateQueries({ queryKey: ['sku-warehouse-stock'] });
+      void qc.invalidateQueries({ queryKey: ['sku-stock-summary'] });
+    },
+  });
+}


### PR DESCRIPTION
## 재고 이동(로케이션↔로케이션) — 물류 현장 앱 + 백엔드 read 1개

Phase 1에서 이연했던 **동일 창고 로케이션↔로케이션 재고 이동** 워크플로우를 `native/warehouse-app`에 구현합니다. (창고간 이동은 은퇴됨 — 이건 동일창고 이동으로 기존 `POST /movement/move`를 재사용)

- 설계 스펙: `docs/superpowers/specs/2026-07-25-warehouse-app-movement-design.md`
- 구현 플랜: `docs/superpowers/plans/2026-07-25-warehouse-app-movement.md`

### 진입 흐름 (로케이션 우선)
출발 로케이션 스캔 → 그 로케이션의 ON_HAND 내용물 조회 → 품목별 단건 이동(수량 + 대상지 스캔/검색 + **직전 대상지 재사용** 칩 + 선택 사유) → 확인 → 이동. 다중 도착지는 각 이동이 자기 도착지를 고르므로 기본 지원됩니다.

### 백엔드 (apps/core) — 전부 additive
- **신규** `GET /inventory/stocks/location/:locationId` — 로케이션 내용물(SKU·상태·수량) 조회. 기존 `getBySkuAndWarehouse` 패턴 복제, 스키마 변경 0 · 마이그레이션 0.
- 이동 자체는 기존 `POST /movement/move`(라인 1개 배치) 재사용 — 서버가 출발지 ON_HAND 부족(400)·동일 로케이션 금지·창고 소속을 검증.

### 프론트 (native/warehouse-app)
- `domains/movement/`: `types.ts`, `useLocationContents`, `useMoveStock`(+`MOVE_REASONS`), `MovementScreen`(상태기계)
- `MovementRoute` + `routeTree`의 `/movement` 스텁 교체
- `errorMessage`에 `movement` 문맥(400 → "출발지 재고가 부족해요") 추가
- Phase 1 컴포넌트/훅 전량 재사용(`useLocationSearch`·`useScanner`·`NumberPad`·`ConfirmDialog`·`WarehousePicker`·창고 컨텍스트)
- 멱등키: 이동마다 UUID, payload 변경 시 회전, 성공 시 회전, 재시도는 재사용

### 검증
- `nest build core` exit 0
- warehouse-app vitest **211/211** green (신규 MovementScreen 8개 + 훅/errorMessage 테스트 포함)
- `tsc -p tsconfig.app.json --noEmit` 0 · oxlint 변경 파일 0
- 백엔드 통합 스펙: dev DB 있을 때 실행(없으면 auto-skip)
- ⏸ 잔여(수동): HID 리더 스캔 1회전 후 admin-web에서 원장 반영(출발 −N/대상 +N, 총량 불변) 스모크

### 후속(범위 밖)
장바구니 일괄 이동, 상품 우선 진입(SkuDetail `[이동]`), 이동 이력 탭, DEFECTIVE 이동.
