### PR TITLE
feat(event-contracts): topic → StreamConfig 레지스트리 추가 (ADR-0029 Task 1)

### DIFF
--- a/docs/superpowers/plans/2026-08-09-events-module-registration.md
+++ b/docs/superpowers/plans/2026-08-09-events-module-registration.md
@@ -83,12 +83,21 @@
 
 순수 추가. 아무것도 소비하지 않으므로 위험 0.
 
-- [ ] `packages/event-contracts/streams/registry.ts` 에 `STREAM_REGISTRY: Record<string, StreamConfig>` 를 만든다. `streams/index.ts` 가 이미 전 스트림을 export 하므로 그것을 모은다
-- [ ] `streamForTopic(topic: string): StreamConfig | undefined` 를 노출
-- [ ] 스펙: 모든 등록 스트림의 `topic.topic` 이 레지스트리 키와 일치하고, 키 중복이 없음을 단언
-- [ ] `npm run type-check` 초록 · 커밋 · 푸시
+- [x] `packages/event-contracts/streams/registry.ts` 에 `STREAM_REGISTRY: Record<string, StreamConfig>` 를 만든다. `streams/index.ts` 가 이미 전 스트림을 export 하므로 그것을 모은다
+- [x] `streamForTopic(topic: string): StreamConfig | undefined` 를 노출
+- [x] 스펙: 모든 등록 스트림의 `topic.topic` 이 레지스트리 키와 일치하고, 키 중복이 없음을 단언
+- [x] `npm run type-check` 초록 · 커밋 · 푸시
 
 **완료 기준:** 레지스트리가 존재하고 스펙이 초록. 소비자는 아직 없다.
+
+**완료 (2026-08-09).** 브랜치 `feat/events-stream-registry`.
+
+- 레지스트리는 선언이 아니라 **도출**이다 — `import * as from './index'` 를 훑어 `StreamConfig` 모양인 export 만 고른다. 스트림을 추가해도 손댈 목록이 없다.
+- 중복 토픽 · 빈 토픽은 **모듈 로드 시점에 throw**. 스펙 단언에 그치지 않고 부팅에서 죽는다.
+- 공개 표면은 패키지 루트 `index.ts` 에만 추가했다. `streams/index.ts` 에 넣으면 순환 import 라 레지스트리가 빈 채로 굳는다 — `registry.public-api.spec.ts` 가 그 회귀를 잡는다.
+- 실측: 도출된 토픽 15개. `TEST_STREAM`·`INVENTORY_STREAM_WITH_SCHEMA` 는 `streams/index.ts` 가 export 하지 않으므로 제외됐고, 어느 앱도 구독하지 않는다(확인함).
+- **Task 3 에 넘기는 사실:** 앱들이 `@OnEvent` 로 실제 구독하는 토픽은 14개이며 **전부 레지스트리에 있다.** 즉 Task 3 의 "레지스트리에 없는 토픽 → 부팅 거부" 는 현재 앱을 하나도 깨지 않는다. (`analytics.events.v1` 은 `retry-policy.decorator.ts` 의 doc 주석, `wiring.*.v1` 은 `event-retry.wiring.spec.ts` 안에만 있다.)
+- 검증: 스펙 13개 초록(계약 패키지 전체 7 suite / 99 tests) · `npm run type-check` 오류 164개로 develop 과 **file:line:code 집합 동일** · `nest build core` 초록 · eslint 초록.
 
 ---
 

--- a/packages/event-contracts/index.ts
+++ b/packages/event-contracts/index.ts
@@ -9,3 +9,7 @@ export * from './types';
 
 // Stream Definitions
 export * from './streams';
+
+// Stream Registry (topic → StreamConfig)
+// `streams/index.ts` 가 아니라 여기서 내보낸다 — streams/index.ts 에 두면 순환 import 가 된다.
+export * from './streams/registry';

--- a/packages/event-contracts/streams/registry.public-api.spec.ts
+++ b/packages/event-contracts/streams/registry.public-api.spec.ts
@@ -1,0 +1,22 @@
+import * as contracts from '../index';
+import { ORDER_STREAM } from './index';
+import { STREAM_REGISTRY, streamForTopic } from './registry';
+
+/**
+ * 소비자(`libs/events`, 각 앱)는 `@packages/event-contracts` 루트로만 import 한다.
+ * 레지스트리가 그 표면에 없으면 존재해도 닿을 수 없다.
+ *
+ * 이 스펙은 순환 import 회귀도 잡는다: 루트 index 를 먼저 로드했을 때
+ * 레지스트리가 빈 채로 굳으면 여기서 터진다.
+ */
+describe('@packages/event-contracts public surface', () => {
+  it('re-exports the registry from the package root', () => {
+    expect(contracts.STREAM_REGISTRY).toBe(STREAM_REGISTRY);
+    expect(contracts.streamForTopic).toBe(streamForTopic);
+  });
+
+  it('is fully populated when reached through the package root', () => {
+    expect(contracts.streamForTopic('orders.events.v1')).toBe(ORDER_STREAM);
+    expect(Object.keys(contracts.STREAM_REGISTRY).length).toBeGreaterThan(1);
+  });
+});

--- a/packages/event-contracts/streams/registry.spec.ts
+++ b/packages/event-contracts/streams/registry.spec.ts
@@ -1,0 +1,111 @@
+import * as allStreams from './index';
+import { CORE_ORDER_STREAM, ORDER_STREAM, PRODUCT_STREAM } from './index';
+import { buildStreamRegistry, STREAM_REGISTRY, streamForTopic } from './registry';
+
+/**
+ * 레지스트리는 `streams/index.ts` 가 export 하는 스트림에서 **도출**된다.
+ * 손으로 유지하는 두 번째 목록이 생기면 어긋나고, 어긋남이 무증상이면
+ * 그 자리에 틀린 주석이 자란다 — ADR-0029 가 고치려는 실패 모드다.
+ */
+describe('STREAM_REGISTRY', () => {
+  /**
+   * 계약 표면의 스냅샷. 스트림을 추가/삭제하면 이 목록도 같이 고쳐야 한다 —
+   * 토픽 집합의 변화는 리뷰에서 눈에 띄어야 하는 종류의 변화다.
+   */
+  const EXPECTED_TOPICS = [
+    'carts.events.v1',
+    'channel-adapter.events.v1',
+    'core.orders.events.v1',
+    'fulfillments.events.v1',
+    'fulfillments.events.v2',
+    'inventory.events.v1',
+    'membership.events.v1',
+    'orders.events.v1',
+    'payments.events.v1',
+    'products.events.v1',
+    'shipments.events.v1',
+    'ugc.commands.v1',
+    'ugc.events.v1',
+    'users.events.v1',
+    'wallet.commands.v1',
+  ];
+
+  it('exposes exactly the topics declared by the contract package', () => {
+    expect(Object.keys(STREAM_REGISTRY).sort()).toEqual(EXPECTED_TOPICS);
+  });
+
+  it('keys every stream by its own topic.topic', () => {
+    for (const [topic, config] of Object.entries(STREAM_REGISTRY)) {
+      expect(config.topic.topic).toBe(topic);
+    }
+  });
+
+  it('holds the exported stream objects themselves, not copies', () => {
+    expect(STREAM_REGISTRY['orders.events.v1']).toBe(ORDER_STREAM);
+    expect(STREAM_REGISTRY['core.orders.events.v1']).toBe(CORE_ORDER_STREAM);
+    expect(STREAM_REGISTRY['products.events.v1']).toBe(PRODUCT_STREAM);
+  });
+
+  it('skips exports that are not stream configs', () => {
+    // `streams/index.ts` 는 스트림 말고도 이벤트명 상수·스키마·타입을 export 한다.
+    expect(allStreams.ORDER_EVENTS).toBeDefined();
+    expect(Object.values(STREAM_REGISTRY)).not.toContain(allStreams.ORDER_EVENTS);
+  });
+});
+
+describe('streamForTopic', () => {
+  it('resolves a registered topic to its stream config', () => {
+    expect(streamForTopic('orders.events.v1')).toBe(ORDER_STREAM);
+  });
+
+  it('returns undefined for an unregistered topic', () => {
+    expect(streamForTopic('analytics.events.v1')).toBeUndefined();
+  });
+
+  it('does not resolve Object.prototype members as streams', () => {
+    // 토픽 문자열은 Task 3 에서 구독 메타데이터로부터 오므로 임의 문자열이 들어올 수 있다.
+    expect(streamForTopic('constructor')).toBeUndefined();
+    expect(streamForTopic('toString')).toBeUndefined();
+  });
+});
+
+describe('buildStreamRegistry', () => {
+  const streamNamed = (topic: string) => ({
+    topic: { topic },
+    aggregateType: 'Thing',
+    events: {},
+  });
+
+  it('throws when two exported streams claim the same topic', () => {
+    const source = {
+      A_STREAM: streamNamed('things.events.v1'),
+      B_STREAM: streamNamed('things.events.v1'),
+    };
+
+    expect(() => buildStreamRegistry(source)).toThrow(/things\.events\.v1/);
+  });
+
+  it('names both colliding exports so the duplicate is findable', () => {
+    const source = {
+      A_STREAM: streamNamed('things.events.v1'),
+      B_STREAM: streamNamed('things.events.v1'),
+    };
+
+    expect(() => buildStreamRegistry(source)).toThrow(/A_STREAM.*B_STREAM|B_STREAM.*A_STREAM/);
+  });
+
+  it('ignores values that are not stream configs', () => {
+    const source = {
+      A_STREAM: streamNamed('things.events.v1'),
+      THING_EVENTS: { Created: 'Created' },
+      someHelper: () => 'noop',
+      nothing: undefined,
+    };
+
+    expect(Object.keys(buildStreamRegistry(source))).toEqual(['things.events.v1']);
+  });
+
+  it('rejects a stream whose topic is an empty string', () => {
+    expect(() => buildStreamRegistry({ A_STREAM: streamNamed('') })).toThrow(/A_STREAM/);
+  });
+});

--- a/packages/event-contracts/streams/registry.ts
+++ b/packages/event-contracts/streams/registry.ts
@@ -1,0 +1,76 @@
+/**
+ * Stream Registry — `topic → StreamConfig`
+ *
+ * 소비 측이 토픽 문자열만 갖고 계약(스키마·이벤트 목록·aggregateType)에 도달할 수 있게 한다.
+ * 이 레지스트리는 손으로 유지하는 목록이 아니라 `streams/index.ts` 의 export 에서 **도출**된다 —
+ * 도출 가능한 사실을 선언으로 받으면 두 벌이 생기고, 두 벌은 어긋나며, 어긋남이 무증상이면
+ * 그 자리에 틀린 주석이 자란다 (ADR-0029 §1·§3).
+ *
+ * ⚠️ 이 파일은 `streams/index.ts` 에서 re-export 하지 않는다. 그러면 순환 import 가 되어
+ *    모듈 초기화 순서에 따라 레지스트리가 빈 채로 굳는다. 공개 표면은 패키지 루트
+ *    `packages/event-contracts/index.ts` 하나뿐이다.
+ */
+
+import type { StreamConfig } from '../types/stream-config.types';
+import * as streamExports from './index';
+
+/**
+ * `streams/index.ts` 는 스트림 말고도 이벤트명 상수(`ORDER_EVENTS` 등)·zod 스키마·헬퍼를
+ * 함께 export 한다. 그중 스트림만 골라낸다.
+ */
+function isStreamConfig(value: unknown): value is StreamConfig {
+  if (typeof value !== 'object' || value === null) return false;
+
+  const candidate = value as Partial<StreamConfig>;
+  if (typeof candidate.aggregateType !== 'string') return false;
+  if (typeof candidate.events !== 'object' || candidate.events === null) return false;
+  if (typeof candidate.topic !== 'object' || candidate.topic === null) return false;
+
+  return typeof candidate.topic.topic === 'string';
+}
+
+/**
+ * export 묶음에서 `topic → StreamConfig` 맵을 만든다.
+ *
+ * 토픽이 비었거나 두 스트림이 같은 토픽을 주장하면 **모듈 로드 시점에** 던진다.
+ * 둘 다 라우팅을 조용히 깨뜨리는 계약 버그라서, 부팅에서 죽는 편이 낫다.
+ *
+ * @param source `streams/index.ts` 의 namespace 또는 그와 같은 모양의 객체
+ */
+export function buildStreamRegistry(source: object): Record<string, StreamConfig> {
+  // null-prototype: 임의의 토픽 문자열이 `constructor` 같은 상속 멤버로 해석되지 않게 한다.
+  // `Object.create` 의 반환 타입이 `any` 라서 캐스팅이 불가피하다 — 만드는 쪽이 모양을 온전히 알고 있다.
+  const registry = Object.create(null) as Record<string, StreamConfig>;
+  const exportNameByTopic = new Map<string, string>();
+
+  for (const [exportName, value] of Object.entries(source)) {
+    if (!isStreamConfig(value)) continue;
+
+    const topic = value.topic.topic;
+    if (topic.length === 0) {
+      throw new Error(`Stream registry: ${exportName} has an empty topic.`);
+    }
+
+    const previous = exportNameByTopic.get(topic);
+    if (previous !== undefined) {
+      throw new Error(`Stream registry: duplicate topic "${topic}" declared by ${previous} and ${exportName}.`);
+    }
+
+    exportNameByTopic.set(topic, exportName);
+    registry[topic] = value;
+  }
+
+  return registry;
+}
+
+/**
+ * 이 계약 패키지가 아는 모든 스트림. 키는 Kafka 토픽 문자열이다.
+ */
+export const STREAM_REGISTRY: Readonly<Record<string, StreamConfig>> = buildStreamRegistry(streamExports);
+
+/**
+ * 토픽 문자열로 계약을 찾는다. 등록되지 않은 토픽이면 `undefined`.
+ */
+export function streamForTopic(topic: string): StreamConfig | undefined {
+  return STREAM_REGISTRY[topic];
+}


### PR DESCRIPTION
[ADR-0029](../blob/develop/docs/adr/0029-events-module-registration-surfaces.md) 워크스트림의 **Task 1**. 실행 계획은 `docs/superpowers/plans/2026-08-09-events-module-registration.md`.

## 무엇

소비 측이 토픽 문자열만 갖고 계약(스키마·이벤트 목록·aggregateType)에 도달할 수 있게 하는 `topic → StreamConfig` 레지스트리.

Task 3 의 `startConsumer` 가 `@OnEvent` 메타데이터에서 **구독 토픽 · 검증 스키마 맵 · 토픽 부트스트랩 목록**을 파생할 때 이 레지스트리를 쓴다. 지금은 **순수 추가이고 아무도 소비하지 않는다** — 배포 요구 없음.

## 설계 결정

- **목록을 손으로 유지하지 않는다.** `streams/index.ts` 의 export 를 훑어 `StreamConfig` 모양인 값만 고른다. 도출 가능한 사실을 선언으로 받으면 두 벌이 생기고, 두 벌은 어긋나고, 어긋남이 무증상이면 그 자리에 틀린 주석이 자란다 — 이 워크스트림이 고치려는 실패 모드 그 자체다 (ADR-0029 §1).
- **중복 토픽·빈 토픽은 모듈 로드 시점에 throw.** 스펙 단언에 그치지 않는다. 둘 다 라우팅을 조용히 깨뜨리는 계약 버그라 부팅에서 죽는 편이 낫다.
- **null-prototype 맵.** Task 3 에서 토픽 문자열이 구독 메타데이터로부터 오므로 `constructor` 같은 상속 멤버가 스트림으로 해석되면 안 된다.
- **공개 표면은 패키지 루트 `index.ts` 에만.** `streams/index.ts` 에 re-export 하면 순환 import 라 레지스트리가 빈 채로 굳는다. `registry.public-api.spec.ts` 가 그 회귀를 잡는다.

## 실측

- 도출된 토픽 **15개**. `TEST_STREAM`·`INVENTORY_STREAM_WITH_SCHEMA` 는 `streams/index.ts` 가 export 하지 않으므로 제외됐고, 어느 앱도 구독하지 않는다.
- 앱들이 `@OnEvent` 로 **실제 구독**하는 토픽은 14개이며 전부 레지스트리에 있다. → Task 3 의 "레지스트리에 없는 토픽이면 부팅 거부" 는 현재 앱을 하나도 깨지 않는다.
  - `analytics.events.v1` 은 `retry-policy.decorator.ts` 의 doc 주석 안에만, `wiring.retry.v1`/`wiring.test.v1` 은 `event-retry.wiring.spec.ts` 안에만 있다.

## 검증

| 게이트 | 결과 |
|---|---|
| `packages/event-contracts` jest | 7 suite / 99 tests 초록 (신규 스펙 13개) |
| `npm run type-check` | 오류 164개 — develop 과 **file:line:code 집합 동일** (신규 0) |
| `nest build core` | 초록 |
| eslint · prettier | 초록 |

## 배포

**필요 없음.** 마이그레이션 0 · 시크릿 0 · env 0. 다음 아무 배포에 묻어가면 된다 (플랜 Global Constraints 의 Task 0~4 구간).