### PR TITLE
멤버십 해지 철회 후 약정 오삭제, 만료·재가입 경합으로 인한 자격·할인 유실 차단

### DIFF
--- a/apps/admin-web/e2e/membership-cancel/admin-cancel.spec.ts
+++ b/apps/admin-web/e2e/membership-cancel/admin-cancel.spec.ts
@@ -303,7 +303,33 @@ test.describe(`관리자 해지·환불 UI (${SCENARIO})`, () => {
     expect(call.body.refundReceiveAccount).toMatchObject({ accountNumber: '110123456789', holderName: '홍길동' });
   });
 
-  // 고객관리 상세창(멤버십 탭)은 동일한 MembershipDetailPanel 을 allowAdminActions 기본값(=true)으로
-  // 렌더한다. 그 화면을 브라우저로 검증하려면 customers 페이지와 core API 스택까지 스텁해야 해서
-  // 이 스펙 범위를 넘는다 — 여기서는 멤버십 메뉴 경로만 검증한다.
+  // 고객관리 상세창(회원정보조회)의 멤버십 탭은 같은 MembershipDetailPanel 을 렌더하고 같은 해지·환불
+  // 액션을 쓴다. CS 가 실제로 여기서 처리하므로 이 경로도 브라우저로 확인한다 — 다른 탭(주문·장바구니)이
+  // 쓰는 Medusa/core API 는 스텁에 없어 404 로 떨어지지만, 그건 이 화면의 렌더를 막지 않아야 한다.
+  test('고객관리 상세창의 멤버십 탭도 같은 해지·환불 화면을 연다', async ({ page }) => {
+    test.skip(!['monthly-cms', 'scheduled'].includes(SCENARIO), '대표 시나리오 두 개로만 확인한다');
+
+    await page.goto('/customer-window/e2e-user');
+    await page.getByRole('button', { name: '멤버십', exact: true }).click();
+
+    const panel = page.getByRole('tabpanel');
+    await page.getByRole('tab', { name: '해지 · 환불' }).click();
+    await expect(panel.getByText('현재 플랜')).toBeVisible();
+
+    if (SCENARIO === 'scheduled') {
+      // 해지 예약 배너와 철회 버튼이 멤버십 메뉴와 똑같이 떠야 한다.
+      await expect(panel.getByText('해지 예약됨', { exact: true })).toBeVisible();
+      await expect(panel.getByRole('button', { name: /해지 예약 철회/ })).toBeVisible();
+      // 수동 송금 계좌도 같은 자리에 있어야 CS 가 여기서 환불을 끝낼 수 있다.
+      await expect(panel.getByTestId('manual-refund-account')).toBeVisible();
+      await expect(panel.getByTestId('complete-manual-refund')).toBeVisible();
+    } else {
+      await expect(panel.getByRole('button', { name: '해지 예약하기' })).toBeVisible();
+    }
+
+    // 즉시 해지 다이얼로그(견적 포함)까지 같은 동작이어야 한다.
+    await panel.getByRole('button', { name: '즉시 해지 + 환불 처리' }).click();
+    const modal = page.getByRole('dialog', { name: '즉시 해지 + 환불' });
+    await expect(modal.getByText('정책 기준 환불액')).toBeVisible();
+  });
 });

--- a/apps/channel-adapter/src/adapters/medusa/membership-medusa-sync.service.spec.ts
+++ b/apps/channel-adapter/src/adapters/medusa/membership-medusa-sync.service.spec.ts
@@ -8,6 +8,9 @@ describe('MembershipMedusaSyncService.handleMembershipStatusChanged', () => {
   function createService(params?: {
     byAlmondUserId?: { id: string; email: string } | null;
     byEmail?: { id: string; email: string } | null;
+    /** SSOT 가 이 사용자를 아직 활성으로 보는지 */
+    ssotActive?: boolean;
+    ssotError?: Error;
   }) {
     const medusaClient = {
       findCustomerByAlmondUserId: jest.fn().mockResolvedValue(params?.byAlmondUserId ?? null),
@@ -20,8 +23,17 @@ describe('MembershipMedusaSyncService.handleMembershipStatusChanged', () => {
       issuePromotionsByTrigger: jest.fn().mockResolvedValue(undefined),
     };
     const eventTracking = { trackEffect: jest.fn().mockResolvedValue(undefined) };
-    const service = new MembershipMedusaSyncService(medusaClient as any, eventTracking as any);
-    return { service, medusaClient };
+    const membershipServiceClient = {
+      getActiveUserIds: params?.ssotError
+        ? jest.fn().mockRejectedValue(params.ssotError)
+        : jest.fn().mockResolvedValue(params?.ssotActive ? [USER_ID] : []),
+    };
+    const service = new MembershipMedusaSyncService(
+      medusaClient as any,
+      eventTracking as any,
+      membershipServiceClient as any,
+    );
+    return { service, medusaClient, membershipServiceClient };
   }
 
   const event = (email?: string): MembershipStatusChangedPayload =>
@@ -67,6 +79,50 @@ describe('MembershipMedusaSyncService.handleMembershipStatusChanged', () => {
     );
   });
 
+  // 만료 크론이 대상을 읽은 뒤 재가입하면 EXPIRED 가 뒤늦게 도착한다.
+  it('SSOT 가 여전히 활성이면 그룹에서 빼지 않는다 (재가입·해지철회 뒤 도착한 EXPIRED)', async () => {
+    const { service, medusaClient } = createService({
+      byAlmondUserId: { id: 'cus_1', email: 'a@example.com' },
+      ssotActive: true,
+    });
+
+    const result = await service.handleMembershipStatusChanged({
+      ...event('a@example.com'),
+      status: 'EXPIRED',
+    });
+
+    expect(medusaClient.removeCustomerFromGroup).not.toHaveBeenCalled();
+    expect(result.data.action).toBe('skipped');
+  });
+
+  it('SSOT 가 활성이 아니면 그대로 그룹에서 뺀다', async () => {
+    const { service, medusaClient } = createService({
+      byAlmondUserId: { id: 'cus_1', email: 'a@example.com' },
+      ssotActive: false,
+    });
+
+    await service.handleMembershipStatusChanged({ ...event('a@example.com'), status: 'CANCELLED' });
+
+    expect(medusaClient.removeCustomerFromGroup).toHaveBeenCalledWith('cus_1', GROUP_ID);
+  });
+
+  // 백스톱이 한쪽에만 있다. 잘못 뺀 건은 02:30 전체 정합화가 도로 넣지만, 빼지 못한 건은
+  // 02:00 정합화가 cafe24 연동 회원만 돌아 자체가입자가 영구히 할인을 유지한다.
+  it('SSOT 조회가 실패하면 제거를 그대로 진행한다 (확인이 없던 동작으로 떨어진다)', async () => {
+    const { service, medusaClient } = createService({
+      byAlmondUserId: { id: 'cus_1', email: 'a@example.com' },
+      ssotError: new Error('membership service down'),
+    });
+
+    const result = await service.handleMembershipStatusChanged({
+      ...event('a@example.com'),
+      status: 'EXPIRED',
+    });
+
+    expect(medusaClient.removeCustomerFromGroup).toHaveBeenCalledWith('cus_1', GROUP_ID);
+    expect(result.success).toBe(true);
+  });
+
   it('어느 경로로도 고객을 못 찾으면 throw 해서 inbox 가 재시도하게 한다', async () => {
     const { service } = createService({ byAlmondUserId: null, byEmail: null });
 
@@ -87,7 +143,12 @@ describe('MembershipMedusaSyncService.ensureInMembershipGroup', () => {
       refreshCustomerCartPrices: jest.fn(),
     };
     const eventTracking = { trackEffect: jest.fn().mockResolvedValue(undefined) };
-    const service = new MembershipMedusaSyncService(medusaClient as any, eventTracking as any);
+    const membershipServiceClient = { getActiveUserIds: jest.fn().mockResolvedValue([]) };
+    const service = new MembershipMedusaSyncService(
+      medusaClient as any,
+      eventTracking as any,
+      membershipServiceClient as any,
+    );
     return { service, medusaClient };
   }
 

--- a/apps/channel-adapter/src/adapters/medusa/membership-medusa-sync.service.ts
+++ b/apps/channel-adapter/src/adapters/medusa/membership-medusa-sync.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import type { MembershipStatusChangedPayload } from '@packages/event-contracts/streams/membership.stream';
 import { MedusaClient } from './medusa.client';
 import { EventTrackingService } from '@app/events';
+import { MembershipServiceClient } from '../../services/membership-service.client';
 import type { SyncResult } from '../../types';
 
 @Injectable()
@@ -11,6 +12,7 @@ export class MembershipMedusaSyncService {
   constructor(
     private readonly medusaClient: MedusaClient,
     private readonly eventTrackingService: EventTrackingService,
+    private readonly membershipServiceClient: MembershipServiceClient,
   ) { }
 
   /** 그룹 변경 후 카트 가격 재계산 트리거.즉시 리턴됨. */
@@ -121,6 +123,22 @@ export class MembershipMedusaSyncService {
       }
 
       if (removeStatuses.has(status)) {
+        // 이벤트 도착이 늦는 사이 재가입·해지철회로 자격이 되살아났을 수 있다. 그대로 빼면
+        // 돈 낸 고객이 할인 없는 장바구니를 본다.
+        if (await this.isStillActiveInSsot(userId)) {
+          this.logger.warn(`멤버십 그룹 제거 취소 — SSOT 기준 여전히 활성 (userId=${userId}, status=${status})`);
+          await this.eventTrackingService
+            .trackEffect({
+              resourceType: 'UserMembership',
+              resourceId: userId,
+              action: 'SKIPPED',
+              description: `멤버십 그룹 제거 취소 — SSOT 활성 (userId=${userId}, status=${status})`,
+              eventType: 'MembershipStatusChanged',
+            })
+            .catch((e) => this.logger.warn(`trackEffect 실패: ${e?.message}`));
+          return { success: true, data: { userId, action: 'skipped' } };
+        }
+
         await this.medusaClient.removeCustomerFromGroup(customer.id, membershipGroupId);
         this.refreshCartPricesAfterGroupChange(customer.id, userId);
         await this.eventTrackingService
@@ -150,6 +168,27 @@ export class MembershipMedusaSyncService {
     } catch (error) {
       this.logger.error(`Failed to sync membership group for userId=${userId}`, error.stack);
       throw error;
+    }
+  }
+
+  /**
+   * SSOT(멤버십 서비스) 기준 자격 생존 여부.
+   *
+   * 조회에 실패하면 **제거를 그대로 진행한다**(=이 확인이 없던 동작). 백스톱이 한쪽에만 있기 때문이다.
+   * 잘못 뺀 건은 02:30 전체 활성회원 정합화가 도로 넣어주지만, 빼지 못한 건은 02:00 정합화가
+   * cafe24 연동 회원만 돌아 자체가입자는 아무도 복구하지 않는다.
+   */
+  private async isStillActiveInSsot(userId: string): Promise<boolean> {
+    try {
+      const activeUserIds = await this.membershipServiceClient.getActiveUserIds([userId]);
+      return activeUserIds.includes(userId);
+    } catch (err) {
+      this.logger.warn(
+        `SSOT 자격 조회 실패 — 제거를 그대로 진행한다 (userId=${userId}): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return false;
     }
   }
 

--- a/apps/membership/src/services/admin/admin-members.reader.ts
+++ b/apps/membership/src/services/admin/admin-members.reader.ts
@@ -9,7 +9,10 @@ import { ContractEventManager } from '../subscription/contract-event.manager';
 import { isAxiosError } from 'axios';
 import { randomUUID } from 'crypto';
 import { PaymentClientService } from '../billing/payment-client.service';
-import { SubscriptionContractReader } from '../subscription/subscription-contract.reader';
+import {
+  isAgreementCleanupWithdrawn,
+  SubscriptionContractReader,
+} from '../subscription/subscription-contract.reader';
 
 export interface AdminMembersQuery {
   page?: number;
@@ -1061,10 +1064,12 @@ export class AdminMembersReader {
    * 영원히 그대로다 — 그 사실이 로그에만 있으면 아무도 모른다.
    */
   async findAgreementCleanupQueue(): Promise<AgreementCleanupListResponse> {
-    const states = await this.contractReader.findLatestAgreementEvents({
+    const found = await this.contractReader.findLatestAgreementEvents({
       eventTypes: ['AGREEMENT_REVOKE_PENDING', 'AGREEMENT_REVOKE_DEFERRED', 'AGREEMENT_REVOKE_ABANDONED'],
       limit: 500,
     });
+    // 해지를 철회한 계약은 정리 대상이 아니다(스케줄러가 다음 실행에서 큐를 닫는다).
+    const states = found.filter((s) => !isAgreementCleanupWithdrawn(s));
     if (states.length === 0) return { data: [], total: 0 };
 
     const contracts = await this.dbService.db

--- a/apps/membership/src/services/billing/billing-outcome.handler.ts
+++ b/apps/membership/src/services/billing/billing-outcome.handler.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { DbService } from '@app/db';
 import { membershipSchema } from '../../shared/schemas/entities/schema';
 import * as schema from '../../shared/schemas/entities/schema';
-import { eq, and, count } from 'drizzle-orm';
+import { eq, and, count, isNull, lt } from 'drizzle-orm';
 import { addDays, addHours, format } from 'date-fns';
 import { ContractEventManager } from '../subscription/contract-event.manager';
 import { MembershipEventPublisher } from '../membership-event.publisher';
@@ -49,6 +49,27 @@ export class BillingOutcomeHandler {
         .returning({ id: schema.billingEvents.id });
       if (paymentIntentId && inserted.length === 0) {
         this.logger.log(`handleSuccess: already processed intent (${paymentIntentId}) — skip`);
+        return null;
+      }
+
+      // 종료된 계약에 뒤늦게 도착한 결제 성공. 자격은 사용자 단위라, 그 사이 재가입했으면
+      // 여기서 늘어나는 건 새 구독의 기간이다. 결제 사실만 남기고 자격은 손대지 않는다.
+      if (row.status === 'CANCELLED' || row.status === 'EXPIRED') {
+        this.logger.error(
+          `handleSuccess: 종료된 계약에 결제 성공 도착 — 수동 환불/정산 검토 필요 (contractId=${contractId}, status=${row.status}, intentId=${paymentIntentId ?? '-'}, amount=${amount})`,
+        );
+        await this.contractEventManager.addEvent(
+          tx,
+          contractId,
+          'BILLING_SUCCESS_AFTER_TERMINATION',
+          { amount, intentId: paymentIntentId ?? null, status: row.status },
+          'SYSTEM',
+          row.userId,
+        );
+        await tx
+          .update(schema.subscriptionContracts)
+          .set({ billingInProgress: false, billingStartedAt: null, updatedAt: new Date() })
+          .where(eq(schema.subscriptionContracts.id, contractId));
         return null;
       }
 
@@ -267,7 +288,31 @@ export class BillingOutcomeHandler {
   }
 
   async handleExpiration(entitlementId: string, userId: string, contractId: string): Promise<void> {
-    await this.dbService.db.transaction(async (tx) => {
+    // 크론이 목록을 읽은 뒤 자격이 갈아치워질 수 있다(해지 철회·재가입·갱신 결제·기간 연장).
+    // 무조건 EXPIRED 를 찍으면 되살아난 고객이 만료되고 그 이벤트가 Medusa 그룹까지 벗긴다.
+    const expired = await this.dbService.db.transaction(async (tx) => {
+      // 아직 만료 대상인 자격만 조건부로 닫는다. 건너뛴 실행은 아무것도 쓰지 않는다.
+      const closed = await tx
+        .update(schema.subscriptionEntitlement)
+        .set({ isCurrent: false, closedAt: new Date() })
+        .where(
+          and(
+            eq(schema.subscriptionEntitlement.id, entitlementId),
+            eq(schema.subscriptionEntitlement.isCurrent, true),
+            // 정지 중에는 종료일이 동결된다 — 지나 보여도 만료 대상이 아니다.
+            isNull(schema.subscriptionEntitlement.pausedAt),
+            lt(schema.subscriptionEntitlement.endsAt, format(new Date(), 'yyyy-MM-dd')),
+          ),
+        )
+        .returning({ id: schema.subscriptionEntitlement.id });
+
+      if (closed.length === 0) {
+        this.logger.log(
+          `handleExpiration: 자격이 이미 교체·연장됨 — 만료 처리 생략 (entitlementId=${entitlementId}, contractId=${contractId})`,
+        );
+        return false;
+      }
+
       const [batch] = await tx
         .insert(schema.eventBatches)
         .values({ type: 'SUBSCRIPTION_EXPIRED', effectiveDate: format(new Date(), 'yyyy-MM-dd') })
@@ -275,7 +320,7 @@ export class BillingOutcomeHandler {
 
       await tx
         .update(schema.subscriptionEntitlement)
-        .set({ isCurrent: false, closedAt: new Date(), closedBatchId: batch.id })
+        .set({ closedBatchId: batch.id })
         .where(eq(schema.subscriptionEntitlement.id, entitlementId));
 
       await tx
@@ -292,7 +337,10 @@ export class BillingOutcomeHandler {
         userId,
         batch.id,
       );
+      return true;
     });
+
+    if (!expired) return;
 
     this.membershipEventPublisher
       .publishStatusChanged({ userId, status: 'EXPIRED', occurredAt: new Date().toISOString(), contractId })
@@ -485,6 +533,7 @@ export class BillingOutcomeHandler {
     const [row] = await tx
       .select({
         userId: schema.subscriptionContracts.userId,
+        status: schema.subscriptionContracts.status,
         durationDays: schema.plan.durationDays,
       })
       .from(schema.subscriptionContracts)

--- a/apps/membership/src/services/subscription-cancellation.service.ts
+++ b/apps/membership/src/services/subscription-cancellation.service.ts
@@ -788,7 +788,16 @@ export class SubscriptionCancellationService {
           `자동이체 약정 미종료 (contractId=${contractId}, reason=${result.skipReason ?? 'UNKNOWN'})`,
         );
         await this.cancellationManager.markAgreementRevokePending(contractId, userId);
+        return;
       }
+      // 앞서 남은 보류/재시도 기록을 닫는다(해지예약 → 즉시해지). 닫지 않으면 이미 끝난 건이
+      // 관리자 정리 큐에 계속 남는다.
+      await this.closeOpenAgreementCleanup(contractId, userId, {
+        agreementFound: result.agreementFound,
+        mandateTerminated: result.mandateTerminated,
+        cancelledWithdrawals: result.cancelledWithdrawals,
+        skipReason: result.skipReason ?? null,
+      });
     } catch (err) {
       this.logger.error(
         `자동이체 약정 종료 실패 — 자동청구는 DB 플래그로 차단됨, 약정 정리는 재시도 필요 (contractId=${contractId}): ${
@@ -797,6 +806,28 @@ export class SubscriptionCancellationService {
         err instanceof Error ? err.stack : undefined,
       );
       await this.cancellationManager.markAgreementRevokePending(contractId, userId);
+    }
+  }
+
+  /**
+   * 열려 있는 정리 기록만 닫는다. 정리할 것이 없던 계약(1회 결제 등)까지 남기면 계약 로그가
+   * 의미 없는 줄로 채워진다. 기록 실패는 삼킨다 — 약정 종료 자체는 이미 끝났다.
+   */
+  private async closeOpenAgreementCleanup(
+    contractId: string,
+    userId: string,
+    metadata: Record<string, unknown>,
+  ): Promise<void> {
+    try {
+      const latest = await this.contractReader.findLatestAgreementEventType(contractId);
+      if (latest !== 'AGREEMENT_REVOKE_PENDING' && latest !== 'AGREEMENT_REVOKE_DEFERRED') return;
+      await this.cancellationManager.markAgreementRevoked(contractId, userId, metadata);
+    } catch (err) {
+      this.logger.warn(
+        `약정 정리 완료 기록 실패 (contractId=${contractId}): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
     }
   }
 }

--- a/apps/membership/src/services/subscription/agreement-cleanup.service.ts
+++ b/apps/membership/src/services/subscription/agreement-cleanup.service.ts
@@ -5,7 +5,14 @@ import { format, subDays } from 'date-fns';
 import { membershipSchema } from '../../shared/schemas/entities/schema';
 import { PaymentClientService } from '../billing/payment-client.service';
 import { ContractEventManager } from './contract-event.manager';
-import { SubscriptionContractReader } from './subscription-contract.reader';
+import {
+  AgreementEventState,
+  isAgreementCleanupWithdrawn,
+  isCleanupWithdrawnBy,
+  SubscriptionContractReader,
+} from './subscription-contract.reader';
+
+type CleanupItem = { contractId: string; userId: string; pendingSince: Date; withdrawn: boolean };
 
 /** 한 번에 처리할 최대 건수. 남은 건은 다음 실행이 이어받는다(스케줄러가 오래 물고 있지 않게). */
 const BATCH_SIZE = 50;
@@ -53,7 +60,7 @@ export class AgreementCleanupService {
    * 계약별 최신 약정 관련 이벤트가 `AGREEMENT_REVOKE_PENDING`/`_DEFERRED` 인 건만 고른다 —
    * 그 뒤에 성공(REVOKED)/포기(ABANDONED) 이벤트가 붙으면 자연히 목록에서 빠진다.
    */
-  private async findPending(): Promise<{ contractId: string; userId: string; pendingSince: Date }[]> {
+  private async findPending(): Promise<CleanupItem[]> {
     // 보류(DEFERRED) 건은 아직 처리 대상이 아니라도 목록을 차지한다. 배치 상한을 그 필터 **뒤**에
     // 적용하려면 넉넉히 읽어야 한다 — 안 그러면 보류 건이 쌓였을 때 정작 재시도해야 할 PENDING 이
     // 상한에 밀려 영영 실행되지 않는다(조용한 굶주림).
@@ -67,17 +74,13 @@ export class AgreementCleanupService {
     // 종료일이 지난 뒤에야 정리 대상이 된다.
     const due = rows
       .filter((r) => {
+        // 해지를 철회한 계약은 보류 기한과 무관하게 즉시 닫는다(기한을 기다리면 살아있는 약정을 지운다).
+        if (isAgreementCleanupWithdrawn(r)) return true;
         if (r.eventType !== 'AGREEMENT_REVOKE_DEFERRED') return true;
         const notBefore = (r.metadata as { notBefore?: string }).notBefore;
         return !notBefore || notBefore < today;
       })
-      .map((r) => ({
-        contractId: r.contractId,
-        userId: r.userId,
-        // 포기(ABANDONED) 시계는 '재시도가 가능해진 시점'부터 센다. 보류 기록 시각부터 세면
-        // 이용 기간이 긴 계약은 첫 재시도 실패에 곧바로 포기 처리된다.
-        pendingSince: this.retryableSince(r.since, r.metadata),
-      }));
+      .map((r) => this.toItem(r));
 
     // 잘라낸 건을 조용히 버리지 않는다 — "0건 남음" 으로 읽히면 아무도 다음 실행을 기다리지 않는다.
     if (due.length > BATCH_SIZE) {
@@ -88,6 +91,17 @@ export class AgreementCleanupService {
     return due.slice(0, BATCH_SIZE);
   }
 
+  private toItem(state: AgreementEventState): CleanupItem {
+    return {
+      contractId: state.contractId,
+      userId: state.userId,
+      // 포기(ABANDONED) 시계는 '재시도가 가능해진 시점'부터 센다. 보류 기록 시각부터 세면
+      // 이용 기간이 긴 계약은 첫 재시도 실패에 곧바로 포기 처리된다.
+      pendingSince: this.retryableSince(state.since, state.metadata),
+      withdrawn: isAgreementCleanupWithdrawn(state),
+    };
+  }
+
   private retryableSince(createdAt: Date, metadata: unknown): Date {
     const notBefore = ((metadata ?? {}) as { notBefore?: string }).notBefore;
     if (!notBefore) return createdAt;
@@ -95,7 +109,16 @@ export class AgreementCleanupService {
     return Number.isNaN(eligibleAt.getTime()) || eligibleAt < createdAt ? createdAt : eligibleAt;
   }
 
-  private async retryOne(item: { contractId: string; userId: string; pendingSince: Date }): Promise<void> {
+  private async retryOne(item: CleanupItem): Promise<void> {
+    // 되살아난 정기결제의 약정은 지우면 안 된다. wallet 을 부르지 않고 큐에서만 닫는다.
+    // 목록을 읽은 시점의 판정만 믿으면 그 사이 들어온 철회를 놓치므로, 지우기 직전에 다시 본다.
+    const withdrawn = item.withdrawn || isCleanupWithdrawnBy(await this.contractReader.findById(item.contractId));
+    if (withdrawn) {
+      await this.record(item, 'AGREEMENT_REVOKE_UNDONE', { reason: 'CANCELLATION_WITHDRAWN' });
+      this.logger.log(`해지 철회로 약정 정리 취소 (contractId=${item.contractId})`);
+      return;
+    }
+
     try {
       const result = await this.paymentClientService.terminateBillingMandate(item.contractId);
 
@@ -131,10 +154,7 @@ export class AgreementCleanupService {
    * 효성 삭제 가드처럼 재시도로 풀리지 않는 실패가 있어서, 계속 두면 매시간 같은 실패만 반복하며
    * 로그를 채우고 실제로는 아무도 처리하지 않는다.
    */
-  private async escalateIfStale(
-    item: { contractId: string; userId: string; pendingSince: Date },
-    reason: string,
-  ): Promise<void> {
+  private async escalateIfStale(item: CleanupItem, reason: string): Promise<void> {
     if (item.pendingSince > subDays(new Date(), ESCALATE_AFTER_DAYS)) return;
 
     await this.record(item, 'AGREEMENT_REVOKE_ABANDONED', { reason, pendingSince: item.pendingSince.toISOString() });
@@ -145,7 +165,7 @@ export class AgreementCleanupService {
 
   private async record(
     item: { contractId: string; userId: string },
-    eventType: 'AGREEMENT_REVOKED' | 'AGREEMENT_REVOKE_ABANDONED',
+    eventType: 'AGREEMENT_REVOKED' | 'AGREEMENT_REVOKE_ABANDONED' | 'AGREEMENT_REVOKE_UNDONE',
     metadata: Record<string, unknown>,
   ): Promise<void> {
     await this.dbService.db.transaction(async (tx) => {

--- a/apps/membership/src/services/subscription/subscription-cancellation.manager.ts
+++ b/apps/membership/src/services/subscription/subscription-cancellation.manager.ts
@@ -376,6 +376,16 @@ export class SubscriptionCancellationManager {
   }
 
   /**
+   * 약정 종료가 끝났음을 남긴다. 앞서 남긴 보류/재시도 기록(`_DEFERRED`/`_PENDING`)을 닫는 용도다 —
+   * 남기지 않으면 이미 끝난 건이 정리 큐에 계속 잡힌다.
+   */
+  async markAgreementRevoked(contractId: string, userId: string, metadata: Record<string, unknown>): Promise<void> {
+    await this.dbService.db.transaction(async (tx) => {
+      await this.contractEventManager.addEvent(tx, contractId, 'AGREEMENT_REVOKED', metadata, 'SYSTEM', userId);
+    });
+  }
+
+  /**
    * 약정 종료를 **미룬** 사실을 남긴다 (INVOICE 경로 해지예약: 남은 수금이 끝나야 지울 수 있다).
    *
    * 남기지 않으면 그 주기에 인보이스 이벤트가 더 오지 않는 계약(이미 수금이 끝난 주기에 해지한 경우)

--- a/apps/membership/src/services/subscription/subscription-contract.reader.ts
+++ b/apps/membership/src/services/subscription/subscription-contract.reader.ts
@@ -9,13 +9,15 @@ type Plan = typeof schema.plan.$inferSelect;
 
 /**
  * 자동이체 약정 정리의 상태 축.
- * PENDING(재시도 대기) · DEFERRED(수금 끝날 때까지 보류) · REVOKED(끝남) · ABANDONED(7일 초과, 사람이 처리).
+ * PENDING(재시도 대기) · DEFERRED(수금 끝날 때까지 보류) · REVOKED(끝남) · ABANDONED(7일 초과, 사람이 처리) ·
+ * UNDONE(해지 철회로 정리 지시 자체가 사라짐).
  */
 export const AGREEMENT_EVENT_TYPES = [
   'AGREEMENT_REVOKE_PENDING',
   'AGREEMENT_REVOKE_DEFERRED',
   'AGREEMENT_REVOKED',
   'AGREEMENT_REVOKE_ABANDONED',
+  'AGREEMENT_REVOKE_UNDONE',
 ] as const;
 
 export type AgreementEventType = (typeof AGREEMENT_EVENT_TYPES)[number];
@@ -26,6 +28,26 @@ export interface AgreementEventState {
   eventType: AgreementEventType;
   metadata: Record<string, unknown>;
   since: Date;
+  /** 계약의 현재 상태. 아직 해지 중인 계약인지 봐야 정리 대상을 가릴 수 있다. */
+  contract: { status: string; autoRenewal: boolean; recurringCancelledAt: Date | null } | null;
+}
+
+/**
+ * 정리 지시가 철회된 계약인지.
+ *
+ * 해지 철회는 wallet 약정을 새로 만들지만 해지 때 남긴 `_PENDING`/`_DEFERRED` 는 그대로 남는다.
+ * 두면 정리 스케줄러가 살아있는 약정을 지우고, 다음 청구가 BILLING_AGREEMENT_NOT_FOUND 로 실패해
+ * 그대로 해지된다.
+ */
+export function isCleanupWithdrawnBy(
+  contract: { status: string; autoRenewal: boolean | null; recurringCancelledAt: Date | null } | null,
+): boolean {
+  if (!contract) return false;
+  return contract.status === 'ACTIVE' && contract.autoRenewal === true && contract.recurringCancelledAt === null;
+}
+
+export function isAgreementCleanupWithdrawn(state: AgreementEventState): boolean {
+  return isCleanupWithdrawnBy(state.contract);
 }
 
 @Injectable()
@@ -319,8 +341,12 @@ export class SubscriptionContractReader {
         eventType: latest.eventType,
         metadata: latest.metadata,
         since: latest.createdAt,
+        status: schema.subscriptionContracts.status,
+        autoRenewal: schema.subscriptionContracts.autoRenewal,
+        recurringCancelledAt: schema.subscriptionContracts.recurringCancelledAt,
       })
       .from(latest)
+      .leftJoin(schema.subscriptionContracts, eq(schema.subscriptionContracts.id, latest.contractId))
       .where(inArray(latest.eventType, params.eventTypes))
       .orderBy(latest.createdAt)
       .limit(params.limit);
@@ -331,7 +357,28 @@ export class SubscriptionContractReader {
       eventType: r.eventType as AgreementEventType,
       metadata: (r.metadata ?? {}) as Record<string, unknown>,
       since: r.since,
+      contract:
+        r.status === null
+          ? null
+          : { status: r.status, autoRenewal: r.autoRenewal === true, recurringCancelledAt: r.recurringCancelledAt },
     }));
+  }
+
+  /** 이 계약의 최신 약정 정리 이벤트 종류. 정리 지시가 아직 열려 있는지 판단하는 용도. */
+  async findLatestAgreementEventType(contractId: string): Promise<AgreementEventType | null> {
+    const [event] = await this.dbService.db
+      .select({ eventType: schema.subscriptionContractEvents.eventType })
+      .from(schema.subscriptionContractEvents)
+      .where(
+        and(
+          eq(schema.subscriptionContractEvents.contractId, contractId),
+          inArray(schema.subscriptionContractEvents.eventType, AGREEMENT_EVENT_TYPES),
+        ),
+      )
+      .orderBy(desc(schema.subscriptionContractEvents.createdAt), desc(schema.subscriptionContractEvents.id))
+      .limit(1);
+
+    return (event?.eventType as AgreementEventType) ?? null;
   }
 
   /**

--- a/apps/membership/test/integration/cancellation-e2e.integration.spec.ts
+++ b/apps/membership/test/integration/cancellation-e2e.integration.spec.ts
@@ -35,6 +35,7 @@ import { InvoiceBillingManager } from '../../src/services/billing/invoice-billin
 import { AdminMembersReader } from '../../src/services/admin/admin-members.reader';
 import { RefundEventHandler } from '../../src/services/refund-event-handler.service';
 import { AgreementCleanupService } from '../../src/services/subscription/agreement-cleanup.service';
+import { BillingOutcomeHandler } from '../../src/services/billing/billing-outcome.handler';
 
 type MembershipSchema = typeof membershipSchema;
 
@@ -54,6 +55,7 @@ describeE2E('멤버십 해지·환불 E2E', () => {
   let adminReader: AdminMembersReader;
   let refundEventHandler: RefundEventHandler;
   let agreementCleanup: AgreementCleanupService;
+  let billingOutcome: BillingOutcomeHandler;
 
   let tierId: string;
   let monthlyPlanId: string;
@@ -96,6 +98,7 @@ describeE2E('멤버십 해지·환불 E2E', () => {
         AdminMembersReader,
         RefundEventHandler,
         AgreementCleanupService,
+        BillingOutcomeHandler,
         { provide: PaymentClientService, useValue: wallet },
         { provide: MembershipEventPublisher, useValue: events },
         { provide: InvoiceBillingManager, useValue: invoices },
@@ -108,6 +111,7 @@ describeE2E('멤버십 해지·환불 E2E', () => {
     adminReader = module.get(AdminMembersReader);
     refundEventHandler = module.get(RefundEventHandler);
     agreementCleanup = module.get(AgreementCleanupService);
+    billingOutcome = module.get(BillingOutcomeHandler);
 
     // 같은 DB 를 쓰는 다른 스펙이 남긴 tier/plan 을 먼저 치운다 — tiers.code 가 유니크라
     // 남아 있으면 삽입이 깨지고, 실행 순서에 따라 결과가 달라진다(flaky).
@@ -1028,6 +1032,95 @@ describeE2E('멤버십 해지·환불 E2E', () => {
       expect(byContract.get(deferredCase.contract.id)?.notBefore).toBe(deferredCase.endsAt);
     });
 
+    // 해지 철회는 wallet 자동이체 약정을 새로 만들어 정기결제를 되살린다. 그런데 해지 때 남긴
+    // 보류 기록은 그대로라, 이용 종료일이 지나면 정리 스케줄러가 **살아있는 약정을 지운다.**
+    // 다음 청구가 BILLING_AGREEMENT_NOT_FOUND 로 실패해 그대로 해지되므로, 계속 쓰겠다고 한
+    // 고객이 멤버십을 잃는다.
+    it('해지를 철회한 계약의 약정은 지우지 않고 큐에서 닫는다', async () => {
+      const { userId, contract } = await givenSubscription({ daysSincePeriodStart: 10, billingPath: 'INVOICE' });
+      await service.cancelSubscription(userId, EMAIL, { reasonCode: 'NOT_USING', cancelType: 'AT_PERIOD_END' });
+      expect(await loadEventTypes(contract.id)).toContain('AGREEMENT_REVOKE_DEFERRED');
+
+      await service.undoCancellation(userId, EMAIL);
+
+      // 보류 기한이 지나도(이용 종료일 경과) 살아있는 정기결제의 약정을 건드리면 안 된다.
+      await db.db
+        .update(schema.subscriptionContractEvents)
+        .set({ metadata: { notBefore: format(subDays(new Date(), 1), 'yyyy-MM-dd') } })
+        .where(
+          and(
+            eq(schema.subscriptionContractEvents.contractId, contract.id),
+            eq(schema.subscriptionContractEvents.eventType, 'AGREEMENT_REVOKE_DEFERRED'),
+          ),
+        );
+      wallet.terminateBillingMandate.mockClear();
+
+      await agreementCleanup.retryPendingAgreementRevokes();
+
+      expect(wallet.terminateBillingMandate).not.toHaveBeenCalled();
+      expect(await loadEventTypes(contract.id)).toContain('AGREEMENT_REVOKE_UNDONE');
+      // 큐가 스스로 비워져야 관리자가 '처리 필요' 로 보지 않는다.
+      const queue = await adminReader.findAgreementCleanupQueue();
+      expect(queue.data.some((row) => row.contractId === contract.id)).toBe(false);
+    });
+
+    // 목록을 읽은 뒤 wallet 을 부르기 전에 철회가 들어오는 창. 읽은 시점 판정만 믿으면 그 사이
+    // 되살아난 약정을 지운다.
+    it('배치가 도는 중에 철회가 들어와도 약정을 지우지 않는다', async () => {
+      wallet.terminateBillingMandate.mockRejectedValueOnce(new Error('wallet down'));
+      const { userId, contract } = await givenSubscription({ daysSincePeriodStart: 10 });
+      await service.cancelSubscription(userId, EMAIL, { reasonCode: 'NOT_USING', cancelType: 'AT_PERIOD_END' });
+      wallet.terminateBillingMandate.mockClear();
+
+      // 목록을 읽은 **뒤** 철회가 커밋되는 인터리빙. 읽은 시점 판정만 믿으면 여기서 걸러지지 않는다.
+      const reader = module.get(SubscriptionContractReader);
+      const readLatest = reader.findLatestAgreementEvents.bind(reader);
+      const spy = jest
+        .spyOn(reader, 'findLatestAgreementEvents')
+        .mockImplementation(async (params) => {
+          const rows = await readLatest(params);
+          await service.undoCancellation(userId, EMAIL);
+          return rows;
+        });
+
+      try {
+        await agreementCleanup.retryPendingAgreementRevokes();
+      } finally {
+        spy.mockRestore();
+      }
+
+      expect(wallet.terminateBillingMandate).not.toHaveBeenCalled();
+      expect(await loadEventTypes(contract.id)).toContain('AGREEMENT_REVOKE_UNDONE');
+      expect((await loadContract(contract.id)).autoRenewal).toBe(true);
+    });
+
+    it('해지를 철회한 계약은 정리가 끝나기 전에도 관리자 목록에 뜨지 않는다', async () => {
+      wallet.terminateBillingMandate.mockRejectedValueOnce(new Error('wallet down'));
+      const { userId, contract } = await givenSubscription({ daysSincePeriodStart: 10 });
+      await service.cancelSubscription(userId, EMAIL, { reasonCode: 'NOT_USING', cancelType: 'AT_PERIOD_END' });
+      expect((await adminReader.findAgreementCleanupQueue()).data.some((r) => r.contractId === contract.id)).toBe(true);
+
+      await service.undoCancellation(userId, EMAIL);
+
+      const queue = await adminReader.findAgreementCleanupQueue();
+      expect(queue.data.some((row) => row.contractId === contract.id)).toBe(false);
+    });
+
+    // 해지예약(INVOICE)은 보류 기록을 남긴다. 그 뒤 즉시해지로 약정이 실제로 종료되면 그 사실을
+    // 남겨야 큐가 비워진다 — 남기지 않으면 이미 끝난 건이 '처리 필요' 로 계속 떠 있는다.
+    it('해지예약 뒤 즉시해지로 약정이 끝나면 보류 기록이 닫힌다', async () => {
+      const { userId, contract } = await givenSubscription({ daysSincePeriodStart: 2, billingPath: 'INVOICE' });
+      await service.cancelSubscription(userId, EMAIL, { reasonCode: 'NOT_USING', cancelType: 'AT_PERIOD_END' });
+      expect((await adminReader.findAgreementCleanupQueue()).data.some((r) => r.contractId === contract.id)).toBe(true);
+
+      await service.cancelSubscription(userId, EMAIL, { reasonCode: 'NOT_USING', cancelType: 'IMMEDIATE_REFUND' });
+
+      expect(wallet.terminateBillingMandate).toHaveBeenCalledWith(contract.id);
+      expect(await loadEventTypes(contract.id)).toContain('AGREEMENT_REVOKED');
+      const queue = await adminReader.findAgreementCleanupQueue();
+      expect(queue.data.some((row) => row.contractId === contract.id)).toBe(false);
+    });
+
     it('정리가 끝난 약정은 관리자 목록에서 빠진다', async () => {
       wallet.terminateBillingMandate.mockResolvedValue({
         agreementFound: true,
@@ -1805,6 +1898,100 @@ describeE2E('멤버십 해지·환불 E2E', () => {
 
       expect((await adminReader.findDetailByUserId(oneTime.userId))?.canUndoCancellation).toBe(false);
       expect((await adminReader.findDetailByUserId(recurring.userId))?.canUndoCancellation).toBe(true);
+    });
+  });
+
+  // 해지·만료와 재가입은 같은 사용자에게서 겹칠 수 있다. 자격(entitlement)은 계약이 아니라 사용자
+  // 단위라, 끝난 계약의 뒤늦은 처리가 **새 구독의 자격**을 건드릴 수 있다.
+  describe('종료된 계약의 뒤늦은 처리 — 재가입과의 경합', () => {
+    /** 이미 끝난 계약과, 그 뒤 재가입해 살아있는 자격을 함께 만든다. */
+    async function givenTerminatedThenResubscribed(status: 'CANCELLED' | 'EXPIRED') {
+      const { userId, contract } = await givenSubscription({ daysSincePeriodStart: 10 });
+      await db.db
+        .update(schema.subscriptionContracts)
+        .set({ status, autoRenewal: false, nextBillingDate: null })
+        .where(eq(schema.subscriptionContracts.id, contract.id));
+      await db.db
+        .update(schema.subscriptionEntitlement)
+        .set({ isCurrent: false, closedAt: new Date() })
+        .where(eq(schema.subscriptionEntitlement.userId, userId));
+
+      // 재가입 — 새 계약과 새 자격.
+      const newEndsAt = format(addDays(new Date(), 30), 'yyyy-MM-dd');
+      const [newContract] = await db.db
+        .insert(schema.subscriptionContracts)
+        .values({
+          userId,
+          planId: monthlyPlanId,
+          billingDate: format(new Date(), 'yyyy-MM-dd'),
+          nextBillingDate: newEndsAt,
+          autoRenewal: true,
+          status: 'ACTIVE',
+          billingPath: 'CHARGE',
+          lastPaymentIntentId: 'intent_new',
+        })
+        .returning();
+      await db.db.insert(schema.subscriptionEntitlement).values({
+        userId,
+        tierId,
+        startsAt: format(new Date(), 'yyyy-MM-dd'),
+        endsAt: newEndsAt,
+        isCurrent: true,
+      });
+
+      return { userId, oldContract: contract, newContract, newEndsAt };
+    }
+
+    it('해지된 계약에 뒤늦게 도착한 결제 성공이 재가입 자격을 늘리지 않는다', async () => {
+      const { userId, oldContract, newEndsAt } = await givenTerminatedThenResubscribed('CANCELLED');
+
+      await billingOutcome.handleSuccess(oldContract.id, MONTHLY_PRICE, 'intent_late');
+
+      // 자격은 새 구독의 것이다 — 옛 계약의 결제로 늘어나면 안 낸 돈만큼 공짜 기간이 생긴다.
+      expect((await loadCurrentEntitlement(userId)).endsAt).toBe(newEndsAt);
+      // 사실은 남긴다 — 수동 환불/정산 검토 대상이다.
+      expect(await loadEventTypes(oldContract.id)).toContain('BILLING_SUCCESS_AFTER_TERMINATION');
+      expect((await loadContract(oldContract.id)).status).toBe('CANCELLED');
+    });
+
+    // 만료 크론은 대상을 먼저 읽고 나중에 처리한다. 그 사이 자격이 갈아치워지면(재가입·해지철회·갱신)
+    // 무조건 만료 처리하는 순간 방금 결제한 고객이 EXPIRED 로 떨어지고, 그 이벤트가 Medusa 할인
+    // 그룹까지 벗긴다.
+    it('만료 처리 전에 자격이 교체됐으면 만료시키지 않는다 (재가입 직후 도착한 만료 처리)', async () => {
+      const { userId, oldContract, newContract, newEndsAt } = await givenTerminatedThenResubscribed('EXPIRED');
+      const staleEntitlementId = (
+        await db.db
+          .select({ id: schema.subscriptionEntitlement.id })
+          .from(schema.subscriptionEntitlement)
+          .where(
+            and(
+              eq(schema.subscriptionEntitlement.userId, userId),
+              eq(schema.subscriptionEntitlement.isCurrent, false),
+            ),
+          )
+      )[0].id;
+      events.publishStatusChanged.mockClear();
+
+      await billingOutcome.handleExpiration(staleEntitlementId, userId, newContract.id);
+
+      // 새 계약은 그대로 살아 있어야 하고, EXPIRED 이벤트도 나가면 안 된다(그룹 제거로 이어진다).
+      expect((await loadContract(newContract.id)).status).toBe('ACTIVE');
+      expect((await loadCurrentEntitlement(userId)).endsAt).toBe(newEndsAt);
+      expect(events.publishStatusChanged).not.toHaveBeenCalled();
+      expect(await loadEventTypes(newContract.id)).not.toContain('EXPIRED');
+      expect(oldContract.id).toBeTruthy();
+    });
+
+    it('정상 만료는 그대로 처리된다 (가드가 과하게 걸리지 않는지)', async () => {
+      const { userId, contract } = await givenSubscription({ daysSincePeriodStart: 40, recurring: false });
+      const entitlement = await loadCurrentEntitlement(userId);
+      events.publishStatusChanged.mockClear();
+
+      await billingOutcome.handleExpiration(entitlement.id, userId, contract.id);
+
+      expect((await loadContract(contract.id)).status).toBe('EXPIRED');
+      expect(await loadCurrentEntitlement(userId)).toBeUndefined();
+      expect(events.publishStatusChanged).toHaveBeenCalled();
     });
   });
 

--- a/docs/membership-cancellation-refund.md
+++ b/docs/membership-cancellation-refund.md
@@ -63,6 +63,12 @@ CMS 는 환불이 불가하므로, 돈을 되돌리는 방법은 두 가지뿐�
   2026-07-08 `f1821f213`)과 무통장 전용(`MEMBERSHIP_REQUIRES_BANK_TRANSFER`, 2026-07-14 `643e66d11`).
   라이브의 POINTS(~07-07)·TOSS(~07-15) charge 는 **전부 가드 도입 이전 데이터**고, 이후로는 0건이다.
   다만 그 이전 결제로 만들어진 계약은 지금도 살아 있으므로 **환불 상한·복합 환불 분기는 유지해야 한다**.
+- **`directCharge`(`POST /v1/direct-billing-charges`)에는 그 가드가 없지만 도달할 수 없다.** 이 경로는
+  `subscribe-with-method` 의 `one_time` 분기만 쓰는데, 라이브 실측(2026-08-04)에서
+  이 경로로 만들어진 payment intent 가 **0건**이고 MEMBERSHIP_FEE intent 915건은 전부 checkout 경로다.
+  `billing_methods` 도 **CMS_BATCH 뿐**(ACTIVE 73)이라 `one_time` 으로 가면 기존
+  `direct-billing-charge.service.ts:54` 의 CMS_BATCH 거부에 먼저 걸린다. 다른 provider 의 billing method 가
+  생기기 전까지는 가드를 더 얹을 실익이 없다 — 생기면 그때 `ConfirmService` 와 같은 판정을 넣는다.
 - 금액이 다른 환불 1건은 정책상의 '부분 보상'이 아니라 **복합결제에서 PG분만 환불**한 건이다
   (포인트 898원은 포인트 원장에서 별도로 처리된다). 그래도 "환불 이벤트 = 구독 취소" 가 성립하지
   않는다는 결론은 같다 — 그 판단은 wallet 의 누적 환불액으로 해야 한다(§8).
@@ -461,6 +467,29 @@ CMS 는 자동환불이 안 돼 관리자가 수동 송금을 승인해야만 �
 **재청구는 세 겹으로 막힌다**: `autoRenewal=false` + `nextBillingDate=null` + dunning 삭제.
 `findDueContracts` 가 어떤 해지 경로로도 그 계약을 다시 집지 않는다(E2E 로 검증).
 
+### Medusa 고객 그룹 — 뺄 때는 SSOT 를 다시 본다
+
+`MembershipStatusChanged(CANCELLED|EXPIRED)` 는 Medusa 멤버십 그룹에서 고객을 뺀다. 그런데 이 이벤트는
+**발행 시점의 사실**이고 도착까지 시간이 걸린다(Inbox 재시도·발행 지연). 그 사이 고객이 재가입하거나
+해지를 철회했으면 그 제거는 **돈 낸 고객의 할인을 뺏는다.** 만료 크론이 대상을 읽은 뒤 고객이 재가입하는
+창이 대표적이다.
+
+그래서 제거 직전에 SSOT(멤버십 서비스 `/internal/memberships/active`)에 현재 자격을 되묻고, 살아 있으면
+빼지 않는다. 판정 기준은 일일 정합화 크론이 쓰던 것과 같다(현재 자격 + 미만료 + 미정지).
+
+**조회가 실패하면 제거를 그대로 진행한다**(=이 확인이 없던 동작). 백스톱이 한쪽에만 있기 때문이다 —
+잘못 뺀 건은 02:30 전체 활성회원 정합화가 도로 넣어주지만, 빼지 못한 건은 02:00 정합화가 cafe24 연동
+회원만 돌아 자체가입자는 아무도 복구하지 않는다.
+
+**만료 처리 자체도 조건부다.** 크론이 목록을 읽은 뒤 자격이 갈아치워질 수 있어(해지 철회·재가입·갱신
+결제·기간 연장), `handleExpiration` 은 아직 만료 대상인 자격만 조건부로 닫고 실제로 닫은 경우에만 계약을
+EXPIRED 로 바꾸고 이벤트를 발행한다. 건너뛴 실행은 아무것도 쓰지 않는다.
+
+**종료된 계약에 뒤늦게 도착한 결제 성공도 자격을 건드리지 않는다.** 자격은 계약이 아니라 사용자 단위라,
+그 사이 재가입했으면 옛 계약의 결제로 **새 구독의 기간이 늘어난다.** CHARGE 경로(`handleSuccess`)도
+INVOICE 경로와 같이 `BILLING_SUCCESS_AFTER_TERMINATION` 으로 사실만 남기고 자격은 손대지 않는다
+(청구 선점 플래그는 정상적으로 해제하므로 reconcile 이 막히지 않는다).
+
 ### 효성 CMS 약정 종료
 
 효성 프로토콜(FMS-TE-0046)에는 **약정해지 API 가 없다.** 유일한 종료 수단이 회원삭제
@@ -487,6 +516,20 @@ POST /v1/billing-agreements/by-subscriber/terminate-mandate
 
 약정 종료가 실패해도 해지는 되돌리지 않는다 — 재청구는 DB 플래그로 이미 막혀 있고,
 `AGREEMENT_REVOKE_PENDING` 계약 이벤트로 후속 정리 대상만 남긴다.
+
+**해지를 철회하면 정리 지시도 함께 철회된다.** 해지 철회(고객 `/cancel/undo`·관리자 자동갱신 재활성)는
+wallet 자동이체 약정을 **새로 만든다.** 그런데 해지 때 남긴 `AGREEMENT_REVOKE_PENDING`/`_DEFERRED` 는
+그대로 남아 있어서, 그대로 두면 정리 스케줄러가 **살아있는 정기결제의 약정을 나중에 지운다** — 특히
+INVOICE 해지예약의 보류 건은 이용 종료일이 지나는 순간 반드시 그렇게 되고, 다음 청구가
+`BILLING_AGREEMENT_NOT_FOUND` 로 실패해 그대로 해지로 이어진다(계속 쓰겠다고 한 고객이 멤버십을 잃는다).
+그래서 정리 대상 판정에 **계약의 현재 상태**를 함께 본다(`isCleanupWithdrawnBy`): 되살아난 계약
+(`ACTIVE` + `autoRenewal` + `recurringCancelledAt=null`)은 wallet 을 부르지 않고 `AGREEMENT_REVOKE_UNDONE`
+로 큐에서 닫는다. 관리자 화면도 같은 판정을 쓴다. **목록을 읽은 시점의 판정만 믿지 않는다** — 지우기
+직전에 계약을 한 번 더 읽는다(배치가 도는 중에 들어온 철회를 놓치면 그 한 건이 약정을 잃는다).
+
+**약정 종료가 성공하면 그 사실도 남긴다.** 해지예약(보류) → 즉시해지처럼 앞선 기록이 열려 있는 경로에서
+성공을 남기지 않으면, 이미 끝난 건이 관리자 정리 큐에 '처리 필요' 로 계속 떠 있는다. 반대로 정리할 것이
+애초에 없던 계약(1회 결제 등)에는 남기지 않는다 — 허위 `AGREEMENT_REVOKE_PENDING` 을 걷어낸 것과 같은 이유다.
 
 **정리가 남은 건은 관리자 화면에 뜬다** — `멤버십 > 정기결제 관리 > 약정 정리` 탭
 (`GET /admin/agreement-cleanup`). 계약별 최신 약정 이벤트가 곧 상태이므로 재시도 스케줄러와 이 화면이
@@ -525,7 +568,7 @@ POST /v1/billing-agreements/by-subscriber/terminate-mandate
 ```bash
 docker compose up -d postgres
 
-# 서비스 + HTTP 계층 (112 케이스)
+# 서비스 + HTTP 계층 (118 케이스)
 npm run test:membership:cancellation-e2e
 
 # 고객 UI — 실제 크로미움, 8 시나리오
@@ -535,7 +578,7 @@ cd web/almondyoung-storefront && npm run test:e2e:membership-cancel
 cd apps/admin-web && npm run test:e2e:membership-cancel
 ```
 
-- 서비스 계층(86): 상태 전이·자격·계약이벤트·더닝·재청구 차단, 관리자 해지예약 대행, 1회 결제 철회 차단
+- 서비스 계층(92): 상태 전이·자격·계약이벤트·더닝·재청구 차단, 관리자 해지예약 대행, 1회 결제 철회 차단
   (고객·관리자 양쪽), 수동 송금 계좌 보존, 수동 송금 환불 완료 처리와 이중 송금 차단, 주기 시작 판정
   (관리자 연장·일시정지·결제기록 없는 옛 계약 폴백·INVOICE), 정지 중 해지, 약정 정리 재시도와
   **관리자 정리 큐**(포기 건 우선·정리된 건 제외), **해지 예약 뒤의 즉시해지 + 환불**
@@ -565,8 +608,9 @@ cd apps/admin-web && npm run test:e2e:membership-cancel
   넣으면 동작한다(행이 없으면 컨슈머가 조용히 no-op 한다).
 - **`markManualRefundCompleted` 는 wallet 에 확정 대기 환불이 있으면 409 로 거부한다** (그 건은
   결제관리가 닫는다). wallet 조회가 실패하면 막지 않는다 — "미완료" 가 영구히 남는 쪽이 더 나쁘다.
-- **고객관리 상세창 멤버십 탭은 브라우저로 검증하지 못했다.** 같은 패널을 렌더하지만 그 화면까지
-  띄우려면 customers 페이지와 core API 스택을 스텁해야 한다.
+- **고객관리 상세창 멤버십 탭도 브라우저로 검증했다** (관리자 UI E2E, `monthly-cms`/`scheduled`).
+  같은 패널이 같은 배너·계좌·즉시해지 다이얼로그를 열고, 다른 탭이 쓰는 Medusa/core API 가 스텁에 없어
+  404 로 떨어져도 이 화면의 렌더를 막지 않는다.
 - **수동 환불 완료 처리**는 멤버십 화면에서 한다 — 해지·환불 탭의 환불 행에 `송금 완료 처리` 버튼
   (`POST /admin/subscriptions/:contractId/refund/manual-complete`). wallet 의 수동 완료
   (`POST /v1/admin/refunds/:id/confirm`)는 **무통장 전용**이고, 효성 CMS 는 wallet 에 환불 행 자체가
@@ -591,13 +635,22 @@ cd apps/admin-web && npm run test:e2e:membership-cancel
   바꾸는 길은 열려 있지만 환불이 가능한 창 안에서만 손해가 없다. 붙일 자리는 결제 경로 위다 —
   비례정산 차액 청구(또는 잔여 환불) → 새 계약 생성 → 자격 이월 → 약정 전환. `subscriptionManager`
   의 upgrade/downgrade 는 청구축(nextBillingDate/billingDate/autoRenewal/agreement)을 정리하지 않아
-  그대로 재사용할 수 없다. 배포 블로커는 아니다 — 라이브 활성 계약 중 연간은 소수이고, 해지·환불
-  경로가 손실 없이 동작하는 한 CS 로 흡수 가능하다.
+  그대로 재사용할 수 없다. 배포 블로커는 아니다.
+
+  **CS 부담인지 라이브 데이터로 확인했다 (2026-08-04, 읽기 전용).** 아니었다.
+  - 활성 자격 703건 중 연간(365일)은 **69건(9.8%)**, 월간 634건. (이 문서가 근거 없이 '소수'라고
+    적어둔 값을 실측으로 대체했다 — 소수이긴 하나 1/10 규모다.)
+  - 계약에 남은 해지 사유 코드는 `ADMIN_FORCED` 74 · `EXPENSIVE` 1 · `NOT_USING` 1. 즉 **고객 셀프
+    해지는 2건뿐**이고 나머지는 관리자 강제취소다.
+  - 강제취소 사유 원문(계약 이벤트) 어디에도 **'플랜 변경' 성격의 사유가 없다.** 대부분 품절 보상
+    환불(`품절로 인해 취소 환불`, `LED 래쉬테이블 품절로 멤버십까지 환불 요청` 등)과 가격 적용
+    오류 정정(`멤버십 가격 적용 오류`, `오류로인해 다시 재가입`)이다. 월간↔연간 전환 요청은 0건.
+
+  → 지금 붙일 근거가 없다. 유료 플랜 변경은 계속 미구현으로 둔다.
 - 아직 열려 있는 것:
   - `refundByIntent` 의 멱등키가 `membership:refund:{intentId}:{amount}` 라, 같은 결제에 **같은 금액**의
     별개 환불이 필요한 경우 wallet 이 첫 응답을 재생한다(현재 경로에서는 발생하지 않는다 — 해지는
     계약당 1회로 막혀 있다).
-  - 해지 후 `isPastDue` 가 남는다. 고객 화면에는 활성 자격이 없으면 노출되지 않는다.
   - 심사 거절(`MANDATE_REJECTED`)로 자격이 회수된 고객에게 **알림이 가지 않는다.** 화면에는
     청구 내역(§B)이 남아 이유를 볼 수 있고 결제수단을 새로 등록해 재가입할 수 있지만, 고객이
     마이페이지에 들어와야만 안다. 알림은 notification 이 성숙한 뒤에 붙인다.
@@ -615,4 +668,5 @@ cd apps/admin-web && npm run test:e2e:membership-cancel
 | membership 이 wallet 보다 먼저 | 새 wallet API(`refundability`·`terminate-mandate`)가 404 → 전부 예외로 흡수된다. 즉시해지가 전부 '수동 송금 대기'로 떨어지고, 약정 종료는 `AGREEMENT_REVOKE_PENDING` 으로 남아 wallet 배포 후 시간당 크론이 스스로 회복한다. 돈이 잘못 나가지는 않는다 |
 | admin-web 이 membership 보다 먼저 | `hasPaymentIntent`/`refundSettlement` 가 undefined. 화면은 `=== false` 로만 판정하므로 "알 수 없음"이 "결제 없음"으로 뒤집히지 않는다(이 판정을 `!` 로 하면 **정상 수동 송금 건의 완료 창구가 전부 사라진다** — E2E `legacy-detail` 이 이를 잠근다). 새 `약정 정리` 탭만 404 로 빈 목록이 된다 |
 | storefront 가 membership 보다 먼저 | `canUndoCancellation` 이 undefined → 철회 버튼이 숨고 그 이유가 안내된다(과보호 방향). 즉시해지 진입점도 숨는다. 돈이 잘못 나가지 않는다 |
-| 롤백 | 새 계약 이벤트(`AGREEMENT_REVOKE_DEFERRED` 등)는 `text` 컬럼의 값일 뿐이고, 옛 코드에는 이 값을 읽는 곳이 없다(`AgreementCleanupService` 자체가 이 브랜치에서 생겼다). 관리자 로그 탭은 eventType 문자열을 그대로 출력한다 — 깨지지 않는다 |
+| 롤백 | 새 계약 이벤트(`AGREEMENT_REVOKE_DEFERRED`/`_UNDONE` 등)는 `text` 컬럼의 값일 뿐이고, 옛 코드에는 이 값을 읽는 곳이 없다(`AgreementCleanupService` 자체가 이 브랜치에서 생겼다). 관리자 로그 탭은 eventType 문자열을 그대로 출력한다 — 깨지지 않는다 |
+| channel-adapter 가 membership 보다 먼저 | 그룹 제거 전 SSOT 재확인이 `/internal/memberships/active` 를 부른다. 그 엔드포인트는 이 브랜치 이전부터 있고(일일 정합화 크론이 쓰던 것) 라이브에서 정상 동작 중이라 과도기에도 그대로다. 호출이 실패해도 제거는 그대로 진행된다(=확인이 없던 동작) |


### PR DESCRIPTION
해지 철회는 wallet 자동이체 약정을 새로 만들지만 해지 때 남긴 정리 지시
(AGREEMENT_REVOKE_PENDING/_DEFERRED)는 그대로 남는다. 그래서 정리 스케줄러가 살아있는 정기결제의 약정을 나중에 지우고, 다음 청구가 BILLING_AGREEMENT_NOT_FOUND 로 실패해 그대로 해지된다 — 계속 쓰겠다고 한 고객이 멤버십을 잃는다. INVOICE 해지예약의 보류 건은 이용 종료일이 지나는 순간 반드시 걸리며, 살아있는 정기결제 21건이 전부 그 경로다.

- 정리 대상 판정에 계약의 현재 상태를 함께 본다. 되살아난 계약은 wallet 을 부르지 않고 AGREEMENT_REVOKE_UNDONE 으로 큐에서 닫는다. 목록을 읽은 시점 판정만 믿지 않고 지우기 직전에 계약을 다시 읽는다(배치가 도는 중에 들어온 철회를 놓치면 그 한 건이 약정을 잃는다). 재시도 스케줄러와 관리자 화면이 같은 판정을 쓴다

- 만료 처리를 조건부로 바꿨다. 크론이 목록을 읽은 뒤 자격이 갈아치워질 수 있는데(해지 철회, 재가입, 갱신 결제, 기간 연장) 무조건 EXPIRED 를 찍으면 방금 결제한 고객이 만료되고 그 이벤트가 Medusa 할인 그룹까지 벗긴다. 아직 만료 대상인 자격만 닫고, 실제로 닫은 경우에만 계약을 만료시킨다. 건너뛴 실행은 아무것도 쓰지 않는다

- 종료된 계약에 뒤늦게 도착한 결제 성공이 자격을 늘리지 않게 했다. 자격은 계약이 아니라 사용자 단위라, 그 사이 재가입했으면 옛 계약의 결제로 새 구독의 기간이 공짜로 늘어난다. INVOICE 경로에만 있던 방어를 CHARGE 경로에도 둔다. 청구 선점 플래그는 그대로 해제해 reconcile 이 막히지 않는다

- Medusa 그룹에서 뺄 때 SSOT 에 현재 자격을 되묻는다. 이벤트는 발행 시점의 사실이라 도착이 늦는 사이 재가입·철회로 되살아난 고객의 할인을 뺏을 수 있다. 판정 기준은 일일 정합화 크론과 같다. 조회가 실패하면 제거를 그대로 진행한다 — 잘못 뺀 건은 전체 활성회원 정합화가 도로 넣지만, 빼지 못한 건은 cafe24 연동 회원만 도는 크론이라 자체가입자를 복구하지 못한다

- 성공한 약정 종료를 기록해 앞서 남은 보류/재시도 기록을 닫는다. 해지예약 뒤 즉시해지처럼 이미 끝난 건이 관리자 정리 큐에 계속 떠 있던 문제

라이브 읽기 전용 실측으로 판단한 것: 유료 플랜 변경은 전환 요청이 0건이라 근거가 없다 (활성 703건 중 연간 69건, 셀프 해지 2건, 강제취소 사유는 전부 품절 보상·가격 오류 정정). directCharge 무통장 가드는 그 경로로 만들어진 intent 가 0건이고 등록 결제수단이 CMS_BATCH 뿐이라 이미 닫혀 있어 넣지 않았다. 해지 후 isPastDue 잔존은 실측 0건이라 문서에서 지웠다.

고객관리 상세창 멤버십 탭을 브라우저로 처음 검증했다.

해지·환불 E2E 119 / 고객 UI 8 시나리오 / 관리자 UI 10 시나리오 통과. 스키마 변경 없음.