### PR TITLE
fix(storefront-app): 하단 인셋을 웹에 넘겨 이중 여백 제거

### DIFF
--- a/native/storefront-app/App.tsx
+++ b/native/storefront-app/App.tsx
@@ -111,7 +111,19 @@ export default function App() {
 
   return (
     <SafeAreaProvider>
-      <SafeAreaView style={styles.root}>
+      {/*
+        상단만 앱이 인셋하고 **하단은 웹에 맡긴다.**
+
+        브라우저에서는 상단을 브라우저 크롬이 차지하므로 웹이 상단 인셋을 처리할 기회가
+        없다 — 그건 앱의 몫이다. 반대로 하단은 웹이 이미 처리해야 하고(iOS 홈 인디케이터)
+        실제로 storefront 의 고정 액션바들이 `pb-safe`(env(safe-area-inset-bottom))를
+        쓴다. 여기서 하단까지 인셋하면 둘이 겹쳐 간격이 정확히 두 배가 된다 —
+        Galaxy S25(내비바 144px)에서 하단 탭바 아래에 148px 짜리 빈 띠가 생겼다.
+
+        Android WebView 는 네이티브가 뷰를 인셋해도 window 기준으로 safe-area 를
+        보고하므로, 앱이 하단을 비워줘야 웹의 계산이 맞아떨어진다.
+      */}
+      <SafeAreaView style={styles.root} edges={["top", "left", "right"]}>
         <StatusBar barStyle="dark-content" />
         {initialUrl === null ? (
           <SplashGate onReady={onReady} pendingPath={pendingPath} />

--- a/native/storefront-app/src/webview/ModalWebView.tsx
+++ b/native/storefront-app/src/webview/ModalWebView.tsx
@@ -1,6 +1,10 @@
 import { Modal, Pressable, StyleSheet, Text, View } from "react-native"
 // App.tsx 와 같은 이유로 `react-native` 내장 SafeAreaView 를 쓰지 않는다(Android no-op).
 // 이 모달은 결제 등 외부 도메인을 띄우므로 닫기 바가 상태바에 깔리면 빠져나갈 수 없게 된다.
+//
+// App.tsx 와 달리 **하단도 인셋한다**(edges 기본값 = 전체). 여기 뜨는 건 우리 storefront 가
+// 아니라 임의의 외부 사이트라 safe-area 를 처리한다는 보장이 없다. 겹칠 위험보다 결제
+// 페이지의 버튼이 시스템 바에 깔릴 위험이 크다.
 import { SafeAreaView } from "react-native-safe-area-context"
 import { WebView } from "react-native-webview"
 


### PR DESCRIPTION
#554 의 후속. 그 PR 이 머지될 때 이 커밋이 아직 브랜치에 없었다(머지 09:00:59 / 커밋 09:11) — 내용 누락이지 새 발견이 아니다.

## 왜 필요한가

#554 는 root SafeAreaView 를 **전체 edge** 로 두었다. 그런데 웹도 하단에 `pb-safe`(`env(safe-area-inset-bottom)`)를 넣으므로 둘이 겹쳐 간격이 정확히 두 배가 된다. Galaxy S25(내비바 144px)에서 하단 탭바 아래에 148px 짜리 빈 띠가 생겼다.

## 책임 경계 — 상단은 앱, 하단은 웹

브라우저에서는 상단을 브라우저 크롬이 차지해 웹이 상단 인셋을 처리할 기회가 없다. 그건 앱의 몫이다. 반대로 하단은 웹이 iOS 홈 인디케이터 때문에 어차피 처리해야 하고, 실제로 `pb-safe` 유틸을 갖추고 있다(#555 에서 누락 4곳을 채웠다).

Android WebView 는 네이티브가 뷰를 인셋해도 **window 기준으로** safe-area 를 보고하므로, 앱이 하단을 비워줘야 웹의 계산이 맞아떨어진다.

`ModalWebView` 는 반대로 하단도 계속 인셋한다(edges 기본값). 거기 뜨는 건 우리 storefront 가 아니라 임의의 외부 결제 사이트라 safe-area 처리를 보장할 수 없다 — 겹칠 위험보다 버튼이 가릴 위험이 크다.

## 배포 순서

짝이 되는 웹 변경(#555)은 **이미 머지·배포 완료**다. 따라서 이 PR 의 앱 빌드는 지금 내보내도 안전하다.

## 검증

- 타입체크 클린, 앱 유닛 테스트 59/59
- ⚠️ 레이아웃이라 유닛 테스트로 잡히지 않는다. 새 preview 빌드를 실기기에 올려 하단 여백이 내비바 높이 하나만큼인지 확인해야 한다