### PR TITLE
fix(storefront): PDP sticky 탭이 숨은 헤더 자리에 떠 있던 문제

### DIFF
--- a/web/almondyoung-storefront/src/domains/products/product-details/components/section-nav/index.tsx
+++ b/web/almondyoung-storefront/src/domains/products/product-details/components/section-nav/index.tsx
@@ -36,18 +36,69 @@ export function SectionTabs({
   const navRef = useRef<HTMLElement>(null)
   const [sectionOffset, setSectionOffset] = useState(DEFAULT_SECTION_OFFSET)
 
+  // 스크롤스파이 판정과 앵커 스크롤(scroll-mt)에 쓰는 값. 헤더가 보이는 상태를 기준으로
+  // 잡는다 — 탭을 눌러 위로 스크롤하면 auto-hide 헤더가 다시 나타나므로 그게 맞다.
   useEffect(() => {
     const measure = () => {
       const headerH = document.getElementById("site-header")?.offsetHeight ?? 0
       const navH = navRef.current?.offsetHeight ?? 0
-      const root = document.documentElement.style
-      root.setProperty("--pdp-header-h", `${headerH}px`)
-      root.setProperty("--pdp-section-offset", `${headerH + navH}px`)
+      document.documentElement.style.setProperty(
+        "--pdp-section-offset",
+        `${headerH + navH}px`
+      )
       setSectionOffset(headerH + navH)
     }
     measure()
     window.addEventListener("resize", measure)
     return () => window.removeEventListener("resize", measure)
+  }, [])
+
+  // sticky 탭의 top 오프셋. 헤더는 스크롤에 따라 `-translate-y-full` 로 숨는데,
+  // `offsetHeight` 는 transform 을 반영하지 않아 헤더가 사라져도 값이 그대로다.
+  // 그걸 top 으로 쓰면 헤더가 없어진 자리에 빈 띠가 남고 그 아래에 탭이 떠 있게 된다.
+  // `getBoundingClientRect().bottom` 은 transform 을 반영하므로 실제로 화면에 보이는
+  // 아래 끝을 준다 — 숨으면 0 이하가 되니 0 으로 클램프한다.
+  useEffect(() => {
+    let raf = 0
+    let lastValue = -1
+    let settledFrames = 0
+
+    const apply = () => {
+      raf = 0
+      const header = document.getElementById("site-header")
+      const visibleBottom = header
+        ? Math.max(0, header.getBoundingClientRect().bottom)
+        : 0
+
+      if (visibleBottom !== lastValue) {
+        lastValue = visibleBottom
+        settledFrames = 0
+        document.documentElement.style.setProperty(
+          "--pdp-header-h",
+          `${visibleBottom}px`
+        )
+      } else {
+        settledFrames += 1
+      }
+
+      // 헤더는 300ms transition 으로 움직인다. 스크롤 이벤트는 그보다 먼저 멎으므로,
+      // 값이 안정될 때까지 몇 프레임 더 따라가야 탭이 헤더와 같이 부드럽게 붙는다.
+      if (settledFrames < 3) schedule()
+    }
+
+    const schedule = () => {
+      if (raf) return
+      raf = requestAnimationFrame(apply)
+    }
+
+    schedule()
+    window.addEventListener("scroll", schedule, { passive: true })
+    window.addEventListener("resize", schedule)
+    return () => {
+      window.removeEventListener("scroll", schedule)
+      window.removeEventListener("resize", schedule)
+      if (raf) cancelAnimationFrame(raf)
+    }
   }, [])
 
   const activeIdRaw = useScrollSpyWindow(tabIds, { topOffset: sectionOffset })


### PR DESCRIPTION
쇼핑몰 앱 스모크 테스트 중 실기기(Galaxy S25)에서 발견했지만, **앱과 무관한 storefront 웹 버그**다. 모바일 폭이면 브라우저에서도 그대로 재현되므로 지금 휴대폰으로 접속하는 고객들도 이미 이 화면을 보고 있다.

## 증상

상품 상세를 아래로 스크롤하면 헤더가 숨는데(정상), 상세정보/리뷰 탭은 화면 상단이 아니라 **헤더 높이만큼 내려온 자리에 고정된 채로** 남는다. 그 위 빈 띠로 콘텐츠가 지나가 레이아웃이 깨져 보인다.

## 원인

두 파일이 서로 다른 전제를 갖고 있었다.

```tsx
// auto-hide-header.tsx — 헤더는 transform 으로 숨는다
hidden ? "-translate-y-full" : "translate-y-0"   // sticky top-0 z-40

// section-nav/index.tsx — 오프셋은 offsetHeight 로 잰다
const headerH = document.getElementById("site-header")?.offsetHeight ?? 0
root.setProperty("--pdp-header-h", `${headerH}px`)   // 마운트/resize 때만
```

`offsetHeight` 는 레이아웃 높이라 **CSS transform 을 반영하지 않는다.** 헤더가 화면 밖으로 밀려나도 값이 그대로이므로 sticky top 이 계속 헤더 높이를 가리킨다. 게다가 마운트/resize 때만 측정해서 스크롤 중에는 갱신되지도 않았다.

## 수정

`getBoundingClientRect().bottom`(transform 반영)으로 바꾸고 0 으로 클램프해, 헤더가 숨으면 탭이 화면 최상단에 붙게 했다. 헤더가 300ms transition 으로 움직이므로 스크롤 이벤트가 멎은 뒤에도 값이 안정될 때까지 rAF 로 몇 프레임 더 따라간다 — 안 그러면 탭이 헤더보다 늦게 뚝 끊기며 움직인다.

스크롤스파이/앵커 스크롤에 쓰는 `--pdp-section-offset` 은 기존 정적 측정을 유지했다. 탭을 눌러 위로 스크롤하면 auto-hide 헤더가 다시 나타나므로 "헤더 보이는 상태" 가 그쪽의 올바른 기준이다.

데스크톱(xl+)은 `xl:translate-y-0` 으로 auto-hide 가 무력화돼 있어 영향이 없다 — `getBoundingClientRect().bottom` 이 그대로 헤더 높이를 준다.

## 검증

- `tsc --noEmit`: 기준선 62 에러 = 변경 후 62 에러, `section-nav` 관련 신규 에러 0 (62 는 storefront 기존 debt)
- ⚠️ **시각적 동작은 아직 미확인이다.** 로직과 타입만 확인했고, 실제 스크롤 거동은 배포 후 모바일에서 봐야 확정된다. 리뷰어가 로컬에서 확인해 주면 더 좋다