### PR TITLE
fix(storefront): 하단 고정 액션바에 safe-area 인셋 누락

### DIFF
--- a/web/almondyoung-storefront/src/domains/cart/components/mobile-checkout-bar/index.tsx
+++ b/web/almondyoung-storefront/src/domains/cart/components/mobile-checkout-bar/index.tsx
@@ -81,7 +81,7 @@ export default function MobileCheckoutBar({
   const isDisabled = hasError || selectedCount === 0 || isPendingCheckout
 
   return (
-    <div className="fixed inset-x-0 bottom-0 z-99 border-t bg-white lg:hidden">
+    <div className="pb-safe fixed inset-x-0 bottom-0 z-99 border-t bg-white lg:hidden">
       {/* 스크롤 페이드 인디케이터 */}
       <div
         className={`pointer-events-none absolute inset-x-0 -top-12 h-12 bg-linear-to-t from-white to-transparent transition-opacity duration-300 ${

--- a/web/almondyoung-storefront/src/domains/payment/components/bank-account-wizard/step3/index.tsx
+++ b/web/almondyoung-storefront/src/domains/payment/components/bank-account-wizard/step3/index.tsx
@@ -191,7 +191,7 @@ export default function BankAgreementStep({
         )}
       </section>
 
-      <div className="fixed right-0 bottom-0 left-0 space-y-2 bg-white p-4">
+      <div className="fixed right-0 bottom-0 left-0 space-y-2 bg-white p-4 pb-[calc(1rem+env(safe-area-inset-bottom))]">
         {/* 전자서명 영역 */}
         <div className="space-y-2">
           <div className="flex items-center justify-between">

--- a/web/almondyoung-storefront/src/domains/payment/components/bnpl-verification-wizard/step3/index.tsx
+++ b/web/almondyoung-storefront/src/domains/payment/components/bnpl-verification-wizard/step3/index.tsx
@@ -45,7 +45,7 @@ export default function BankAccountStep({
         <BankAccountList bnplProfiles={bnplProfiles} />
       )}
 
-      <div className="bg-background fixed bottom-0 left-0 w-full px-4 pb-4">
+      <div className="bg-background fixed bottom-0 left-0 w-full px-4 pb-[calc(1rem+env(safe-area-inset-bottom))]">
         <Button variant="default" className="w-full" onClick={openModal}>
           + {bnplProfiles.length === 0 ? "결제수단 등록" : "결제수단 추가"}
         </Button>

--- a/web/almondyoung-storefront/src/domains/products/product-details/components/product-actions/mobile-actions.tsx
+++ b/web/almondyoung-storefront/src/domains/products/product-details/components/product-actions/mobile-actions.tsx
@@ -65,7 +65,7 @@ const MobileActions: React.FC<MobileActionsProps> = ({
       {/* 하단 고정 바 */}
       <div
         className={cn(
-          "fixed inset-x-0 bottom-0 z-999 transition-all duration-300 lg:hidden",
+          "pb-safe fixed inset-x-0 bottom-0 z-999 transition-all duration-300 lg:hidden",
           show && !open
             ? "translate-y-0 opacity-100"
             : "pointer-events-none translate-y-full opacity-0"


### PR DESCRIPTION
쇼핑몰 앱 스모크 중 발견했지만 **모바일 브라우저에도 그대로 있는 웹 버그**다.

## 증상

`pb-safe`(= `padding-bottom: env(safe-area-inset-bottom)`)가 하단 네비게이션 바에만 있고 나머지 고정 액션바에는 빠져 있었다. 그래서 모바일 브라우저에서 장바구니 구매바·상품 상세 액션바·결제 마법사 버튼이 iOS 홈 인디케이터나 안드로이드 제스처 바에 깔린다.

```
bottom-nav.tsx:37       "... pb-safe fixed ... bottom-0 ..."   ← 처리함
mobile-checkout-bar:84  "fixed inset-x-0 bottom-0 z-99 ..."    ← 누락
```

## 채워 넣은 곳

- `cart/mobile-checkout-bar` — 구매 버튼
- `product-details/product-actions/mobile-actions` — 장바구니 담기 / 바로구매
- `payment/bank-account-wizard/step3`, `bnpl-verification-wizard/step3` — 하단 버튼

기존 패딩이 있는 두 곳은 `pb-[calc(1rem+env(safe-area-inset-bottom))]` 로 합산했다 (`full-screen-dialog` 가 이미 쓰는 패턴).

shadcn `components/ui/`(toast·drawer)는 CLAUDE.md 규칙상 직접 수정하지 않았고, `sheet` 는 액션바가 아니라 컨테이너라 범위에서 제외했다.

## ⚠️ 배포 순서 — 앱 PR #554 와 짝이다

앱은 지금까지 하단을 **네이티브로** 인셋하고 있었고, 웹도 `pb-safe` 를 넣으면 간격이 두 배가 된다. 실제로 Galaxy S25(내비바 144px)에서 하단 탭바 아래에 148px 짜리 빈 띠가 생겼다. #554 에서 앱의 하단 인셋을 제거해 **상단=앱 / 하단=웹** 으로 경계를 정리했다.

**이 PR(웹)을 먼저 배포한 뒤 #554 의 앱 빌드를 내보내야 한다.**

- 웹 먼저 → 앱에서 간격이 잠깐 넓어질 뿐 (사용 가능)
- 앱 먼저 → 구매바가 시스템 바에 깔림 (누를 수 없음)

## 검증

- `tsc --noEmit`: 기준선 62 에러 = 변경 후 62 에러, 변경 파일 관련 신규 에러 0
- ⚠️ 시각 확인은 배포 후 모바일에서 해야 한다. 특히 iOS Safari(홈 인디케이터)는 이번에 검증하지 못했다