### PR TITLE
고아결제 근본 차단: PG 승인을 주문 생성 이후로 이동

### DIFF
--- a/apps/medusa/integration-tests/http/deferred-approval-checkout.spec.ts
+++ b/apps/medusa/integration-tests/http/deferred-approval-checkout.spec.ts
@@ -1,0 +1,516 @@
+import { medusaIntegrationTestRunner } from '@medusajs/test-utils';
+import { Modules, ContainerRegistrationKeys } from '@medusajs/framework/utils';
+import { createServer, Server } from 'http';
+import jwt from 'jsonwebtoken';
+import {
+  createRegionsWorkflow,
+  createSalesChannelsWorkflow,
+  createProductsWorkflow,
+  createApiKeysWorkflow,
+  createStockLocationsWorkflow,
+  linkSalesChannelsToApiKeyWorkflow,
+  linkSalesChannelsToStockLocationWorkflow,
+} from '@medusajs/core-flows';
+
+jest.setTimeout(300 * 1000);
+
+/**
+ * 지연 승인(deferred approval) end-to-end 검증 — 고아결제 원천 차단.
+ *
+ * 요지: 카드/토스는 capture 가 아니라 **승인(approve)** 에서 돈이 빠진다. 승인이 주문 생성보다
+ * 먼저 일어나면 재고예약 실패 시 "돈은 빠졌는데 주문 없음" 이 된다. 그래서 승인을
+ * completeCartWorkflow 의 마지막 단계로 옮겼다.
+ *
+ * 가짜 wallet 서버가 실제 wallet 의 규칙을 그대로 흉내낸다:
+ *   - 결제창 완료(simulateCheckout) 시, intent 에 approvalMode='DEFERRED' 표식이 **없으면**
+ *     그 자리에서 승인 + 자동캡처 (= 수정 전 동작)
+ *   - 표식이 **있으면** 승인 파라미터만 적재하고 REQUIRES_ACTION 유지, 승인은 finalize-approval 때
+ *
+ * 따라서 "재고 부족인데 승인이 일어났는가" 를 그대로 관찰할 수 있고, 수정 전 코드(표식 미부여)에서는
+ * 아래 재고 관련 케이스들이 실제로 실패한다.
+ */
+
+const WALLET_PORT = 39117;
+const WALLET_BASE_URL = `http://127.0.0.1:${WALLET_PORT}`;
+process.env.WALLET_BASE_URL = WALLET_BASE_URL;
+process.env.WALLET_API_KEY = 'test-wallet-key';
+
+interface FakeIntent {
+  id: string;
+  amount: number;
+  deferred: boolean;
+  staged: boolean;
+  approved: boolean;
+  status: string;
+  refunded: number;
+  canceled: boolean;
+}
+
+/** 실제 wallet 의 상태/규칙을 흉내내는 최소 스텁. */
+class FakeWallet {
+  server?: Server;
+  intents = new Map<string, FakeIntent>();
+  calls: Array<{ path: string; method: string; intentId?: string }> = [];
+  /** true 면 finalize-approval 이 PG 승인 거절(422)로 응답한다. */
+  rejectApproval = false;
+  private seq = 0;
+
+  async start(): Promise<void> {
+    this.server = createServer((req, res) => {
+      const url = new URL(req.url ?? '/', WALLET_BASE_URL);
+      let body = '';
+      req.on('data', (chunk) => (body += chunk));
+      req.on('end', () => {
+        const parsed: any = body ? JSON.parse(body) : {};
+        const { status, payload } = this.route(req.method ?? 'GET', url.pathname, parsed);
+        res.writeHead(status, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(payload));
+      });
+    });
+    await new Promise<void>((resolve) => this.server!.listen(WALLET_PORT, '127.0.0.1', resolve));
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) return;
+    await new Promise<void>((resolve) => this.server!.close(() => resolve()));
+  }
+
+  reset(): void {
+    this.intents.clear();
+    this.calls = [];
+    this.rejectApproval = false;
+  }
+
+  /** 고객이 결제창을 완료한 상황. 실제 wallet 의 TossApproveService.approve 규칙과 동일하게 분기한다. */
+  simulateCheckout(intentId: string): void {
+    const intent = this.intents.get(intentId)!;
+    if (intent.deferred) {
+      intent.staged = true;
+      intent.status = 'REQUIRES_ACTION';
+      return;
+    }
+    // 수정 전 동작: 결제창을 닫는 즉시 승인 + 자동캡처 (= 이 시점에 돈이 빠진다)
+    intent.approved = true;
+    intent.status = 'CAPTURED';
+  }
+
+  /** 무통장 입금대기 상태. almond-payment 는 이 상태를 'authorized' 로 매핑한다. */
+  simulateAwaitingDeposit(intentId: string): void {
+    const intent = this.intents.get(intentId)!;
+    intent.staged = false;
+    intent.status = 'AWAITING_DEPOSIT';
+  }
+
+  callsTo(suffix: string): number {
+    return this.calls.filter((c) => c.path.endsWith(suffix)).length;
+  }
+
+  private route(method: string, path: string, body: any): { status: number; payload: any } {
+    this.calls.push({ path, method });
+
+    if (method === 'POST' && path === '/v1/payment-intents') {
+      const id = `int_${++this.seq}`;
+      this.intents.set(id, {
+        id,
+        amount: body.amount ?? 0,
+        deferred: body.metadata?.approvalMode === 'DEFERRED',
+        staged: false,
+        approved: false,
+        status: 'CREATED',
+        refunded: 0,
+        canceled: false,
+      });
+      return { status: 201, payload: { id } };
+    }
+
+    const match = /^\/v1\/payment-intents\/([^/]+)(\/.*)?$/.exec(path);
+    if (!match) return { status: 404, payload: { error: 'NOT_FOUND', message: path } };
+
+    const intent = this.intents.get(match[1]);
+    if (!intent) return { status: 404, payload: { error: 'INTENT_NOT_FOUND', message: match[1] } };
+    const action = match[2] ?? '';
+
+    if (method === 'GET' && !action) {
+      return {
+        status: 200,
+        payload: { id: intent.id, status: intent.status, payableAmount: intent.amount, currency: 'KRW' },
+      };
+    }
+
+    if (action === '/finalize-approval') {
+      if (intent.approved) return { status: 200, payload: { status: intent.status } };
+      if (!intent.staged) {
+        return { status: 409, payload: { error: 'NO_STAGED_APPROVAL', message: 'nothing staged' } };
+      }
+      if (this.rejectApproval) {
+        // 승인 실패 시 실제 wallet 은 charge FAILED + intent CREATED 로 되돌린다.
+        intent.staged = false;
+        intent.status = 'CREATED';
+        return { status: 422, payload: { error: 'REJECT_CARD_COMPANY', message: '카드사 승인 거절' } };
+      }
+      intent.approved = true;
+      intent.status = 'CAPTURED'; // 실제 wallet 은 승인 직후 auto-capture 한다
+      return { status: 200, payload: { status: intent.status } };
+    }
+
+    if (action === '/capture') {
+      if (!intent.approved) return { status: 400, payload: { error: 'INTENT_NOT_CAPTURABLE', message: intent.status } };
+      intent.status = 'CAPTURED';
+      return { status: 200, payload: { status: intent.status } };
+    }
+
+    if (action === '/cancel') {
+      intent.canceled = true;
+      intent.status = 'CANCELED';
+      return { status: 200, payload: { status: intent.status } };
+    }
+
+    if (action === '/refund') {
+      intent.refunded += body.amount ?? 0;
+      return { status: 200, payload: { status: intent.status, refunded: intent.refunded } };
+    }
+
+    return { status: 404, payload: { error: 'NOT_FOUND', message: path } };
+  }
+}
+
+const wallet = new FakeWallet();
+
+medusaIntegrationTestRunner({
+  inApp: true,
+  env: { WALLET_BASE_URL, WALLET_API_KEY: 'test-wallet-key' },
+  disableAutoTeardown: true,
+  testSuite: ({ api, getContainer }) => {
+    let storeHeaders: { headers: Record<string, string> };
+    let regionId: string;
+    let salesChannelId: string;
+    let variantId: string;
+    let inventoryItemId: string;
+    let locationId: string;
+
+    const setStock = async (quantity: number) => {
+      const inventory = getContainer().resolve(Modules.INVENTORY);
+      const [level] = await inventory.listInventoryLevels({
+        inventory_item_id: inventoryItemId,
+        location_id: locationId,
+      });
+      await inventory.updateInventoryLevels([
+        { inventory_item_id: inventoryItemId, location_id: locationId, stocked_quantity: quantity, id: level.id },
+      ]);
+    };
+
+    const reservationCount = async (): Promise<number> => {
+      const inventory = getContainer().resolve(Modules.INVENTORY);
+      const reservations = await inventory.listReservationItems({ inventory_item_id: inventoryItemId });
+      return reservations.length;
+    };
+
+    const orderIdForCart = async (cartId: string): Promise<string | null> => {
+      const query = getContainer().resolve(ContainerRegistrationKeys.QUERY);
+      const { data } = await query.graph({
+        entity: 'order_cart',
+        fields: ['cart_id', 'order_id'],
+        filters: { cart_id: cartId },
+      });
+      return (data[0] as any)?.order_id ?? null;
+    };
+
+    const cartCompletedAt = async (cartId: string) => {
+      const cartModule = getContainer().resolve(Modules.CART);
+      const cart = await cartModule.retrieveCart(cartId, { select: ['id', 'completed_at'] });
+      return cart.completed_at ?? null;
+    };
+
+    /** 카트 생성 → 결제 세션 생성 → 결제창 완료까지. 반환값의 intentId 로 wallet 상태를 관찰한다. */
+    const startCheckout = async (quantity: number) => {
+      const cartRes = await api.post(
+        '/store/carts',
+        {
+          region_id: regionId,
+          sales_channel_id: salesChannelId,
+          email: 'buyer@deferred.test',
+          items: [{ variant_id: variantId, quantity }],
+        },
+        storeHeaders,
+      );
+      const cartId = cartRes.data.cart.id as string;
+
+      // 배송수단 설정은 이 스펙의 검증 대상이 아니다(결제·재고 순서가 대상). 라인아이템을
+      // 배송 불필요로 두어 validateShippingStep 을 통과시킨다.
+      const cartModule = getContainer().resolve(Modules.CART);
+      const cartRow = await cartModule.retrieveCart(cartId, { relations: ['items'] });
+      await cartModule.updateLineItems(
+        (cartRow.items ?? []).map((item: any) => ({ id: item.id, requires_shipping: false })),
+      );
+
+      const pcRes = await api.post('/store/payment-collections', { cart_id: cartId }, storeHeaders);
+      const paymentCollectionId = pcRes.data.payment_collection.id as string;
+
+      const sessionRes = await api.post(
+        `/store/payment-collections/${paymentCollectionId}/payment-sessions`,
+        { provider_id: 'pp_almond-payment_almond-payment' },
+        storeHeaders,
+      );
+      const session = sessionRes.data.payment_collection.payment_sessions[0];
+      const intentId = session.data.intentId as string;
+
+      wallet.simulateCheckout(intentId);
+      return { cartId, intentId };
+    };
+
+    beforeAll(async () => {
+      await wallet.start();
+
+      const container = getContainer();
+      const config = container.resolve(ContainerRegistrationKeys.CONFIG_MODULE) as any;
+      const secret = config.projectConfig.http.jwtSecret;
+      const userModule = container.resolve(Modules.USER);
+      const [user] = await userModule.createUsers([{ email: 'admin@deferred.test' }]);
+
+      const { result: scRes } = await createSalesChannelsWorkflow(container).run({
+        input: { salesChannelsData: [{ name: 'Deferred SC' }] },
+      });
+      salesChannelId = scRes[0].id;
+
+      const { result: regionRes } = await createRegionsWorkflow(container).run({
+        input: { regions: [{ name: 'KR-deferred', currency_code: 'krw', countries: ['kr'] }] },
+      });
+      regionId = regionRes[0].id;
+
+      const { result: locRes } = await createStockLocationsWorkflow(container).run({
+        input: { locations: [{ name: 'Deferred WH' }] },
+      });
+      locationId = locRes[0].id;
+      await linkSalesChannelsToStockLocationWorkflow(container).run({
+        input: { id: locationId, add: [salesChannelId] },
+      });
+
+      const fulfillment = container.resolve(Modules.FULFILLMENT);
+      const profiles = await fulfillment.listShippingProfiles({});
+      const shippingProfileId =
+        profiles[0]?.id ??
+        (await fulfillment.createShippingProfiles([{ name: 'default', type: 'default' }]))[0].id;
+
+      const { result: prodRes } = await createProductsWorkflow(container).run({
+        input: {
+          products: [
+            {
+              title: 'Deferred Product',
+              status: 'published',
+              shipping_profile_id: shippingProfileId,
+              sales_channels: [{ id: salesChannelId }],
+              options: [{ title: 'Size', values: ['M'] }],
+              variants: [
+                {
+                  title: 'M',
+                  sku: 'DEFERRED-M',
+                  manage_inventory: true,
+                  allow_backorder: false,
+                  options: { Size: 'M' },
+                  prices: [{ amount: 10000, currency_code: 'krw' }],
+                },
+              ],
+            },
+          ],
+        },
+      });
+      variantId = prodRes[0].variants[0].id;
+
+      const query = container.resolve(ContainerRegistrationKeys.QUERY);
+      const { data: variantInventory } = await query.graph({
+        entity: 'product_variant_inventory_item',
+        fields: ['variant_id', 'inventory_item_id'],
+        filters: { variant_id: variantId },
+      });
+      inventoryItemId = (variantInventory[0] as any).inventory_item_id;
+
+      const inventory = container.resolve(Modules.INVENTORY);
+      // 배송 없는 상품으로 두어 shipping option 설정 없이 카트를 완료할 수 있게 한다
+      // (검증 대상은 결제·재고 순서이지 배송이 아니다).
+      await inventory.updateInventoryItems([{ id: inventoryItemId, requires_shipping: false }]);
+      await inventory.createInventoryLevels([
+        { inventory_item_id: inventoryItemId, location_id: locationId, stocked_quantity: 5 },
+      ]);
+
+      const { result: keyRes } = await createApiKeysWorkflow(container).run({
+        input: { api_keys: [{ title: 'pk-deferred', type: 'publishable', created_by: user.id }] },
+      });
+      await linkSalesChannelsToApiKeyWorkflow(container).run({
+        input: { id: keyRes[0].id, add: [salesChannelId] },
+      });
+      storeHeaders = { headers: { 'x-publishable-api-key': keyRes[0].token } };
+      void jwt; // 인증 고객 컨텍스트는 이 스펙에서 불필요
+    });
+
+    afterAll(async () => {
+      await wallet.stop();
+    });
+
+    beforeEach(async () => {
+      wallet.reset();
+      // 케이스 간 격리: 이전 테스트가 만든 예약이 남아 있으면 가용재고 판정이 오염된다.
+      const inventory = getContainer().resolve(Modules.INVENTORY);
+      const leftovers = await inventory.listReservationItems({ inventory_item_id: inventoryItemId });
+      if (leftovers.length) {
+        await inventory.deleteReservationItems(leftovers.map((r: any) => r.id));
+      }
+      await setStock(5);
+    });
+
+    it('결제 세션 생성 시 지연 승인 표식을 wallet 에 전달한다', async () => {
+      const { intentId } = await startCheckout(1);
+
+      expect(wallet.intents.get(intentId)!.deferred).toBe(true);
+      // 표식이 있으므로 결제창 완료만으로는 승인되지 않는다 (= 아직 돈이 안 빠진 상태)
+      expect(wallet.intents.get(intentId)!.approved).toBe(false);
+    });
+
+    it('정상 결제: 주문 생성 후에 승인되고 캡처까지 반영된다', async () => {
+      const { cartId, intentId } = await startCheckout(1);
+
+      const res = await api.post(`/store/carts/${cartId}/complete`, {}, storeHeaders);
+
+      expect(res.data.type).toBe('order');
+      expect(wallet.callsTo('/finalize-approval')).toBe(1);
+      expect(wallet.intents.get(intentId)!.approved).toBe(true);
+      expect(await orderIdForCart(cartId)).toBeTruthy();
+      expect(await reservationCount()).toBe(1);
+
+      const paymentModule = getContainer().resolve(Modules.PAYMENT);
+      const [payment] = await paymentModule.listPayments({}, { order: { created_at: 'DESC' }, take: 1 });
+      expect(payment.captured_at).toBeTruthy();
+    });
+
+    it('재고 초과 주문: 승인에 도달하지 못해 돈이 빠지지 않는다', async () => {
+      // 담기 시점엔 재고가 충분했고(그래서 카트에 담겼고), 결제 시점에 부족해진 상황.
+      // (담기 시점 초과는 Medusa 가 카트 생성에서 이미 거부한다 — 1차 방어)
+      const { cartId, intentId } = await startCheckout(2);
+      await setStock(1);
+
+      await api.post(`/store/carts/${cartId}/complete`, {}, storeHeaders).catch((e: any) => e.response);
+
+      // 핵심: 재고예약이 승인보다 먼저이므로 승인 자체가 일어나지 않는다.
+      expect(wallet.intents.get(intentId)!.approved).toBe(false);
+      expect(wallet.callsTo('/finalize-approval')).toBe(0);
+      expect(await orderIdForCart(cartId)).toBeNull();
+      expect(await cartCompletedAt(cartId)).toBeNull();
+      expect(await reservationCount()).toBe(0);
+    });
+
+    it('담은 뒤 재고가 0이 된 경우(드리프트): 승인 없이 실패하고 주문도 없다', async () => {
+      await setStock(1);
+      const { cartId, intentId } = await startCheckout(1);
+
+      // 결제창을 완료한 사이에 다른 주문/재고조정으로 재고가 사라진 상황
+      await setStock(0);
+
+      await api.post(`/store/carts/${cartId}/complete`, {}, storeHeaders).catch((e: any) => e.response);
+
+      expect(wallet.intents.get(intentId)!.approved).toBe(false);
+      expect(await orderIdForCart(cartId)).toBeNull();
+      expect(await reservationCount()).toBe(0);
+    });
+
+    it('동시 2주문 경쟁: 재고 1개면 한 건만 주문되고 나머지는 미승인으로 남는다', async () => {
+      await setStock(1);
+      const a = await startCheckout(1);
+      const b = await startCheckout(1);
+
+      await Promise.all([
+        api.post(`/store/carts/${a.cartId}/complete`, {}, storeHeaders).catch((e: any) => e.response),
+        api.post(`/store/carts/${b.cartId}/complete`, {}, storeHeaders).catch((e: any) => e.response),
+      ]);
+
+      const orders = [await orderIdForCart(a.cartId), await orderIdForCart(b.cartId)].filter(Boolean);
+      const approved = [a.intentId, b.intentId].filter((id) => wallet.intents.get(id)!.approved);
+
+      expect(orders).toHaveLength(1);
+      // 주문이 안 된 쪽은 돈도 빠지지 않아야 한다 (오버셀도 고아결제도 없음)
+      expect(approved).toHaveLength(1);
+      expect(await reservationCount()).toBe(1);
+    });
+
+    it('PG 승인 거절: 주문·재고예약·카트완료가 모두 롤백된다', async () => {
+      const { cartId, intentId } = await startCheckout(1);
+      wallet.rejectApproval = true;
+
+      const res = await api
+        .post(`/store/carts/${cartId}/complete`, {}, storeHeaders)
+        .catch((e: any) => e.response);
+
+      expect(res.data.type).not.toBe('order');
+      expect(wallet.callsTo('/finalize-approval')).toBe(1);
+      expect(wallet.intents.get(intentId)!.approved).toBe(false);
+      expect(await orderIdForCart(cartId)).toBeNull();
+      expect(await cartCompletedAt(cartId)).toBeNull();
+      expect(await reservationCount()).toBe(0);
+    });
+
+    it('승인 거절 후 재시도하면 정상적으로 주문된다', async () => {
+      const { cartId, intentId } = await startCheckout(1);
+      wallet.rejectApproval = true;
+      await api.post(`/store/carts/${cartId}/complete`, {}, storeHeaders).catch((e: any) => e.response);
+
+      // 고객이 결제를 다시 시도 (wallet 은 실패 시 intent 를 CREATED 로 되돌려 세션을 재사용한다)
+      wallet.rejectApproval = false;
+      wallet.simulateCheckout(intentId);
+      const res = await api.post(`/store/carts/${cartId}/complete`, {}, storeHeaders);
+
+      expect(res.data.type).toBe('order');
+      expect(wallet.intents.get(intentId)!.approved).toBe(true);
+      expect(await reservationCount()).toBe(1);
+    });
+
+    it('complete 재호출은 멱등: 같은 주문을 돌려주고 승인을 다시 하지 않는다', async () => {
+      const { cartId } = await startCheckout(1);
+      const first = await api.post(`/store/carts/${cartId}/complete`, {}, storeHeaders);
+      const orderId = first.data.order.id;
+
+      const second = await api
+        .post(`/store/carts/${cartId}/complete`, {}, storeHeaders)
+        .catch((e: any) => e.response);
+
+      expect(wallet.callsTo('/finalize-approval')).toBe(1);
+      expect(await orderIdForCart(cartId)).toBe(orderId);
+    });
+
+    it('무통장 입금대기는 폴백 경로로도 완료되지 않는다 (미입금 출고 차단)', async () => {
+      // 정상 무통장 주문은 wallet 웹훅이 marker 와 함께 선생성한다. 이 경로로 완료되면
+      // marker 없는 authorized 주문이 생겨 WMS 수집 게이트를 통과해버린다.
+      const { cartId, intentId } = await startCheckout(1);
+      wallet.simulateAwaitingDeposit(intentId);
+
+      const res = await api
+        .post(`/store/payment-intents/${intentId}/complete`, {}, storeHeaders)
+        .catch((e: any) => e.response);
+
+      expect(res.status).toBe(409);
+      expect(res.data.code).toBe('BANK_TRANSFER_AWAITING_DEPOSIT');
+      expect(await orderIdForCart(cartId)).toBeNull();
+      expect(await cartCompletedAt(cartId)).toBeNull();
+    });
+
+    it('무통장 입금대기는 cart.complete 로도 완료되지 않는다 (기존 가드 회귀)', async () => {
+      const { cartId, intentId } = await startCheckout(1);
+      wallet.simulateAwaitingDeposit(intentId);
+
+      const res = await api
+        .post(`/store/carts/${cartId}/complete`, {}, storeHeaders)
+        .catch((e: any) => e.response);
+
+      expect(res.status).toBe(409);
+      expect(await orderIdForCart(cartId)).toBeNull();
+    });
+
+    it('카트를 특정 못 한 콜백 폴백: intent 로 서버사이드 완료가 된다', async () => {
+      const { cartId, intentId } = await startCheckout(1);
+
+      const res = await api.post(`/store/payment-intents/${intentId}/complete`, {}, storeHeaders);
+
+      expect(res.data.type).toBe('order');
+      expect(res.data.cart_id).toBe(cartId);
+      expect(wallet.intents.get(intentId)!.approved).toBe(true);
+      expect(await orderIdForCart(cartId)).toBe(res.data.order_id);
+    });
+  },
+});

--- a/apps/medusa/src/api/hooks/payment-events/__tests__/payment-events.unit.spec.ts
+++ b/apps/medusa/src/api/hooks/payment-events/__tests__/payment-events.unit.spec.ts
@@ -327,6 +327,27 @@ describe('handleAwaitingDepositProjection', () => {
 });
 
 describe('handleCaptureProjection', () => {
+  it('카트는 완료됐는데 payment 행이 아직 없으면 throw 해서 재배달로 재시도한다', async () => {
+    // 지연 승인: 승인 직후(=워크플로가 payment 를 만들기 직전) 캡처 이벤트가 도착하는 창.
+    // 여기서 조용히 넘기면 captured_at 투영이 영영 유실된다.
+    const graph: GraphFn = async ({ entity }) => {
+      if (entity === 'payment_collection')
+        return { data: [{ id: 'pc_1', cart: { id: 'cart_1', completed_at: '2026-07-31T00:00:00Z' } }] };
+      return { data: [] };
+    };
+    const { scope } = makeScope({
+      paymentModule: {
+        listPaymentSessions: jest.fn().mockResolvedValue([{ id: 'payses_1', payment_collection_id: 'pc_1' }]),
+        listPayments: jest.fn().mockResolvedValue([]),
+      },
+      graph,
+    });
+
+    await expect(
+      handleCaptureProjection(scope as any, 'intent_inflight', 'msg_inflight', logger as any),
+    ).rejects.toThrow(/no payment row yet/);
+  });
+
   it('session 자체가 없으면 무통장 복구를 시도하지 않고 skip 한다', async () => {
     const { scope } = makeScope({
       paymentModule: { listPaymentSessions: jest.fn().mockResolvedValue([]) },

--- a/apps/medusa/src/api/hooks/payment-events/route.ts
+++ b/apps/medusa/src/api/hooks/payment-events/route.ts
@@ -772,12 +772,13 @@ export async function handleCaptureProjection(
     payment = payments[0];
 
     if (!payment) {
-      // Recovery completed idempotently (cart was already completed via another path
-      // or the order already existed). No payment row to update — log and exit cleanly.
-      logger.warn(
-        `[payment-events] handleCaptureProjection: no payment row after recovery for intentId=${intentId}, skipping capture projection (messageId=${messageId})`,
+      // 세션은 있는데 payment 행이 없다 = 카트 완료(주문 생성) 워크플로가 아직 payment 를 만들기
+      // 전이다. 지연 승인 흐름에서는 승인 직후(=워크플로 마지막 단계 진행 중) 캡처 이벤트가 도착해
+      // 이 창에 빠질 수 있다. 여기서 조용히 넘기면 captured_at 투영이 영영 유실되므로 throw 해
+      // 재배달(지수 백오프)로 재시도한다. 워크플로가 끝나면 다음 배달에서 정상 투영된다.
+      throw new Error(
+        `[payment-events] handleCaptureProjection: no payment row yet for intentId=${intentId} (order creation in flight?), retrying (messageId=${messageId})`,
       );
-      return;
     }
   }
 

--- a/apps/medusa/src/api/store/carts/[id]/complete/route.ts
+++ b/apps/medusa/src/api/store/carts/[id]/complete/route.ts
@@ -1,9 +1,51 @@
 import { MedusaRequest, MedusaResponse, prepareRetrieveQuery } from '@medusajs/framework/http';
-import { ContainerRegistrationKeys } from '@medusajs/framework/utils';
+import { ContainerRegistrationKeys, Modules } from '@medusajs/framework/utils';
 import { completeCartWorkflow } from '@medusajs/medusa/core-flows';
+import { capturePaymentWorkflow } from '@medusajs/core-flows';
 import { MedusaError } from '@medusajs/utils';
 import { refetchCart } from '../../helpers';
 import { defaultStoreCartFields } from '../../query-config';
+
+/**
+ * 주문 생성이 끝난 카트의 결제를 캡처한다.
+ *
+ * 지연 승인 흐름에서 PG 승인은 completeCartWorkflow 의 마지막 단계에서 일어나고, wallet 은 승인 직후
+ * 자동 캡처하며 payment.intent.captured 웹훅을 쏜다. 그런데 그 웹훅은 워크플로가 아직 payment 행을
+ * 만들기 전에 도착할 수 있어(카트 completed_at 은 이미 찍힌 상태) 캡처 투영이 유실될 수 있다.
+ * 여기서 명시적으로 캡처를 돌려 Medusa 쪽 captured_at 을 결정적으로 만든다.
+ *
+ * 멱등: 이미 captured 면 skip 하고, wallet 캡처 API 도 CAPTURED intent 에 대해 no-op 이다.
+ * 실패는 삼킨다 — 주문은 이미 생성됐고 결제도 이미 승인됐으므로 응답을 실패로 만들면 안 된다.
+ * 놓친 캡처는 wallet 웹훅과 orphan-payment-reconcile 잡이 뒤늦게 맞춘다.
+ */
+async function capturePaymentForCart(scope: any, cartId: string, logger: any): Promise<void> {
+  try {
+    const query = scope.resolve(ContainerRegistrationKeys.QUERY);
+    const { data: carts } = await query.graph({
+      entity: 'cart',
+      fields: ['id', 'payment_collection.payment_sessions.id'],
+      filters: { id: cartId },
+    });
+
+    const sessionIds: string[] = (
+      (carts[0] as any)?.payment_collection?.payment_sessions ?? []
+    ).map((s: any) => s?.id).filter(Boolean);
+    if (!sessionIds.length) return;
+
+    const paymentModule = scope.resolve(Modules.PAYMENT);
+    for (const sessionId of sessionIds) {
+      const payments = await paymentModule.listPayments({ payment_session_id: sessionId }, {});
+      const payment = payments[0];
+      if (!payment || payment.captured_at || payment.canceled_at) continue;
+
+      await capturePaymentWorkflow(scope).run({ input: { payment_id: payment.id } });
+      logger.info(`[cart-complete] captured payment ${payment.id} for cart ${cartId}`);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error(`[cart-complete] capture after completion failed for cart ${cartId}: ${msg}`);
+  }
+}
 
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const cart_id = req.params.id;
@@ -56,6 +98,8 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     });
     return;
   }
+
+  await capturePaymentForCart(req.scope, cart_id, req.scope.resolve(ContainerRegistrationKeys.LOGGER));
 
   const { data } = await query.graph({
     entity: 'order',

--- a/apps/medusa/src/api/store/carts/middlewares/reject-awaiting-deposit-complete.ts
+++ b/apps/medusa/src/api/store/carts/middlewares/reject-awaiting-deposit-complete.ts
@@ -13,7 +13,7 @@ import { ContainerRegistrationKeys } from '@medusajs/framework/utils';
 // 이면 비정상(직접 호출 / 레이스)이므로 거부해도 정상 흐름에 영향이 없다(주문은 웹훅이 만든다).
 // 카드 intent 는 AWAITING_DEPOSIT 이 아니므로 항상 통과한다.
 
-const AWAITING_DEPOSIT_STATUS = 'AWAITING_DEPOSIT';
+export const AWAITING_DEPOSIT_STATUS = 'AWAITING_DEPOSIT';
 
 type MwLogger = { warn: (msg: string) => void; error: (msg: string) => void };
 
@@ -28,7 +28,7 @@ type MwLogger = { warn: (msg: string) => void; error: (msg: string) => void };
  * env 누락 시 fail-CLOSED 로 막으면 카드 포함 모든 cart.complete 가 중단되는 전면 장애가 되므로,
  * 여기서는 fail-open 을 유지하되 loud 로깅으로 관측 가능하게 한다.
  */
-async function fetchIntentStatus(intentId: string, logger: MwLogger): Promise<string | null> {
+export async function fetchIntentStatus(intentId: string, logger: MwLogger): Promise<string | null> {
   const base = process.env.WALLET_BASE_URL;
   const key = process.env.WALLET_API_KEY;
   if (!base || !key) {

--- a/apps/medusa/src/api/store/payment-intents/[intentId]/complete/route.ts
+++ b/apps/medusa/src/api/store/payment-intents/[intentId]/complete/route.ts
@@ -1,0 +1,104 @@
+import { MedusaRequest, MedusaResponse } from '@medusajs/framework/http';
+import { ContainerRegistrationKeys, MedusaError, Modules } from '@medusajs/framework/utils';
+import { completeCartWorkflow } from '@medusajs/medusa/core-flows';
+import { capturePaymentWorkflow } from '@medusajs/core-flows';
+
+/**
+ * intentId 로 결제 대상 카트를 서버사이드에서 찾아 주문을 완료한다.
+ *
+ * 스토어프론트 콜백은 보통 checkout cart id 를 들고 오지만, wallet 크로스도메인 리다이렉트로
+ * sessionStorage 매핑이 유실되면 카트를 특정하지 못한다. 지연 승인 도입 전에는 그 경우
+ * "wallet capture 웹훅이 주문을 만든다" 는 폴백이 있었지만, 지금은 승인 자체가 주문 생성
+ * 시점에 일어나므로 아무도 카트를 완료하지 않으면 결제도 주문도 성립하지 않는다.
+ * 이 엔드포인트가 그 폴백을 대체한다 — intent → payment_session → payment_collection → cart.
+ *
+ * 멱등: 이미 주문이 있으면 그 주문을 그대로 반환한다.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const intentId = req.params.intentId;
+  const logger = req.scope.resolve(ContainerRegistrationKeys.LOGGER);
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY);
+  const paymentModule = req.scope.resolve(Modules.PAYMENT);
+
+  const sessions = await paymentModule.listPaymentSessions({ data: { intentId } } as any, {
+    select: ['id', 'payment_collection_id'],
+  });
+  const session = sessions[0];
+  if (!session) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, `No payment session for intent ${intentId}`);
+  }
+
+  const { data: collections } = await query.graph({
+    entity: 'payment_collection',
+    fields: ['id', 'cart.id', 'cart.completed_at'],
+    filters: { id: (session as any).payment_collection_id },
+  });
+  const cartId = (collections[0] as any)?.cart?.id as string | undefined;
+  if (!cartId) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, `No cart for intent ${intentId}`);
+  }
+
+  const existingOrderId = await findOrderId(query, cartId);
+  if (existingOrderId) {
+    res.status(200).json({ type: 'order', order_id: existingOrderId, cart_id: cartId });
+    return;
+  }
+
+  const { errors, result } = await completeCartWorkflow(req.scope).run({
+    input: { id: cartId },
+    context: { transactionId: cartId },
+    throwOnError: false,
+  });
+
+  if (errors?.[0]) {
+    const error = errors[0].error as any;
+    logger.warn(
+      `[store/payment-intents/complete] completeCartWorkflow failed for cart ${cartId} intentId=${intentId}: ${error?.message}`,
+    );
+    res.status(200).json({
+      type: 'error',
+      cart_id: cartId,
+      error: { message: error?.message, name: error?.name, type: error?.type },
+    });
+    return;
+  }
+
+  await captureCartPayment(req.scope, cartId, logger);
+
+  res.status(200).json({ type: 'order', order_id: result.id, cart_id: cartId });
+};
+
+async function findOrderId(query: any, cartId: string): Promise<string | null> {
+  const { data: links } = await query.graph({
+    entity: 'order_cart',
+    fields: ['cart_id', 'order_id'],
+    filters: { cart_id: cartId },
+  });
+  return ((links[0] as any)?.order_id as string | undefined) ?? null;
+}
+
+/** 캡처 실패는 삼킨다 — 주문·승인은 이미 끝났고, 놓친 캡처는 웹훅/리컨실 잡이 맞춘다. */
+async function captureCartPayment(scope: any, cartId: string, logger: any): Promise<void> {
+  try {
+    const query = scope.resolve(ContainerRegistrationKeys.QUERY);
+    const { data: carts } = await query.graph({
+      entity: 'cart',
+      fields: ['id', 'payment_collection.payment_sessions.id'],
+      filters: { id: cartId },
+    });
+    const sessionIds: string[] = ((carts[0] as any)?.payment_collection?.payment_sessions ?? [])
+      .map((s: any) => s?.id)
+      .filter(Boolean);
+
+    const paymentModule = scope.resolve(Modules.PAYMENT);
+    for (const sessionId of sessionIds) {
+      const payment = (await paymentModule.listPayments({ payment_session_id: sessionId }, {}))[0];
+      if (!payment || payment.captured_at || payment.canceled_at) continue;
+      await capturePaymentWorkflow(scope).run({ input: { payment_id: payment.id } });
+    }
+  } catch (err) {
+    logger.error(
+      `[store/payment-intents/complete] capture failed for cart ${cartId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/apps/medusa/src/api/store/payment-intents/[intentId]/complete/route.ts
+++ b/apps/medusa/src/api/store/payment-intents/[intentId]/complete/route.ts
@@ -2,6 +2,10 @@ import { MedusaRequest, MedusaResponse } from '@medusajs/framework/http';
 import { ContainerRegistrationKeys, MedusaError, Modules } from '@medusajs/framework/utils';
 import { completeCartWorkflow } from '@medusajs/medusa/core-flows';
 import { capturePaymentWorkflow } from '@medusajs/core-flows';
+import {
+  AWAITING_DEPOSIT_STATUS,
+  fetchIntentStatus,
+} from '../../../carts/middlewares/reject-awaiting-deposit-complete';
 
 /**
  * intentId 로 결제 대상 카트를 서버사이드에서 찾아 주문을 완료한다.
@@ -19,6 +23,18 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const logger = req.scope.resolve(ContainerRegistrationKeys.LOGGER);
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY);
   const paymentModule = req.scope.resolve(Modules.PAYMENT);
+
+  // 무통장 입금대기 주문은 이 경로로 완료하면 안 된다. almond-payment 가 AWAITING_DEPOSIT 을
+  // 'authorized' 로 매핑하므로 완료 자체는 성공해버리고, 그러면 marker 없는 authorized 주문이 생겨
+  // WMS 수집 게이트를 통과한다(미입금 출고). 정상 무통장 주문은 wallet 웹훅이 marker 와 함께
+  // 선생성하므로 여기서 막아도 잃는 것이 없다. /store/carts/:id/complete 의 가드와 같은 정책.
+  if ((await fetchIntentStatus(intentId, logger)) === AWAITING_DEPOSIT_STATUS) {
+    res.status(409).json({
+      message: '무통장 입금대기 주문은 입금 확인 후 자동으로 처리됩니다. 주문내역에서 확인해 주세요.',
+      code: 'BANK_TRANSFER_AWAITING_DEPOSIT',
+    });
+    return;
+  }
 
   const sessions = await paymentModule.listPaymentSessions({ data: { intentId } } as any, {
     select: ['id', 'payment_collection_id'],

--- a/apps/medusa/src/jobs/orphan-payment-reconcile.ts
+++ b/apps/medusa/src/jobs/orphan-payment-reconcile.ts
@@ -1,0 +1,18 @@
+import type { MedusaContainer } from '@medusajs/framework/types';
+import orphanPaymentReconcile from '../scripts/orphan-payment-reconcile';
+
+// 고아결제(돈은 빠졌는데 주문 없음) 백스톱. 지연 승인이 원천 차단하는 구조이지만, 남는
+// 잔여 케이스(웹훅 유실, 승인 후 주문 복구 실패 등)를 주기적으로 훑어 환불/취소/캡처로 정리한다.
+// 동작은 `medusa exec ./src/scripts/orphan-payment-reconcile` 와 동일.
+//
+// 중복 실행 주의: Medusa 가 worker_mode 미분리(shared) + 다중 인스턴스면 이 잡이 인스턴스마다
+// 돈다. wallet 의 환불/취소/캡처는 모두 멱등(이미 처리된 intent 는 no-op)이라 결과는 안전하다.
+export default async function orphanPaymentReconcileJob(container: MedusaContainer) {
+  await orphanPaymentReconcile({ container, args: [] });
+}
+
+export const config = {
+  name: 'orphan-payment-reconcile',
+  // 매 시각 17분 — 정시 배치들과 겹치지 않게.
+  schedule: '17 * * * *',
+};

--- a/apps/medusa/src/modules/almond-payment/service.ts
+++ b/apps/medusa/src/modules/almond-payment/service.ts
@@ -55,7 +55,11 @@ export class AlmondPaymentProviderService extends AbstractPaymentProvider<Almond
     const res = await fetch(url, { ...options, headers });
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
-      throw new Error(body?.message ?? `Wallet API error ${res.status}: ${path}`);
+      const message = body?.message ?? `Wallet API error ${res.status}: ${path}`;
+      // 에러 코드를 메시지 앞에 붙인다 — 호출부가 코드로 분기할 수 있어야 한다
+      // (예: NO_STAGED_APPROVAL, INTENT_NOT_CANCELABLE). 코드 없이 메시지 문구에만
+      // 의존하면 wallet 쪽 문구가 바뀔 때 조용히 분기가 죽는다.
+      throw new Error(body?.error ? `${body.error}: ${message}` : message);
     }
     return res.json();
   }
@@ -110,6 +114,9 @@ export class AlmondPaymentProviderService extends AbstractPaymentProvider<Almond
     const medusaSessionId = (data as any)?.session_id as string | undefined;
     if (medusaSessionId) metadata.medusaSessionId = medusaSessionId;
 
+    // 지연 승인 표식. wallet 은 이 값이 있는 intent 만 결제창 완료 시 승인을 보류한다.
+    if (this.deferredApprovalEnabled) metadata.approvalMode = 'DEFERRED';
+
     // userId는 wallet-web에서 첫 번째 JWT 인증 GET 요청 시 자동으로 claim되므로 여기서 전달하지 않음
     const intent = await this.walletFetch<{ id: string }>('/v1/payment-intents', {
       method: 'POST',
@@ -130,12 +137,56 @@ export class AlmondPaymentProviderService extends AbstractPaymentProvider<Almond
     return { id: intent.id, data: sessionData as unknown as Record<string, unknown> };
   }
 
+  /**
+   * 지연 승인(deferred approval): intent 생성 시 이 플래그를 달면 wallet 은 결제창 완료 시점에
+   * PG 승인(=실제 출금)을 하지 않고 파라미터만 적재해 둔다. 승인은 아래 authorizePayment —
+   * 즉 completeCartWorkflow 가 주문 생성과 재고예약을 모두 끝낸 마지막 단계 — 에서 트리거된다.
+   * 재고부족으로 워크플로가 실패하면 승인에 도달하지 못하므로 고아결제가 생기지 않는다.
+   *
+   * 롤백 스위치: ALMOND_DEFERRED_APPROVAL=false 로 두면 기존(결제창 완료 즉시 승인) 동작으로 되돌아간다.
+   * 플래그가 없는 intent 를 wallet 은 기존 방식으로 처리하므로, 이미 진행 중인 결제는 영향받지 않는다.
+   */
+  private get deferredApprovalEnabled(): boolean {
+    return process.env.ALMOND_DEFERRED_APPROVAL !== 'false';
+  }
+
   async authorizePayment(input: AuthorizePaymentInput): Promise<AuthorizePaymentOutput> {
     const data = input.data as unknown as WalletSessionData;
     const intent = await this.walletFetch<{ id: string; status: string }>(`/v1/payment-intents/${data.intentId}`);
 
+    // 적재된 승인이 있으면 여기서 확정한다 — 주문과 재고예약이 이미 확보된 시점이다.
+    // 승인 실패는 throw 되어 워크플로가 주문/예약을 롤백하고, 고객 돈은 움직이지 않는다.
+    if (this.mapStatus(intent.status, data.captured) === 'pending') {
+      const finalized = await this.finalizeDeferredApproval(data.intentId);
+      if (finalized) {
+        return { data: input.data, status: this.mapStatus(finalized, data.captured) };
+      }
+    }
+
     const status = this.mapStatus(intent.status, data.captured);
     return { data: input.data, status };
+  }
+
+  /**
+   * 적재된 승인을 확정한다. 확정할 것이 없으면(고객이 결제창을 완료하지 않았거나 적재가 만료 회수됨)
+   * null 을 돌려 기존 상태 매핑으로 진행한다 — 이 경우 Medusa 가 'pending' 을 승인 실패로 처리한다.
+   * 승인 API 자체가 실패하면(카드 한도초과 등) throw 해서 워크플로를 롤백시킨다.
+   */
+  private async finalizeDeferredApproval(intentId: string): Promise<string | null> {
+    try {
+      const result = await this.walletFetch<{ status: string }>(
+        `/v1/payment-intents/${intentId}/finalize-approval`,
+        { method: 'POST' },
+      );
+      return result.status ?? null;
+    } catch (err: any) {
+      const msg = (err?.message ?? '') as string;
+      // 적재된 승인 없음 / 지연 승인 대상 아님 → 구식 intent 이거나 미결제. 기존 경로로 진행.
+      if (msg.includes('NO_STAGED_APPROVAL') || msg.includes('NOT_DEFERRED_APPROVAL_INTENT')) {
+        return null;
+      }
+      throw err;
+    }
   }
 
   async capturePayment(input: CapturePaymentInput): Promise<CapturePaymentOutput> {
@@ -223,11 +274,14 @@ export class AlmondPaymentProviderService extends AbstractPaymentProvider<Almond
     }
 
     // create new intent — userId는 wallet-web에서 첫 GET 요청 시 자동 claim됨
+    // 금액 변경으로 intent 를 갈아끼워도 지연 승인 표식은 유지돼야 한다. 빠지면 그 카트만
+    // 결제창 완료 즉시 승인되는 옛 동작으로 돌아가 고아결제 창이 다시 열린다.
     const intent = await this.walletFetch<{ id: string }>('/v1/payment-intents', {
       method: 'POST',
       body: JSON.stringify({
         amount: newAmount,
         currency: newCurrency,
+        ...(this.deferredApprovalEnabled ? { metadata: { approvalMode: 'DEFERRED' } } : {}),
       }),
     });
 

--- a/apps/medusa/src/scripts/orphan-payment-reconcile.ts
+++ b/apps/medusa/src/scripts/orphan-payment-reconcile.ts
@@ -1,0 +1,248 @@
+import { ContainerRegistrationKeys, Modules } from '@medusajs/framework/utils';
+import { capturePaymentWorkflow } from '@medusajs/core-flows';
+import type { ExecArgs } from '@medusajs/framework/types';
+import { handleCaptureProjection } from '../api/hooks/payment-events/route';
+
+/**
+ * 고아결제(돈은 빠졌는데 주문이 없는 결제) 백스톱 리컨실.
+ *
+ * 정상 흐름에서는 지연 승인(deferred approval)이 고아를 원천 차단한다 — PG 승인이
+ * completeCartWorkflow 의 마지막 단계에서 일어나므로 재고예약 실패는 승인 전에 롤백된다.
+ * 이 잡은 그 앞뒤로 남는 잔여 케이스를 잡는 그물이다:
+ *
+ *   1) 주문 없음 + wallet CAPTURED  → 먼저 주문 복구를 시도하고, 그래도 안 되면 자동 환불
+ *   2) 주문 없음 + wallet AUTHORIZED → intent 취소 (토스는 취소가 곧 승인취소 = 돈 반환)
+ *   3) 주문 있음 + wallet CAPTURED/AUTHORIZED 인데 Medusa payment 미캡처 → 캡처 투영/실행
+ *
+ * core-flows 의 compensatePaymentIfNeededStep 은 Medusa payment.captured_at 만 보므로
+ * (1)(2)를 잡지 못한다 — 주문 생성 실패 시엔 Medusa payment 행 자체가 없기 때문이다.
+ *
+ * 환경변수:
+ *   ORPHAN_RECONCILE_MIN_AGE_MINUTES  기본 30 — 이보다 최근 결제는 진행 중으로 보고 건드리지 않는다
+ *   ORPHAN_RECONCILE_LOOKBACK_HOURS   기본 48
+ *   ORPHAN_RECONCILE_AUTO_REFUND      'false' 로 두면 탐지·로깅만 하고 환불/취소는 하지 않는다
+ */
+
+interface WalletIntent {
+  id: string;
+  status: string;
+  payableAmount: number;
+}
+
+interface ReconcileSummary {
+  scanned: number;
+  recovered: number;
+  refunded: number;
+  canceled: number;
+  captured: number;
+  failed: number;
+  dryRunFindings: string[];
+}
+
+function minAgeMs(): number {
+  const raw = Number(process.env.ORPHAN_RECONCILE_MIN_AGE_MINUTES);
+  return (Number.isFinite(raw) && raw > 0 ? raw : 30) * 60_000;
+}
+
+function lookbackMs(): number {
+  const raw = Number(process.env.ORPHAN_RECONCILE_LOOKBACK_HOURS);
+  return (Number.isFinite(raw) && raw > 0 ? raw : 48) * 60 * 60_000;
+}
+
+/** 한 회차에 훑는 payment_collection 상한. 상한에 걸리면 경고를 남긴다. */
+const SCAN_LIMIT = 1000;
+
+function autoRefundEnabled(): boolean {
+  return process.env.ORPHAN_RECONCILE_AUTO_REFUND !== 'false';
+}
+
+async function walletFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const baseUrl = process.env.WALLET_BASE_URL || 'http://localhost:3100';
+  const apiKey = process.env.WALLET_API_KEY || 'dev-secret';
+  const method = (options.method ?? 'GET').toUpperCase();
+
+  const res = await fetch(`${baseUrl}${path}`, {
+    ...options,
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+      ...(method !== 'GET' ? { 'Idempotency-Key': crypto.randomUUID() } : {}),
+    },
+    ...(method !== 'GET' && options.body == null ? { body: JSON.stringify({}) } : {}),
+  });
+
+  if (!res.ok) {
+    const body: any = await res.json().catch(() => ({}));
+    throw new Error(body?.error ? `${body.error}: ${body?.message ?? ''}` : `Wallet API ${res.status}: ${path}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+/** cart_id → order_id (링크가 없으면 미포함) */
+async function loadOrderLinks(scope: any, cartIds: string[]): Promise<Map<string, string>> {
+  if (!cartIds.length) return new Map();
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY);
+  const { data: links } = await query.graph({
+    entity: 'order_cart',
+    fields: ['cart_id', 'order_id'],
+    filters: { cart_id: cartIds },
+  });
+  return new Map(
+    (links as Array<{ cart_id: string; order_id: string }>).map((l) => [l.cart_id, l.order_id]),
+  );
+}
+
+export default async function orphanPaymentReconcile({ container }: ExecArgs): Promise<ReconcileSummary> {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER);
+  const query = container.resolve(ContainerRegistrationKeys.QUERY);
+  const paymentModule = container.resolve(Modules.PAYMENT);
+
+  const now = Date.now();
+  const since = new Date(now - lookbackMs());
+  const cutoff = now - minAgeMs();
+
+  const summary: ReconcileSummary = {
+    scanned: 0,
+    recovered: 0,
+    refunded: 0,
+    canceled: 0,
+    captured: 0,
+    failed: 0,
+    dryRunFindings: [],
+  };
+
+  const { data: collections } = await query.graph({
+    entity: 'payment_collection',
+    fields: [
+      'id',
+      'created_at',
+      'cart.id',
+      'cart.completed_at',
+      'payment_sessions.id',
+      'payment_sessions.data',
+      'payment_sessions.created_at',
+    ],
+    filters: { created_at: { $gte: since.toISOString() } },
+    pagination: { take: SCAN_LIMIT, skip: 0, order: { created_at: 'ASC' } },
+  });
+
+  if ((collections as any[]).length >= SCAN_LIMIT) {
+    // 조용한 절단 금지: 스캔 상한에 걸리면 뒤쪽 결제는 이번 회차에서 안 본 것이다.
+    logger.warn(
+      `[orphan-reconcile] scan hit the ${SCAN_LIMIT} cap — older collections in this window were not scanned this run`,
+    );
+  }
+
+  const cartIds = (collections as any[])
+    .map((c) => c?.cart?.id)
+    .filter((id): id is string => Boolean(id));
+  const orderByCart = await loadOrderLinks(container, cartIds);
+
+  for (const collection of collections as any[]) {
+    const cartId: string | undefined = collection?.cart?.id;
+    const session = (collection?.payment_sessions ?? [])[0];
+    const intentId: string | undefined = session?.data?.intentId;
+    if (!cartId || !intentId) continue;
+
+    const createdAt = new Date(session?.created_at ?? collection?.created_at ?? 0).getTime();
+    if (createdAt > cutoff) continue; // 진행 중일 수 있음 — 건드리지 않는다
+
+    summary.scanned++;
+
+    try {
+      const intent = await walletFetch<WalletIntent>(`/v1/payment-intents/${intentId}`);
+      const orderId = orderByCart.get(cartId);
+
+      if (orderId) {
+        await reconcileCapturedOrder(container, paymentModule, intentId, session.id, intent, logger, summary);
+        continue;
+      }
+
+      // 주문 없음 — 돈이 움직인 상태인지에 따라 복구/환불/취소.
+      if (intent.status === 'CAPTURED' || intent.status === 'PARTIALLY_CAPTURED') {
+        // 먼저 주문 복구를 시도한다(재고가 회복됐다면 주문이 살아난다).
+        try {
+          await handleCaptureProjection(container, intentId, `orphan-reconcile:${intentId}`, logger);
+          const refreshed = await loadOrderLinks(container, [cartId]);
+          if (refreshed.get(cartId)) {
+            summary.recovered++;
+            logger.info(`[orphan-reconcile] recovered order for intentId=${intentId} cart=${cartId}`);
+            continue;
+          }
+        } catch (recoveryErr) {
+          const msg = recoveryErr instanceof Error ? recoveryErr.message : String(recoveryErr);
+          logger.warn(`[orphan-reconcile] recovery failed for intentId=${intentId}: ${msg}`);
+        }
+
+        if (!autoRefundEnabled()) {
+          summary.dryRunFindings.push(`ORPHAN_CAPTURED intentId=${intentId} cart=${cartId} amount=${intent.payableAmount}`);
+          logger.warn(`[orphan-reconcile] ORPHAN (report-only) intentId=${intentId} cart=${cartId}`);
+          continue;
+        }
+
+        await walletFetch(`/v1/payment-intents/${intentId}/refund`, {
+          method: 'POST',
+          body: JSON.stringify({ amount: intent.payableAmount, reasonCode: 'ORPHAN_PAYMENT_RECONCILE' }),
+        });
+        summary.refunded++;
+        logger.error(
+          `[orphan-reconcile] refunded orphan payment intentId=${intentId} cart=${cartId} amount=${intent.payableAmount}`,
+        );
+        continue;
+      }
+
+      if (intent.status === 'AUTHORIZED') {
+        // 승인만 되고 주문이 안 만들어진 상태. 토스는 승인이 곧 출금이므로 취소로 되돌린다.
+        if (!autoRefundEnabled()) {
+          summary.dryRunFindings.push(`ORPHAN_AUTHORIZED intentId=${intentId} cart=${cartId}`);
+          continue;
+        }
+        await walletFetch(`/v1/payment-intents/${intentId}/cancel`, { method: 'POST' });
+        summary.canceled++;
+        logger.error(`[orphan-reconcile] canceled stranded authorization intentId=${intentId} cart=${cartId}`);
+      }
+    } catch (err) {
+      summary.failed++;
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error(`[orphan-reconcile] failed for intentId=${intentId} cart=${cartId}: ${msg}`);
+    }
+  }
+
+  logger.info(
+    `[orphan-reconcile] done scanned=${summary.scanned} recovered=${summary.recovered} refunded=${summary.refunded} canceled=${summary.canceled} captured=${summary.captured} failed=${summary.failed}`,
+  );
+  return summary;
+}
+
+/**
+ * 주문은 있는데 Medusa 결제가 미캡처인 경우를 맞춘다.
+ * - wallet CAPTURED  → 캡처 투영(handleCaptureProjection: DB-only, PG 재호출 없음)
+ * - wallet AUTHORIZED → 실제 캡처 실행(capturePaymentWorkflow → wallet /capture)
+ */
+async function reconcileCapturedOrder(
+  scope: any,
+  paymentModule: any,
+  intentId: string,
+  sessionId: string,
+  intent: WalletIntent,
+  logger: any,
+  summary: ReconcileSummary,
+): Promise<void> {
+  const payments = await paymentModule.listPayments({ payment_session_id: sessionId }, {});
+  const payment = payments[0];
+  if (!payment || payment.captured_at || payment.canceled_at) return;
+
+  if (intent.status === 'CAPTURED') {
+    await handleCaptureProjection(scope, intentId, `orphan-reconcile:${intentId}`, logger);
+    summary.captured++;
+    logger.info(`[orphan-reconcile] projected missing capture for intentId=${intentId} payment=${payment.id}`);
+    return;
+  }
+
+  if (intent.status === 'AUTHORIZED') {
+    await capturePaymentWorkflow(scope).run({ input: { payment_id: payment.id } });
+    summary.captured++;
+    logger.info(`[orphan-reconcile] captured authorized payment intentId=${intentId} payment=${payment.id}`);
+  }
+}

--- a/apps/wallet/src/payment-intents/deferred-approval.service.ts
+++ b/apps/wallet/src/payment-intents/deferred-approval.service.ts
@@ -1,0 +1,78 @@
+import { ConflictException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { DbService } from '@app/db';
+import { eq } from 'drizzle-orm';
+import { WalletSchema, paymentIntents } from '../schema';
+import { ChargesService } from '../charges/charges.service';
+import { TossApproveService } from './toss-approve.service';
+import { isDeferredApprovalIntent, readStagedApproval } from './deferred-approval';
+
+/** 이미 승인(또는 그 이후 단계)이 끝난 상태 — finalize 는 멱등 no-op 이 된다. */
+const ALREADY_APPROVED_STATUSES = ['AUTHORIZED', 'CAPTURED', 'PARTIALLY_CAPTURED', 'SUCCEEDED'];
+
+/**
+ * 적재된 PG 승인을 실제 승인으로 확정한다.
+ *
+ * 호출자는 Medusa 의 almond-payment provider — completeCartWorkflow 가 주문 생성과 재고예약을
+ * 모두 성공시킨 마지막 단계(authorizePaymentSession)에서 호출한다. 즉 이 호출이 성공해야만
+ * 고객 돈이 움직이고, 그 전에 워크플로가 실패하면 승인은 일어나지 않는다.
+ */
+@Injectable()
+export class DeferredApprovalService {
+  private readonly logger = new Logger(DeferredApprovalService.name);
+
+  constructor(
+    private readonly dbService: DbService<WalletSchema>,
+    private readonly chargesService: ChargesService,
+    private readonly tossApproveService: TossApproveService,
+  ) {}
+
+  async finalize(intentId: string, correlationId: string): Promise<{ status: string }> {
+    const intent = await this.loadIntent(intentId);
+
+    // 재시도/중복 호출 멱등: 이미 승인된 intent 는 그대로 성공 응답.
+    if (ALREADY_APPROVED_STATUSES.includes(intent.status)) {
+      return { status: intent.status };
+    }
+
+    if (!isDeferredApprovalIntent(intent.metadata)) {
+      throw new ConflictException({
+        error: 'NOT_DEFERRED_APPROVAL_INTENT',
+        message: `Intent is not in deferred approval mode: ${intentId}`,
+      });
+    }
+
+    const charge = await this.chargesService.findActiveByIntentAndOperation(intentId, 'AUTHORIZE');
+    const staged = charge && charge.status === 'REQUIRES_ACTION' ? readStagedApproval(charge) : null;
+
+    if (!charge || !staged) {
+      // 고객이 결제창을 완료하지 않았거나, 적재 후 만료 회수(TossActionExpirationJob)된 경우.
+      // 승인할 대상이 없으므로 호출자(Medusa)가 주문을 롤백하게 409 로 알린다.
+      throw new ConflictException({
+        error: 'NO_STAGED_APPROVAL',
+        message: `No staged approval to finalize for intent: ${intentId} (status=${intent.status})`,
+      });
+    }
+
+    this.logger.log(`finalizing staged approval: intentId=${intentId} provider=${staged.provider}`);
+    await this.tossApproveService.confirmStaged(charge, staged, correlationId);
+
+    const updated = await this.loadIntent(intentId);
+    return { status: updated.status };
+  }
+
+  private async loadIntent(intentId: string): Promise<typeof paymentIntents.$inferSelect> {
+    const [intent] = await this.dbService.db
+      .select()
+      .from(paymentIntents)
+      .where(eq(paymentIntents.id, intentId))
+      .limit(1);
+
+    if (!intent) {
+      throw new NotFoundException({
+        error: 'INTENT_NOT_FOUND',
+        message: `Payment intent not found: ${intentId}`,
+      });
+    }
+    return intent;
+  }
+}

--- a/apps/wallet/src/payment-intents/deferred-approval.spec.ts
+++ b/apps/wallet/src/payment-intents/deferred-approval.spec.ts
@@ -99,6 +99,60 @@ describe('deferred approval — staging', () => {
   });
 });
 
+describe('deferred approval — confirmStaged', () => {
+  const staged = {
+    provider: 'TOSS' as const,
+    providerToken: 'pk_live_1',
+    orderId: ORDER_ID,
+    amount: 10000,
+    stagedAt: new Date(0).toISOString(),
+  };
+
+  it('적재된 파라미터로 승인하고 AUTHORIZED 로 올린 뒤 캡처를 태운다', async () => {
+    const ctx = makeTossContext({ approvalMode: 'DEFERRED' });
+
+    await ctx.service.confirmStaged(makeCharge(), staged, 'corr-1');
+
+    expect(ctx.tossApi.confirmPayment).toHaveBeenCalledWith('pk_live_1', 10000, ORDER_ID);
+    expect(ctx.stateTransitionService.transitionIntent).toHaveBeenCalledWith(
+      'intent-1',
+      'AUTHORIZED',
+      expect.anything(),
+      undefined,
+      expect.anything(),
+    );
+    expect(ctx.autoCaptureService.attemptAutoCapture).toHaveBeenCalled();
+  });
+
+  it('PG 승인 거절이면 charge 를 FAILED, intent 를 CREATED 로 되돌리고 throw 한다', async () => {
+    // throw 해야 호출자(Medusa completeCartWorkflow)가 주문·재고예약을 롤백한다.
+    // intent 를 CREATED 로 되돌려야 고객이 같은 결제 세션으로 재시도할 수 있다.
+    const ctx = makeTossContext({ approvalMode: 'DEFERRED' }, makeCharge(), {
+      ok: false,
+      error: { code: 'REJECT_CARD_COMPANY', message: '카드사 승인 거절' },
+    });
+
+    await expect(ctx.service.confirmStaged(makeCharge(), staged, 'corr-1')).rejects.toMatchObject({
+      response: expect.objectContaining({ error: 'REJECT_CARD_COMPANY' }),
+    });
+
+    expect(ctx.chargesService.updateStatus).toHaveBeenCalledWith(
+      CHARGE_ID,
+      'FAILED',
+      expect.objectContaining({ errorCode: 'REJECT_CARD_COMPANY' }),
+      expect.anything(),
+    );
+    expect(ctx.stateTransitionService.transitionIntent).toHaveBeenCalledWith(
+      'intent-1',
+      'CREATED',
+      expect.anything(),
+      undefined,
+      expect.anything(),
+    );
+    expect(ctx.autoCaptureService.attemptAutoCapture).not.toHaveBeenCalled();
+  });
+});
+
 describe('deferred approval — finalize', () => {
   function makeFinalizeContext(
     intentStatus: string,

--- a/apps/wallet/src/payment-intents/deferred-approval.spec.ts
+++ b/apps/wallet/src/payment-intents/deferred-approval.spec.ts
@@ -1,0 +1,157 @@
+import { TossApproveService } from './toss-approve.service';
+import { DeferredApprovalService } from './deferred-approval.service';
+import { readStagedApproval } from './deferred-approval';
+
+// 지연 승인(deferred approval): Medusa 체크아웃 intent 는 결제창 완료 시점에 PG 승인을 하지 않고
+// 파라미터만 적재하고, 주문 생성 + 재고예약이 끝난 뒤 finalize 에서 비로소 승인한다.
+
+const CHARGE_ID = '11111111-2222-3333-4444-555555555555';
+const ORDER_ID = CHARGE_ID.replace(/-/g, '');
+
+function makeCharge(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: CHARGE_ID,
+    intentId: 'intent-1',
+    paymentMethodId: 'pm-1',
+    amount: 10000,
+    currency: 'KRW',
+    operation: 'AUTHORIZE',
+    status: 'REQUIRES_ACTION',
+    responsePayload: {},
+    ...overrides,
+  } as never;
+}
+
+function makeDb(intent: Record<string, unknown>) {
+  return {
+    db: {
+      select: () => ({
+        from: () => ({ where: () => ({ limit: () => Promise.resolve([intent]) }) }),
+      }),
+      update: () => ({ set: () => ({ where: () => Promise.resolve() }) }),
+      transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn({}),
+    },
+  } as never;
+}
+
+function makeTossContext(
+  intentMetadata: Record<string, unknown>,
+  charge = makeCharge(),
+  confirmResult: { ok: boolean; data?: { paymentKey: string }; error?: { code: string; message: string } } = {
+    ok: true,
+    data: { paymentKey: 'pk_live_1' },
+  },
+) {
+  const intent = { id: 'intent-1', status: 'REQUIRES_ACTION', userId: 'u1', currency: 'KRW', payableAmount: 10000, metadata: intentMetadata };
+  const chargesService = {
+    findActiveByIntentAndOperation: jest.fn().mockResolvedValue(charge),
+    updateStatus: jest.fn().mockResolvedValue(undefined),
+  };
+  const stateTransitionService = { transitionIntent: jest.fn().mockResolvedValue(undefined) };
+  const autoCaptureService = { attemptAutoCapture: jest.fn().mockResolvedValue(undefined) };
+  const tossApi = { confirmPayment: jest.fn().mockResolvedValue(confirmResult) };
+  const cashReceiptsService = { issue: jest.fn() };
+
+  const service = new TossApproveService(
+    makeDb(intent),
+    chargesService as never,
+    autoCaptureService as never,
+    stateTransitionService as never,
+    tossApi as never,
+    cashReceiptsService as never,
+  );
+
+  return { service, chargesService, tossApi, autoCaptureService, stateTransitionService, intent };
+}
+
+describe('deferred approval — staging', () => {
+  it('결제창 완료 시 승인 API 를 부르지 않고 파라미터만 적재한다', async () => {
+    const ctx = makeTossContext({ approvalMode: 'DEFERRED' });
+
+    await ctx.service.approve('intent-1', 'pk_live_1', ORDER_ID, 10000, 'corr-1');
+
+    expect(ctx.tossApi.confirmPayment).not.toHaveBeenCalled();
+    expect(ctx.autoCaptureService.attemptAutoCapture).not.toHaveBeenCalled();
+
+    const [, status, extra] = ctx.chargesService.updateStatus.mock.calls[0];
+    expect(status).toBe('REQUIRES_ACTION');
+    const staged = readStagedApproval(makeCharge({ responsePayload: extra.responsePayload }));
+    expect(staged).toEqual(
+      expect.objectContaining({ provider: 'TOSS', providerToken: 'pk_live_1', orderId: ORDER_ID, amount: 10000 }),
+    );
+    // 미승인 토큰이 providerTransactionId 로 새어나가면 취소/환불이 잘못 시도된다.
+    expect(extra.providerTransactionId).toBeUndefined();
+  });
+
+  it('금액이 charge 와 다르면 적재하지 않는다', async () => {
+    const ctx = makeTossContext({ approvalMode: 'DEFERRED' });
+
+    await expect(ctx.service.approve('intent-1', 'pk_live_1', ORDER_ID, 9999, 'corr-1')).rejects.toThrow();
+    expect(ctx.chargesService.updateStatus).not.toHaveBeenCalled();
+  });
+
+  it('지연 승인 표식이 없는 intent 는 기존대로 즉시 승인한다', async () => {
+    const ctx = makeTossContext({});
+
+    await ctx.service.approve('intent-1', 'pk_live_1', ORDER_ID, 10000, 'corr-1');
+
+    expect(ctx.tossApi.confirmPayment).toHaveBeenCalledWith('pk_live_1', 10000, ORDER_ID);
+  });
+});
+
+describe('deferred approval — finalize', () => {
+  function makeFinalizeContext(
+    intentStatus: string,
+    charge: unknown,
+    metadata: Record<string, unknown> = { approvalMode: 'DEFERRED' },
+  ) {
+    const intent = { id: 'intent-1', status: intentStatus, metadata };
+    const chargesService = { findActiveByIntentAndOperation: jest.fn().mockResolvedValue(charge) };
+    const tossApproveService = { confirmStaged: jest.fn().mockResolvedValue(undefined) };
+    const service = new DeferredApprovalService(
+      makeDb(intent),
+      chargesService as never,
+      tossApproveService as never,
+    );
+    return { service, tossApproveService };
+  }
+
+  const stagedCharge = makeCharge({
+    responsePayload: {
+      stagedApproval: {
+        provider: 'TOSS',
+        providerToken: 'pk_live_1',
+        orderId: ORDER_ID,
+        amount: 10000,
+        stagedAt: new Date(0).toISOString(),
+      },
+    },
+  });
+
+  it('적재된 승인을 실제 PG 승인으로 확정한다', async () => {
+    const ctx = makeFinalizeContext('REQUIRES_ACTION', stagedCharge);
+
+    await ctx.service.finalize('intent-1', 'corr-1');
+
+    expect(ctx.tossApproveService.confirmStaged).toHaveBeenCalledWith(
+      stagedCharge,
+      expect.objectContaining({ providerToken: 'pk_live_1', amount: 10000 }),
+      'corr-1',
+    );
+  });
+
+  it('이미 승인된 intent 는 멱등 no-op', async () => {
+    const ctx = makeFinalizeContext('CAPTURED', stagedCharge);
+
+    await expect(ctx.service.finalize('intent-1', 'corr-1')).resolves.toEqual({ status: 'CAPTURED' });
+    expect(ctx.tossApproveService.confirmStaged).not.toHaveBeenCalled();
+  });
+
+  it('적재된 승인이 없으면 409 로 알려 호출자가 주문을 롤백하게 한다', async () => {
+    const ctx = makeFinalizeContext('REQUIRES_ACTION', makeCharge());
+
+    await expect(ctx.service.finalize('intent-1', 'corr-1')).rejects.toMatchObject({
+      response: expect.objectContaining({ error: 'NO_STAGED_APPROVAL' }),
+    });
+  });
+});

--- a/apps/wallet/src/payment-intents/deferred-approval.ts
+++ b/apps/wallet/src/payment-intents/deferred-approval.ts
@@ -1,0 +1,56 @@
+import { Charge } from '../types';
+
+/**
+ * 지연 승인(deferred approval) — PG 승인(=실제 출금)을 주문 생성 이후로 미루는 모드.
+ *
+ * 카드/토스는 결제창 완료가 아니라 **서버의 승인 API 호출** 시점에 돈이 빠진다. 기본 흐름은
+ * wallet-web 이 결제창 리다이렉트 직후 승인까지 끝내므로, 그 뒤 Medusa 가 주문을 만들다
+ * 재고부족으로 실패하면 "돈은 빠졌는데 주문은 없는" 고아결제가 된다.
+ *
+ * 지연 승인 모드에서는 결제창 완료 시 승인 파라미터만 charge 에 적재(stage)해 두고,
+ * Medusa 의 completeCartWorkflow 가 주문 생성 + 재고예약을 모두 성공시킨 뒤 마지막 단계
+ * (authorizePaymentSession → almond-payment.authorizePayment)에서 wallet 의
+ * finalize-approval 을 부를 때 비로소 승인 API 를 호출한다. 재고부족으로 워크플로가 실패하면
+ * 승인 자체에 도달하지 못하므로 고객 돈은 움직이지 않는다.
+ *
+ * 적재된 승인은 결제창 완료 후 짧은 시간 안에 확정돼야 한다(PG 승인 유효시간). 확정되지 않은
+ * 채로 actionExpiresAt 이 지나면 TossActionExpirationJob 이 charge 를 CANCELED 로 회수하고,
+ * PG 쪽 미승인 결제는 자동 만료된다 — 역시 돈이 빠지지 않는 안전한 방향이다.
+ */
+export const DEFERRED_APPROVAL_METADATA_KEY = 'approvalMode';
+export const DEFERRED_APPROVAL_METADATA_VALUE = 'DEFERRED';
+
+export interface StagedApproval {
+  provider: 'TOSS';
+  /** PG 승인 토큰 (Toss paymentKey) */
+  providerToken: string;
+  /** PG 주문번호 (chargeId 에서 대시 제거한 값) */
+  orderId: string;
+  amount: number;
+  stagedAt: string;
+}
+
+/** intent.metadata 가 지연 승인 모드를 요구하는지 판정한다. */
+export function isDeferredApprovalIntent(metadata: Record<string, unknown> | null | undefined): boolean {
+  return metadata?.[DEFERRED_APPROVAL_METADATA_KEY] === DEFERRED_APPROVAL_METADATA_VALUE;
+}
+
+/** charge.responsePayload 에 적재된 승인 파라미터를 읽는다. 없거나 형식이 깨졌으면 null. */
+export function readStagedApproval(charge: Charge): StagedApproval | null {
+  const raw = (charge.responsePayload as Record<string, unknown> | null | undefined)?.stagedApproval;
+  if (!raw || typeof raw !== 'object') return null;
+
+  const staged = raw as Partial<StagedApproval>;
+  if (staged.provider !== 'TOSS') return null;
+  if (typeof staged.providerToken !== 'string' || staged.providerToken.length === 0) return null;
+  if (typeof staged.orderId !== 'string' || staged.orderId.length === 0) return null;
+  if (typeof staged.amount !== 'number') return null;
+
+  return {
+    provider: staged.provider,
+    providerToken: staged.providerToken,
+    orderId: staged.orderId,
+    amount: staged.amount,
+    stagedAt: typeof staged.stagedAt === 'string' ? staged.stagedAt : new Date(0).toISOString(),
+  };
+}

--- a/apps/wallet/src/payment-intents/payment-intents.controller.ts
+++ b/apps/wallet/src/payment-intents/payment-intents.controller.ts
@@ -106,6 +106,20 @@ export class PaymentIntentsController {
     return this.toResponse(updated);
   }
 
+  @Post(':id/finalize-approval')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Finalize a staged PG approval after the order was created (API-key, Medusa 전용)',
+    description:
+      '지연 승인(deferred approval) 모드 intent 의 적재된 승인 파라미터로 실제 PG 승인을 수행한다. ' +
+      '주문 생성 + 재고예약이 끝난 뒤에만 호출되므로, 이 호출 전에 워크플로가 실패하면 고객 돈은 움직이지 않는다.',
+  })
+  async finalizeApproval(@Param('id') id: string): Promise<PaymentIntentResponseDto> {
+    await this.service.finalizeDeferredApproval(id);
+    const updated = await this.service.findByIdOrThrow(id);
+    return this.toResponse(updated);
+  }
+
   @Post(':id/capture')
   @HttpCode(200)
   @ApiOperation({ summary: 'Capture an authorized payment intent (API-key authenticated, merchant backend)' })

--- a/apps/wallet/src/payment-intents/payment-intents.service.ts
+++ b/apps/wallet/src/payment-intents/payment-intents.service.ts
@@ -25,6 +25,7 @@ import { CaptureService } from './capture.service';
 import { CancelService } from './cancel.service';
 import { AbandonService } from './abandon.service';
 import { TossApproveService } from './toss-approve.service';
+import { DeferredApprovalService } from './deferred-approval.service';
 
 const DEFAULT_INTENT_EXPIRY_MINUTES = 60 * 24; // 24 hours
 
@@ -52,6 +53,7 @@ export class PaymentIntentsService {
     private readonly cancelService: CancelService,
     private readonly abandonService: AbandonService,
     private readonly tossApproveService: TossApproveService,
+    private readonly deferredApprovalService: DeferredApprovalService,
   ) {}
 
   async create(dto: CreatePaymentIntentDto): Promise<typeof paymentIntents.$inferSelect> {
@@ -302,6 +304,15 @@ export class PaymentIntentsService {
     await this.findByIdOrThrow(intentId);
     const correlationId = `toss-approve:${intentId}:${Date.now()}`;
     await this.tossApproveService.approve(intentId, dto.paymentKey, dto.orderId, dto.amount, correlationId);
+  }
+
+  /**
+   * 지연 승인 확정 — Medusa 가 주문 생성 + 재고예약을 성공시킨 뒤에만 호출한다.
+   * 여기서 비로소 PG 승인(실제 출금)이 일어난다.
+   */
+  async finalizeDeferredApproval(intentId: string): Promise<{ status: string }> {
+    const correlationId = `finalize-approval:${intentId}:${Date.now()}`;
+    return this.deferredApprovalService.finalize(intentId, correlationId);
   }
 
   async capture(intentId: string): Promise<void> {

--- a/apps/wallet/src/payment-intents/toss-approve.service.ts
+++ b/apps/wallet/src/payment-intents/toss-approve.service.ts
@@ -13,6 +13,14 @@ import {
 } from '../messaging/gateway-event.builder';
 import { TossApiClient } from '../providers/toss/toss-api.client';
 import { CashReceiptsService } from '../cash-receipts/cash-receipts.service';
+import { StagedApproval, isDeferredApprovalIntent } from './deferred-approval';
+
+/**
+ * 적재된 승인이 확정되기를 기다리는 시간. Medusa 가 cart.complete 로 주문을 만들고 승인을
+ * 트리거하기까지의 정상 소요는 수 초이므로 넉넉하다. 지나면 TossActionExpirationJob 이
+ * charge 를 회수하고 PG 미승인 결제는 자동 만료된다(= 돈이 빠지지 않는 방향).
+ */
+const DEFAULT_STAGED_APPROVAL_TTL_MINUTES = 10;
 
 @Injectable()
 export class TossApproveService {
@@ -46,12 +54,92 @@ export class TossApproveService {
       });
     }
 
-    // 2. Call Toss API confirm
+    // 2. 지연 승인 모드(Medusa 체크아웃): 여기서 승인하지 않고 파라미터만 적재한다.
+    //    실제 승인은 주문 생성 + 재고예약이 끝난 뒤 Medusa 가 finalize-approval 로 트리거한다.
+    const intent = await this.loadIntent(intentId);
+    if (isDeferredApprovalIntent(intent.metadata)) {
+      await this.stageApproval(charge, paymentKey, orderId, amount);
+      this.logger.log(`approve staged (deferred approval): intentId=${intentId} chargeId=${charge.id}`);
+      return;
+    }
+
+    // 3. Call Toss API confirm
     const result = await this.tossApi.confirmPayment(paymentKey, amount, orderId);
     this.logger.log(`Toss API confirm response: ok=${result.ok}`);
 
     if (!result.ok) {
       this.logger.error(`Toss API confirm failed: ${JSON.stringify(result.error)}`);
+      await this.finalizeFailure(charge, result.error.code ?? 'TOSS_CONFIRM_FAILED', correlationId);
+      throw new UnprocessableEntityException({
+        error: result.error.code ?? 'TOSS_CONFIRM_FAILED',
+        message: result.error.message,
+      });
+    }
+
+    await this.finalizeApproval(charge, result.data.paymentKey, correlationId);
+  }
+
+  /**
+   * 결제창 완료 파라미터를 charge 에 적재만 하고 승인 API 는 호출하지 않는다.
+   *
+   * charge 는 REQUIRES_ACTION 그대로 두어 intent 도 REQUIRES_ACTION 에 머문다
+   * (almond-payment 가 'pending' 으로 매핑 → completeCartWorkflow 가 정상 진행).
+   * providerTransactionId 는 승인 전이므로 비워 둔다 — 미승인 paymentKey 로 취소/환불이
+   * 시도되지 않게 하기 위함이다.
+   */
+  private async stageApproval(charge: Charge, paymentKey: string, orderId: string, amount: number): Promise<void> {
+    if (charge.amount !== amount) {
+      throw new UnprocessableEntityException({
+        error: 'TOSS_AMOUNT_MISMATCH',
+        message: `Expected amount ${charge.amount}, received ${amount}`,
+      });
+    }
+
+    const expectedOrderId = charge.id.replace(/-/g, '');
+    if (orderId !== expectedOrderId) {
+      throw new UnprocessableEntityException({
+        error: 'TOSS_ORDER_ID_MISMATCH',
+        message: 'orderId does not match the charge',
+      });
+    }
+
+    const staged: StagedApproval = {
+      provider: 'TOSS',
+      providerToken: paymentKey,
+      orderId,
+      amount,
+      stagedAt: new Date().toISOString(),
+    };
+
+    await this.chargesService.updateStatus(charge.id, 'REQUIRES_ACTION', {
+      responsePayload: { ...(charge.responsePayload ?? {}), stagedApproval: staged },
+    });
+
+    // 확정 대기 창을 다시 연다. 고객이 결제창에서 오래 머물러 원래 actionExpiresAt 이 임박했더라도
+    // 주문 생성까지의 몇 초를 확보하기 위함.
+    await this.dbService.db
+      .update(paymentIntents)
+      .set({ actionExpiresAt: new Date(Date.now() + this.stagedApprovalTtlMs()) })
+      .where(eq(paymentIntents.id, charge.intentId));
+  }
+
+  private stagedApprovalTtlMs(): number {
+    const raw = Number(process.env.WALLET_STAGED_APPROVAL_TTL_MINUTES);
+    const minutes = Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_STAGED_APPROVAL_TTL_MINUTES;
+    return minutes * 60_000;
+  }
+
+  /**
+   * 적재된 승인을 실제 PG 승인으로 확정한다 (주문 생성 성공 후 Medusa 가 트리거).
+   * 승인 실패는 charge/intent 를 실패 처리하고 throw 해, 호출자인 Medusa 워크플로가
+   * 주문·재고예약을 롤백하게 한다.
+   */
+  async confirmStaged(charge: Charge, staged: StagedApproval, correlationId: string): Promise<void> {
+    const result = await this.tossApi.confirmPayment(staged.providerToken, staged.amount, staged.orderId);
+    this.logger.log(`staged approval confirm: intentId=${charge.intentId} ok=${result.ok}`);
+
+    if (!result.ok) {
+      this.logger.error(`Toss API confirm failed (staged): ${JSON.stringify(result.error)}`);
       await this.finalizeFailure(charge, result.error.code ?? 'TOSS_CONFIRM_FAILED', correlationId);
       throw new UnprocessableEntityException({
         error: result.error.code ?? 'TOSS_CONFIRM_FAILED',

--- a/apps/wallet/src/wallet.module.ts
+++ b/apps/wallet/src/wallet.module.ts
@@ -54,6 +54,7 @@ import { CancelService } from './payment-intents/cancel.service';
 import { ChargeReleaseService } from './payment-intents/charge-release.service';
 import { AbandonService } from './payment-intents/abandon.service';
 import { TossApproveService } from './payment-intents/toss-approve.service';
+import { DeferredApprovalService } from './payment-intents/deferred-approval.service';
 
 // Refunds
 import { RefundsService } from './refunds/refunds.service';
@@ -486,6 +487,7 @@ async function resolveCanActivate(result: boolean | Promise<boolean> | unknown):
     ChargeReleaseService,
     AbandonService,
     TossApproveService,
+    DeferredApprovalService,
 
     // Refunds
     RefundsService,

--- a/docs/adr/0028-deferred-pg-approval.md
+++ b/docs/adr/0028-deferred-pg-approval.md
@@ -1,0 +1,75 @@
+# 지연 PG 승인 (deferred approval) — 고아결제 원천 차단
+
+## Status
+Accepted (2026-07-31).
+
+## Context
+
+"결제는 됐는데 주문이 없는" 고아결제가 반복 발생했다. 발생 경로는 다음과 같다.
+
+1. 카드/토스 결제에서 **돈이 빠지는 시점은 wallet 의 Toss 승인 API 호출**
+   (`TossApproveService.approve` → `tossApi.confirmPayment`)이다. 결제창을 닫자마자
+   wallet-web 이 이 승인까지 끝낸다. (capture 는 토스에선 no-op 상태 전이일 뿐이다 —
+   즉 auto-capture 를 꺼도 돈은 이미 빠진 뒤다.)
+2. 그 뒤에야 스토어프론트가 `cart.complete` 를 부른다. Medusa `completeCartWorkflow` 의
+   단계 순서는 `create-order → reserveInventory → authorizePayment` 이고,
+   `reserveInventoryStep` 은 `manage_inventory=true && allow_backorder=false && 가용재고 < 필요수량`
+   이면 throw 한다.
+3. 이때 주문은 롤백되지만 wallet 은 이미 승인/캡처 상태다. core-flows 의
+   `compensatePaymentIfNeededStep` 은 **Medusa payment 행의 `captured_at` 만** 보는데,
+   주문 생성 실패 경로에서는 Medusa payment 행 자체가 없다 → 보상 환불도 안 탄다 → 고아 확정.
+
+담기 시점 검증(Medusa 가 "수량 > 가용재고" 를 거부)은 예약이 아니라 조회라, 담은 뒤 결제 완료
+사이의 경쟁(같은 재고를 두 고객이 각각 담고 둘 다 결제)과 드리프트(담은 뒤 재고 감소)를 막지 못한다.
+과거 임시조치였던 `allow_backorder=true` 대량 적용은 오버셀을 유발해 폐기됐다.
+
+## Decision
+
+**PG 승인을 주문 생성 이후로 미룬다.** Medusa 체크아웃에서 생성한 intent 에는
+`metadata.approvalMode='DEFERRED'` 표식을 달고, wallet 은 그 표식이 있는 intent 에 한해
+결제창 완료 시 승인 API 를 호출하지 않고 승인 파라미터(paymentKey/orderId/amount)만
+charge 에 적재(stage)한다. intent 는 `REQUIRES_ACTION` 에 머문다(= almond-payment 가
+`pending` 으로 매핑 → `validateCartPaymentsStep` 통과).
+
+실제 승인은 `completeCartWorkflow` 의 **마지막 단계**인 `authorizePaymentSessionStep`
+→ `almond-payment.authorizePayment` → wallet `POST /v1/payment-intents/:id/finalize-approval`
+에서 일어난다. 즉 주문 생성과 재고예약이 모두 성공한 뒤에만 고객 돈이 움직인다.
+재고부족이면 워크플로가 승인 전에 실패하고, 적재된 승인은 미승인 상태로 만료된다(돈 안 빠짐).
+
+부수 결정:
+
+- **적재 만료**: 적재 시 `actionExpiresAt` 을 다시 찍는다(기본 10분,
+  `WALLET_STAGED_APPROVAL_TTL_MINUTES`). 지나면 기존 `TossActionExpirationJob` 이 회수하고
+  PG 미승인 결제는 자동 만료된다 — fail-closed.
+- **미승인 토큰 격리**: 적재 단계에서는 `providerTransactionId` 를 채우지 않는다.
+  미승인 paymentKey 로 취소/환불이 시도되는 것을 막기 위함이다.
+- **캡처 결정성**: 승인 직후 wallet 이 자동 캡처하며 `payment.intent.captured` 를 발행하는데,
+  이 웹훅이 워크플로가 payment 행을 만들기 전에 도착할 수 있다. 그래서 (a) `cart.complete`
+  라우트가 완료 직후 캡처를 명시 실행하고, (b) 캡처 훅은 "카트는 완료됐는데 payment 행이 없음"
+  을 조용히 넘기지 않고 throw 해 재배달로 재시도한다.
+- **카트 식별 실패 폴백 교체**: 예전에는 콜백이 checkout cart 를 특정 못 하면
+  "capture 웹훅이 주문을 만든다" 에 맡겼다. 지연 승인에서는 카트를 완료해야 승인이 일어나므로
+  이 폴백이 성립하지 않는다. `POST /store/payment-intents/:intentId/complete` 가
+  intent → session → cart 로 역추적해 서버사이드에서 완료한다.
+- **백스톱**: `orphan-payment-reconcile` 잡(매시 17분)이 잔여 케이스를 정리한다.
+  주문 없음 + CAPTURED → 주문 복구 시도 후 실패 시 자동 환불, 주문 없음 + AUTHORIZED → 취소,
+  주문 있음 + 미캡처 → 캡처. `ORPHAN_RECONCILE_AUTO_REFUND=false` 로 탐지 전용 전환 가능.
+- **결제 전 게이트 강화**: 스토어프론트 체크아웃이 품절뿐 아니라 "담은 수량 > 가용재고" 도 막는다.
+  (근본 차단은 지연 승인이지만, 결제창까지 갔다 실패하는 UX 를 줄인다.)
+
+## Consequences
+
+- 오버셀/품절 정책은 그대로다 — `allow_backorder` 를 건드리지 않는다.
+- 무통장(BANK_TRANSFER)은 영향 없다. `offline-wait` 승인 경로라 toss-approve 를 타지 않고,
+  캡처는 관리자 입금확인 시점 그대로다. 멤버십/정기결제(INVOICE·CMS)도 Medusa 세션이 없어
+  `approvalMode` 표식이 붙지 않으므로 기존 경로를 그대로 탄다.
+- 배포 순서: **wallet 먼저, Medusa 나중**. wallet 은 표식이 있는 intent 만 지연 처리하므로,
+  구버전 Medusa(표식 없음) + 신버전 wallet 조합은 기존 동작 그대로다. 반대 순서면 Medusa 가
+  표식을 다는데 wallet 이 finalize 엔드포인트를 모른다.
+- 롤백: Medusa 쪽 `ALMOND_DEFERRED_APPROVAL=false` 로 표식 부여를 끄면 즉시 기존 동작.
+  이미 적재된 intent 는 finalize 로 마무리되거나 만료 회수된다.
+- 남는 창: 승인(=워크플로 마지막 단계) 이후 링크/트랜잭션 기록 단계에서 실패하면 주문은
+  롤백되는데 돈은 빠진 상태가 된다. `compensatePaymentIfNeededStep` 은 Medusa 캡처 기준이라
+  이때도 안 돈다 → 리컨실 잡의 자동 환불이 유일한 회수 경로다(1시간 내).
+- 브라우저가 콜백 도달 전에 죽으면 승인이 아예 안 일어난다. 고객은 과금되지 않고 주문도 없다
+  (이전에는 돈만 빠졌다). 결제 실패로 재시도하면 된다.

--- a/web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/callback/actions.ts
+++ b/web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/callback/actions.ts
@@ -267,6 +267,35 @@ async function removePurchasedItemsFromSourceCart(
   }
 }
 
+interface IntentCompletionResult {
+  type: "order" | "error"
+  order_id?: string
+  cart_id?: string
+  error?: { message?: string; name?: string; type?: string }
+}
+
+/**
+ * checkout cart 를 특정하지 못했을 때의 서버사이드 완료 경로.
+ * Medusa 가 intent 로 카트를 역추적해 completeCartWorkflow 를 돌린다(이미 주문이 있으면 그대로 반환).
+ */
+async function completeCartByIntent(
+  intentId: string
+): Promise<IntentCompletionResult | null> {
+  try {
+    const headers = { ...(await getAuthHeaders()) }
+    return await sdk.client.fetch<IntentCompletionResult>(
+      `/store/payment-intents/${intentId}/complete`,
+      { method: "POST", headers }
+    )
+  } catch (err) {
+    logger.error("storefront.checkout.intent_complete.request_failed", {
+      error: err,
+      attributes: { intent_id: intentId },
+    })
+    return null
+  }
+}
+
 export async function processPaymentCallback(
   countryCode: string,
   intentId: string,
@@ -421,8 +450,11 @@ export async function processPaymentCallback(
       }
     }
 
-    // targetCartId(=cartId) 식별 실패 — 위 if 블록을 타지 않은 경우. 주문은 서버측 capture 웹훅이
-    // 생성하므로 쿠키를 건드리지 않고 성공 페이지로 보낸다(빈 장바구니 방지).
+    // targetCartId(=cartId) 식별 실패 — sessionStorage 매핑 유실 등. 이 경우 Medusa 가
+    // intent → payment_session → cart 로 결제 대상 카트를 서버사이드에서 찾아 주문을 완료한다.
+    // (지연 승인에서는 카트를 완료해야 비로소 PG 승인이 일어나므로, 아무도 완료하지 않으면
+    //  결제도 주문도 성립하지 않는다 — 예전처럼 capture 웹훅에 맡길 수 없다.)
+    // 쿠키는 건드리지 않는다(어느 카트인지 모르므로 빈 장바구니 사고 방지).
     logger.info("storefront.checkout.payment_callback.no_checkout_cart_mapping", {
       attributes: {
         country_code: countryCode,
@@ -430,9 +462,28 @@ export async function processPaymentCallback(
         mode: mode ?? null,
       },
     })
+
+    const completion = await completeCartByIntent(intentId)
+    if (completion?.type === "order") {
+      revalidateTag(await getCacheTag("orders"))
+      return {
+        success: true,
+        redirectUrl: `/${countryCode}/checkout/success/${intentId}?orderId=${completion.order_id}`,
+      }
+    }
+
+    const fallbackError =
+      completion?.error?.message ?? "주문 처리에 실패했습니다."
+    logger.warn("storefront.checkout.payment_callback.intent_complete_failed", {
+      attributes: {
+        intent_id: intentId,
+        result_type: completion?.type ?? null,
+        error_message: fallbackError,
+      },
+    })
     return {
-      success: true,
-      redirectUrl: `/${countryCode}/checkout/success/${intentId}`,
+      success: false,
+      redirectUrl: `/${countryCode}/checkout/fail?code=ORDER_FAILED&message=${encodeURIComponent(fallbackError)}`,
     }
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : "알 수 없는 오류"

--- a/web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/page.tsx
+++ b/web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/page.tsx
@@ -61,14 +61,17 @@ async function CheckoutManager({
   // 보조 가드: 1차 차단은 장바구니에서 하지만, 만일의 경우를 대비해서 작성했음
   // draft/미게시(판매중단) 상품을 직접 감지해서,
   // 결제를 진행하면 어차피 터질 카트를 미리 안내 화면으로 막는다.
-  const { productNames: unavailableNames } = await findUnavailableLineItems(
-    cart,
-    countryCode
+  // 담은 뒤 재고가 줄어 "담은 수량 > 가용재고"가 된 라인도 같이 막는다. 그대로 결제로 보내면
+  // 결제 후 cart.complete 의 재고예약이 실패해 주문이 생성되지 않는다.
+  const { productNames: unavailableNames, insufficientNames } =
+    await findUnavailableLineItems(cart, countryCode)
+  const blockedNames = Array.from(
+    new Set(unavailableNames.concat(insufficientNames))
   )
-  if (unavailableNames.length > 0) {
+  if (blockedNames.length > 0) {
     return (
       <ProtectedRoute>
-        <UnavailableItemsNotice unavailableNames={unavailableNames} />
+        <UnavailableItemsNotice unavailableNames={blockedNames} />
       </ProtectedRoute>
     )
   }

--- a/web/almondyoung-storefront/src/lib/api/medusa/cart.ts
+++ b/web/almondyoung-storefront/src/lib/api/medusa/cart.ts
@@ -10,7 +10,10 @@ import {
   setCartId,
 } from "@lib/data/cookies"
 import medusaError from "@lib/utils/medusa-error"
-import { isVariantSoldOut } from "@lib/utils/cart-availability"
+import {
+  isVariantQuantityUnavailable,
+  isVariantSoldOut,
+} from "@lib/utils/cart-availability"
 import { HttpTypes } from "@medusajs/types"
 import { revalidateTag } from "next/cache"
 import { redirect } from "next/navigation"
@@ -110,12 +113,22 @@ export async function retrieveCart(
 }
 
 /**
- * 카트 라인아이템 중 draft/미게시/삭제(또는 판매채널 이탈)된 상품을 가려낸다.
+ * 카트 라인아이템 중 draft/미게시/삭제(또는 판매채널 이탈)된 상품과,
+ * 담은 뒤 재고가 줄어 "담은 수량 > 가용 재고"가 된 상품을 가려낸다.
+ *
+ * 후자(insufficient*)는 담기 시점엔 통과했다가 결제 직전에야 부족해지는 케이스다. 이걸 막지
+ * 않으면 결제 후 cart.complete 의 재고예약이 실패해 주문이 안 생긴다.
+ * (지연 승인 도입으로 그때도 돈은 빠지지 않지만, 결제창까지 갔다가 실패하는 UX 는 막는 게 낫다.)
  */
 export async function findUnavailableLineItems(
   cart: HttpTypes.StoreCart,
   countryCode: string
-): Promise<{ variantIds: string[]; productNames: string[] }> {
+): Promise<{
+  variantIds: string[]
+  productNames: string[]
+  insufficientVariantIds: string[]
+  insufficientNames: string[]
+}> {
   const items = cart.items ?? []
   const productIds = Array.from(
     new Set(
@@ -125,13 +138,20 @@ export async function findUnavailableLineItems(
     )
   )
 
+  const empty = {
+    variantIds: [],
+    productNames: [],
+    insufficientVariantIds: [],
+    insufficientNames: [],
+  }
+
   if (productIds.length === 0) {
-    return { variantIds: [], productNames: [] }
+    return empty
   }
 
   const region = await getRegion(countryCode)
   if (!region) {
-    return { variantIds: [], productNames: [] }
+    return empty
   }
 
   const headers = {
@@ -179,22 +199,39 @@ export async function findUnavailableLineItems(
     return isVariantSoldOut(variant)
   })
 
-  const variantIds = Array.from(
-    new Set(
-      unavailableItems
-        .map((item) => item.variant_id)
-        .filter((id): id is string => Boolean(id))
-    )
-  )
-  const productNames = Array.from(
-    new Set(
-      unavailableItems
-        .map((item) => item.product_title || item.title || "")
-        .filter(Boolean)
-    )
-  )
+  // 품절은 아니지만 담은 수량이 가용 재고를 넘어선 라인 (담은 뒤 재고가 줄어든 경우).
+  const unavailableSet = new Set(unavailableItems)
+  const insufficientItems = items.filter((item) => {
+    if (unavailableSet.has(item)) return false
+    const variant =
+      (item.variant_id ? variantById.get(item.variant_id) : undefined) ??
+      item.variant
+    return isVariantQuantityUnavailable(variant, item.quantity)
+  })
 
-  return { variantIds, productNames }
+  const toVariantIds = (list: typeof items) =>
+    Array.from(
+      new Set(
+        list
+          .map((item) => item.variant_id)
+          .filter((id): id is string => Boolean(id))
+      )
+    )
+  const toNames = (list: typeof items) =>
+    Array.from(
+      new Set(
+        list
+          .map((item) => item.product_title || item.title || "")
+          .filter(Boolean)
+      )
+    )
+
+  return {
+    variantIds: toVariantIds(unavailableItems),
+    productNames: toNames(unavailableItems),
+    insufficientVariantIds: toVariantIds(insufficientItems),
+    insufficientNames: toNames(insufficientItems),
+  }
 }
 
 export async function getOrSetCart(countryCode: string) {

--- a/web/almondyoung-storefront/src/lib/utils/cart-availability.test.ts
+++ b/web/almondyoung-storefront/src/lib/utils/cart-availability.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import { isVariantQuantityUnavailable, isVariantSoldOut } from "./cart-availability"
+
+// 담기 시점엔 통과했다가 결제 직전에 부족해지는 라인을 가려내는 판정.
+// 품절(isVariantSoldOut)만 보던 기존 게이트는 이 케이스를 통과시켰고, 그대로 결제로 가면
+// cart.complete 의 재고예약이 실패해 주문이 생성되지 않았다.
+describe("isVariantQuantityUnavailable", () => {
+  const tracked = { manage_inventory: true, allow_backorder: false }
+
+  it("담은 수량이 가용재고를 넘으면 불가로 본다", () => {
+    expect(isVariantQuantityUnavailable({ ...tracked, inventory_quantity: 1 }, 2)).toBe(true)
+  })
+
+  it("가용재고와 같은 수량은 구매 가능하다", () => {
+    expect(isVariantQuantityUnavailable({ ...tracked, inventory_quantity: 2 }, 2)).toBe(false)
+  })
+
+  it("품절(재고 0)은 기존 판정과 겹친다", () => {
+    const variant = { ...tracked, inventory_quantity: 0 }
+    expect(isVariantSoldOut(variant)).toBe(true)
+    expect(isVariantQuantityUnavailable(variant, 1)).toBe(true)
+  })
+
+  it("재고관리를 안 하거나 백오더 허용이면 수량 제한이 없다", () => {
+    expect(
+      isVariantQuantityUnavailable({ manage_inventory: false, inventory_quantity: 0 }, 10)
+    ).toBe(false)
+    expect(
+      isVariantQuantityUnavailable(
+        { manage_inventory: true, allow_backorder: true, inventory_quantity: 0 },
+        10
+      )
+    ).toBe(false)
+  })
+
+  it("variant 정보가 없으면 막지 않는다 (조회 실패로 구매를 막지 않기 위함)", () => {
+    expect(isVariantQuantityUnavailable(undefined, 3)).toBe(false)
+    expect(isVariantQuantityUnavailable(null, 3)).toBe(false)
+  })
+})

--- a/web/almondyoung-storefront/src/lib/utils/cart-availability.ts
+++ b/web/almondyoung-storefront/src/lib/utils/cart-availability.ts
@@ -37,6 +37,25 @@ export function extractUnavailableVariantIds(error: unknown): string[] {
  * 어드민 "수동 품절" 은 Medusa 재고를 0 으로 만들므로 이 함수로 잡힌다.
  * (상품은 여전히 published 라 publish 상태 기반 가드로는 안 잡힌다)
  */
+/**
+ * variant 가 품절은 아니지만 요청 수량을 감당하지 못하는지 판단한다.
+ * 담기 시점엔 Medusa 가 "수량 > 가용재고"를 거부하지만, 담은 뒤 다른 주문/재고 조정으로
+ * 재고가 줄면 결제 직전에 이 상태가 된다.
+ */
+export function isVariantQuantityUnavailable(
+  variant?: {
+    manage_inventory?: boolean | null
+    allow_backorder?: boolean | null
+    inventory_quantity?: number | null
+  } | null,
+  quantity?: number | null
+): boolean {
+  if (!variant) return false
+  if (!variant.manage_inventory) return false
+  if (variant.allow_backorder) return false
+  return (quantity ?? 0) > (variant.inventory_quantity ?? 0)
+}
+
 export function isVariantSoldOut(
   variant?: {
     manage_inventory?: boolean | null


### PR DESCRIPTION
## 배경

결제는 됐는데 주문이 없는 고아결제가 계속 나옴

1. 카드/토스는 **capture 가 아니라 approve(`tossApi.confirmPayment`) 에서 돈이 빠진다.** capture 는 토스에선 상태 전이일 뿐이라, auto-capture 를 꺼도 이미 늦는다.
2. approve 는 결제창을 닫자마자 wallet-web 이 호출하고, 스토어프론트가 `cart.complete` 를 부르는 건 그 뒤다.
3. `completeCartWorkflow` 는 `create-order → reserveInventory → authorizePayment` 순서라, 재고가 모자라면 `reserveInventoryStep` 이 throw 하고 주문이 롤백된다. 이때 Medusa payment 행 자체가 없어서 `compensatePaymentIfNeededStep`(captured_at 기준)도 안 돈다 → 보상 환불 없이 고아 확정.

담기 시점 검증은 예약이 아니라 조회라서 경쟁(같은 재고를 둘이 담고 둘 다 결제)과 드리프트(담은 뒤 재고 감소)를 못 막는다.

## 변경

**승인 시점을 주문 생성 이후로 옮겼다.** Medusa 체크아웃 intent 에 `metadata.approvalMode='DEFERRED'` 를 달면, wallet 은 결제창 완료 시 승인하지 않고 승인 파라미터만 charge 에 적재한다. 실제 승인은 `completeCartWorkflow` 의 마지막 단계(`authorizePaymentSessionStep` → `almond-payment.authorizePayment` → wallet `POST /:id/finalize-approval`)에서 일어난다. 재고부족이면 승인에 도달하지 못하고, 적재된 승인은 미승인 상태로 만료된다(돈 안 빠짐).

부수 변경:

- **캡처 결정성**: 승인 직후 도착하는 capture 웹훅이 payment 행 생성보다 빠를 수 있어, `cart.complete` 직후 캡처를 명시 실행하고 훅은 payment 행이 없으면 throw 해 재배달로 재시도한다.
- **카트 미식별 폴백 교체**: 콜백이 checkout cart 를 특정 못 하던 경우 예전엔 capture 웹훅이 주문을 만들어줬는데, 지연 승인에선 카트를 완료해야 승인이 일어나므로 성립하지 않는다. `POST /store/payment-intents/:intentId/complete` 로 intent → session → cart 역추적해 서버사이드 완료.
- **백스톱**: `orphan-payment-reconcile` 잡(매시 17분). 주문 없이 캡처된 결제는 주문 복구 시도 후 자동 환불, 승인만 된 건 취소, 주문 있는데 미캡처면 캡처.
- **결제 전 게이트**: 체크아웃에서 품절뿐 아니라 "담은 수량 > 가용재고" 도 막는다.

`allow_backorder` 는 건드리지 않는다 — 오버셀 금지/품절 구매 불가 그대로.

## 영향 없는 경로

- 무통장: `offline-wait` 이라 toss-approve 를 안 타고, 캡처는 관리자 입금확인 시점 그대로.
- 멤버십/정기결제(INVOICE·CMS): Medusa 세션이 없어 표식이 안 붙으므로 기존 경로.

## 배포 / 롤백

- **순서: wallet 먼저 → Medusa 나중.** wallet 은 표식 있는 intent 만 지연 처리하므로 구버전 Medusa + 신버전 wallet 조합은 기존 동작 그대로다. 반대로 하면 Medusa 가 표식을 다는데 wallet 이 finalize 를 모른다.
- 롤백: Medusa `ALMOND_DEFERRED_APPROVAL=false`.
- 리컨실 자동 환불 끄기: `ORPHAN_RECONCILE_AUTO_REFUND=false` (탐지·로깅만).

## 남는 창

승인 이후(워크플로 마지막 링크/트랜잭션 단계)에서 실패하면 주문은 롤백되는데 돈은 빠진 상태가 된다. 이건 리컨실 잡의 자동 환불이 유일한 회수 경로다(1시간 내).

## 검증

- 유닛: wallet 지연 승인 적재/확정 8케이스, medusa payment-events 14케이스 통과. 기존 실패 2건(cash-receipts, 오래된 integration import)은 이 PR 이전부터 깨져 있던 것.
- 타입체크: wallet 빌드 통과, medusa/storefront tsc 신규 에러 없음.
- **미수행(배포 후 필요)**: 재고 1개 상품으로 ① 단일 초과주문 ② 동시 2주문 ③ 담은 뒤 재고 0으로 낮추고 결제 — 셋 다 돈이 안 빠지거나 즉시 환불되는지 확인.

설계 상세는 `docs/adr/0028-deferred-pg-approval.md`.