### PR TITLE
feat(events): transport port + 인메모리 하네스 — 소비 전면 장애 발견·수정 (ADR-0029 Task 2)

### DIFF
--- a/docs/adr/0029-events-module-registration-surfaces.md
+++ b/docs/adr/0029-events-module-registration-surfaces.md
@@ -172,11 +172,14 @@ if (!(kafkaContext instanceof KafkaContext)) return next.handle();
 
 1. ~~**`apps/analytics/src/main.ts:65–75` 의 틀린 주석을 즉시 삭제한다.**~~ **완료 (2026-08-09).** 실제 동작을 설명하는 주석으로 교체했다. 검증: `ProductEventsConsumer` 는 `analytics.module.ts:50` 의 `controllers` 에 등록돼 있고 `products.events.v1` 핸들러 6개를 선언하므로 해당 토픽은 정상 구독된다 — 옛 주석의 "have never received a live message" 는 틀렸다. `apps/search/src/search.module.ts:26` 은 **고치지 않았다**: "forConsumerModule 은 provider 만 등록하고 connectMicroservice 를 부르지 않으므로 두 번째 컨슈머를 만들지 않는다"는 사실이며 #510 회귀 방지 근거로 유효하다. 두 표면을 "짝"이라 부른 표현만 느슨할 뿐이다.
 2. 계약 레지스트리(`topic → StreamConfig`) 추가 — 순수 추가, 위험 0.
-3. **인메모리 transport 어댑터 + 발행→소비 왕복 테스트.** 원래 마지막에 두려던 것을 앞으로 당긴다. 지금은 발행→소비를 브로커 없이 검증할 방법이 **아예 없어서**(`libs/events/src` 소스 29 / 스펙 5, 페이크 트랜스포트 0), 어댑터가 없으면 이후 모든 단계가 자기 증거를 남기지 못한다. 여러 세션에 걸쳐 진행되는 작업에서 이는 치명적이다 — 다음 작업자는 앞 단계가 실제로 무엇을 보장했는지 알 수 없다. **검증 도구를 먼저 만들고 나머지를 그 위에 얹는다.**
+3. ~~**인메모리 transport 어댑터 + 발행→소비 왕복 테스트.**~~ **완료 (2026-08-09).** 하네스가 첫 실행에서 실재 버그를 찾았다: Nest 는 수신 `value` 를 `KafkaParser` 로 JSON 파싱해 넘기는데(즉 **객체**), `schema-validation.interceptor.ts:69` · `event-retry.interceptor.ts:194` · `chain-context.interceptor.ts:26` 이 `String(value)` 관용구로 `"[object Object]"` 를 만들어 `JSON.parse` 가 터졌다. `validateOnConsume: true` 인 core·analytics·search 에서 **모든 메시지가 재시도 3회 후 DLQ 전송마저 실패 → offset 미커밋 → 무한 재전달**이었다. `utils/envelope.util.ts` 의 `parseEnvelope` 로 수정. **이 ADR 이 "두 번째 어댑터가 없어서 배선 문제가 어떤 테스트로도 안 잡힌다"고 한 주장의 실증 사례다.** 남은 별건: 소비 경로에 CLS 컨텍스트가 열리지 않아(`middleware.mount: false` + RPC 용 ClsGuard 부재) `chainId` 전파가 죽어 있다 — `round-trip.spec.ts` 에 `it.failing` 으로 박아뒀다. 아래 9번.
+
+   착수 당시 근거(보존): 원래 마지막에 두려던 것을 앞으로 당겼다. 발행→소비를 브로커 없이 검증할 방법이 **아예 없어서**(`libs/events/src` 소스 29 / 스펙 5, 페이크 트랜스포트 0) 어댑터가 없으면 이후 모든 단계가 자기 증거를 남기지 못하고, 여러 세션에 걸친 작업에서 다음 작업자는 앞 단계가 무엇을 보장했는지 알 수 없기 때문이다. **검증 도구를 먼저 만들고 나머지를 그 위에 얹는다** — 그 판단은 결과로 정당화됐다.
 4. `startConsumer(app)` 도입 + `forConsumer` 의 `streams` deprecated. 앱 수정 없이 동작해야 한다.
 5. `@On` / `@InjectPublisher` 를 기존 데코레이터와 병행 도입, 앱별 이주 (7개 앱 = 7 PR).
 6. 공용 outbox 에 `idempotencyKey`·`partitionKey`·enqueue 시점 검증 추가 후 앱 자체 판본 5벌 회수. **core 의 두 벌은 import 경로만 다른 동일 파일이므로 이 작업과 무관하게 지금 하나로 합칠 수 있다.**
 7. 옛 표면(`forRoot`/`forConsumerModule`/`forConsumer`) 제거 — contract phase.
 8. channel-adapter 가 `forConsumerModule` 을 호출하지 않는 현재 상태는 이 ADR 이 시행되기 전까지 남는 실재 구멍이다 — 소비 측 zod 검증이 없다. 4번 이전에 단독으로 메울지, 이주에 묶을지 결정한다.
+9. **소비 경로 CLS 컨텍스트 부재** (2026-08-09 발견, 미수정). `ClsModule.forRoot({ middleware: { mount: false } })` 이고 RPC 경로에 ClsGuard/ClsInterceptor 가 없어 `EventChainService.setChainId` 가 "No CLS context available" 로 던지고, `ChainContextInterceptor` 의 `catch {}` 가 그것을 삼킨다. 결과적으로 **소비 측 `chainId`/`eventId` 전파가 전 앱에서 죽어 있다.** 3번의 파싱 버그와 원인이 다르므로 별도 수정이 필요하다 — 이 워크스트림에 묶을지 독립 처리할지 결정한다. 회귀 감지는 `round-trip.spec.ts` 의 `it.failing` 이 맡는다.
 
 실행 계획은 [`docs/superpowers/plans/2026-08-09-events-module-registration.md`](../superpowers/plans/2026-08-09-events-module-registration.md).

--- a/docs/adr/0029-events-module-registration-surfaces.md
+++ b/docs/adr/0029-events-module-registration-surfaces.md
@@ -103,6 +103,29 @@ envelope 를 최외곽 인터셉터에서 한 번 파싱해 컨텍스트에 싣�
 
 deep module 이 소유할 것: envelope 구성 · 검증 · `messageId`/`correlationId`/`chainId` 전파 · retry·DLQ 분류. 어댑터가 소유할 것: 전송뿐. 프로덕션 Kafka 와 인메모리, **두 어댑터가 생겨야 이 seam 이 가설이 아니라 실재가 된다** — 어댑터가 하나뿐인 seam 은 간접층일 뿐이다.
 
+**port 는 발행 방향에만 긋는다. 소비 방향은 port 가 아니다** (2026-08-09 결정):
+
+```ts
+export interface EventTransport {
+  send(topic: string, message: { key: string; value: string; headers?: Record<string, string> }): Promise<void>;
+}
+```
+
+`subscribe(topics, handler)` 를 같은 port 에 넣지 않는 이유는 **소비 루프를 `libs/events` 가 소유하고 있지 않기 때문**이다. 소비는 각 앱 `main.ts` 의 `app.connectMicroservice()` 가 만든 Nest `ServerKafka` 가 수행하며, `libs/events` 는 설정값만 넘긴다 — 그나마 그 설정값 중 `subscribe.topics` 는 Nest 가 덮어쓴다(이 ADR Context 참조). 따라서 `KafkaTransport.subscribe()` 는 ① Nest 의 컨슈머를 대체하거나(대규모 동작 변경, 이 ADR 의 expand-contract 규율 위반) ② 스텁으로 남는(한 어댑터가 구현 못 하는 메서드 = 거짓 인터페이스) 두 길뿐이고, 둘 다 나쁘다.
+
+대신 **소비 방향의 다형성은 Nest 가 이미 제공하는 확장점에서 얻는다** — `CustomTransportStrategy`. 운영은 Nest 의 `ServerKafka`, 테스트는 `InMemoryServer` 를 `connectMicroservice({ strategy })` 로 붙인다. 두 구현 모두 실재이고, 운영 경로는 한 줄도 바뀌지 않는다.
+
+**인메모리 배달은 반드시 진짜 `KafkaContext` 인스턴스를 만들어야 한다.** 이것이 이 비대칭 설계의 결정적 제약이다:
+
+```ts
+// libs/events/src/interceptors/event-retry.interceptor.ts:72
+if (!(kafkaContext instanceof KafkaContext)) return next.handle();
+```
+
+가짜 context 객체를 넣으면 이 줄에서 빠져나가 **재시도·DLQ 분류가 통째로 건너뛰어진다.** 그러면 "스키마 위반 → DLQ" 테스트는 초록불이 뜨지만 아무것도 증명하지 못한다 — 이 ADR 이 없애려는 실패 모드(무증상 거짓)를 테스트 안에서 재생산하는 꼴이다. `EventTypeGuard`(52곳에서 `@UseInterceptors` 로 부착)와 `SchemaValidationInterceptor` 도 같은 이유로 `KafkaContext` 를 요구한다. `Server` 를 상속한 전략은 이 요구를 자연히 만족하지만, 손으로 만든 페이크 디스패처는 만족하지 못한다.
+
+**Kafka 로 나가는 모든 경로가 이 port 를 지난다.** `StreamPublisher.sendMessage` · `OutboxDispatcher`(publisher 경유) · `DLQHandler.sendToDLQ`. 특히 `DLQHandler` 는 `@Inject('KAFKA_CLIENT')` 로 `ClientKafka` 를 직접 잡고 있었으므로 함께 이관한다 — 그러지 않으면 DLQ 적재를 관찰할 방법이 port 밖에 따로 생겨 "모든 발행은 port 를 지난다" 가 거짓이 된다. `GracefulShutdownService` 는 전송이 아니라 연결 종료가 관심사이므로 `KAFKA_CLIENT` 를 계속 쓴다.
+
 ### 명시적으로 하지 않는 것
 
 - **두 리스트를 부팅 시 대조(reconcile)하는 안은 기각한다.** 어긋남을 시끄럽게 만들 뿐 중복은 그대로 남는다. 중복을 없애는 파생이 우월하다.

--- a/docs/superpowers/plans/2026-08-09-events-module-registration.md
+++ b/docs/superpowers/plans/2026-08-09-events-module-registration.md
@@ -54,9 +54,11 @@
 | 파일 | 책임 | 태스크 |
 |---|---|---|
 | `packages/event-contracts/streams/registry.ts` (신규) | `topic → StreamConfig` 레지스트리 | 1 |
-| `libs/events/src/transport/transport.port.ts` (신규) | 전송 port 인터페이스 | 2 |
-| `libs/events/src/transport/in-memory.transport.ts` (신규) | 테스트용 어댑터 | 2 |
+| `libs/events/src/transport/transport.port.ts` (신규) | 발행 port 인터페이스 + `EVENT_TRANSPORT` 토큰 | 2 |
 | `libs/events/src/transport/kafka.transport.ts` (신규) | 프로덕션 어댑터 (기존 배선 이관) | 2 |
+| `libs/events/src/transport/in-memory.broker.ts` (신규) | 토픽별 발행 로그 · 적대적 입력 주입 | 2 |
+| `libs/events/src/transport/in-memory.transport.ts` (신규) | 테스트용 발행 어댑터 | 2 |
+| `libs/events/src/transport/in-memory.server.ts` (신규) | 테스트용 **소비** 전략 (Nest `CustomTransportStrategy`) | 2 |
 | `libs/events/src/events.module.ts` | `startConsumer` 추가, `forConsumer({streams})` deprecate | 3 |
 | `libs/events/src/consumers/decorators.ts` | `@On` / `@Payload` 추가 (기존 `@OnEvent` 병행 유지) | 4 |
 | `libs/events/src/publishers/stream-publisher.service.ts` | `publish`/`enqueue` 통합 인터페이스, `publishRawEnvelope` zod 우회 제거 | 6 |
@@ -105,12 +107,17 @@
 
 **이 워크스트림에서 가장 중요한 태스크다.** ADR-0029 는 이것을 원래 마지막에 두려 했으나 앞으로 당겼다 — 지금은 발행→소비를 브로커 없이 검증할 방법이 아예 없어서, 이게 없으면 이후 모든 태스크가 "되는 것 같다"로 끝나고 다음 세션의 작업자는 앞 단계가 무엇을 보장했는지 알 수 없다.
 
-- [ ] `TransportPort` 정의: 발행(`send(topic, key, envelope)`) + 구독(`subscribe(topics, handler)`) 최소 표면
-- [ ] `KafkaTransport` — 기존 배선을 그대로 옮긴다. **동작 변경 없음**
-- [ ] `InMemoryTransport` — 토픽별 큐, 동기 디스패치, 테스트에서 관찰 가능한 발행 로그
+**⚠️ port 표면은 브레인스토밍에서 확정됐다 (2026-08-09): 발행 방향만.** `subscribe(topics, handler)` 는 port 에 넣지 않는다 — 소비 루프는 `libs/events` 가 아니라 Nest `ServerKafka` 가 소유하므로 정직한 Kafka 구현이 없다. 근거와 대안(`CustomTransportStrategy`)은 ADR-0029 §7 에 있다. **이 플랜의 옛 문구(`send` + `subscribe` 대칭)는 ADR 과 충돌해 폐기됐다.**
+
+- [ ] `EventTransport` 정의: `send(topic, {key, value, headers})` 만. `EVENT_TRANSPORT` DI 토큰 동봉
+- [ ] `KafkaTransport` — `ClientKafka.emit` + `firstValueFrom` 을 그대로 옮긴다. **동작 변경 없음** (GZIP 압축은 어댑터 내부로)
+- [ ] `InMemoryBroker` — 토픽별 발행 로그(`messagesOn`), 적대적 envelope 주입(`inject`)
+- [ ] `InMemoryTransport` — `send` → broker 적재 → 구독 서버에 **동기** 배달 (await 후 단언 가능해야 함)
+- [ ] `InMemoryServer` — `Server implements CustomTransportStrategy`. **진짜 `KafkaContext` 인스턴스**를 만들어야 한다 (`event-retry.interceptor.ts:72` 의 `instanceof` 게이트). 디스패치는 `ServerKafka.handleEvent` 를 그대로 흉내 — `handler(data, ctx)` 한 번만 부르면 다중 핸들러 체인은 `ListenersController.forkJoinHandlersIfAttached` 가 알아서 순회한다
+- [ ] `StreamPublisher` · `DLQHandler` 생성자를 port 로 교체, `events.module.ts` 배선 4곳 조정. **앱 코드 변경 0**
 - [ ] 왕복 스펙: `StreamPublisher.publishEvent` → 인메모리 → `@OnEvent` 핸들러 호출까지 한 프로세스에서 검증
 - [ ] 왕복 스펙에 **`EventTypeGuard` 필터링**(같은 토픽 다중 핸들러 중 1개만 실행) 케이스 포함
-- [ ] 왕복 스펙에 **스키마 위반 → DLQ 분류** 케이스 포함
+- [ ] 왕복 스펙에 **스키마 위반 → DLQ 분류** 케이스 포함. ⚠️ `validateOnPublish` 기본값이 `true` 라 잘못된 payload 는 발행 단계에서 먼저 터진다 — publisher 를 우회해 `broker.inject()` 로 적대적 envelope 를 직접 넣을 것 (실제로도 그런 메시지는 *다른 서비스가* 보낸다)
 - [ ] `npm run type-check` 초록 · 커밋 · 푸시
 
 **완료 기준:** 브로커 없이 발행→소비 왕복이 테스트로 증명된다. 이후 모든 태스크는 이 하네스 위에서 증거를 남긴다.

--- a/docs/superpowers/plans/2026-08-09-events-module-registration.md
+++ b/docs/superpowers/plans/2026-08-09-events-module-registration.md
@@ -109,18 +109,42 @@
 
 **⚠️ port 표면은 브레인스토밍에서 확정됐다 (2026-08-09): 발행 방향만.** `subscribe(topics, handler)` 는 port 에 넣지 않는다 — 소비 루프는 `libs/events` 가 아니라 Nest `ServerKafka` 가 소유하므로 정직한 Kafka 구현이 없다. 근거와 대안(`CustomTransportStrategy`)은 ADR-0029 §7 에 있다. **이 플랜의 옛 문구(`send` + `subscribe` 대칭)는 ADR 과 충돌해 폐기됐다.**
 
-- [ ] `EventTransport` 정의: `send(topic, {key, value, headers})` 만. `EVENT_TRANSPORT` DI 토큰 동봉
-- [ ] `KafkaTransport` — `ClientKafka.emit` + `firstValueFrom` 을 그대로 옮긴다. **동작 변경 없음** (GZIP 압축은 어댑터 내부로)
-- [ ] `InMemoryBroker` — 토픽별 발행 로그(`messagesOn`), 적대적 envelope 주입(`inject`)
-- [ ] `InMemoryTransport` — `send` → broker 적재 → 구독 서버에 **동기** 배달 (await 후 단언 가능해야 함)
-- [ ] `InMemoryServer` — `Server implements CustomTransportStrategy`. **진짜 `KafkaContext` 인스턴스**를 만들어야 한다 (`event-retry.interceptor.ts:72` 의 `instanceof` 게이트). 디스패치는 `ServerKafka.handleEvent` 를 그대로 흉내 — `handler(data, ctx)` 한 번만 부르면 다중 핸들러 체인은 `ListenersController.forkJoinHandlersIfAttached` 가 알아서 순회한다
-- [ ] `StreamPublisher` · `DLQHandler` 생성자를 port 로 교체, `events.module.ts` 배선 4곳 조정. **앱 코드 변경 0**
-- [ ] 왕복 스펙: `StreamPublisher.publishEvent` → 인메모리 → `@OnEvent` 핸들러 호출까지 한 프로세스에서 검증
-- [ ] 왕복 스펙에 **`EventTypeGuard` 필터링**(같은 토픽 다중 핸들러 중 1개만 실행) 케이스 포함
-- [ ] 왕복 스펙에 **스키마 위반 → DLQ 분류** 케이스 포함. ⚠️ `validateOnPublish` 기본값이 `true` 라 잘못된 payload 는 발행 단계에서 먼저 터진다 — publisher 를 우회해 `broker.inject()` 로 적대적 envelope 를 직접 넣을 것 (실제로도 그런 메시지는 *다른 서비스가* 보낸다)
-- [ ] `npm run type-check` 초록 · 커밋 · 푸시
+- [x] `EventTransport` 정의: `send(topic, {key, value, headers})` 만. `EVENT_TRANSPORT` DI 토큰 동봉
+- [x] `KafkaTransport` — `ClientKafka.emit` + `firstValueFrom` 을 그대로 옮긴다. **동작 변경 없음** (GZIP 압축은 어댑터 내부로)
+- [x] `InMemoryBroker` — 토픽별 발행 로그(`messagesOn`), 적대적 envelope 주입(`inject`)
+- [x] `InMemoryTransport` — `send` → broker 적재 → 구독 서버에 **동기** 배달 (await 후 단언 가능해야 함)
+- [x] `InMemoryServer` — `Server implements CustomTransportStrategy`. **진짜 `KafkaContext` 인스턴스**를 만들어야 한다 (`event-retry.interceptor.ts:72` 의 `instanceof` 게이트). 디스패치는 `ServerKafka.handleEvent` 를 그대로 흉내 — `handler(data, ctx)` 한 번만 부르면 다중 핸들러 체인은 `ListenersController.forkJoinHandlersIfAttached` 가 알아서 순회한다
+- [x] `StreamPublisher` · `DLQHandler` 생성자를 port 로 교체, `events.module.ts` 배선 4곳 조정. **앱 코드 변경 0**
+- [x] 왕복 스펙: `StreamPublisher.publishEvent` → 인메모리 → `@OnEvent` 핸들러 호출까지 한 프로세스에서 검증
+- [x] 왕복 스펙에 **`EventTypeGuard` 필터링**(같은 토픽 다중 핸들러 중 1개만 실행) 케이스 포함
+- [x] 왕복 스펙에 **스키마 위반 → DLQ 분류** 케이스 포함. ⚠️ `validateOnPublish` 기본값이 `true` 라 잘못된 payload 는 발행 단계에서 먼저 터진다 — publisher 를 우회해 `broker.inject()` 로 적대적 envelope 를 직접 넣을 것 (실제로도 그런 메시지는 *다른 서비스가* 보낸다)
+- [x] `npm run type-check` 초록 · 커밋 · 푸시
 
 **완료 기준:** 브로커 없이 발행→소비 왕복이 테스트로 증명된다. 이후 모든 태스크는 이 하네스 위에서 증거를 남긴다.
+
+**완료 (2026-08-09).** 브랜치 `feat/events-transport-port`.
+
+- port 표면은 **발행만**(`send`). 소비 다형성은 Nest `CustomTransportStrategy` 에서 얻는다 — 근거는 ADR-0029 §7.
+- **하네스는 `EventsModule` 을 실제로 import 한다.** `forRoot` + `forConsumerModule` 을 그대로 쓰고 `EVENT_TRANSPORT` 하나만 `overrideProvider` 로 바꾼다. 즉 인터셉터·가드·파라미터 데코레이터·생성자 DI 가 전부 실물이다.
+- `InMemoryServer` 는 Nest 가 export 하는 `KafkaParser` 를 **그대로 재사용**한다. 흉내내면 운영과 다른 것을 테스트하게 된다.
+- **`Kafka 로 나가는 모든 경로`가 port 를 지난다** — `StreamPublisher` · `OutboxDispatcher`(publisher 경유) · `DLQHandler`. `GracefulShutdownService` 만 연결 종료 목적으로 `KAFKA_CLIENT` 를 계속 쓴다.
+
+**🔴 하네스가 첫 실행에서 실재 프로덕션 버그를 찾았다 (같은 브랜치에서 수정).**
+
+Nest 는 수신 `value` 를 `KafkaParser.decode` 로 **JSON 파싱해서** 넘긴다(`keepBinary` 기본 false). 즉 운영에서 `KafkaContext.getMessage().value` 는 Buffer 가 **아니라 객체**다. 그런데 세 곳이 `Buffer.isBuffer(v) ? v.toString() : String(v)` 관용구를 써서 `"[object Object]"` 를 만들고 `JSON.parse` 가 터졌다:
+
+| 위치 | 증상 |
+|---|---|
+| `schema-validation.interceptor.ts:69` | 모든 메시지가 SyntaxError → 재시도 3회(7초 블로킹) |
+| `event-retry.interceptor.ts:194` | DLQ 전송도 같은 이유로 실패 → `DlqDeliveryError` → **offset 미커밋 → 무한 재전달** |
+| `chain-context.interceptor.ts:26` | `catch {}` 로 삼킴 → 조용히 no-op |
+
+`validateOnConsume: true` 인 앱(**core · analytics · search**)이 해당. 수정은 `utils/envelope.util.ts` 의 `parseEnvelope` 하나로 모았다. 인접한 4곳(`event-type.guard.ts:41`, `decorators.ts` 3곳)은 원래부터 객체를 처리하고 있었다 — 관용구가 불일치했던 것.
+
+**⚠️ 고치지 않고 남긴 것:** 소비 경로에서 `chainId` 가 CLS 로 전파되지 않는다. 파싱과 **무관한 별개 원인** — `ClsModule.forRoot({ middleware: { mount: false } })` 이고 RPC 경로에 ClsGuard/Interceptor 가 없어 `setChainId` 가 "No CLS context available" 로 던지며 `ChainContextInterceptor` 의 `catch {}` 가 삼킨다(실측 확인). 범위 밖이라 `round-trip.spec.ts` 에 **`it.failing`** 으로 박아뒀다 — 누가 고치면 그 테스트가 실패해서 알린다.
+
+- 검증: `libs/events`+계약 패키지 **14 suite / 129 tests 초록** · `npm run type-check` **164 = develop 기준선과 동일**(libs/events 잔여 4건은 전부 기존 부채) · **9개 앱 전부 `nest build` 초록** · 신규 파일 eslint 초록(libs/events 기존 부채 116건은 별개) · 전체 jest 실패 suite 집합이 develop 과 **동일**(18), 통과 테스트 +9.
+- **Task 3 에 넘기는 사실:** `InMemoryServer.dispatch` 는 `handler(data, ctx)` 를 **한 번만** 부른다. 같은 토픽 다중 핸들러 순회는 `ListenersController.forkJoinHandlersIfAttached` 가 하므로 운영과 동일하다. 또한 같은 토픽 핸들러가 N개면 인터셉터 체인도 N번 돌아 **스키마 위반 시 DLQ 메시지가 N개** 생긴다(하네스에서 확인) — Task 6 의 "토픽당 한 번 파싱" 설계가 이것도 같이 없앤다.
 
 ---
 

--- a/libs/events/src/dlq/dlq-handler.service.ts
+++ b/libs/events/src/dlq/dlq-handler.service.ts
@@ -8,10 +8,9 @@
  */
 
 import { Injectable, Logger, Inject } from '@nestjs/common';
-import { ClientKafka } from '@nestjs/microservices';
 import { Kafka } from 'kafkajs';
-import { firstValueFrom } from 'rxjs';
 import { MessageEnvelope, KafkaConfig } from '@packages/event-contracts/types';
+import { EVENT_TRANSPORT, EventTransport } from '../transport/transport.port';
 import { getDLQTopicName } from '@packages/event-contracts/types';
 import { generateMessageId } from '../utils/message-id.util';
 import { DLQMessage, BatchReprocessResult } from './dlq.types';
@@ -22,8 +21,8 @@ export class DLQHandler {
   private readonly logger = new Logger(DLQHandler.name);
 
   constructor(
-    @Inject('KAFKA_CLIENT')
-    private readonly kafkaClient: ClientKafka,
+    @Inject(EVENT_TRANSPORT)
+    private readonly transport: EventTransport,
   ) {}
 
   /**
@@ -90,22 +89,20 @@ export class DLQHandler {
 
     try {
       // DLQ 토픽으로 발행
-      await firstValueFrom(
-        this.kafkaClient.emit(dlqTopic, {
-          key: params.originalMessage.source.aggregateId,
-          value: JSON.stringify(dlqMessage),
-          headers: {
-            'dlq-message-id': dlqMessageId,
-            'original-topic': params.originalTopic,
-            'original-message-type': params.originalMessage.messageType,
-            'original-message-id': params.originalMessage.messageId,
-            'original-aggregate-id': params.originalMessage.source.aggregateId,
-            'failure-reason': params.error.name,
-            'retry-count': String(params.context.retryCount),
-            'failed-at': dlqMessage.failedAt,
-          },
-        }),
-      );
+      await this.transport.send(dlqTopic, {
+        key: params.originalMessage.source.aggregateId,
+        value: JSON.stringify(dlqMessage),
+        headers: {
+          'dlq-message-id': dlqMessageId,
+          'original-topic': params.originalTopic,
+          'original-message-type': params.originalMessage.messageType,
+          'original-message-id': params.originalMessage.messageId,
+          'original-aggregate-id': params.originalMessage.source.aggregateId,
+          'failure-reason': params.error.name,
+          'retry-count': String(params.context.retryCount),
+          'failed-at': dlqMessage.failedAt,
+        },
+      });
 
       this.logger.warn(`📤 Message sent to DLQ: ${params.originalMessage.messageType}`, {
         dlqTopic,
@@ -173,19 +170,17 @@ export class DLQHandler {
 
     try {
       // 원본 토픽으로 재발행
-      await firstValueFrom(
-        this.kafkaClient.emit(dlqMessage.originalTopic, {
-          key: dlqMessage.originalMessage.source.aggregateId,
-          value: JSON.stringify(dlqMessage.originalMessage),
-          partition: params.options?.targetPartition,
-          headers: {
-            'reprocess-attempt': 'true',
-            'original-dlq-id': dlqMessage.dlqMessageId,
-            'reprocess-count': String(dlqMessage.reprocessAttempts + 1),
-            'reprocessed-at': new Date().toISOString(),
-          },
-        }),
-      );
+      await this.transport.send(dlqMessage.originalTopic, {
+        key: dlqMessage.originalMessage.source.aggregateId,
+        value: JSON.stringify(dlqMessage.originalMessage),
+        partition: params.options?.targetPartition,
+        headers: {
+          'reprocess-attempt': 'true',
+          'original-dlq-id': dlqMessage.dlqMessageId,
+          'reprocess-count': String(dlqMessage.reprocessAttempts + 1),
+          'reprocessed-at': new Date().toISOString(),
+        },
+      });
 
       this.logger.log(`✅ DLQ message reprocessed: ${dlqMessage.dlqMessageId}`, {
         originalTopic: dlqMessage.originalTopic,

--- a/libs/events/src/dlq/dlq.metrics.spec.ts
+++ b/libs/events/src/dlq/dlq.metrics.spec.ts
@@ -1,8 +1,7 @@
-import { of, throwError } from 'rxjs';
-import type { ClientKafka } from '@nestjs/microservices';
 import type { MessageEnvelope } from '@packages/event-contracts/types';
 import { DLQHandler } from './dlq-handler.service';
 import { dlqMessagesTotal, dlqSendFailuresTotal } from './dlq.metrics';
+import type { EventTransport } from '../transport/transport.port';
 
 function buildParams() {
   const originalMessage = {
@@ -32,8 +31,9 @@ describe('DLQHandler metrics', () => {
   });
 
   it('DLQ 발행 성공 시 events_dlq_messages_total 을 라벨과 함께 증가시킨다', async () => {
-    const kafka = { emit: () => of(undefined) } as unknown as ClientKafka;
-    const handler = new DLQHandler(kafka);
+    // port 덕분에 캐스팅 없이 그대로 만족하는 테스트 더블
+    const transport: EventTransport = { send: async () => undefined };
+    const handler = new DLQHandler(transport);
 
     await handler.sendToDLQ(buildParams());
 
@@ -48,10 +48,12 @@ describe('DLQHandler metrics', () => {
   });
 
   it('DLQ 발행 실패 시 events_dlq_send_failures_total 을 증가시키고 에러를 재던진다', async () => {
-    const kafka = {
-      emit: () => throwError(() => new Error('broker down')),
-    } as unknown as ClientKafka;
-    const handler = new DLQHandler(kafka);
+    const transport: EventTransport = {
+      send: async () => {
+        throw new Error('broker down');
+      },
+    };
+    const handler = new DLQHandler(transport);
 
     await expect(handler.sendToDLQ(buildParams())).rejects.toThrow('broker down');
 

--- a/libs/events/src/events.module.ts
+++ b/libs/events/src/events.module.ts
@@ -5,7 +5,7 @@
  */
 
 import { DynamicModule, Global, Inject, Module, OnApplicationShutdown, Logger } from '@nestjs/common';
-import { ClientsModule, Transport } from '@nestjs/microservices';
+import { ClientKafka, ClientsModule, Transport } from '@nestjs/microservices';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ClsModule } from 'nestjs-cls';
 import { StreamPublisher } from './publishers/stream-publisher.service';
@@ -28,6 +28,18 @@ import { outboxSchema } from './outbox/outbox.schema';
 import { trackingSchema } from './tracking/tracking.schema';
 import { ScheduleModule } from '@nestjs/schedule';
 import { DbService } from '@app/db';
+import { EVENT_TRANSPORT, EventTransport } from './transport/transport.port';
+import { KafkaTransport } from './transport/kafka.transport';
+
+/**
+ * Kafka 로 나가는 유일한 통로 (ADR-0029 §7). `KAFKA_CLIENT` 를 감싸며,
+ * `GracefulShutdownService` 만 연결 종료 목적으로 `KAFKA_CLIENT` 를 계속 직접 쓴다.
+ */
+const eventTransportProvider = {
+  provide: EVENT_TRANSPORT,
+  useFactory: (kafkaClient: ClientKafka): EventTransport => new KafkaTransport(kafkaClient),
+  inject: ['KAFKA_CLIENT'],
+};
 
 /**
  * EventsModule 설정 옵션 (Publisher용)
@@ -87,12 +99,12 @@ export class EventsModule {
     const publisherProviders = options.streams.map((stream) => ({
       provide: this.getPublisherToken(stream.topic.topic),
       useFactory: (
-        kafkaClient: any,
+        transport: EventTransport,
         eventChainService: EventChainService,
         eventTrackingService: EventTrackingService,
       ) => {
         return new StreamPublisher(
-          kafkaClient,
+          transport,
           stream,
           serviceName,
           options.validation, // 스키마 검증 옵션 전달
@@ -100,17 +112,17 @@ export class EventsModule {
           eventTrackingService,
         );
       },
-      inject: ['KAFKA_CLIENT', EventChainService, EventTrackingService],
+      inject: [EVENT_TRANSPORT, EventChainService, EventTrackingService],
     }));
 
     // DLQ Handler 제공자 (DLQ가 활성화된 경우에만)
     const dlqProvider = enableDLQ
       ? {
           provide: DLQHandler,
-          useFactory: (kafkaClient: any) => {
-            return new DLQHandler(kafkaClient);
+          useFactory: (transport: EventTransport) => {
+            return new DLQHandler(transport);
           },
-          inject: ['KAFKA_CLIENT'],
+          inject: [EVENT_TRANSPORT],
         }
       : null;
 
@@ -146,7 +158,7 @@ export class EventsModule {
             provide: OutboxDispatcher,
             useFactory: (
               dbService: DbService,
-              kafkaClient: any,
+              transport: EventTransport,
               eventChainService: EventChainService,
               eventTrackingService: EventTrackingService,
             ) => {
@@ -154,7 +166,7 @@ export class EventsModule {
               const publisherMap = new Map<string, StreamPublisher>();
               options.streams.forEach((stream) => {
                 const publisher = new StreamPublisher(
-                  kafkaClient,
+                  transport,
                   stream,
                   serviceName,
                   options.validation,
@@ -166,7 +178,7 @@ export class EventsModule {
 
               return new OutboxDispatcher(dbService, publisherMap, options.outbox);
             },
-            inject: [DbService, 'KAFKA_CLIENT', EventChainService, EventTrackingService],
+            inject: [DbService, EVENT_TRANSPORT, EventChainService, EventTrackingService],
           },
         ]
       : [];
@@ -186,6 +198,7 @@ export class EventsModule {
 
     const providers = [
       retryInterceptorProvider, // 최외곽 — 등록 순서가 래핑 순서
+      eventTransportProvider, // Kafka 로 나가는 유일한 통로
       ...publisherProviders,
       ...(dlqProvider ? [dlqProvider] : []),
       ...outboxProviders,
@@ -253,10 +266,10 @@ export class EventsModule {
     const dlqProvider = enableAutoDLQ
       ? {
           provide: DLQHandler,
-          useFactory: (kafkaClient: any) => {
-            return new DLQHandler(kafkaClient);
+          useFactory: (transport: EventTransport) => {
+            return new DLQHandler(transport);
           },
-          inject: ['KAFKA_CLIENT'],
+          inject: [EVENT_TRANSPORT],
         }
       : null;
 
@@ -300,6 +313,7 @@ export class EventsModule {
     };
 
     const providers = [
+      eventTransportProvider, // Kafka 로 나가는 유일한 통로
       ...(dlqProvider ? [dlqProvider] : []),
       retryInterceptorProvider, // 최외곽 — 등록 순서가 래핑 순서
       interceptorProvider, // 스키마 검증 Interceptor는 항상 등록

--- a/libs/events/src/index.ts
+++ b/libs/events/src/index.ts
@@ -13,6 +13,14 @@ export * from './events.module';
 // Kafka Config Builder
 export { createKafkaConfigFromEnv } from './kafka-config.util';
 
+// Transport Port + 어댑터 (ADR-0029 §7)
+export * from './transport/transport.port';
+export * from './transport/kafka.transport';
+// 테스트 하네스 — 앱 스펙에서도 쓸 수 있게 공개 표면에 둔다
+export * from './transport/in-memory.broker';
+export * from './transport/in-memory.transport';
+export * from './transport/in-memory.server';
+
 // Publisher
 export * from './publishers/stream-publisher.service';
 

--- a/libs/events/src/interceptors/chain-context.interceptor.ts
+++ b/libs/events/src/interceptors/chain-context.interceptor.ts
@@ -2,8 +2,8 @@ import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nes
 import { Observable } from 'rxjs';
 import { KafkaContext } from '@nestjs/microservices';
 import { v7 } from 'uuid';
-import { MessageEnvelope } from '@packages/event-contracts/types';
 import { EventChainService } from '../tracking/event-chain.service';
+import { parseEnvelope } from '../utils/envelope.util';
 
 /**
  * Kafka 메시지 수신 시 envelope에서 chainId/eventId를 CLS에 설정하는 인터셉터
@@ -23,8 +23,7 @@ export class ChainContextInterceptor implements NestInterceptor {
       const value = message.value;
 
       if (value) {
-        const jsonString = Buffer.isBuffer(value) ? value.toString('utf-8') : String(value);
-        const envelope = JSON.parse(jsonString) as MessageEnvelope;
+        const envelope = parseEnvelope(value);
 
         const chainId = envelope.chainId ?? v7();
         const eventId = envelope.messageId;

--- a/libs/events/src/interceptors/event-retry.interceptor.ts
+++ b/libs/events/src/interceptors/event-retry.interceptor.ts
@@ -16,7 +16,8 @@ import { Reflector } from '@nestjs/core';
 import { KafkaContext, KafkaHeaders } from '@nestjs/microservices';
 import { defer, lastValueFrom, Observable } from 'rxjs';
 import { DLQHandler } from '../dlq/dlq-handler.service';
-import { MessageEnvelope, SchemaValidationError } from '@packages/event-contracts/types';
+import { SchemaValidationError } from '@packages/event-contracts/types';
+import { parseEnvelope } from '../utils/envelope.util';
 import {
   RETRY_POLICY_METADATA,
   DISABLE_DLQ_METADATA,
@@ -190,11 +191,10 @@ export class EventRetryInterceptor implements NestInterceptor {
     const topic = kafkaContext.getTopic();
 
     try {
-      const value = message.value;
-      const jsonString: string = Buffer.isBuffer(value) ? value.toString('utf-8') : String(value ?? '{}');
-      // as 정당화: JSON.parse 는 unknown 을 반환하며 런타임 스키마 검증은 SchemaValidationInterceptor 소관.
-      // DLQ 전송은 실패 메시지 보존이 목적이라 envelope 형태를 신뢰하고 전달한다 (schema-validation.interceptor.ts:70 과 동일 관례).
-      const envelope = JSON.parse(jsonString) as MessageEnvelope;
+      // DLQ 전송은 실패 메시지 보존이 목적이라 envelope 형태를 신뢰하고 전달한다.
+      // 파싱 관용구를 직접 쓰지 않는 이유는 parseEnvelope 주석 참조 — 여기서 터지면
+      // DlqDeliveryError 가 되어 offset 미커밋 → 무한 재전달이 된다.
+      const envelope = parseEnvelope(message.value);
 
       await dlqHandler.sendToDLQ({
         originalTopic: topic,

--- a/libs/events/src/interceptors/schema-validation.interceptor.ts
+++ b/libs/events/src/interceptors/schema-validation.interceptor.ts
@@ -17,6 +17,7 @@ import {
 } from '@packages/event-contracts/types';
 import { validateSchemaOrThrow, isZodSchema, formatValidationErrors } from '../validation/schema-validation.util';
 import { EVENT_TYPE_FILTER } from '../consumers/decorators';
+import { parseEnvelope } from '../utils/envelope.util';
 
 @Injectable()
 export class SchemaValidationInterceptor implements NestInterceptor {
@@ -60,14 +61,8 @@ export class SchemaValidationInterceptor implements NestInterceptor {
         return next.handle();
       }
 
-      // 메시지 파싱
-      const message = kafkaContext.getMessage();
-      const value = message.value;
-      if (!value) {
-        throw new Error('Kafka message value is null or undefined');
-      }
-      const jsonString: string = Buffer.isBuffer(value) ? value.toString('utf-8') : String(value);
-      const envelope = JSON.parse(jsonString) as MessageEnvelope;
+      // 메시지 파싱 — Nest 가 이미 객체로 파싱해 넘긴다 (parseEnvelope 주석 참조)
+      const envelope = parseEnvelope(kafkaContext.getMessage().value);
 
       // 이벤트 타입별 스키마 검증
       const eventType = envelope.messageType;

--- a/libs/events/src/publishers/stream-publisher.service.ts
+++ b/libs/events/src/publishers/stream-publisher.service.ts
@@ -5,9 +5,6 @@
  */
 
 import { Injectable, Inject, Logger, Optional } from '@nestjs/common';
-import { ClientKafka } from '@nestjs/microservices';
-import { CompressionTypes } from 'kafkajs';
-import { firstValueFrom } from 'rxjs';
 import { v7 } from 'uuid';
 import { DomainEvent, DomainCommand, MessageEnvelope } from '@packages/event-contracts/types';
 import { StreamConfig, StreamEventTypes, EventType } from '@packages/event-contracts/types';
@@ -16,6 +13,7 @@ import { SchemaValidationOptions, DEFAULT_SCHEMA_VALIDATION_OPTIONS } from '@pac
 import { validateSchemaOrThrow, logValidationError, isZodSchema } from '../validation/schema-validation.util';
 import { EventChainService } from '../tracking/event-chain.service';
 import { EventTrackingService } from '../tracking/event-tracking.service';
+import { EventTransport } from '../transport/transport.port';
 
 export interface CausedByResource {
   resourceType: string;
@@ -60,7 +58,7 @@ export class StreamPublisher<TEvents extends StreamEventTypes = StreamEventTypes
   private readonly validationOptions: Required<SchemaValidationOptions>;
 
   constructor(
-    private readonly kafkaClient: ClientKafka,
+    private readonly transport: EventTransport,
     private readonly streamConfig: StreamConfig<TEvents>,
     private readonly serviceName: string,
     validationOptions?: SchemaValidationOptions,
@@ -204,28 +202,26 @@ export class StreamPublisher<TEvents extends StreamEventTypes = StreamEventTypes
   }
 
   /**
-   * Kafka로 메시지 전송 (내부 메서드)
+   * 전송 (내부 메서드) — 어댑터가 Kafka 인지 인메모리인지 여기서는 모른다
    */
   private async sendMessage(envelope: MessageEnvelope, partitionKey: string): Promise<void> {
     const topic = this.streamConfig.topic.topic;
 
     try {
-      await firstValueFrom(
-        this.kafkaClient.emit(topic, {
-          key: partitionKey, // 파티션 키 (순서 보장)
-          value: JSON.stringify(envelope),
-          compression: CompressionTypes.GZIP, // 압축
-          headers: {
-            'message-id': envelope.messageId,
-            'message-type': envelope.messageType,
-            'message-kind': envelope.messageKind,
-            'aggregate-type': envelope.source.aggregateType,
-            'aggregate-id': envelope.source.aggregateId,
-            'correlation-id': envelope.correlationId,
-            timestamp: envelope.timestamp,
-          },
-        }),
-      );
+      await this.transport.send(topic, {
+        key: partitionKey, // 파티션 키 (순서 보장)
+        value: JSON.stringify(envelope),
+        compress: true,
+        headers: {
+          'message-id': envelope.messageId,
+          'message-type': envelope.messageType,
+          'message-kind': envelope.messageKind,
+          'aggregate-type': envelope.source.aggregateType,
+          'aggregate-id': envelope.source.aggregateId,
+          'correlation-id': envelope.correlationId,
+          timestamp: envelope.timestamp,
+        },
+      });
 
       this.logger.debug(`📤 ${envelope.messageKind} published: ${envelope.messageType}`, {
         messageId: envelope.messageId,

--- a/libs/events/src/transport/in-memory.broker.ts
+++ b/libs/events/src/transport/in-memory.broker.ts
@@ -1,0 +1,132 @@
+/**
+ * In-Memory Broker (테스트 전용)
+ *
+ * 발행 어댑터(`InMemoryTransport`)와 소비 전략(`InMemoryServer`)이 공유하는 버스.
+ * 토픽별 발행 로그를 남겨 테스트가 관찰할 수 있게 하고, 외부 서비스가 보낸 메시지를
+ * 흉내내는 `inject()` 를 제공한다.
+ */
+
+import { MessageEnvelope } from '@packages/event-contracts/types';
+
+export interface BrokerRecord {
+  topic: string;
+  partition: number;
+  offset: string;
+  key: string;
+  /** 직렬화된 상태 그대로 — Kafka 가 바이트를 나르는 것과 같다 */
+  value: string;
+  headers: Record<string, string>;
+  timestamp: string;
+}
+
+export interface DeliveryFailure {
+  record: BrokerRecord;
+  error: unknown;
+}
+
+type Subscriber = (record: BrokerRecord) => Promise<void>;
+
+export interface InjectOptions {
+  key?: string;
+  headers?: Record<string, string>;
+}
+
+export class InMemoryBroker {
+  private readonly records: BrokerRecord[] = [];
+  private readonly subscribers = new Set<Subscriber>();
+  private readonly nextOffset = new Map<string, number>();
+  private readonly failures: DeliveryFailure[] = [];
+
+  /** 소비 전략이 자신을 등록한다. 반환값을 호출하면 해지된다. */
+  subscribe(subscriber: Subscriber): () => void {
+    this.subscribers.add(subscriber);
+    return () => {
+      this.subscribers.delete(subscriber);
+    };
+  }
+
+  /**
+   * 발행 경로 — `InMemoryTransport` 가 부른다.
+   *
+   * 배달은 **동기**다(구독자 처리를 await 한다). 그래야 테스트가
+   * `await publisher.publishEvent(...)` 직후에 바로 단언할 수 있다.
+   */
+  async publish(
+    topic: string,
+    message: { key: string; value: string; headers?: Record<string, string>; partition?: number },
+  ): Promise<BrokerRecord> {
+    const offset = this.nextOffset.get(topic) ?? 0;
+    this.nextOffset.set(topic, offset + 1);
+
+    const record: BrokerRecord = {
+      topic,
+      partition: message.partition ?? 0,
+      offset: String(offset),
+      key: message.key,
+      value: message.value,
+      headers: { ...(message.headers ?? {}) },
+      timestamp: String(Date.now()),
+    };
+
+    // 로그를 먼저 남긴다 — 핸들러가 다시 발행해도 로그 순서가 인과와 일치한다
+    this.records.push(record);
+    await this.deliver(record);
+    return record;
+  }
+
+  /**
+   * 외부 서비스가 보낸 메시지를 흉내낸다.
+   *
+   * `StreamPublisher` 를 우회하므로 `validateOnPublish` 를 타지 않는다 —
+   * 스키마를 만족하지 않는 인바운드 메시지를 만들 수 있는 유일한 경로이며,
+   * 실제로도 그런 메시지는 *다른 서비스가* 보낸다. 문자열을 그대로 넘기면
+   * 깨진 JSON 도 주입할 수 있다.
+   */
+  async inject(topic: string, envelope: unknown, options?: InjectOptions): Promise<BrokerRecord> {
+    const value = typeof envelope === 'string' ? envelope : JSON.stringify(envelope);
+    return this.publish(topic, {
+      key: options?.key ?? 'injected',
+      value,
+      headers: options?.headers,
+    });
+  }
+
+  /** 해당 토픽으로 나간(또는 주입된) 메시지 전부 */
+  messagesOn(topic: string): BrokerRecord[] {
+    return this.records.filter((record) => record.topic === topic);
+  }
+
+  /** `messagesOn` 의 envelope 파싱본 */
+  envelopesOn<T = MessageEnvelope>(topic: string): T[] {
+    return this.messagesOn(topic).map((record) => JSON.parse(record.value) as T);
+  }
+
+  /** 발행된 토픽 이름 전부 (중복 없음, 발행 순서) */
+  get topics(): string[] {
+    return [...new Set(this.records.map((record) => record.topic))];
+  }
+
+  /**
+   * 소비 중 터진 에러. 발행자에게는 전파되지 않는다 — 운영에서 Kafka 발행은
+   * 소비자 실패와 무관하게 성공하므로, 그 분리를 여기서도 지킨다.
+   */
+  get deliveryFailures(): readonly DeliveryFailure[] {
+    return this.failures;
+  }
+
+  reset(): void {
+    this.records.length = 0;
+    this.failures.length = 0;
+    this.nextOffset.clear();
+  }
+
+  private async deliver(record: BrokerRecord): Promise<void> {
+    for (const subscriber of [...this.subscribers]) {
+      try {
+        await subscriber(record);
+      } catch (error) {
+        this.failures.push({ record, error });
+      }
+    }
+  }
+}

--- a/libs/events/src/transport/in-memory.server.ts
+++ b/libs/events/src/transport/in-memory.server.ts
@@ -1,0 +1,154 @@
+/**
+ * In-Memory Consumer Strategy (테스트 전용)
+ *
+ * Nest 의 `CustomTransportStrategy` 로 붙는 소비 측 어댑터. 운영의 `ServerKafka`
+ * 자리에 들어가며, **Nest 파이프라인(인터셉터·가드·파라미터 데코레이터·DI)은
+ * 그대로 살아 있다.**
+ *
+ * ## 왜 진짜 `KafkaContext` 를 만드는가
+ *
+ * `EventRetryInterceptor` 는 `instanceof KafkaContext` 로 게이트한다
+ * (`interceptors/event-retry.interceptor.ts:72`). 손으로 만든 context 객체를
+ * 넣으면 그 줄에서 빠져나가 **재시도·DLQ 분류가 통째로 건너뛰어진다** — 테스트는
+ * 초록불이 뜨지만 아무것도 증명하지 못한다. `EventTypeGuard` 와
+ * `SchemaValidationInterceptor` 도 같은 이유로 `KafkaContext` 를 요구한다.
+ *
+ * ## 왜 `KafkaParser` 를 재사용하는가
+ *
+ * Nest 는 수신 메시지의 `value` 를 그대로 넘기지 않고 `KafkaParser.decode` 로
+ * **JSON 파싱해서** 넘긴다. 즉 운영에서 `getMessage().value` 는 Buffer 가 아니라
+ * 객체다. 이 하네스가 Buffer 를 넘기면 운영과 다른 것을 테스트하게 되므로,
+ * 흉내내지 않고 Nest 가 export 하는 파서를 그대로 쓴다.
+ */
+
+import { CustomTransportStrategy, KafkaContext, KafkaParser, Server } from '@nestjs/microservices';
+import { isObservable, lastValueFrom } from 'rxjs';
+import { BrokerRecord, InMemoryBroker } from './in-memory.broker';
+
+export const IN_MEMORY_TRANSPORT = Symbol('IN_MEMORY_TRANSPORT');
+
+/**
+ * `KafkaContext` 가 요구하지만 인메모리에서 의미가 없는 협력자들.
+ *
+ * as 정당화: Nest 의 `Consumer`/`Producer` 타입은 `@nestjs/microservices` 공개
+ * 표면에 없고(내부 `external/kafka.interface`), 우리 코드 경로에서 실제로 쓰이는
+ * 것은 `getHeartbeat()` 뿐이다. 나머지가 호출되면 조용히 통과하는 대신 즉시
+ * 터지도록 Proxy 로 막아, 이 하네스가 무엇을 보장하지 *않는지*를 분명히 한다.
+ */
+function unsupportedCollaborator<T>(name: string): T {
+  return new Proxy(
+    {},
+    {
+      get(_target, property) {
+        throw new Error(
+          `InMemoryServer: KafkaContext.${name}().${String(property)} 는 인메모리 하네스가 제공하지 않는다. ` +
+            `이 경로를 검증해야 한다면 실제 브로커가 필요하다.`,
+        );
+      },
+    },
+  ) as T;
+}
+
+export class InMemoryServer extends Server implements CustomTransportStrategy {
+  transportId = IN_MEMORY_TRANSPORT;
+
+  private readonly parser = new KafkaParser();
+  private readonly statusListeners = new Map<string, unknown[]>();
+  private unsubscribe?: () => void;
+
+  constructor(private readonly broker: InMemoryBroker) {
+    super();
+  }
+
+  listen(callback: (...optionalParams: unknown[]) => void): void {
+    this.unsubscribe = this.broker.subscribe((record) => this.dispatch(record));
+    callback();
+  }
+
+  close(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = undefined;
+  }
+
+  /**
+   * 상태 이벤트 리스너 등록. 인메모리 어댑터는 상태 이벤트를 발화하지 않으므로
+   * 보관만 한다.
+   *
+   * `Function` 을 쓰는 이유: 베이스 `Server<EventsMap = Record<string, Function>>` 가
+   * `EventCallback extends EventsMap[EventKey]` 를 요구해, 더 좁은 시그니처로 좁히면
+   * override 가 assignable 하지 않다(TS2416). 타입 규칙과 lint 규칙이 충돌하는
+   * 자리이며 베이스 클래스 쪽을 따른다.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  on<EventKey extends string = string, EventCallback extends Function = Function>(
+    event: EventKey,
+    callback: EventCallback,
+  ): void {
+    const listeners = this.statusListeners.get(event) ?? [];
+    listeners.push(callback);
+    this.statusListeners.set(event, listeners);
+  }
+
+  unwrap<T>(): T {
+    // as 정당화: `unwrap` 은 정의상 어댑터의 내부 구현체를 반환하며, 호출자가
+    // 기대 타입을 지정한다. 인메모리 어댑터의 내부 구현체는 broker 다.
+    return this.broker as T;
+  }
+
+  /**
+   * `ServerKafka.handleMessage` → `handleEvent` 경로를 그대로 흉내낸다.
+   *
+   * 핸들러를 **한 번만** 부르는 것이 맞다 — 같은 토픽에 걸린 다중 핸들러 순회는
+   * `ListenersController.forkJoinHandlersIfAttached` 가 `handlerRef.next` 를 타고
+   * 수행하며, 이는 운영과 동일하다.
+   */
+  private async dispatch(record: BrokerRecord): Promise<void> {
+    const handler = this.getHandlerByPattern(record.topic);
+    if (!handler) {
+      // 아무도 구독하지 않은 토픽 — Kafka 였다면 배달 자체가 없다
+      return;
+    }
+
+    const rawMessage = this.parser.parse<Record<string, unknown>>({
+      topic: record.topic,
+      partition: record.partition,
+      key: Buffer.from(record.key),
+      value: Buffer.from(record.value),
+      headers: Object.fromEntries(Object.entries(record.headers).map(([name, value]) => [name, Buffer.from(value)])),
+      timestamp: record.timestamp,
+      offset: record.offset,
+      size: Buffer.byteLength(record.value),
+      attributes: 0,
+    });
+
+    const context = new KafkaContext([
+      // as 정당화: `parser.parse` 의 반환 타입은 입력 형태를 따라가는 제네릭이라
+      // Nest 내부 `KafkaMessage` 로 좁혀지지 않는다. 형태는 위에서 그 인터페이스대로
+      // 구성했고, 운영 경로(ServerKafka)도 같은 파서 결과를 그대로 싣는다.
+      rawMessage as never,
+      record.partition,
+      record.topic,
+      unsupportedCollaborator('getConsumer'),
+      async () => {
+        /* heartbeat — EventRetryInterceptor 가 backoff 중 호출한다 */
+      },
+      unsupportedCollaborator('getProducer'),
+    ]);
+
+    // KafkaRequestDeserializer.mapToSchema 와 동일: value 가 있으면 value, 없으면 메시지 전체
+    const data = rawMessage.value ?? rawMessage;
+
+    // 기본 훅은 `done()` 의 Promise 를 그대로 반환하지만 (`server.js:19`) Nest 타입은
+    // 반환을 void 로 선언한다. 동기 배달을 보장해야 하므로 실제 반환을 확인해 기다린다.
+    const settled: unknown = this.onProcessingStartHook(this.transportId, context, async () => {
+      const resultOrStream: unknown = await handler(data, context);
+      if (isObservable(resultOrStream)) {
+        await lastValueFrom(resultOrStream, { defaultValue: undefined });
+        this.onProcessingEndHook?.(this.transportId, context);
+      }
+    });
+    if (settled instanceof Promise) {
+      await settled;
+    }
+  }
+}

--- a/libs/events/src/transport/in-memory.transport.ts
+++ b/libs/events/src/transport/in-memory.transport.ts
@@ -1,0 +1,24 @@
+/**
+ * In-Memory Transport Adapter (테스트 전용)
+ *
+ * `EventTransport` 의 두 번째 구현. 어댑터가 하나뿐인 seam 은 간접층일 뿐이라는
+ * ADR-0029 §7 의 요구를 이것이 충족한다.
+ */
+
+import { EventTransport, TransportMessage } from './transport.port';
+import { InMemoryBroker } from './in-memory.broker';
+
+export class InMemoryTransport implements EventTransport {
+  constructor(private readonly broker: InMemoryBroker) {}
+
+  async send(topic: string, message: TransportMessage): Promise<void> {
+    // compress 는 의도적으로 무시한다 — 압축은 Kafka 어댑터의 관심사이고,
+    // 인메모리 경로에서 관찰 대상은 압축 여부가 아니라 envelope 내용이다.
+    await this.broker.publish(topic, {
+      key: message.key,
+      value: message.value,
+      headers: message.headers,
+      partition: message.partition,
+    });
+  }
+}

--- a/libs/events/src/transport/kafka.transport.ts
+++ b/libs/events/src/transport/kafka.transport.ts
@@ -1,0 +1,28 @@
+/**
+ * Kafka Transport Adapter (프로덕션)
+ *
+ * `StreamPublisher.sendMessage` 와 `DLQHandler.sendToDLQ` 에 흩어져 있던
+ * `ClientKafka` 배선을 그대로 옮긴 것이다. **동작 변경 없음** — 압축 여부까지
+ * 호출부가 지정하던 그대로 유지한다.
+ */
+
+import { ClientKafka } from '@nestjs/microservices';
+import { CompressionTypes } from 'kafkajs';
+import { firstValueFrom } from 'rxjs';
+import { EventTransport, TransportMessage } from './transport.port';
+
+export class KafkaTransport implements EventTransport {
+  constructor(private readonly client: ClientKafka) {}
+
+  async send(topic: string, message: TransportMessage): Promise<void> {
+    await firstValueFrom(
+      this.client.emit(topic, {
+        key: message.key,
+        value: message.value,
+        ...(message.compress ? { compression: CompressionTypes.GZIP } : {}),
+        ...(message.partition !== undefined ? { partition: message.partition } : {}),
+        headers: message.headers,
+      }),
+    );
+  }
+}

--- a/libs/events/src/transport/round-trip.spec.ts
+++ b/libs/events/src/transport/round-trip.spec.ts
@@ -1,0 +1,234 @@
+/**
+ * 발행 → 소비 왕복 하네스 (ADR-0029 §7, 플랜 Task 2)
+ *
+ * 브로커 없이 한 프로세스 안에서 `StreamPublisher.publishEvent` 부터 `@OnEvent`
+ * 핸들러 호출까지를 검증한다. **Nest 파이프라인은 실물이다** — `EventsModule` 을
+ * 실제로 import 하고, 인터셉터·가드·파라미터 데코레이터·DI 가 모두 살아 있으며,
+ * 바뀐 것은 `EVENT_TRANSPORT` 바인딩과 소비 전략뿐이다.
+ *
+ * 이 하네스가 없던 동안 `forConsumer({streams})` 가 무효라는 사실이 아무 테스트에도
+ * 걸리지 않았고, 그래서 2026-08-08 아키텍처 리뷰가 오판했다.
+ */
+
+import { Controller, INestMicroservice, UseInterceptors } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { z } from 'zod';
+import { event, getDLQTopicName, stream } from '@packages/event-contracts/types';
+import type { DLQMessage } from '../dlq/dlq.types';
+import { EventsModule } from '../events.module';
+import { EventPayload, OnEvent } from '../consumers/decorators';
+import { EventTypeGuard } from '../guards/event-type.guard';
+import { StreamPublisher } from '../publishers/stream-publisher.service';
+import { EventChainService } from '../tracking/event-chain.service';
+import { EVENT_TRANSPORT } from './transport.port';
+import { InMemoryBroker } from './in-memory.broker';
+import { InMemoryTransport } from './in-memory.transport';
+import { InMemoryServer } from './in-memory.server';
+
+// ===== 하네스 전용 계약 =====
+// 실제 스트림을 쓰지 않는다 — 계약이 바뀌었다고 이 하네스가 깨지면 안 되고,
+// `streams/index.ts` 밖이라 Task 1 의 STREAM_REGISTRY 에도 영향이 없다.
+
+const OrderCreatedSchema = z.object({
+  orderId: z.string(),
+  amount: z.number().int().positive(),
+});
+type OrderCreatedPayload = z.infer<typeof OrderCreatedSchema>;
+
+const HARNESS_STREAM = stream({
+  topic: 'harness.events.v1',
+  partitions: 1,
+  aggregateType: 'Harness',
+  events: {
+    OrderCreated: event('OrderCreated', OrderCreatedSchema),
+    OrderCancelled: event<'OrderCancelled', { orderId: string }>('OrderCancelled'),
+    OrderShipped: event<'OrderShipped', { orderId: string }>('OrderShipped'),
+  },
+});
+
+const StrictSchema = z.object({ userId: z.string(), age: z.number() });
+
+const STRICT_STREAM = stream({
+  topic: 'harness.strict.v1',
+  partitions: 1,
+  aggregateType: 'Strict',
+  events: {
+    StrictEvent: event('StrictEvent', StrictSchema),
+  },
+});
+
+// ===== 관찰 기록 =====
+
+interface HandlerCall {
+  handler: string;
+  payload: unknown;
+  chainId?: string;
+}
+
+const calls: HandlerCall[] = [];
+
+@Controller()
+@UseInterceptors(EventTypeGuard)
+class HarnessConsumer {
+  // 생성자 주입이 하네스에서도 살아 있어야 한다 — 클로저 기반 핸들러였다면 잃었을 것
+  constructor(private readonly chain: EventChainService) {}
+
+  @OnEvent('harness.events.v1', 'OrderCreated')
+  onCreated(@EventPayload() payload: OrderCreatedPayload): void {
+    calls.push({ handler: 'onCreated', payload, chainId: this.chain.getChainId() });
+  }
+
+  @OnEvent('harness.events.v1', 'OrderCancelled')
+  onCancelled(@EventPayload() payload: unknown): void {
+    calls.push({ handler: 'onCancelled', payload });
+  }
+
+  @OnEvent('harness.events.v1', 'OrderShipped')
+  onShipped(@EventPayload() payload: unknown): void {
+    calls.push({ handler: 'onShipped', payload });
+  }
+}
+
+@Controller()
+@UseInterceptors(EventTypeGuard)
+class StrictConsumer {
+  @OnEvent('harness.strict.v1', 'StrictEvent')
+  onStrict(@EventPayload() payload: unknown): void {
+    calls.push({ handler: 'onStrict', payload });
+  }
+}
+
+describe('발행 → 소비 왕복 (인메모리 transport)', () => {
+  let app: INestMicroservice;
+  let broker: InMemoryBroker;
+  let publisher: StreamPublisher<typeof HARNESS_STREAM.events>;
+
+  beforeAll(async () => {
+    // 토픽 부트스트랩은 Kafka admin 에 붙는다 — 하네스에서는 꺼야 한다
+    process.env.KAFKA_BOOTSTRAP_TOPICS = 'false';
+
+    broker = new InMemoryBroker();
+
+    const kafka = { clientId: 'harness', brokers: ['unused:9092'] };
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        EventsModule.forRoot({ streams: [HARNESS_STREAM, STRICT_STREAM], serviceName: 'harness', kafka }),
+        EventsModule.forConsumerModule({
+          streams: [HARNESS_STREAM, STRICT_STREAM],
+          groupId: 'harness-consumer',
+          kafka,
+        }),
+      ],
+      controllers: [HarnessConsumer, StrictConsumer],
+    })
+      // 유일한 교체 지점 — 나머지 배선은 운영과 같다
+      .overrideProvider(EVENT_TRANSPORT)
+      .useValue(new InMemoryTransport(broker))
+      .compile();
+
+    app = moduleRef.createNestMicroservice({
+      strategy: new InMemoryServer(broker),
+      logger: false,
+    });
+    await app.listen();
+
+    publisher = app.get(EventsModule.getPublisherToken(HARNESS_STREAM.topic.topic));
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  beforeEach(() => {
+    calls.length = 0;
+    broker.reset();
+  });
+
+  it('publishEvent 가 @OnEvent 핸들러까지 도달하고 payload 가 보존된다', async () => {
+    await publisher.publishEvent({
+      eventType: 'OrderCreated',
+      aggregateId: 'order-1',
+      payload: { orderId: 'order-1', amount: 12_000 },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      handler: 'onCreated',
+      payload: { orderId: 'order-1', amount: 12_000 },
+    });
+
+    // 발행 로그도 관찰 가능해야 한다
+    const published = broker.envelopesOn(HARNESS_STREAM.topic.topic);
+    expect(published).toHaveLength(1);
+    expect(published[0]).toMatchObject({
+      messageType: 'OrderCreated',
+      messageKind: 'event',
+      source: { service: 'harness', aggregateType: 'Harness', aggregateId: 'order-1' },
+    });
+  });
+
+  /**
+   * ⚠️ 알려진 실재 결함 — 이 태스크 범위 밖이라 고치지 않고 실행 가능한 형태로 박아둔다.
+   *
+   * 소비 경로에서 `chainId` 가 CLS 로 전파되지 않는다. 원인은 파싱이 아니라
+   * (그건 `parseEnvelope` 로 고쳤다) **CLS 컨텍스트가 아예 열리지 않는 것**이다:
+   * `ClsModule.forRoot({ middleware: { mount: false } })` 이고 RPC 경로에
+   * ClsGuard/ClsInterceptor 가 없어 `setChainId` 가
+   * "No CLS context available" 로 던지며, `ChainContextInterceptor` 의
+   * `catch {}` 가 그것을 삼킨다 (2026-08-09 실측).
+   *
+   * `it.failing` 이므로 **지금은 통과**하고, 누군가 CLS 배선을 고치면 이 테스트가
+   * 실패해 "이제 고쳐졌으니 일반 `it` 으로 바꿔라"고 알린다.
+   */
+  it.failing('ChainContextInterceptor 가 envelope 의 chainId 를 CLS 로 전파한다', async () => {
+    await publisher.publishEvent({
+      eventType: 'OrderCreated',
+      aggregateId: 'order-3',
+      payload: { orderId: 'order-3', amount: 500 },
+    });
+
+    const published = broker.envelopesOn(HARNESS_STREAM.topic.topic);
+    expect(calls[0].chainId).toBeDefined();
+    expect(calls[0].chainId).toBe(published[0].chainId);
+  });
+
+  it('EventTypeGuard 가 같은 토픽의 다중 핸들러 중 messageType 이 맞는 하나만 실행한다', async () => {
+    await publisher.publishEvent({
+      eventType: 'OrderCancelled',
+      aggregateId: 'order-2',
+      payload: { orderId: 'order-2' },
+    });
+
+    // 세 핸들러 모두 같은 토픽에 걸려 있고 셋 다 파이프라인을 타지만,
+    // messageType 이 다른 둘은 EventTypeGuard 가 조용히 버린다
+    expect(calls.map((call) => call.handler)).toEqual(['onCancelled']);
+  });
+
+  it('스키마를 위반한 인바운드 메시지는 핸들러에 닿지 않고 DLQ 로 분류된다', async () => {
+    // publisher 를 우회한다 — validateOnPublish 가 발행 단계에서 먼저 막기 때문이고,
+    // 실제로도 스키마를 안 지키는 메시지는 *다른 서비스가* 보낸다
+    await broker.inject(STRICT_STREAM.topic.topic, {
+      messageId: 'msg-bad',
+      messageType: 'StrictEvent',
+      messageVersion: 1,
+      messageKind: 'event',
+      correlationId: 'corr-bad',
+      timestamp: new Date().toISOString(),
+      occurredAt: new Date().toISOString(),
+      source: { service: 'other-service', aggregateType: 'Strict', aggregateId: 'user-1' },
+      payload: { userId: 'user-1', age: 'not-a-number' }, // ← 스키마 위반
+    });
+
+    expect(calls).toHaveLength(0);
+
+    const dlq = broker.envelopesOn<DLQMessage>(getDLQTopicName(STRICT_STREAM.topic.topic));
+    expect(dlq).toHaveLength(1);
+    expect(dlq[0].error.name).toBe('SchemaValidationError');
+    expect(dlq[0].originalTopic).toBe(STRICT_STREAM.topic.topic);
+    expect(dlq[0].originalMessage.messageId).toBe('msg-bad');
+
+    // 소비 실패가 발행자에게 전파되지 않았음 — 운영에서도 그 둘은 분리돼 있다
+    expect(broker.deliveryFailures).toHaveLength(0);
+  });
+});

--- a/libs/events/src/transport/transport.port.ts
+++ b/libs/events/src/transport/transport.port.ts
@@ -1,0 +1,37 @@
+/**
+ * Event Transport Port
+ *
+ * 이벤트가 이 프로세스 밖으로 나가는 유일한 통로. 운영은 `KafkaTransport`,
+ * 테스트는 `InMemoryTransport` 가 구현한다.
+ *
+ * **소비 방향은 이 port 에 없다.** 소비 루프는 `libs/events` 가 아니라 각 앱
+ * `main.ts` 의 `connectMicroservice()` 가 만든 Nest `ServerKafka` 가 소유하므로,
+ * `subscribe()` 를 여기 두면 Kafka 쪽에 정직한 구현이 존재할 수 없다. 소비 방향의
+ * 다형성은 Nest 의 `CustomTransportStrategy` 확장점에서 얻는다 (ADR-0029 §7).
+ */
+
+export interface TransportMessage {
+  /** 파티션 키 — 순서 보장 단위 */
+  key: string;
+  /** 직렬화된 envelope */
+  value: string;
+  headers?: Record<string, string>;
+  /**
+   * 대상 파티션 지정. 생략하면 어댑터가 `key` 로 결정한다.
+   * (`DLQHandler.reprocessDLQ` 만 명시적으로 쓴다.)
+   */
+  partition?: number;
+  /**
+   * 전송 압축 요청. 브로커 중립적인 불리언이며 어댑터가 자기 방식으로 해석한다.
+   * (`KafkaTransport` 는 GZIP. 기존 동작 보존용 — `StreamPublisher` 는 압축했고
+   * `DLQHandler` 는 압축하지 않았다.)
+   */
+  compress?: boolean;
+}
+
+export interface EventTransport {
+  send(topic: string, message: TransportMessage): Promise<void>;
+}
+
+/** DI 토큰. `EventsModule` 이 어댑터를 여기에 바인딩한다. */
+export const EVENT_TRANSPORT = Symbol('EVENT_TRANSPORT');

--- a/libs/events/src/utils/envelope.util.spec.ts
+++ b/libs/events/src/utils/envelope.util.spec.ts
@@ -1,0 +1,34 @@
+import { parseEnvelope } from './envelope.util';
+
+const ENVELOPE = {
+  messageId: 'msg-1',
+  messageType: 'OrderCreated',
+  messageKind: 'event',
+  source: { service: 'core', aggregateType: 'Order', aggregateId: 'order-1' },
+  payload: { orderId: 'order-1' },
+};
+
+describe('parseEnvelope', () => {
+  it('객체를 그대로 받는다 — 운영에서 Nest KafkaParser 가 넘기는 형태다', () => {
+    // 이것이 회귀의 핵심. `String(object)` 는 "[object Object]" 가 되어
+    // JSON.parse 가 터지고, 그 결과 소비자가 통째로 멎었다.
+    expect(parseEnvelope(ENVELOPE)).toEqual(ENVELOPE);
+  });
+
+  it('Buffer 를 파싱한다', () => {
+    expect(parseEnvelope(Buffer.from(JSON.stringify(ENVELOPE)))).toEqual(ENVELOPE);
+  });
+
+  it('문자열을 파싱한다', () => {
+    expect(parseEnvelope(JSON.stringify(ENVELOPE))).toEqual(ENVELOPE);
+  });
+
+  it('null/undefined 는 던진다', () => {
+    expect(() => parseEnvelope(null)).toThrow(/null or undefined/);
+    expect(() => parseEnvelope(undefined)).toThrow(/null or undefined/);
+  });
+
+  it('깨진 JSON 은 던진다', () => {
+    expect(() => parseEnvelope('{not json')).toThrow();
+  });
+});

--- a/libs/events/src/utils/envelope.util.ts
+++ b/libs/events/src/utils/envelope.util.ts
@@ -1,0 +1,34 @@
+/**
+ * Kafka 메시지 value → MessageEnvelope
+ *
+ * **Nest 는 수신 메시지의 `value` 를 그대로 넘기지 않는다.** `KafkaParser.decode` 가
+ * `keepBinary` 기본값(false)에서 JSON 을 파싱해 넘기므로, 운영에서
+ * `KafkaContext.getMessage().value` 는 Buffer 가 아니라 **객체**다
+ * (`@nestjs/microservices/helpers/kafka-parser.js`, `server-kafka.js:113`).
+ *
+ * `Buffer.isBuffer(value) ? value.toString() : String(value)` 관용구는 객체가 오면
+ * `"[object Object]"` 를 만들고 `JSON.parse` 가 터진다. 이 헬퍼는 세 형태를 모두 받아
+ * 그 함정을 한 곳에 가둔다.
+ */
+
+import { MessageEnvelope } from '@packages/event-contracts/types';
+
+export function parseEnvelope(value: unknown): MessageEnvelope {
+  if (value === null || value === undefined) {
+    throw new Error('Kafka message value is null or undefined');
+  }
+
+  // as 정당화: JSON.parse 는 unknown 을 반환하고 런타임 스키마 검증은
+  // SchemaValidationInterceptor 소관이다. 여기서는 envelope 형태를 신뢰한다.
+  if (Buffer.isBuffer(value)) {
+    return JSON.parse(value.toString('utf-8')) as MessageEnvelope;
+  }
+  if (typeof value === 'string') {
+    return JSON.parse(value) as MessageEnvelope;
+  }
+  if (typeof value === 'object') {
+    return value as MessageEnvelope;
+  }
+
+  throw new Error(`Unsupported Kafka message value type: ${typeof value}`);
+}


### PR DESCRIPTION
ADR-0029 워크스트림 Task 2. 브로커 없이 발행→소비 왕복을 검증하는 하네스를 만들고, **그 하네스가 첫 실행에서 찾은 실재 프로덕션 버그를 함께 고친다.**

## 설계 — port 는 발행 방향에만 긋는다

플랜의 옛 문구는 `send` + `subscribe` 대칭 표면이었으나, **소비 루프를 `libs/events` 가 소유하지 않는다.** 소비는 각 앱 `main.ts` 의 `connectMicroservice()` 가 만든 Nest `ServerKafka` 가 수행하며(그나마 넘긴 `subscribe.topics` 는 Nest 가 덮어쓴다), 따라서 `KafkaTransport.subscribe()` 는 ① Nest 컨슈머를 대체하거나 ② 스텁으로 남는 두 길뿐이고 둘 다 나쁘다.

대신 소비 방향의 다형성은 Nest 가 이미 제공하는 확장점 `CustomTransportStrategy` 에서 얻는다 — 운영은 `ServerKafka`, 테스트는 `InMemoryServer`. 두 구현 모두 실재이고 **운영 경로는 한 줄도 바뀌지 않는다.** 설계 근거는 ADR-0029 §7 에 기록했다(이 PR 의 첫 커밋).

**결정적 제약:** 인메모리 배달도 진짜 `KafkaContext` 인스턴스를 만들어야 한다. `event-retry.interceptor.ts:72` 가 `instanceof KafkaContext` 로 게이트하므로, 가짜 context 를 쓰면 재시도·DLQ 분류가 통째로 건너뛰어져 테스트가 무증상 거짓이 된다.

## 🔴 하네스가 찾은 실재 버그 (함께 수정)

Nest 는 수신 `value` 를 `KafkaParser.decode` 로 **JSON 파싱해서** 넘긴다(`keepBinary` 기본 false). 즉 운영에서 `KafkaContext.getMessage().value` 는 Buffer 가 **아니라 객체**다. 그런데 세 곳이 `Buffer.isBuffer(v) ? v.toString() : String(v)` 관용구를 써서 `"[object Object]"` 를 만들고 `JSON.parse` 가 터졌다:

| 위치 | 증상 |
|---|---|
| `schema-validation.interceptor.ts:69` | 모든 메시지가 SyntaxError → 재시도 3회(7초 블로킹) |
| `event-retry.interceptor.ts:194` | DLQ 전송도 같은 이유로 실패 → `DlqDeliveryError` → **offset 미커밋 → 무한 재전달** |
| `chain-context.interceptor.ts:26` | `catch {}` 로 삼킴 → 조용히 no-op |

`validateOnConsume: true` 인 **core · analytics · search** 가 해당한다. 인접한 4곳(`event-type.guard.ts:41`, `decorators.ts` 3곳)은 원래부터 객체를 처리하고 있었다 — 관용구가 불일치했던 것. 수정은 `utils/envelope.util.ts` 의 `parseEnvelope` 하나로 모았다.

> 이 ADR 이 "두 번째 어댑터가 없어서 배선 문제가 어떤 테스트로도 안 잡힌다"고 한 주장의 실증 사례다.

## ⚠️ 고치지 않고 남긴 것

소비 경로에서 `chainId` 가 CLS 로 전파되지 않는다. **파싱과 무관한 별개 원인** — `ClsModule.forRoot({ middleware: { mount: false } })` 이고 RPC 경로에 ClsGuard/ClsInterceptor 가 없어 `setChainId` 가 "No CLS context available" 로 던지며 `ChainContextInterceptor` 의 `catch {}` 가 삼킨다(실측 확인). 범위 밖이라 `round-trip.spec.ts` 에 **`it.failing`** 으로 박아뒀다 — 누가 CLS 배선을 고치면 그 테스트가 실패해서 알린다. ADR-0029 Follow-up 9.

## 변경 범위

- 신규: `transport/{transport.port,kafka.transport,in-memory.broker,in-memory.transport,in-memory.server}.ts`, `utils/envelope.util.ts`
- 이관: `StreamPublisher` · `DLQHandler` 생성자를 port 로 (동작 동일, GZIP 압축 여부까지 보존)
- **앱 코드 변경 0.** `KAFKA_CLIENT` 는 `GracefulShutdownService` 가 계속 쓴다
- 하네스는 `EventsModule` 을 실제로 import 하고 `EVENT_TRANSPORT` 하나만 `overrideProvider` → 인터셉터·가드·파라미터 데코레이터·생성자 DI 가 전부 실물

## 검증

- `libs/events` + 계약 패키지 **14 suite / 129 tests 초록**
- `npm run type-check` **164 = develop 기준선과 동일** (libs/events 잔여 4건은 전부 기존 부채)
- **9개 앱 전부 `nest build` 초록**
- 전체 jest 실패 suite 집합이 develop 과 **동일(18)**, 통과 테스트 **+9**
- 신규/수정 파일 eslint 초록 (libs/events 기존 부채 116건은 별개)

## 배포

마이그레이션 0 / 시크릿 0 / env 0 / 이벤트 계약 변경 0 → **배포 순서 제약 없음.** 다만 위 버그 수정 때문에 **core · analytics · search 는 빨리 배포할 값어치가 있다** — 배포 전까지 그 세 앱의 소비는 계속 망가진 상태다.
