### PR TITLE
fix(security): 내부 API 호출자가 인증 키를 보내도록 (P0 배포 1/2 — 라이브 장애 복구)

### DIFF
--- a/apps/medusa/.env.template
+++ b/apps/medusa/.env.template
@@ -28,3 +28,11 @@ KAFKA_GROUP_ID=medusa-consumer
 
 # Almond Payment Provider 설정
 ALMOND_PAYMENT_ENDPOINT=http://localhost:3001
+
+# === 서버 간(internal) 호출 키 ===
+# 받는 쪽 서비스의 같은 이름 env 와 값이 일치해야 한다. 불일치/누락이면 401.
+# UGC_INTERNAL_KEY 가 없으면 구매확정(confirm-purchase)이 실패한다 — 리뷰자격 등록이 워크플로
+# step 2 라 실패가 step 1(결제 캡처) 롤백으로 번진다.
+UGC_SERVICE_URL=http://localhost:3030
+UGC_INTERNAL_KEY=local-dev-ugc-internal-key
+MEMBERSHIP_INTERNAL_KEY=local-dev-membership-internal-key

--- a/apps/medusa/src/subscribers/__tests__/membership-benefit-order.unit.spec.ts
+++ b/apps/medusa/src/subscribers/__tests__/membership-benefit-order.unit.spec.ts
@@ -1,4 +1,4 @@
-import {
+import handleMembershipBenefitOrder, {
   calculateMembershipDiscount,
   resolveMembershipDiscount,
   resolveQuantity,
@@ -285,5 +285,64 @@ describe('resolveMembershipDiscount - 멤버십 귀속 할인 분리', () => {
     const container = { resolve: () => { throw new Error('불려서는 안 된다'); } };
 
     await expect(resolveMembershipDiscount(items, 'grp_membership', container, logger)).resolves.toBe(0);
+  });
+});
+
+/**
+ * membership 의 `internal/*` 는 내부키 인증을 요구한다(2026-08 API 인가 감사 P0-2).
+ *
+ * `order.canceled` 경로는 주문/가격 조회 없이 곧장 fetch 로 가므로, 헤더가 **실제 호출에
+ * 실려 나가는지**를 스텁 없이 확인할 수 있는 지점이다. 헤더 생성 함수만 따로 테스트하면
+ * "초록인데 배선은 죽어있는" 상태를 못 잡는다.
+ */
+describe('internal 호출 인증 — order.canceled', () => {
+  const logger = { warn: jest.fn(), error: jest.fn(), info: jest.fn() };
+  const container = { resolve: () => logger };
+  const cancelEvent = { name: 'order.canceled', data: { id: 'order_1' } };
+  const keyBefore = process.env.MEMBERSHIP_INTERNAL_KEY;
+
+  type FetchResult = { ok: boolean; status: number; text: () => Promise<string> };
+  const fetchMock = jest.fn<Promise<FetchResult>, [string, RequestInit]>();
+  const respondWith = (ok: boolean, status: number, body = '') =>
+    fetchMock.mockResolvedValue({ ok, status, text: () => Promise.resolve(body) });
+
+  const run = () => handleMembershipBenefitOrder({ event: cancelEvent, container } as never);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.MEMBERSHIP_INTERNAL_KEY = 'test-internal-key';
+    global.fetch = fetchMock as unknown as typeof fetch;
+    respondWith(true, 200);
+  });
+
+  afterAll(() => {
+    if (keyBefore === undefined) delete process.env.MEMBERSHIP_INTERNAL_KEY;
+    else process.env.MEMBERSHIP_INTERNAL_KEY = keyBefore;
+  });
+
+  it('Authorization: Bearer <키> 를 실어 보낸다', async () => {
+    await run();
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/membership/benefits/internal/cancel');
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer test-internal-key' });
+  });
+
+  it('키가 없으면 호출 자체를 하지 않는다 — 헤더 없이 보내면 401 이고 그건 조용한 유실이다', async () => {
+    delete process.env.MEMBERSHIP_INTERNAL_KEY;
+
+    await run();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('membership 이 401 을 내면 성공으로 치지 않고 에러로 남긴다', async () => {
+    respondWith(false, 401, 'Invalid internal API key');
+
+    await run();
+
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('cancel failed (401)'));
+    expect(logger.info).not.toHaveBeenCalled();
   });
 });

--- a/apps/medusa/src/subscribers/membership-benefit-order.ts
+++ b/apps/medusa/src/subscribers/membership-benefit-order.ts
@@ -3,6 +3,20 @@ import { type SubscriberConfig, type SubscriberArgs } from '@medusajs/medusa';
 
 const MEMBERSHIP_SERVICE_URL = process.env.MEMBERSHIP_SERVICE_URL || 'http://localhost:3040';
 
+/**
+ * membership 의 `internal/*` 라우트는 `Authorization: Bearer ${MEMBERSHIP_INTERNAL_KEY}` 를 요구한다.
+ *
+ * 키가 없으면 호출을 아예 하지 않고 던진다(바깥 try/catch 가 로그로 받는다). 헤더 없이 보내면 401 이
+ * 되는데, 그 실패는 "혜택 미사용" 판정 → 부당 전액 환불로 이어지므로 조용히 흘려보내면 안 된다.
+ */
+function internalHeaders(): Record<string, string> {
+  const key = process.env.MEMBERSHIP_INTERNAL_KEY;
+  if (!key) {
+    throw new Error('MEMBERSHIP_INTERNAL_KEY is not configured');
+  }
+  return { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` };
+}
+
 export type OrderItem = {
   id: string;
   variant_id?: string | null;
@@ -247,7 +261,7 @@ export default async function handleMembershipBenefitOrder({ event, container }:
 
       const recordRes = await fetch(`${MEMBERSHIP_SERVICE_URL}/membership/benefits/internal/record`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: internalHeaders(),
         body: JSON.stringify({
           orderId,
           userId,
@@ -272,12 +286,22 @@ export default async function handleMembershipBenefitOrder({ event, container }:
         `[MembershipBenefit] Recorded discount: userId=${userId}, orderId=${orderId}, amount=${discountAmount}`,
       );
     } else if (eventName === 'order.canceled') {
-      await fetch(`${MEMBERSHIP_SERVICE_URL}/membership/benefits/internal/cancel`, {
+      const cancelRes = await fetch(`${MEMBERSHIP_SERVICE_URL}/membership/benefits/internal/cancel`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: internalHeaders(),
         body: JSON.stringify({ orderId }),
         signal: AbortSignal.timeout(5000),
       });
+
+      // record 와 같은 이유로 응답을 확인한다. 안 보면 401/500 이 조용히 삼켜져 취소가 영영 반영되지
+      // 않고, 그 주문의 혜택이 계속 "사용됨" 으로 남는다.
+      if (!cancelRes.ok) {
+        const body = await cancelRes.text().catch(() => '');
+        logger.error(
+          `[MembershipBenefit] cancel failed (${cancelRes.status}) orderId=${orderId}: ${body.slice(0, 300)}`,
+        );
+        return;
+      }
 
       logger.info(`[MembershipBenefit] Cancelled benefit for order ${orderId}`);
     }

--- a/apps/medusa/src/workflows/orders/steps/create-review-eligibility-step.ts
+++ b/apps/medusa/src/workflows/orders/steps/create-review-eligibility-step.ts
@@ -17,6 +17,14 @@ export const createReviewEligibilityStep = createStep(
       throw new Error('UGC_SERVICE_URL is not configured');
     }
 
+    // ugc 의 리뷰자격 등록은 내부 전용 라우트다(바디의 userId 를 그대로 신뢰한다).
+    // 키가 없으면 여기서 끊는다 — 헤더 없이 보내면 ugc 가 401 을 내고, 이 스텝은 워크플로의
+    // step 2 라 실패가 step 1(결제 캡처) 롤백으로 번진다. 조용히 빠뜨리는 게 가장 위험하다.
+    const ugcInternalKey = process.env.UGC_INTERNAL_KEY;
+    if (!ugcInternalKey) {
+      throw new Error('UGC_INTERNAL_KEY is not configured');
+    }
+
     // customer metadata에서 almond_user_id 조회
     const query = container.resolve<RemoteQueryFunction>(ContainerRegistrationKeys.QUERY);
     const { data: customers } = await query.graph({
@@ -43,7 +51,10 @@ export const createReviewEligibilityStep = createStep(
 
     const response = await fetch(`${ugcServiceUrl}/reviews/eligibilities`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${ugcInternalKey}`,
+      },
       body: JSON.stringify({
         userId: almondUserId,
         orderId: input.orderId,

--- a/deployments/lcnine/services/infra/services.ts
+++ b/deployments/lcnine/services/infra/services.ts
@@ -61,6 +61,9 @@ export function setup(infra: SharedInfra) {
   // Membership — 서버 간(internal) 라우트 인증 키 (channel-adapter/medusa → membership)
   const membershipInternalKey = new sst.Secret('MembershipInternalKey');
 
+  // UGC — 서버 간(internal) 라우트 인증 키 (medusa 구매확정 → ugc 리뷰자격 등록)
+  const ugcInternalKey = new sst.Secret('UgcInternalKey');
+
   // Notification
   const nhnAppKey = new sst.Secret('NhnAppKey');
   const nhnSecretKey = new sst.Secret('NhnSecretKey');
@@ -267,6 +270,7 @@ export function setup(infra: SharedInfra) {
     AUTH_SECRET: authSecret.value,
     JWT_ISSUER: 'almondyoung-auth',
     OIDC_ISSUER_URL: idpUserServiceUrl,
+    UGC_INTERNAL_KEY: ugcInternalKey.value,
   });
   const searchEnv = withPrefix('SEARCH', {
     // search 백엔드는 Railway OpenSearch. AWS OpenSearch 도메인은 미사용으로 제거됨 (shared.ts 참조).
@@ -538,6 +542,7 @@ export function setup(infra: SharedInfra) {
       MEMBERSHIP_SERVICE_URL: url('membership'),
       MEMBERSHIP_INTERNAL_KEY: membershipInternalKey.value,
       UGC_SERVICE_URL: url('ugc'),
+      UGC_INTERNAL_KEY: ugcInternalKey.value,
       MEDUSA_MEMBERSHIP_GROUP_ID: 'cusgroup_01KFZ12A1M344F6HKGDV35J28A',
       // S3
       S3_FILE_URL: 'https://almondyoung-medusa-digital-asset.s3.ap-northeast-2.amazonaws.com',

--- a/web/almondyoung-storefront/src/components/orders/order-card/order-actions.tsx
+++ b/web/almondyoung-storefront/src/components/orders/order-card/order-actions.tsx
@@ -47,7 +47,6 @@ interface OrderActionsProps {
   productName: string
   variantId: string
   showInquiry?: boolean
-  orderItems?: Array<{ productId: string; orderLineId: string }>
   coreActions?: StoreOrderActionsResponse
   availableActions?: StoreOrderAction[]
   cancelUnavailableReason?: StoreCancelUnavailableReason
@@ -85,7 +84,6 @@ export default function OrderActions({
   productName,
   variantId,
   showInquiry = true,
-  orderItems,
   coreActions,
   availableActions: availableActionsProp,
   cancelUnavailableReason: cancelUnavailableReasonProp,
@@ -142,7 +140,7 @@ export default function OrderActions({
   const handleConfirmPurchaseSubmit = () => {
     setShowConfirmPurchaseDialog(false)
     startTransition(async () => {
-      const result = await captureOrderPayment(orderId, orderItems)
+      const result = await captureOrderPayment(orderId)
       if (!result.success) {
         toast.error(result.message ?? "구매확정에 실패했습니다.")
         return

--- a/web/almondyoung-storefront/src/domains/mypage/template/main/wrappers/shipping-items-wrapper.tsx
+++ b/web/almondyoung-storefront/src/domains/mypage/template/main/wrappers/shipping-items-wrapper.tsx
@@ -58,14 +58,6 @@ export async function ShippingItemsWrapper() {
         quantity: order.items?.length || 0,
         options,
         showInquiry: false,
-        orderItems: (order.items ?? [])
-          .filter(
-            (item: any) => item.variant?.product?.handle || item.product_handle
-          )
-          .map((item: any) => ({
-            productId: item.variant?.product?.handle ?? item.product_handle,
-            orderLineId: item.id,
-          })),
         variantId: firstItem?.variant_id ?? "",
         bankTransferStatus:
           ((order.metadata as Record<string, unknown> | null)

--- a/web/almondyoung-storefront/src/domains/mypage/types/mypage-types.ts
+++ b/web/almondyoung-storefront/src/domains/mypage/types/mypage-types.ts
@@ -48,7 +48,6 @@ export interface ShippingOrder {
   quantity: number
   options: string[]
   showInquiry: boolean
-  orderItems: Array<{ productId: string; orderLineId: string }>
   variantId: string
   bankTransferStatus?: string
 }

--- a/web/almondyoung-storefront/src/domains/order/list/order-list.tsx
+++ b/web/almondyoung-storefront/src/domains/order/list/order-list.tsx
@@ -87,7 +87,6 @@ interface OrderItem {
   quantity: string
   options: string[]
   showInquiry: boolean
-  orderItems: Array<{ productId: string; orderLineId: string }>
   variantId: string
   bankTransferStatus?: string
 }
@@ -191,13 +190,6 @@ const mapStoreOrderToOrderItem = (
     quantity: `${ctx.tList("items", { count: lineItemCount })} · ${ctx.tList("totalQuantity", { count: totalQuantity })}`,
     options,
     showInquiry: order.fulfillment_status === "fulfilled",
-    orderItems: (order.items ?? [])
-      .filter((item) => item.variant?.product?.handle || item.product_handle)
-      .map((item) => ({
-        productId: (item.variant?.product?.handle ??
-          item.product_handle) as string,
-        orderLineId: item.id,
-      })),
     variantId: firstItem?.variant_id ?? "",
     bankTransferStatus:
       ((order.metadata as Record<string, unknown> | null)
@@ -454,7 +446,6 @@ export function OrderList({
                     paymentStatus={order.paymentStatus}
                     productName={order.productName}
                     variantId={order.variantId}
-                    orderItems={order.orderItems}
                     showInquiry={order.showInquiry}
                     coreActions={actions}
                     bankTransferStatus={order.bankTransferStatus}

--- a/web/almondyoung-storefront/src/lib/api/medusa/orders.ts
+++ b/web/almondyoung-storefront/src/lib/api/medusa/orders.ts
@@ -5,7 +5,6 @@ import { HttpTypes, OrderStatus } from "@medusajs/types"
 import { revalidatePath } from "next/cache"
 import { handleMedusaAuthError } from "./auth-utils"
 import { getAuthHeaders, getCacheOptions } from "../../data/cookies"
-import { createReviewEligibility } from "../ugc/reviews"
 
 export interface MedusaOrder {
   id: string
@@ -144,9 +143,10 @@ export async function getOrder(
     })
 }
 
+// 리뷰 작성 자격은 여기서 따로 만들지 않는다. 아래 confirm-purchase 가 Medusa 쪽에서
+// confirmPurchaseWorkflow 를 돌리고, 그 step 2 가 ugc 에 등록한다(내부키 인증).
 export async function captureOrderPayment(
-  orderId: string,
-  items?: Array<{ productId: string; orderLineId: string }>
+  orderId: string
 ): Promise<{ success: boolean; message?: string }> {
   const authHeaders = await getAuthHeaders()
   if (!authHeaders) {
@@ -168,15 +168,6 @@ export async function captureOrderPayment(
       method: "POST",
       headers,
     })
-
-    if (items && items.length > 0) {
-      try {
-        await createReviewEligibility({ orderId, items })
-      } catch (e) {
-        console.error("createReviewEligibility error:", e)
-        // eligibility 생성 실패해도 구매 확정은 성공으로 처리
-      }
-    }
 
     revalidatePath("/mypage/order/list")
     return { success: true }

--- a/web/almondyoung-storefront/src/lib/api/ugc/reviews.ts
+++ b/web/almondyoung-storefront/src/lib/api/ugc/reviews.ts
@@ -12,7 +12,6 @@ import {
   CommentResponseDto,
   RewardPolicyResponseDto,
   ReviewEligibilityResponseDto,
-  CreateReviewEligibilityDto,
 } from "@/lib/types/dto/ugc"
 import { PaginatedResponseDto } from "@/lib/types/common/pagination"
 import { api } from "../api"
@@ -139,19 +138,6 @@ export const getReviewEligibilities = async ({
     params,
     withAuth: true,
     next: { tags: ["review-eligibilities"] },
-  })
-}
-
-/**
- * 리뷰 작성 자격 생성 (구매 확정 시 호출)
- */
-export const createReviewEligibility = async (
-  dto: CreateReviewEligibilityDto
-): Promise<void> => {
-  await api("ugc", `/reviews/eligibilities`, {
-    method: "POST",
-    body: dto,
-    withAuth: true,
   })
 }
 

--- a/web/almondyoung-storefront/src/lib/types/dto/ugc.ts
+++ b/web/almondyoung-storefront/src/lib/types/dto/ugc.ts
@@ -99,11 +99,6 @@ interface ReviewEligibilityResponseDto {
   expiresAt: string
 }
 
-interface CreateReviewEligibilityDto {
-  orderId: string
-  items: Array<{ productId: string; orderLineId: string }>
-}
-
 type EligibilityStatus = "available" | "consumed"
 
 interface ReviewEligibilityListQueryDto {
@@ -234,7 +229,6 @@ export type {
   RewardPolicyResponseDto,
   ReviewRewardType,
   ReviewEligibilityResponseDto,
-  CreateReviewEligibilityDto,
   EligibilityStatus,
   ReviewEligibilityListQueryDto,
 }


### PR DESCRIPTION
## ⚠️ 라이브 장애 복구 PR — 즉시 머지·배포 필요

#574(가드)가 **이 PR보다 먼저** 머지·배포되면서 순서가 뒤집혔습니다. 현재 라이브 상태:

- ugc 컨테이너에 `UGC_INTERNAL_KEY` env 가 없음 → 가드가 fail-closed 분기로 빠져 `POST /reviews/eligibilities` 가 **무조건 401**
- Medusa 는 교체되지 않아(태스크 08-07 20:54) 키를 안 보냄
- 결과: **구매확정 → 결제 캡처 → ugc 401 → step2 실패 → 캡처한 결제를 PG 에 환불 → 구매확정 실패**
  (`captureOrderPaymentsStep` 의 보상 트랜잭션이 `refundPaymentWorkflow` 를 부른다)
- membership `internal/{record,cancel}` 도 401 → 혜택 기록·취소 유실

이 PR 이 빠진 조각(키 전송 + env 배선)을 채워 최종 상태로 만듭니다.

## 변경

- **SST**: `UgcInternalKey` 시크릿(이미 `sst secret set` 완료) + `UGC_INTERNAL_KEY` 를 ugc·Medusa 양쪽 env 에 배선
- **Medusa**: ugc 리뷰자격 등록 / membership 혜택 기록·취소 호출에 `Authorization: Bearer` 추가. 키 미설정이면 조용히 넘기지 않고 throw
- **Medusa**: `cancel` 응답에 `res.ok` 검사 추가 — 지금은 응답을 안 봐서 401 이 나도 영영 모른다 (`record` 에는 이미 있던 검사)
- **스토어프론트**: `POST /reviews/eligibilities` 중복 호출 제거. `userId` 를 안 보내 서버 DTO 검증에서 **항상 400** 이었고 try/catch 가 삼켜 왔다 — 같은 일을 Medusa 워크플로가 이미 하므로 중복이고, 누가 `userId` 를 채워 "고치면" 무인증 포인트 발행 경로가 되살아난다

## 검증

- medusa unit 131건 통과 (내부키 헤더가 실제 fetch 에 실리는지 검증하는 3건 포함 — 변경 전 소스에서 빨간 것 확인)
- 인가 회귀 스펙 2건 통과
- 변경 파일 tsc 0 / eslint 신규 0 (스토어프론트 50·medusa 3 = 기존 debt와 동일)
- 마이그레이션 0건

## 배포 후 확인 (이번엔 필수)

`sst deploy --stage live` 후 **Medusa 와 ServicesBundleB 타임스탬프가 둘 다 갱신됐는지** 확인할 것.
#574 배포 때는 ServicesBundleA/B 만 교체되고 Medusa 는 어제 태스크 그대로였는데, 배포는 `COMPLETED` 로 성공 보고됐다. **배포 성공 ≠ 기능 정상**.

Fixes 순서 위반 (#574)

https://claude.ai/code/session_01TUStsws7nvvLB77PpuawCV