### PR TITLE
fix(storefront-app): Android 에서 시스템 바에 콘텐츠가 깔리던 문제 (safe-area)

### DIFF
--- a/native/storefront-app/App.tsx
+++ b/native/storefront-app/App.tsx
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react"
-import { SafeAreaView, StatusBar, StyleSheet } from "react-native"
+import { StatusBar, StyleSheet } from "react-native"
+// `react-native` 내장 SafeAreaView 를 쓰면 안 된다 — 그건 iOS 전용 구현이고 Android 에서는
+// 사실상 no-op 이다. Android 15 부터는 edge-to-edge 가 강제되어 앱이 상태바/내비게이션 바
+// **뒤까지** 그리는 것이 기본이므로, 인셋을 실제로 적용하지 않으면 웹 콘텐츠가 시스템 바에
+// 깔린다. 실제로 Galaxy S25(Android 16)에서 상단 헤더의 뒤로가기 버튼이 상태바 시계에,
+// 장바구니의 구매 버튼이 내비게이션 바에 가려 둘 다 누를 수 없었다.
+import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context"
 import * as Notifications from "expo-notifications"
 import * as SecureStore from "expo-secure-store"
 import { MainWebView } from "./src/webview/MainWebView"
@@ -104,22 +110,26 @@ export default function App() {
   }, [])
 
   return (
-    <SafeAreaView style={styles.root}>
-      <StatusBar barStyle="dark-content" />
-      {initialUrl === null ? (
-        <SplashGate onReady={onReady} pendingPath={pendingPath} />
-      ) : (
-        <>
-          <MainWebView
-            initialUrl={initialUrl}
-            onExternalUrl={setExternalUrl}
-            onBridgeMessage={onBridgeMessage}
-          />
-          <ModalWebView url={externalUrl} onClose={() => setExternalUrl(null)} />
-        </>
-      )}
-    </SafeAreaView>
+    <SafeAreaProvider>
+      <SafeAreaView style={styles.root}>
+        <StatusBar barStyle="dark-content" />
+        {initialUrl === null ? (
+          <SplashGate onReady={onReady} pendingPath={pendingPath} />
+        ) : (
+          <>
+            <MainWebView
+              initialUrl={initialUrl}
+              onExternalUrl={setExternalUrl}
+              onBridgeMessage={onBridgeMessage}
+            />
+            <ModalWebView url={externalUrl} onClose={() => setExternalUrl(null)} />
+          </>
+        )}
+      </SafeAreaView>
+    </SafeAreaProvider>
   )
 }
 
-const styles = StyleSheet.create({ root: { flex: 1 } })
+// 인셋 영역에는 이 배경색이 보인다. storefront 의 헤더/하단바가 흰색이라 흰색으로 맞춰야
+// 시스템 바 옆에 이질적인 띠가 생기지 않는다. 투명하게 두면 검은 띠가 된다.
+const styles = StyleSheet.create({ root: { flex: 1, backgroundColor: "#fff" } })

--- a/native/storefront-app/app.config.ts
+++ b/native/storefront-app/app.config.ts
@@ -6,7 +6,10 @@ const config: ExpoConfig = {
   slug: "almondyoung",
   // 계정이 여럿(lcnine / lcnine-co)이라 소유 조직을 명시한다. 프로젝트는 @lcnine-co/almondyoung.
   owner: "lcnine-co",
-  version: "1.0.0",
+  // 네이티브 의존성(react-native-safe-area-context)이 추가되면 runtimeVersion 도 달라져야
+  // 한다 — runtimeVersion 정책이 appVersion 이므로 version 을 올리지 않으면, 그 모듈이 없는
+  // 옛 빌드가 새 JS 를 OTA 로 받아 import 에서 죽는다.
+  version: "1.0.1",
   orientation: "portrait",
   scheme: "almondyoung",
   android: {

--- a/native/storefront-app/package-lock.json
+++ b/native/storefront-app/package-lock.json
@@ -21,6 +21,7 @@
         "expo-web-browser": "~57.0.2",
         "react": "19.2.3",
         "react-native": "0.86.0",
+        "react-native-safe-area-context": "~5.7.0",
         "react-native-webview": "13.16.1"
       },
       "devDependencies": {
@@ -9847,6 +9848,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-safe-area-context": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.7.0.tgz",
+      "integrity": "sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-webview": {

--- a/native/storefront-app/package.json
+++ b/native/storefront-app/package.json
@@ -16,6 +16,7 @@
     "expo-web-browser": "~57.0.2",
     "react": "19.2.3",
     "react-native": "0.86.0",
+    "react-native-safe-area-context": "~5.7.0",
     "react-native-webview": "13.16.1"
   },
   "devDependencies": {

--- a/native/storefront-app/src/webview/ModalWebView.tsx
+++ b/native/storefront-app/src/webview/ModalWebView.tsx
@@ -1,4 +1,7 @@
-import { Modal, Pressable, SafeAreaView, StyleSheet, Text, View } from "react-native"
+import { Modal, Pressable, StyleSheet, Text, View } from "react-native"
+// App.tsx 와 같은 이유로 `react-native` 내장 SafeAreaView 를 쓰지 않는다(Android no-op).
+// 이 모달은 결제 등 외부 도메인을 띄우므로 닫기 바가 상태바에 깔리면 빠져나갈 수 없게 된다.
+import { SafeAreaView } from "react-native-safe-area-context"
 import { WebView } from "react-native-webview"
 
 type Props = { url: string | null; onClose: () => void }
@@ -23,7 +26,7 @@ export function ModalWebView({ url, onClose }: Props) {
 }
 
 const styles = StyleSheet.create({
-  root: { flex: 1 },
+  root: { flex: 1, backgroundColor: "#fff" },
   bar: {
     height: 48,
     justifyContent: "center",


### PR DESCRIPTION
## 증상

Galaxy S25(Android 16) 실기기에서 상단 헤더의 뒤로가기 버튼이 상태바 시계에, 장바구니 하단의 구매 버튼이 내비게이션 바에 가려 **둘 다 누를 수 없었다.** 기기가 보고하는 상단 인셋은 103px(34.3dp)인데 전혀 적용되지 않고 있었다.

## 원인

`react-native` 내장 `SafeAreaView` 는 iOS 전용 구현이고 **Android 에서는 사실상 no-op** 이다. 여기에 Android 15 부터 edge-to-edge 가 강제되어 앱이 시스템 바 뒤까지 그리는 것이 기본이 되면서, 인셋이 전혀 적용되지 않은 채 웹 콘텐츠가 시스템 바 아래로 들어갔다.

SMOKE.md 가 "Android 회귀 위험" 으로 미리 표시해 둔 항목이었고, 실제로 그대로 재현됐다.

## 수정

`react-native-safe-area-context` 로 교체하고 root 를 `SafeAreaProvider` 로 감쌌다. 외부 도메인 모달(`ModalWebView`)도 같은 내장 SafeAreaView 를 쓰고 있어 함께 교체했다 — 그쪽은 닫기 바가 상태바에 깔리면 결제 화면에서 빠져나갈 수 없게 되는 자리라 더 위험했다.

인셋 영역 배경은 흰색으로 뒀다(storefront 헤더/하단바와 같은 색. 투명하면 검은 띠가 생긴다).

`version` 을 1.0.1 로 올렸다. runtimeVersion 정책이 `appVersion` 이라, 올리지 않으면 이 네이티브 모듈이 없는 옛 빌드가 새 JS 를 OTA 로 받아 import 에서 죽는다.

## 검증

EAS preview 빌드(`fbda2000`, version 1.0.1)를 실기기에 설치해 **스크린샷으로 확인했다.**

| | 수정 전 | 수정 후 |
|---|---|---|
| 상단 | 뒤로가기 `←` 가 상태바 시계와 겹침 | 상태바 전용 여백, 헤더 온전히 아래 |
| 하단(장바구니) | 구매 버튼이 내비게이션 바 뒤에 깔림 | 버튼 전체가 내비 바 위에 노출 |

- 타입체크 클린, 앱 유닛 테스트 59/59
- `react-native` 에서 `SafeAreaView` 를 import 하는 곳 0 건

## 남은 확인

- **제스처 내비게이션 모드 미검증** — 테스트 기기가 3버튼 모드였다. SMOKE.md 는 두 모드 모두를 요구한다
- iOS 는 이 앱의 후속 단계라 대상 아님