### PR TITLE
feat(events): startConsumer 로 소비 집합 도출 + 소비 인터셉터 배선 (ADR-0029 Task 3)

### DIFF
--- a/docs/adr/0029-events-module-registration-surfaces.md
+++ b/docs/adr/0029-events-module-registration-surfaces.md
@@ -15,10 +15,12 @@ Proposed (2026-08-09). `@app/events` 등록 방식을 규정하는 첫 ADR. 기�
 async bindEvents(consumer) {
   const registeredPatterns = [...this.messageHandlers.keys()];
   const consumerSubscribeOptions = this.options.subscribe || {};
-  await this.consumer.subscribe({
-    ...consumerSubscribeOptions,
-    topics: registeredPatterns,   // ← spread 뒤에 오므로 subscribe.topics 를 덮어쓴다
-  });
+  if (registeredPatterns.length > 0) {        // ← 0개면 subscribe 자체를 건너뛴다
+    await this.consumer.subscribe({
+      ...consumerSubscribeOptions,
+      topics: registeredPatterns,             // ← spread 뒤에 오므로 subscribe.topics 를 덮어쓴다
+    });
+  }
 }
 ```
 
@@ -126,6 +128,51 @@ if (!(kafkaContext instanceof KafkaContext)) return next.handle();
 
 **Kafka 로 나가는 모든 경로가 이 port 를 지난다.** `StreamPublisher.sendMessage` · `OutboxDispatcher`(publisher 경유) · `DLQHandler.sendToDLQ`. 특히 `DLQHandler` 는 `@Inject('KAFKA_CLIENT')` 로 `ClientKafka` 를 직접 잡고 있었으므로 함께 이관한다 — 그러지 않으면 DLQ 적재를 관찰할 방법이 port 밖에 따로 생겨 "모든 발행은 port 를 지난다" 가 거짓이 된다. `GracefulShutdownService` 는 전송이 아니라 연결 종료가 관심사이므로 `KAFKA_CLIENT` 를 계속 쓴다.
 
+### 8. 소비 측 전역 인터셉터는 `APP_INTERCEPTOR` 가 아니라 마이크로서비스 스코프로 붙인다
+
+**(2026-08-09 실측으로 추가된 결정. 이 ADR 이 고치려는 실패 모드의 세 번째 실례다.)**
+
+`EventRetryInterceptor`(재시도·DLQ·offset commit) · `SchemaValidationInterceptor` · `ChainContextInterceptor` 는 `forRoot`/`forConsumerModule` 에서 `APP_INTERCEPTOR` 로 등록된다. `event-retry.interceptor.ts` 의 주석은 "전역(APP_INTERCEPTOR) 등록 전제"라고 못박고 있다. **그 전제가 현재 7개 소비 앱 전부에서 성립하지 않는다.**
+
+```js
+// node_modules/@nestjs/core/nest-application.js:125–131  (v11.1.17)
+connectMicroservice(microserviceOptions, hybridAppOptions = {}) {
+  const { inheritAppConfig } = hybridAppOptions;
+  const applicationConfig = inheritAppConfig
+    ? this.config
+    : new ApplicationConfig();          // ← 기본값: 전역 enhancer 가 하나도 없는 새 config
+  const instance = new NestMicroservice(this.container, microserviceOptions, this.graphInspector, applicationConfig);
+```
+
+7개 앱 모두 `app.connectMicroservice(consumerOptions)` 를 두 번째 인자 없이 부른다(실측). 따라서 Kafka 핸들러는 **빈 `ApplicationConfig`** 위에서 바인딩되고, `APP_INTERCEPTOR` 로 모은 전역 인터셉터 목록은 소비 경로에 **적용되지 않는다**. 컨트롤러 레벨 `@UseInterceptors(EventTypeGuard)`(52곳)는 메타데이터에서 해석되므로 영향이 없다 — 그래서 필터링은 동작하고 검증·재시도·DLQ 만 조용히 죽어 있었다.
+
+인메모리 하네스로 확인한 결과 (`libs/events/src/transport/start-consumer.spec.ts`):
+
+| 배선 | 스키마 위반 메시지 | DLQ | `onModuleInit` 호출 |
+|---|---|---|---|
+| `connectMicroservice(opts)` — **현재 7개 앱** | **핸들러까지 도달** | 0건 | 1회 |
+| `connectMicroservice(opts, { inheritAppConfig: true })` | 차단 | 1건 | 1회 |
+| `connectMicroservice(opts, { deferInitialization: true })` + `useGlobalInterceptors` | 차단 | 1건 | **2회** ⚠️ |
+| 위 + `registerListeners()` + `setIsInitialized/setIsInitHookCalled` | 차단 | 1건 | 1회 |
+
+`inheritAppConfig: true` 는 기각한다. HTTP 앱의 전역 파이프·필터·**가드**까지 통째로 RPC 핸들러에 얹히며, 앱마다 그 목록이 다르다 — 이벤트 소비가 각 앱의 HTTP 인증 가드를 통과해야 하는 상태가 된다.
+
+`deferInitialization: true` 단독도 기각한다. 초기화가 미뤄진 마이크로서비스는 `listen()` 에서 `registerModules()` 를 부르고, 그 안에서 `callInitHook()`/`callBootstrapHook()` 이 **컨테이너 전체에 대해 다시** 실행된다(`nest-microservice.js:66–79`). 위 표의 `onModuleInit` 2회가 그것이다.
+
+**따라서 `startConsumer` 는 마이크로서비스 자신의 `ApplicationConfig` 에만 이벤트 인터셉터를 얹는다:**
+
+```ts
+const microservice = app.connectMicroservice(options, { deferInitialization: true });
+microservice.useGlobalInterceptors(retry, schemaValidation, chainContext);  // 등록 순서 = 래핑 순서
+microservice.registerListeners();          // 비-defer 경로가 하던 일을 그대로
+microservice.setIsInitialized(true);       // 초기화 훅 재실행을 막는다
+microservice.setIsInitHookCalled(true);
+```
+
+붙는 것은 이벤트 인터셉터 셋뿐이고 앱의 HTTP 설정은 건드리지 않는다. `useGlobalInterceptors` 는 인스턴스를 받으므로 `startConsumer` 가 직접 생성한다 — `SchemaValidationInterceptor` 는 **도출된** 스트림 목록을, 검증 정책(`validateOnConsume` 등)은 앱이 이미 선언한 것을 컨테이너에서 읽어 쓴다. 정책은 도출 불가한 사실이므로 선언이 옳고(§1), 스트림 목록은 도출 가능하므로 선언을 지운다.
+
+**이행 결과: 앱 이주(§Follow-up 5)는 동작 중립이 아니다.** `startConsumer` 로 옮기는 순간 그 앱에서 스키마 검증·재시도·DLQ 가 **처음으로 켜진다.** 지금까지 검증 없이 소비해 온 인바운드 payload 가 스키마를 만족하지 않으면 이주 자체가 DLQ 폭탄이 된다. channel-adapter 에만 붙어 있던 경고가 **7개 앱 전부**로 확대된다.
+
 ### 명시적으로 하지 않는 것
 
 - **두 리스트를 부팅 시 대조(reconcile)하는 안은 기각한다.** 어긋남을 시끄럽게 만들 뿐 중복은 그대로 남는다. 중복을 없애는 파생이 우월하다.
@@ -144,6 +191,7 @@ if (!(kafkaContext instanceof KafkaContext)) return next.handle();
 | `forConsumerModule` 에 스트림 누락 | 메시지마다 warn, 검증 없이 통과 | 파생되므로 불가능 |
 | outbox 에 잘못된 payload | 검증 0 → 소비자에서 터지거나 조용히 통과 | enqueue 실패 = 도메인 연산 실패 |
 | `forRoot` 에 스트림 누락 + 발행 | DI 실패 / 디스패처 throw | 동일 (이미 시끄럽다) |
+| 하이브리드 앱에서 소비 인터셉터 미적용 | **완전 무증상** (검증·재시도·DLQ 가 통째로 죽음) | `startConsumer` 가 마이크로서비스 스코프로 직접 붙인다 (§8) |
 
 **가장 치명적인 실수가 가장 조용하다는 현재의 역전이 해소된다.**
 
@@ -172,14 +220,18 @@ if (!(kafkaContext instanceof KafkaContext)) return next.handle();
 
 1. ~~**`apps/analytics/src/main.ts:65–75` 의 틀린 주석을 즉시 삭제한다.**~~ **완료 (2026-08-09).** 실제 동작을 설명하는 주석으로 교체했다. 검증: `ProductEventsConsumer` 는 `analytics.module.ts:50` 의 `controllers` 에 등록돼 있고 `products.events.v1` 핸들러 6개를 선언하므로 해당 토픽은 정상 구독된다 — 옛 주석의 "have never received a live message" 는 틀렸다. `apps/search/src/search.module.ts:26` 은 **고치지 않았다**: "forConsumerModule 은 provider 만 등록하고 connectMicroservice 를 부르지 않으므로 두 번째 컨슈머를 만들지 않는다"는 사실이며 #510 회귀 방지 근거로 유효하다. 두 표면을 "짝"이라 부른 표현만 느슨할 뿐이다.
 2. 계약 레지스트리(`topic → StreamConfig`) 추가 — 순수 추가, 위험 0.
-3. ~~**인메모리 transport 어댑터 + 발행→소비 왕복 테스트.**~~ **완료 (2026-08-09).** 하네스가 첫 실행에서 실재 버그를 찾았다: Nest 는 수신 `value` 를 `KafkaParser` 로 JSON 파싱해 넘기는데(즉 **객체**), `schema-validation.interceptor.ts:69` · `event-retry.interceptor.ts:194` · `chain-context.interceptor.ts:26` 이 `String(value)` 관용구로 `"[object Object]"` 를 만들어 `JSON.parse` 가 터졌다. `validateOnConsume: true` 인 core·analytics·search 에서 **모든 메시지가 재시도 3회 후 DLQ 전송마저 실패 → offset 미커밋 → 무한 재전달**이었다. `utils/envelope.util.ts` 의 `parseEnvelope` 로 수정. **이 ADR 이 "두 번째 어댑터가 없어서 배선 문제가 어떤 테스트로도 안 잡힌다"고 한 주장의 실증 사례다.** 남은 별건: 소비 경로에 CLS 컨텍스트가 열리지 않아(`middleware.mount: false` + RPC 용 ClsGuard 부재) `chainId` 전파가 죽어 있다 — `round-trip.spec.ts` 에 `it.failing` 으로 박아뒀다. 아래 9번.
+3. ~~**인메모리 transport 어댑터 + 발행→소비 왕복 테스트.**~~ **완료 (2026-08-09).** 하네스가 첫 실행에서 실재 버그를 찾았다: Nest 는 수신 `value` 를 `KafkaParser` 로 JSON 파싱해 넘기는데(즉 **객체**), `schema-validation.interceptor.ts:69` · `event-retry.interceptor.ts:194` · `chain-context.interceptor.ts:26` 이 `String(value)` 관용구로 `"[object Object]"` 를 만들어 `JSON.parse` 가 터졌다. `utils/envelope.util.ts` 의 `parseEnvelope` 로 수정.
+
+   ⚠️ **2026-08-09 정정 (아래 10번의 발견에 따름).** 당시 이 항목은 "`validateOnConsume: true` 인 core·analytics·search 에서 모든 메시지가 재시도 3회 후 DLQ 전송마저 실패 → offset 미커밋 → **무한 재전달**"이라고 단언했다. **그 결론은 틀렸다.** 그 세 인터셉터는 `APP_INTERCEPTOR` 전역 등록에 의존하는데, 7개 소비 앱 모두 하이브리드 `connectMicroservice` 를 쓰므로 애초에 소비 경로에 붙지 않는다(§8). 즉 파싱 버그의 프로덕션 영향 범위는 **0** 이었다 — 터질 코드가 실행되지 않았기 때문이다. 수정 자체는 유효하고 필요하다: §8 의 배선이 켜지는 순간 그 경로가 살아나며, 그때 이 버그가 없어야 한다. 하네스가 "실재 버그를 찾았다"는 것도 여전히 사실이다. 틀린 것은 **영향 범위 추정**이며, 그 오판의 원인도 같다 — 두 번째 어댑터가 없어 배선을 실행해 본 적이 없었다. **이 ADR 이 "두 번째 어댑터가 없어서 배선 문제가 어떤 테스트로도 안 잡힌다"고 한 주장의 실증 사례다.** 남은 별건: 소비 경로에 CLS 컨텍스트가 열리지 않아(`middleware.mount: false` + RPC 용 ClsGuard 부재) `chainId` 전파가 죽어 있다 — `round-trip.spec.ts` 에 `it.failing` 으로 박아뒀다. 아래 9번.
 
    착수 당시 근거(보존): 원래 마지막에 두려던 것을 앞으로 당겼다. 발행→소비를 브로커 없이 검증할 방법이 **아예 없어서**(`libs/events/src` 소스 29 / 스펙 5, 페이크 트랜스포트 0) 어댑터가 없으면 이후 모든 단계가 자기 증거를 남기지 못하고, 여러 세션에 걸친 작업에서 다음 작업자는 앞 단계가 무엇을 보장했는지 알 수 없기 때문이다. **검증 도구를 먼저 만들고 나머지를 그 위에 얹는다** — 그 판단은 결과로 정당화됐다.
-4. `startConsumer(app)` 도입 + `forConsumer` 의 `streams` deprecated. 앱 수정 없이 동작해야 한다.
-5. `@On` / `@InjectPublisher` 를 기존 데코레이터와 병행 도입, 앱별 이주 (7개 앱 = 7 PR).
+4. ~~`startConsumer(app)` 도입 + `forConsumer` 의 `streams` deprecated. 앱 수정 없이 동작해야 한다.~~ **완료 (2026-08-09).** 소비 집합은 `@OnEvent` 데코레이터에서 도출되고, 레지스트리에 없는 토픽·핸들러 0개는 부팅을 거부한다. 도출 과정에서 §8 과 아래 10번을 발견했다.
+5. `@On` / `@InjectPublisher` 를 기존 데코레이터와 병행 도입, 앱별 이주 (7개 앱 = 7 PR). ⚠️ **§8 에 따라 이주는 동작 중립이 아니다** — 그 앱에서 스키마 검증·재시도·DLQ 가 처음으로 켜진다.
 6. 공용 outbox 에 `idempotencyKey`·`partitionKey`·enqueue 시점 검증 추가 후 앱 자체 판본 5벌 회수. **core 의 두 벌은 import 경로만 다른 동일 파일이므로 이 작업과 무관하게 지금 하나로 합칠 수 있다.**
 7. 옛 표면(`forRoot`/`forConsumerModule`/`forConsumer`) 제거 — contract phase.
 8. channel-adapter 가 `forConsumerModule` 을 호출하지 않는 현재 상태는 이 ADR 이 시행되기 전까지 남는 실재 구멍이다 — 소비 측 zod 검증이 없다. 4번 이전에 단독으로 메울지, 이주에 묶을지 결정한다.
-9. **소비 경로 CLS 컨텍스트 부재** (2026-08-09 발견, 미수정). `ClsModule.forRoot({ middleware: { mount: false } })` 이고 RPC 경로에 ClsGuard/ClsInterceptor 가 없어 `EventChainService.setChainId` 가 "No CLS context available" 로 던지고, `ChainContextInterceptor` 의 `catch {}` 가 그것을 삼킨다. 결과적으로 **소비 측 `chainId`/`eventId` 전파가 전 앱에서 죽어 있다.** 3번의 파싱 버그와 원인이 다르므로 별도 수정이 필요하다 — 이 워크스트림에 묶을지 독립 처리할지 결정한다. 회귀 감지는 `round-trip.spec.ts` 의 `it.failing` 이 맡는다.
+9. **소비 경로 CLS 컨텍스트 부재** (2026-08-09 발견, 미수정).
+ `ClsModule.forRoot({ middleware: { mount: false } })` 이고 RPC 경로에 ClsGuard/ClsInterceptor 가 없어 `EventChainService.setChainId` 가 "No CLS context available" 로 던지고, `ChainContextInterceptor` 의 `catch {}` 가 그것을 삼킨다. 결과적으로 **소비 측 `chainId`/`eventId` 전파가 전 앱에서 죽어 있다.** 3번의 파싱 버그와 원인이 다르므로 별도 수정이 필요하다 — 이 워크스트림에 묶을지 독립 처리할지 결정한다. 회귀 감지는 `round-trip.spec.ts` 의 `it.failing` 이 맡는다. (그 인터셉터 자체가 하이브리드 앱에서 붙지 않는다는 §8 이 겹친다 — 두 원인이 독립적으로 존재한다.)
+10. 🔴 **라이브 구멍: 7개 소비 앱 전부에서 스키마 검증·재시도·DLQ·chain 인터셉터가 적용되지 않고 있다** (2026-08-09 발견, §8). `startConsumer` 는 이 구멍이 없는 새 배선을 제공하지만, **앱들이 이주하기 전까지 라이브 상태는 그대로다.** 옛 표면(`forConsumer`)에 같은 배선을 소급 적용하는 것은 의도적으로 하지 않았다 — 7개 앱에서 검증·DLQ 가 한 배포에 동시에 켜지며, 지금까지 검증 없이 통과하던 인바운드 payload 가 있다면 그 배포가 DLQ 폭탄이 된다. 대신 앱별 이주(5번)에서 하나씩, 관찰 가능한 단위로 켠다. **이 항목이 닫히는 시점은 마지막 앱이 이주한 때다.**
 
 실행 계획은 [`docs/superpowers/plans/2026-08-09-events-module-registration.md`](../superpowers/plans/2026-08-09-events-module-registration.md).

--- a/docs/adr/0029-events-module-registration-surfaces.md
+++ b/docs/adr/0029-events-module-registration-surfaces.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Proposed (2026-08-09). `@app/events` 등록 방식을 규정하는 첫 ADR. 기존 ADR 을 대체하지 않는다.
+Accepted (2026-08-09). `@app/events` 등록 방식을 규정하는 첫 ADR. 기존 ADR 을 대체하지 않는다.
+
+설계가 코드로 실현되기 시작한 시점에 Accepted 로 올렸다 — 계약 레지스트리(Follow-up 2) · 인메모리 어댑터(3) · `startConsumer` 도출과 소비 인터셉터 배선(4·§8)이 머지됐다. 남은 Follow-up 5~7 은 이 결정의 **이행**이지 재검토가 아니다. 이행 중 설계가 바뀌면 이 문서를 먼저 고친다.
 
 ## Context
 

--- a/docs/superpowers/plans/2026-08-09-events-module-registration.md
+++ b/docs/superpowers/plans/2026-08-09-events-module-registration.md
@@ -38,7 +38,9 @@
 
 이 플랜이 의존하는 사실. **재확인 없이 뒤집지 말 것.**
 
-- `ServerKafka.bindEvents()` 가 `subscribe.topics` 를 `[...this.messageHandlers.keys()]` 로 덮어쓴다 (`node_modules/@nestjs/microservices/server/server-kafka.js:92`, v11.1.17). 따라서 `forConsumer({streams})` 의 `streams` 는 **무효**다.
+- `ServerKafka.bindEvents()` 가 `subscribe.topics` 를 `[...this.messageHandlers.keys()]` 로 덮어쓴다 (`node_modules/@nestjs/microservices/server/server-kafka.js:92`, v11.1.17). 따라서 `forConsumer({streams})` 의 `streams` 는 **무효**다. 같은 함수에 `registeredPatterns.length > 0` 가드가 있어, 핸들러가 0개면 **subscribe 자체를 건너뛴다** — 컨트롤러 미등록이 로그조차 남기지 않는 이유다 (2026-08-09 추가 확인).
+- `NestApplication.connectMicroservice(opts)` 를 두 번째 인자 없이 부르면 마이크로서비스에 **새 `ApplicationConfig`** 가 주어진다 (`nest-application.js:128`). **7개 소비 앱 전부가 그렇게 부르므로 `APP_INTERCEPTOR` 전역 인터셉터가 소비 경로에 적용되지 않는다** — 스키마 검증·재시도·DLQ·chain 이 전부 죽어 있다. 컨트롤러 레벨 `@UseInterceptors(EventTypeGuard)` 만 살아 있다 (2026-08-09 실측, ADR-0029 §8).
+- `deferInitialization: true` 로 붙인 마이크로서비스는 `listen()` 에서 `registerModules()` 를 타고, 그 안에서 `callInitHook()` 이 컨테이너 전체에 대해 **다시** 실행된다 — `onModuleInit` 2회 (실측). 그래서 `startConsumer` 는 `registerListeners()` + 초기화 플래그를 직접 세운다.
 - `@OnEvent(topic, type)` = `EventPattern(topic)` + `SetMetadata(EVENT_TYPE_FILTER, type)` (`libs/events/src/consumers/decorators.ts:76`). 등록 패턴이 곧 토픽 문자열.
 - 한 토픽의 event handler 는 링크드 리스트로 이어져 **전부 실행**된다 (`server.js:51–56` + `listeners-controller.js:87`). `EventTypeGuard` 가 `messageType` 불일치 시 `of(undefined)` 로 조용히 버리며, **호출마다 `JSON.parse`** 한다.
 - `OutboxPublisher.saveEvent` 는 검증하지 않고, `OutboxDispatcher` 는 `publishRawEnvelope` → `sendMessage` 로 zod 를 우회한다. **outbox 경로에 스키마 검증이 없다.**
@@ -150,15 +152,36 @@ Nest 는 수신 `value` 를 `KafkaParser.decode` 로 **JSON 파싱해서** 넘�
 
 ## Task 3: `startConsumer(app)` 도입, `forConsumer({streams})` deprecate
 
-- [ ] `EventsModule.startConsumer(app, { groupId, kafka })` 추가. `DiscoveryService` 로 `@OnEvent`/`@On` 메타데이터를 훑어 `(topic, eventType)` 집합을 얻는다
-- [ ] 그 집합에서 **구독 토픽 · 검증 스키마 맵 · 토픽 부트스트랩 목록**을 파생 (Task 1 레지스트리 사용)
-- [ ] 레지스트리에 없는 토픽을 구독하려 하면 **부팅 거부**
-- [ ] `@OnEvent` 핸들러가 하나도 없는데 `startConsumer` 를 부르면 **부팅 거부** (컨트롤러 미등록 = 현재 가장 조용한 실수)
-- [ ] `forConsumer({streams})` 의 `streams` 를 `@deprecated` 로 표시하고 무시. 시그니처는 유지 — 앱을 아직 고치지 않는다
-- [ ] Task 2 하네스로 파생 결과를 검증하는 스펙
-- [ ] `npm run type-check` 초록 · 커밋 · 푸시
+- [x] `EventsModule.startConsumer(app, { groupId, kafka })` 추가. `DiscoveryService` 로 `@OnEvent`/`@On` 메타데이터를 훑어 `(topic, eventType)` 집합을 얻는다
+- [x] 그 집합에서 **구독 토픽 · 검증 스키마 맵 · 토픽 부트스트랩 목록**을 파생 (Task 1 레지스트리 사용)
+- [x] 레지스트리에 없는 토픽을 구독하려 하면 **부팅 거부**
+- [x] `@OnEvent` 핸들러가 하나도 없는데 `startConsumer` 를 부르면 **부팅 거부** (컨트롤러 미등록 = 현재 가장 조용한 실수)
+- [x] `forConsumer({streams})` 의 `streams` 를 `@deprecated` 로 표시하고 무시. 시그니처는 유지 — 앱을 아직 고치지 않는다
+- [x] Task 2 하네스로 파생 결과를 검증하는 스펙
+- [x] `npm run type-check` 초록 · 커밋 · 푸시
 
 **완료 기준:** `startConsumer` 가 존재하고 테스트되며, **기존 8개 앱은 한 줄도 고치지 않았고 전부 그대로 동작한다.**
+
+**완료 (2026-08-09).** 브랜치 `feat/events-start-consumer`.
+
+- 도출은 Nest 자신의 `ListenerMetadataExplorer` 로 한다 (`consumers/consumer-discovery.ts`). 흉내낸 스캐너를 쓰면 "우리가 도출한 집합"과 "Nest 가 바인딩하는 집합"이 갈라질 수 있고, 그 어긋남이 정확히 이 워크스트림이 없애려는 종류의 무증상 결함이다. **컨트롤러만 훑는다** — Nest 의 `setupListeners` 도 `module.controllers` 만 순회하므로 provider 의 `@OnEvent` 는 지금도 아무 일을 하지 않는다(스펙으로 고정).
+- 도출은 순수 함수 2개로 갈랐다: `discoverEventHandlers(app)`(컨테이너 → 핸들러 목록) · `deriveConsumerConfig(handlers)`(핸들러 목록 → 토픽·계약, 거부 판정). 후자는 컨테이너 없이 테스트된다.
+- 부팅 거부 두 건 다 실행 가능한 스펙으로 박혔다. 에러 메시지가 **어느 컨트롤러의 어느 메서드**인지 지목한다.
+- `forConsumer` 는 이제 `subscribe.topics` 를 **만들지 않는다.** 남겨두면 "이 목록이 구독을 결정한다"는 틀린 모델이 다시 자란다. 옵션 타입도 `ConsumerTransportOptions` 로 갈라 `streams` 를 optional + `@deprecated` 로 표시했다 — 기존 7개 호출부는 그대로 컴파일된다.
+- 실측 보강: `ServerKafka.bindEvents` 에는 `registeredPatterns.length > 0` 가드가 있다. 즉 핸들러 0개면 **subscribe 자체를 건너뛴다** — 로그조차 남지 않으므로 "핸들러 0개 → 부팅 거부"는 장식이 아니다. (ADR Context 의 인용문을 이 가드까지 포함하도록 고쳤다.)
+
+**🔴 이 태스크가 두 번째 실재 프로덕션 결함을 찾았다 — 이번엔 영향 범위가 크다.**
+
+`app.connectMicroservice(opts)` 를 두 번째 인자 없이 부르면 Nest 가 마이크로서비스에 **빈 `ApplicationConfig`** 를 만들어 준다(`nest-application.js:128`). **7개 소비 앱 전부가 그렇게 부른다.** 따라서 `APP_INTERCEPTOR` 로 등록한 `SchemaValidationInterceptor` · `EventRetryInterceptor`(재시도·DLQ·offset commit) · `ChainContextInterceptor` 가 **소비 경로에 하나도 붙지 않는다.** 컨트롤러 레벨 `@UseInterceptors(EventTypeGuard)` 는 메타데이터에서 해석되므로 살아 있다 — 그래서 필터링만 동작하고 검증·재시도·DLQ 는 조용히 죽어 있었다.
+
+하네스로 4가지 배선을 실행해 비교했고(ADR-0029 §8 표), 채택한 것은 **마이크로서비스 스코프 전역 인터셉터**다: `deferInitialization: true` → `useGlobalInterceptors` → `registerListeners()` → 초기화 플래그 수동 세팅. `inheritAppConfig: true` 는 앱의 HTTP 전역 파이프·필터·**가드**까지 RPC 에 얹혀 기각했고, `deferInitialization` 단독은 `onModuleInit` 이 **2회** 실행돼 기각했다(둘 다 실측).
+
+**파급 1 — Task 2 의 결론 일부가 틀렸다.** Task 2 는 파싱 버그가 "core·analytics·search 에서 무한 재전달"을 일으킨다고 적었다. 그 세 인터셉터가 애초에 붙지 않으므로 **프로덕션 영향 범위는 0** 이었다. 수정 자체는 유효하다(§8 배선이 켜지면 그 경로가 살아난다). ADR Follow-up 3 에 정정을 남겼다.
+
+**파급 2 — Task 5 는 동작 중립이 아니다.** 아래 Task 5 경고 참조.
+
+- 검증: `libs/events`+계약 패키지 **16 suite / 145 tests 초록**(Task 2 대비 +2 suite / +16 tests) · `npm run type-check` **164 = develop 기준선과 동일** · **10개 앱 전부 `nest build` 초록** · 신규 파일 eslint 초록(`events.module.ts` 는 기존 부채 11 error / 4 warning 그대로) · 전체 jest 실패 suite 집합이 develop 과 **동일**(18).
+- **Task 4·5 에 넘기는 사실:** `startConsumer` 는 검증 **정책**(`validateOnConsume` 등)을 `EVENTS_CONSUMER_POLICY` 토큰으로 컨테이너에서 읽는다 — `forConsumerModule({validation})` 이 등록한다. 정책은 도출 불가한 사실이라 선언이 맞고, 스트림 목록만 도출로 대체됐다. **`forConsumerModule` 을 부르지 않는 앱(channel-adapter)은 이 토큰이 없어 기본값(`validateOnConsume: true`)으로 떨어진다.** Task 7 에서 `forConsumerModule` 을 걷어낼 때 이 정책을 `forApp` 으로 옮겨야 하며, 그 전에는 정책 선언을 지우면 안 된다 — 지우는 순간 `validateOnConsume: false` 를 명시한 앱(notification·membership·wallet)에서 검증이 켜진다.
 
 ---
 
@@ -197,7 +220,15 @@ Nest 는 수신 `value` 를 `KafkaParser.decode` 로 **JSON 파싱해서** 넘�
 - [ ] `nest build <app>` · `npm run type-check` 초록
 - [ ] 커밋 · 푸시 · **배포 후 다음 앱으로**
 
-**⚠️ 5g 전에 반드시:** channel-adapter 의 인바운드 payload 가 실제로 zod 스키마를 만족하는지 확인한다. 지금까지 검증 없이 소비해 왔으므로, 확인 없이 이주하면 **이주 자체가 DLQ 폭탄이 된다.** 확인 방법은 5g 착수 시 결정 — 스테이징 트래픽 샘플링 또는 `validateOnConsume: false` 로 먼저 붙이고 로그만 관찰.
+**⚠️ 이주는 동작 중립이 아니다 — 7개 앱 전부에 해당 (Task 3 발견, ADR-0029 §8).**
+
+원래 이 경고는 5g(channel-adapter) 에만 붙어 있었다. Task 3 이 밝혀낸 바에 따르면 **7개 앱 모두** 지금 소비 측 스키마 검증·재시도·DLQ 가 적용되지 않고 있다 — `app.connectMicroservice(opts)` 가 빈 `ApplicationConfig` 를 만들기 때문이다. `startConsumer` 로 이주하는 순간 그 앱에서 이 셋이 **처음으로 켜진다.**
+
+따라서 각 앱 이주 PR 은 다음을 포함해야 한다:
+
+- [ ] 그 앱의 `validateOnConsume` 선언 확인. `false` 를 명시한 앱(notification·membership·wallet)은 검증이 계속 꺼진 채 이주하므로 위험이 낮다. 명시하지 않은 앱(core·analytics·search = 기본값 `true`)과 `forConsumerModule` 자체가 없는 앱(channel-adapter)은 **이주가 곧 검증 활성화**다.
+- [ ] 검증이 새로 켜지는 앱은 인바운드 payload 가 실제로 zod 스키마를 만족하는지 먼저 확인한다. 확인 없이 이주하면 **이주 자체가 DLQ 폭탄이 된다.** 확인 방법은 착수 시 결정 — 스테이징 트래픽 샘플링 또는 `validateOnConsume: false` 로 먼저 붙이고 로그만 관찰.
+- [ ] 재시도·DLQ 가 새로 켜지는 것은 **전 앱 공통**이다. 지금까지 핸들러 에러는 아무 분류 없이 Nest 기본 경로로 갔다. 이주 후에는 `@RetryPolicy` 분류 → backoff 재시도 → DLQ 로 흐른다. 그 앱의 핸들러가 idempotent 한지 확인한다 (재시도가 처음으로 실재하게 된다).
 
 **완료 기준:** 7개 앱 전부 `startConsumer` 를 쓰고, `forConsumer` 호출이 0건이다.
 

--- a/libs/events/src/consumers/consumer-discovery.spec.ts
+++ b/libs/events/src/consumers/consumer-discovery.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * 소비 집합 도출 (ADR-0029 §3, 플랜 Task 3)
+ *
+ * 여기서 증명하는 것은 "선언 없이도 소비 집합을 정확히 알 수 있다" 하나다.
+ * 도출이 틀리면 구독·검증·부트스트랩이 한꺼번에 틀어지므로, 경계 조건을 전부 건다.
+ */
+
+import { Controller, Injectable } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { CART_STREAM } from '@packages/event-contracts/streams/cart.stream';
+import { ORDER_STREAM } from '@packages/event-contracts/streams/orders.stream';
+import { OnEvent } from './decorators';
+import { deriveConsumerConfig, discoverEventHandlers, type DiscoveredEventHandler } from './consumer-discovery';
+
+@Controller()
+class CartConsumer {
+  @OnEvent('carts.events.v1', 'CartCreated')
+  onCreated(): void {}
+
+  @OnEvent('carts.events.v1', 'CartUpdated')
+  onUpdated(): void {}
+
+  /** 이벤트 핸들러가 아닌 메서드는 도출에 잡히면 안 된다 */
+  helper(): void {}
+}
+
+@Controller()
+class OrderConsumer {
+  @OnEvent('orders.events.v1', 'OrderCreated')
+  onOrderCreated(): void {}
+}
+
+/** 상속받은 핸들러도 구독된다 — Nest 의 MetadataScanner 가 프로토타입 체인을 탄다 */
+class BaseConsumer {
+  @OnEvent('orders.events.v1', 'OrderCancelled')
+  onInherited(): void {}
+}
+
+@Controller()
+class DerivedConsumer extends BaseConsumer {}
+
+@Controller()
+class UnregisteredTopicConsumer {
+  @OnEvent('nobody.declared.this.v1', 'Whatever')
+  onGhost(): void {}
+}
+
+/**
+ * provider 에 붙인 `@OnEvent` 는 지금도 아무 일도 하지 않는다 —
+ * Nest 의 `setupListeners` 가 `module.controllers` 만 순회하기 때문이다.
+ * 도출도 같은 규칙을 따라야 한다. 안 그러면 "구독한다고 도출됐는데 실제로는
+ * 안 오는" 토픽이 생겨, 이 ADR 이 없애려는 어긋남을 우리 손으로 다시 만든다.
+ */
+@Injectable()
+class NotAController {
+  @OnEvent('carts.events.v1', 'CartCreated')
+  onCreated(): void {}
+}
+
+describe('discoverEventHandlers', () => {
+  it('컨트롤러의 @OnEvent 에서 (topic, eventType) 집합을 도출한다', async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [CartConsumer, OrderConsumer],
+    }).compile();
+
+    const handlers = discoverEventHandlers(moduleRef);
+
+    expect(handlers).toEqual(
+      expect.arrayContaining([
+        { topic: 'carts.events.v1', eventType: 'CartCreated', controller: 'CartConsumer', methodName: 'onCreated' },
+        { topic: 'carts.events.v1', eventType: 'CartUpdated', controller: 'CartConsumer', methodName: 'onUpdated' },
+        {
+          topic: 'orders.events.v1',
+          eventType: 'OrderCreated',
+          controller: 'OrderConsumer',
+          methodName: 'onOrderCreated',
+        },
+      ]),
+    );
+    expect(handlers).toHaveLength(3);
+  });
+
+  it('상속받은 핸들러도 도출한다', async () => {
+    const moduleRef = await Test.createTestingModule({ controllers: [DerivedConsumer] }).compile();
+
+    expect(discoverEventHandlers(moduleRef)).toEqual([
+      {
+        topic: 'orders.events.v1',
+        eventType: 'OrderCancelled',
+        controller: 'DerivedConsumer',
+        methodName: 'onInherited',
+      },
+    ]);
+  });
+
+  it('provider 의 @OnEvent 는 도출하지 않는다 — Nest 도 바인딩하지 않는다', async () => {
+    const moduleRef = await Test.createTestingModule({ providers: [NotAController] }).compile();
+
+    expect(discoverEventHandlers(moduleRef)).toEqual([]);
+  });
+
+  it('컨트롤러가 없으면 빈 집합', async () => {
+    const moduleRef = await Test.createTestingModule({}).compile();
+
+    expect(discoverEventHandlers(moduleRef)).toEqual([]);
+  });
+});
+
+describe('deriveConsumerConfig', () => {
+  const handler = (topic: string, eventType: string): DiscoveredEventHandler => ({
+    topic,
+    eventType,
+    controller: 'SomeConsumer',
+    methodName: `on${eventType}`,
+  });
+
+  it('토픽을 중복 없이 모으고 계약을 레지스트리에서 찾는다', () => {
+    const derived = deriveConsumerConfig([
+      handler('carts.events.v1', 'CartCreated'),
+      handler('carts.events.v1', 'CartUpdated'),
+      handler('orders.events.v1', 'OrderCreated'),
+    ]);
+
+    expect(derived.topics).toEqual(['carts.events.v1', 'orders.events.v1']);
+    expect(derived.streams).toEqual([CART_STREAM, ORDER_STREAM]);
+    expect(derived.handlers).toHaveLength(3);
+  });
+
+  it('핸들러가 하나도 없으면 던진다 — 컨트롤러 미등록이 가장 조용한 실수였다', () => {
+    expect(() => deriveConsumerConfig([])).toThrow(/controllers/);
+  });
+
+  it('레지스트리에 없는 토픽이면 어느 핸들러인지 지목하며 던진다', () => {
+    expect(() => deriveConsumerConfig([handler('nobody.declared.this.v1', 'Whatever')])).toThrow(
+      /nobody\.declared\.this\.v1.*SomeConsumer\.onWhatever/s,
+    );
+  });
+
+  it('알 수 없는 토픽이 하나라도 있으면 나머지가 멀쩡해도 던진다', () => {
+    expect(() =>
+      deriveConsumerConfig([handler('carts.events.v1', 'CartCreated'), handler('nobody.declared.this.v1', 'Whatever')]),
+    ).toThrow(/nobody\.declared\.this\.v1/);
+  });
+});
+
+describe('도출 → 거부 (컨테이너 통합)', () => {
+  it('레지스트리에 없는 토픽을 구독하는 컨트롤러가 있으면 도출 단계에서 막힌다', async () => {
+    const moduleRef = await Test.createTestingModule({ controllers: [UnregisteredTopicConsumer] }).compile();
+
+    expect(() => deriveConsumerConfig(discoverEventHandlers(moduleRef))).toThrow(
+      /nobody\.declared\.this\.v1.*UnregisteredTopicConsumer\.onGhost/s,
+    );
+  });
+});

--- a/libs/events/src/consumers/consumer-discovery.ts
+++ b/libs/events/src/consumers/consumer-discovery.ts
@@ -1,0 +1,150 @@
+/**
+ * 소비 집합 도출 (ADR-0029 §1·§3)
+ *
+ * 이 프로세스가 무엇을 소비하는지는 **선언하지 않는다** — `@OnEvent` 데코레이터가
+ * 이미 authoritative 하기 때문이다. Nest 의 `ServerKafka.bindEvents()` 는
+ * `subscribe.topics` 를 `[...this.messageHandlers.keys()]` 로 덮어쓰므로
+ * (`server-kafka.js:92`), 실제 구독 집합은 컨테이너 안의 데코레이터가 결정한다.
+ * 같은 사실을 따로 선언하면 두 벌이 생기고, 두 벌은 어긋나며, 어긋남이 무증상이면
+ * 그 자리에 틀린 주석이 자란다 — 2026-08-08 아키텍처 리뷰의 오판이 그것이었다.
+ *
+ * 도출은 Nest 자신의 `ListenerMetadataExplorer` 로 한다. 흉내낸 스캐너를 쓰면
+ * "우리가 도출한 집합"과 "Nest 가 바인딩하는 집합"이 다를 수 있고, 그 어긋남이
+ * 정확히 이 모듈이 없애려는 종류의 무증상 결함이다.
+ */
+
+import type { INestApplicationContext } from '@nestjs/common';
+import { DiscoveryService, MetadataScanner, ModulesContainer } from '@nestjs/core';
+import type { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
+import { ListenerMetadataExplorer } from '@nestjs/microservices/listener-metadata-explorer';
+import type { StreamConfig } from '@packages/event-contracts/types';
+import { streamForTopic } from '@packages/event-contracts/streams/registry';
+import { EVENT_TYPE_FILTER } from './decorators';
+
+/** 컨테이너에서 발견된 이벤트 핸들러 하나. */
+export interface DiscoveredEventHandler {
+  /** `@OnEvent` 의 첫 인자 = Kafka 토픽 = Nest 의 등록 패턴 */
+  topic: string;
+  /** `@OnEvent` 의 두 번째 인자. 토픽 전체를 받는 핸들러면 undefined */
+  eventType?: string;
+  controller: string;
+  methodName: string;
+}
+
+/** 발견된 핸들러들에서 파생된 소비 설정. */
+export interface DerivedConsumerConfig {
+  /** 구독 토픽 (중복 없음, 발견 순서) */
+  topics: string[];
+  /** 각 토픽의 계약 — 스키마 검증 맵과 토픽 부트스트랩이 이것으로 만들어진다 */
+  streams: StreamConfig[];
+  handlers: DiscoveredEventHandler[];
+}
+
+/**
+ * `metatype` 이 있으면 그쪽을 쓴다 — request-scoped 컨트롤러는 정적 인스턴스가 없다.
+ */
+function controllerPrototype(wrapper: InstanceWrapper): object | undefined {
+  const metatype: unknown = wrapper.metatype;
+  if (typeof metatype === 'function') {
+    // as 정당화: `InstanceWrapper.metatype` 은 `Type<any> | Function` 이라 prototype 이
+    // 타입상 드러나지 않는다. 컨트롤러 metatype 은 정의상 클래스다.
+    const prototype = (metatype as { prototype?: object }).prototype;
+    if (prototype) return prototype;
+  }
+  if (wrapper.instance) return Object.getPrototypeOf(wrapper.instance) as object;
+  return undefined;
+}
+
+/**
+ * 컨테이너의 모든 컨트롤러에서 이벤트 핸들러를 훑는다.
+ *
+ * 컨트롤러만 본다 — Nest 도 그렇다 (`microservices-module.js` 의 `setupListeners` 는
+ * `module.controllers` 만 순회한다). provider 에 `@OnEvent` 를 달면 지금도 아무 일이
+ * 일어나지 않으며, 여기서도 발견되지 않는다.
+ */
+export function discoverEventHandlers(app: INestApplicationContext): DiscoveredEventHandler[] {
+  const discovery = new DiscoveryService(app.get(ModulesContainer));
+  const explorer = new ListenerMetadataExplorer(new MetadataScanner());
+  const handlers: DiscoveredEventHandler[] = [];
+
+  for (const wrapper of discovery.getControllers()) {
+    const prototype = controllerPrototype(wrapper);
+    if (!prototype) continue;
+
+    // `explore()` 는 인스턴스에서 프로토타입을 되짚는다. 프로토타입만 가진 경우를
+    // 위해 빈 껍데기를 씌운다 — 메서드 조회는 프로토타입 체인을 그대로 탄다.
+    const probe = Object.create(prototype) as object;
+
+    for (const definition of explorer.explore(probe)) {
+      if (!definition.isEventHandler) continue;
+
+      const eventType: unknown = Reflect.getMetadata(EVENT_TYPE_FILTER, definition.targetCallback);
+      const controller = String(wrapper.name ?? prototype.constructor?.name ?? 'UnknownController');
+
+      for (const pattern of definition.patterns ?? []) {
+        if (typeof pattern !== 'string' || pattern.length === 0) {
+          throw new Error(
+            `startConsumer(): ${controller}.${definition.methodKey} 의 이벤트 패턴이 토픽 문자열이 아니다 ` +
+              `(${JSON.stringify(pattern)}). @OnEvent 는 첫 인자로 토픽 문자열을 받는다.`,
+          );
+        }
+
+        handlers.push({
+          topic: pattern,
+          eventType: typeof eventType === 'string' ? eventType : undefined,
+          controller,
+          methodName: definition.methodKey,
+        });
+      }
+    }
+  }
+
+  return handlers;
+}
+
+/**
+ * 발견된 핸들러에서 구독 토픽 · 계약 목록을 파생한다.
+ *
+ * 두 가지를 부팅에서 거부한다. 둘 다 지금은 완전 무증상인 실수다:
+ * - 핸들러 0개 — 컨슈머 컨트롤러를 `controllers: []` 에 등록하지 않은 경우
+ * - 계약 레지스트리에 없는 토픽 — 오타이거나 계약 미등록
+ */
+export function deriveConsumerConfig(handlers: DiscoveredEventHandler[]): DerivedConsumerConfig {
+  if (handlers.length === 0) {
+    throw new Error(
+      'startConsumer(): @OnEvent 핸들러가 하나도 발견되지 않았다. ' +
+        '컨슈머 컨트롤러를 모듈의 `controllers: []` 에 등록했는지 확인하라 — ' +
+        '등록 누락은 이 시스템에서 가장 조용한 실수였다 (ADR-0029).',
+    );
+  }
+
+  const streams = new Map<string, StreamConfig>();
+  const unregistered = new Map<string, DiscoveredEventHandler>();
+
+  for (const handler of handlers) {
+    if (streams.has(handler.topic) || unregistered.has(handler.topic)) continue;
+
+    const config = streamForTopic(handler.topic);
+    if (config) {
+      streams.set(handler.topic, config);
+    } else {
+      unregistered.set(handler.topic, handler);
+    }
+  }
+
+  if (unregistered.size > 0) {
+    const detail = [...unregistered.values()]
+      .map((handler) => `  - ${handler.topic}  (${handler.controller}.${handler.methodName})`)
+      .join('\n');
+    throw new Error(
+      `startConsumer(): 계약 레지스트리에 없는 토픽을 구독하려 한다.\n${detail}\n` +
+        'packages/event-contracts/streams 에 스트림을 추가하고 streams/index.ts 에서 export 하라.',
+    );
+  }
+
+  return {
+    topics: [...streams.keys()],
+    streams: [...streams.values()],
+    handlers,
+  };
+}

--- a/libs/events/src/consumers/consumer-interceptors.ts
+++ b/libs/events/src/consumers/consumer-interceptors.ts
@@ -1,0 +1,72 @@
+/**
+ * 소비 경로 인터셉터 배선 (ADR-0029 §8)
+ *
+ * 이 인터셉터들은 `forRoot`/`forConsumerModule` 에서 `APP_INTERCEPTOR` 로도 등록되지만,
+ * **하이브리드 앱에서는 그 등록이 소비 경로에 닿지 않는다.** `app.connectMicroservice(opts)`
+ * 를 두 번째 인자 없이 부르면 Nest 가 마이크로서비스에 **새 `ApplicationConfig`** 를
+ * 만들어 주기 때문이다 (`nest-application.js:128`). 그래서 `startConsumer` 는 마이크로서비스
+ * 자신의 config 에 인스턴스를 직접 얹는다 — 앱의 HTTP 전역 파이프·필터·가드는 건드리지 않고
+ * 이벤트 인터셉터만 붙는다.
+ *
+ * `useGlobalInterceptors` 는 클래스가 아니라 인스턴스를 받으므로 여기서 생성한다.
+ * 생성자 인자는 컨테이너에서 가져오되, 없을 수 있는 것(DLQ 비활성 등)은 optional 로 다룬다.
+ */
+
+import type { INestApplicationContext, NestInterceptor, Type } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import type { SchemaValidationOptions, StreamConfig } from '@packages/event-contracts/types';
+import { DLQHandler } from '../dlq/dlq-handler.service';
+import { ChainContextInterceptor } from '../interceptors/chain-context.interceptor';
+import { EventRetryInterceptor } from '../interceptors/event-retry.interceptor';
+import { SchemaValidationInterceptor } from '../interceptors/schema-validation.interceptor';
+import { EventChainService } from '../tracking/event-chain.service';
+
+/**
+ * 앱이 선언한 소비 정책. **스트림 목록은 여기 없다** — 그건 데코레이터에서 도출된다.
+ * 정책(검증을 켤지, 에러를 던질지)은 코드에서 도출할 수 없으므로 선언이 맞다 (ADR-0029 §1).
+ */
+export const EVENTS_CONSUMER_POLICY = 'EVENTS_CONSUMER_POLICY';
+
+export interface EventsConsumerPolicy {
+  validation?: SchemaValidationOptions;
+}
+
+/**
+ * 컨테이너에 없을 수도 있는 provider 조회.
+ *
+ * Nest 11 의 `get()` 은 `optional` 옵션이 없고 못 찾으면 던진다. 던지는 조건이
+ * "등록되지 않음" 하나뿐이므로 catch 로 흡수한다.
+ */
+function optionalGet<T>(app: INestApplicationContext, token: Type<T> | string): T | undefined {
+  try {
+    return app.get<T>(token, { strict: false });
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * 마이크로서비스 스코프 전역 인터셉터를 만든다.
+ *
+ * **배열 순서 = 래핑 순서.** 재시도·분류·DLQ 가 최외곽이어야 안쪽에서 나온
+ * `SchemaValidationError` 도 분류망에 걸린다 (`events.module.ts` 의 APP_INTERCEPTOR
+ * 등록 순서와 같은 이유·같은 순서).
+ *
+ * @param streams `@OnEvent` 에서 **도출된** 스트림 목록 — 검증 스키마 맵이 된다
+ */
+export function buildConsumerInterceptors(app: INestApplicationContext, streams: StreamConfig[]): NestInterceptor[] {
+  const reflector = app.get(Reflector, { strict: false });
+  const policy = optionalGet<EventsConsumerPolicy>(app, EVENTS_CONSUMER_POLICY);
+
+  const interceptors: NestInterceptor[] = [
+    new EventRetryInterceptor(reflector, optionalGet(app, DLQHandler)),
+    new SchemaValidationInterceptor(reflector, streams, policy?.validation),
+  ];
+
+  const eventChainService = optionalGet(app, EventChainService);
+  if (eventChainService) {
+    interceptors.push(new ChainContextInterceptor(eventChainService));
+  }
+
+  return interceptors;
+}

--- a/libs/events/src/events.module.ts
+++ b/libs/events/src/events.module.ts
@@ -4,8 +4,22 @@
  * Stream 기반 이벤트 시스템을 위한 NestJS 모듈
  */
 
-import { DynamicModule, Global, Inject, Module, OnApplicationShutdown, Logger } from '@nestjs/common';
-import { ClientKafka, ClientsModule, Transport } from '@nestjs/microservices';
+import {
+  DynamicModule,
+  Global,
+  INestApplication,
+  Inject,
+  Module,
+  OnApplicationShutdown,
+  Logger,
+} from '@nestjs/common';
+import {
+  ClientKafka,
+  ClientsModule,
+  CustomTransportStrategy,
+  NestMicroservice,
+  Transport,
+} from '@nestjs/microservices';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ClsModule } from 'nestjs-cls';
 import { StreamPublisher } from './publishers/stream-publisher.service';
@@ -30,6 +44,8 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { DbService } from '@app/db';
 import { EVENT_TRANSPORT, EventTransport } from './transport/transport.port';
 import { KafkaTransport } from './transport/kafka.transport';
+import { DerivedConsumerConfig, deriveConsumerConfig, discoverEventHandlers } from './consumers/consumer-discovery';
+import { buildConsumerInterceptors, EVENTS_CONSUMER_POLICY } from './consumers/consumer-interceptors';
 
 /**
  * Kafka 로 나가는 유일한 통로 (ADR-0029 §7). `KAFKA_CLIENT` 를 감싸며,
@@ -73,6 +89,49 @@ export interface ConsumerModuleOptions {
 
   // 스키마 검증 설정
   validation?: SchemaValidationOptions; // 스키마 검증 옵션
+}
+
+/**
+ * `forConsumer()` 전송 설정 (deprecated 경로)
+ *
+ * `streams` 만 빠져 있다 — Nest 가 `subscribe.topics` 를 덮어쓰므로 무의미했다.
+ * 아래 `forConsumer` 의 JSDoc 참조.
+ */
+export interface ConsumerTransportOptions extends Omit<ConsumerModuleOptions, 'streams'> {
+  /**
+   * @deprecated 무시된다. Nest 의 `ServerKafka.bindEvents()` 가 `subscribe.topics` 를
+   * 등록된 `@OnEvent` 패턴으로 덮어쓰기 때문에 이 목록은 한 번도 효과를 낸 적이 없다
+   * (ADR-0029 Context). 필드는 기존 호출부 호환을 위해 남겨두었다.
+   */
+  streams?: StreamConfig[];
+}
+
+/**
+ * `startConsumer()` 옵션 (ADR-0029 §3)
+ *
+ * **구독 목록이 없다.** 소비 집합은 `@OnEvent` 데코레이터에서 도출된다.
+ * 여기 남는 것은 코드에서 도출할 수 없는 사실 — 전송 설정뿐이다.
+ */
+export interface StartConsumerOptions {
+  groupId: string;
+  kafka?: KafkaConfig; // 없으면 환경변수에서 생성
+
+  sessionTimeout?: number; // ms (기본: 30000)
+  heartbeatInterval?: number; // ms (기본: 3000)
+  maxPollInterval?: number; // ms (기본: 300000)
+  autoCommit?: boolean; // 기본: false
+
+  /** 도출된 토픽의 DLQ 토픽까지 부트스트랩할지 (기본: true) */
+  enableAutoDLQ?: boolean;
+
+  /**
+   * 소비 전략 교체 (ADR-0029 §7).
+   *
+   * 생략하면 Nest `ServerKafka`. 테스트는 `InMemoryServer` 를 넘겨 브로커 없이 같은
+   * 파이프라인(인터셉터·가드·파라미터 데코레이터·DI)을 그대로 탄다. 전략을 넘기면
+   * Kafka 토픽 부트스트랩은 건너뛴다 — 붙을 브로커가 없다.
+   */
+  strategy?: CustomTransportStrategy;
 }
 
 @Global()
@@ -312,12 +371,21 @@ export class EventsModule {
       useClass: ChainContextInterceptor,
     };
 
+    // 앱이 선언한 검증 정책. `startConsumer` 가 읽어 마이크로서비스 스코프 인터셉터를
+    // 만들 때 쓴다 (ADR-0029 §8) — 정책은 도출 불가한 사실이라 선언이 맞고, 스트림
+    // 목록만 도출로 대체된다.
+    const consumerPolicyProvider = {
+      provide: EVENTS_CONSUMER_POLICY,
+      useValue: { validation: options.validation },
+    };
+
     const providers = [
       eventTransportProvider, // Kafka 로 나가는 유일한 통로
       ...(dlqProvider ? [dlqProvider] : []),
       retryInterceptorProvider, // 최외곽 — 등록 순서가 래핑 순서
       interceptorProvider, // 스키마 검증 Interceptor는 항상 등록
       chainInterceptorProvider, // chain context 전파 인터셉터
+      consumerPolicyProvider, // startConsumer 가 읽는 소비 정책
       shutdownProvider, // Graceful shutdown 항상 등록
       topicBootstrapProvider, // MSK Serverless 등 auto-create 불가 환경 대응
       { provide: EventChainService, useClass: EventChainService },
@@ -353,31 +421,33 @@ export class EventsModule {
   }
 
   /**
-   * Consumer 설정 반환 (main.ts에서 connectMicroservice()에 사용)
+   * Consumer 전송 설정 반환 (main.ts에서 connectMicroservice()에 사용)
    *
-   * 주의: 이 메서드는 자동 DLQ 처리를 포함하지 않습니다.
-   * 자동 DLQ 처리를 원하면 forConsumerModule()을 사용하세요.
+   * @deprecated `startConsumer(app, { groupId })` 를 쓴다. 두 가지 이유다 (ADR-0029):
+   *
+   * 1. **`streams` 인자가 무효다.** Nest 의 `ServerKafka.bindEvents()` 가
+   *    `subscribe.topics` 를 등록된 `@OnEvent` 패턴으로 덮어쓴다. 이 목록은 한 번도
+   *    구독에 영향을 준 적이 없으며, 그럼에도 "여기 없으면 메시지가 안 온다"는 틀린
+   *    모델이 주석으로 자라 2026-08-08 아키텍처 리뷰의 오판을 낳았다.
+   * 2. **이 경로로 붙인 마이크로서비스에는 소비 인터셉터가 적용되지 않는다.**
+   *    호출부가 `app.connectMicroservice(opts)` 를 두 번째 인자 없이 부르면 Nest 가
+   *    빈 `ApplicationConfig` 를 만들어, `APP_INTERCEPTOR` 로 등록한 스키마 검증·재시도·
+   *    DLQ 인터셉터가 전부 무력화된다 (ADR-0029 §8). `startConsumer` 는 그 배선을 한다.
    *
    * @example
-   * // apps/events-test/src/main.ts
-   * const consumerOptions = EventsModule.forConsumer({
-   *   streams: [TEST_STREAM],
-   *   groupId: 'events-test-consumer',
-   * });
-   *
+   * const consumerOptions = EventsModule.forConsumer({ groupId: 'events-test-consumer' });
    * app.connectMicroservice(consumerOptions);
    * await app.startAllMicroservices();
    */
-  static forConsumer(options: ConsumerModuleOptions): {
+  static forConsumer(options: ConsumerTransportOptions): {
     transport: Transport.KAFKA;
     options: any;
   } {
     // Kafka 설정 (환경변수 또는 명시적)
     const kafka = options.kafka || this.createKafkaConfigFromEnv();
 
-    // 모든 stream의 토픽 수집
-    const topics = options.streams.map((s) => s.topic.topic);
-
+    // subscribe.topics 를 만들지 않는다 — Nest 가 어차피 덮어쓴다. 만들어 두면
+    // "이 목록이 구독을 결정한다"는 틀린 모델이 다시 자란다.
     return {
       transport: Transport.KAFKA,
       options: {
@@ -396,7 +466,6 @@ export class EventsModule {
           allowAutoTopicCreation: false,
         },
         subscribe: {
-          topics,
           fromBeginning: false,
         },
         run: {
@@ -406,6 +475,73 @@ export class EventsModule {
         },
       },
     };
+  }
+
+  /**
+   * 소비를 시작한다 — 구독 목록 인자 없음 (ADR-0029 §3)
+   *
+   * 컨테이너를 훑어 `@OnEvent` 핸들러를 찾고, 거기서 **구독 토픽 · 검증 스키마 맵 ·
+   * 토픽 부트스트랩 목록을 전부 파생**한다. 선언과 실제가 어긋날 자리가 없다.
+   *
+   * 두 가지를 부팅에서 거부한다 — 둘 다 지금까지 완전 무증상이던 실수다:
+   * - 계약 레지스트리에 없는 토픽 구독
+   * - `@OnEvent` 핸들러 0개 (컨트롤러를 `controllers: []` 에 등록하지 않은 경우.
+   *   Nest 는 이때 `subscribe` 자체를 건너뛰므로 로그조차 남지 않는다)
+   *
+   * 그리고 소비 인터셉터(재시도·DLQ·스키마 검증·chain)를 **마이크로서비스 스코프**로
+   * 붙인다. 하이브리드 앱에서 `APP_INTERCEPTOR` 가 소비 경로에 닿지 않기 때문이며,
+   * 근거와 대안 비교는 ADR-0029 §8 에 있다.
+   *
+   * @example
+   * const app = await NestFactory.create(AppModule);
+   * await EventsModule.startConsumer(app, { groupId: 'search-indexer' });
+   * await app.listen(port);
+   *
+   * @returns 도출 결과 — 로깅·테스트용
+   */
+  static async startConsumer(app: INestApplication, options: StartConsumerOptions): Promise<DerivedConsumerConfig> {
+    const logger = new Logger('EventsConsumer');
+    const derived = deriveConsumerConfig(discoverEventHandlers(app));
+
+    const kafka = options.kafka || this.createKafkaConfigFromEnv();
+    const enableAutoDLQ = options.enableAutoDLQ ?? true;
+
+    if (!options.strategy) {
+      await bootstrapKafkaTopics({ kafka, streams: derived.streams, includeDLQ: enableAutoDLQ });
+    }
+
+    const microserviceOptions = options.strategy
+      ? { strategy: options.strategy }
+      : this.forConsumer({
+          groupId: options.groupId,
+          kafka,
+          sessionTimeout: options.sessionTimeout,
+          heartbeatInterval: options.heartbeatInterval,
+          maxPollInterval: options.maxPollInterval,
+          autoCommit: options.autoCommit,
+        });
+
+    // deferInitialization 없이 부르면 Nest 가 즉시 리스너를 바인딩해버려
+    // useGlobalInterceptors 가 늦는다. 미룬 뒤 인터셉터를 얹고, 비-defer 경로가
+    // 하던 일(리스너 바인딩 + 초기화 플래그)을 직접 한다 — 플래그를 세우지 않으면
+    // listen() 이 registerModules() 를 타면서 onModuleInit 이 두 번 실행된다.
+    const microservice = app.connectMicroservice(microserviceOptions, {
+      deferInitialization: true,
+    }) as NestMicroservice;
+
+    microservice.useGlobalInterceptors(...buildConsumerInterceptors(app, derived.streams));
+    microservice.registerListeners();
+    microservice.setIsInitialized(true);
+    microservice.setIsInitHookCalled(true);
+
+    await app.startAllMicroservices();
+
+    logger.log(
+      `Consumer started (groupId=${options.groupId}) — ${derived.handlers.length} handler(s) on ` +
+        `${derived.topics.length} topic(s): ${derived.topics.join(', ')}`,
+    );
+
+    return derived;
   }
 
   /**

--- a/libs/events/src/index.ts
+++ b/libs/events/src/index.ts
@@ -28,6 +28,10 @@ export * from './publishers/stream-publisher.service';
 export * from './consumers/decorators';
 export * from './guards/event-type.guard';
 
+// 소비 집합 도출 + 소비 인터셉터 배선 (ADR-0029 §3·§8)
+export * from './consumers/consumer-discovery';
+export * from './consumers/consumer-interceptors';
+
 // DLQ
 export * from './dlq/dlq.types';
 export * from './dlq/dlq-handler.service';

--- a/libs/events/src/transport/start-consumer.spec.ts
+++ b/libs/events/src/transport/start-consumer.spec.ts
@@ -1,0 +1,264 @@
+/**
+ * `startConsumer` 통합 스펙 (ADR-0029 §3·§8, 플랜 Task 3)
+ *
+ * Task 2 하네스 위에서 돌아간다 — `EventsModule` 은 실물이고, 바뀐 것은
+ * `EVENT_TRANSPORT` 바인딩과 소비 전략뿐이다. 앱 배선을 **운영 순서 그대로** 따른다:
+ * 컨테이너 생성 → `startConsumer` → `app.init()`. 그래야 초기화 훅 중복 같은
+ * 순서 의존 결함이 여기서 드러난다.
+ *
+ * 계약은 실제 등록된 `CART_STREAM` 을 쓴다 — `startConsumer` 가 레지스트리에 없는
+ * 토픽을 거부하므로 하네스 전용 가짜 스트림을 쓸 수 없고, 레지스트리 통합 자체가
+ * 이 태스크의 검증 대상이기도 하다. 어느 앱도 이 토픽을 소비하지 않는다.
+ */
+
+import { Controller, Injectable, INestApplication, OnModuleInit, UseInterceptors } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDLQTopicName } from '@packages/event-contracts/types';
+import { CART_STREAM } from '@packages/event-contracts/streams/cart.stream';
+import type { DLQMessage } from '../dlq/dlq.types';
+import { EventsModule } from '../events.module';
+import { EventPayload, OnEvent } from '../consumers/decorators';
+import { EventTypeGuard } from '../guards/event-type.guard';
+import { StreamPublisher } from '../publishers/stream-publisher.service';
+import { EVENT_TRANSPORT } from './transport.port';
+import { InMemoryBroker } from './in-memory.broker';
+import { InMemoryTransport } from './in-memory.transport';
+import { InMemoryServer } from './in-memory.server';
+
+const TOPIC = CART_STREAM.topic.topic;
+
+interface HandlerCall {
+  handler: string;
+  payload: unknown;
+}
+
+const calls: HandlerCall[] = [];
+let moduleInitCount = 0;
+
+@Injectable()
+class InitCounter implements OnModuleInit {
+  onModuleInit(): void {
+    moduleInitCount += 1;
+  }
+}
+
+@Controller()
+@UseInterceptors(EventTypeGuard)
+class CartConsumer {
+  @OnEvent('carts.events.v1', 'CartCreated')
+  onCreated(@EventPayload() payload: unknown): void {
+    calls.push({ handler: 'onCreated', payload });
+  }
+
+  @OnEvent('carts.events.v1', 'CartUpdated')
+  onUpdated(@EventPayload() payload: unknown): void {
+    calls.push({ handler: 'onUpdated', payload });
+  }
+}
+
+@Controller()
+class GhostConsumer {
+  @OnEvent('nobody.declared.this.v1', 'Whatever')
+  onGhost(): void {}
+}
+
+const kafka = { clientId: 'start-consumer-spec', brokers: ['unused:9092'] };
+
+function validCartPayload(id: string) {
+  return {
+    id,
+    customerId: 'cust-1',
+    regionId: 'region-1',
+    createdAt: new Date().toISOString(),
+  };
+}
+
+async function buildModule(controllers: unknown[], broker: InMemoryBroker): Promise<TestingModule> {
+  process.env.KAFKA_BOOTSTRAP_TOPICS = 'false';
+
+  return Test.createTestingModule({
+    imports: [
+      EventsModule.forRoot({ streams: [CART_STREAM], serviceName: 'start-consumer-spec', kafka }),
+      // ⚠️ streams 를 넘기지만 startConsumer 는 이것을 쓰지 않는다 — 검증 맵은 도출된다.
+      // 여기서 살아남는 것은 정책(validation)과 DLQ 설정뿐이다.
+      EventsModule.forConsumerModule({ streams: [], groupId: 'spec-consumer', kafka }),
+    ],
+    // as 정당화: Nest 의 `controllers` 는 `Type<any>[]` 를 받고, 이 헬퍼는 테스트마다
+    // 다른 컨트롤러 묶음을 받기 위해 unknown[] 로 선언돼 있다.
+    controllers: controllers as never[],
+    providers: [InitCounter],
+  })
+    .overrideProvider(EVENT_TRANSPORT)
+    .useValue(new InMemoryTransport(broker))
+    .compile();
+}
+
+describe('startConsumer — 소비 집합 도출', () => {
+  let app: INestApplication;
+  let broker: InMemoryBroker;
+  let publisher: StreamPublisher<typeof CART_STREAM.events>;
+
+  beforeAll(async () => {
+    broker = new InMemoryBroker();
+    const moduleRef = await buildModule([CartConsumer], broker);
+
+    app = moduleRef.createNestApplication({ logger: false });
+
+    // 운영 main.ts 와 같은 순서 — connect 가 init 보다 먼저다
+    const derived = await EventsModule.startConsumer(app, {
+      groupId: 'spec-consumer',
+      kafka,
+      strategy: new InMemoryServer(broker),
+    });
+    await app.init();
+
+    expect(derived.topics).toEqual([TOPIC]);
+    expect(derived.streams).toEqual([CART_STREAM]);
+
+    publisher = app.get<StreamPublisher<typeof CART_STREAM.events>>(EventsModule.getPublisherToken(TOPIC));
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  beforeEach(() => {
+    calls.length = 0;
+    broker.reset();
+  });
+
+  it('구독 목록을 아무 데도 선언하지 않았는데 메시지가 핸들러까지 도달한다', async () => {
+    await publisher.publishEvent({
+      eventType: 'CartCreated',
+      aggregateId: 'cart-1',
+      payload: validCartPayload('cart-1'),
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ handler: 'onCreated', payload: { id: 'cart-1', customerId: 'cust-1' } });
+  });
+
+  it('EventTypeGuard 가 같은 토픽의 다중 핸들러 중 하나만 실행한다', async () => {
+    await publisher.publishEvent({
+      eventType: 'CartUpdated',
+      aggregateId: 'cart-2',
+      payload: {
+        id: 'cart-2',
+        items: [],
+        total: 0,
+        subtotal: 0,
+        updatedAt: new Date().toISOString(),
+      },
+    });
+
+    expect(calls.map((call) => call.handler)).toEqual(['onUpdated']);
+  });
+
+  /**
+   * ADR-0029 §8 의 핵심 증거.
+   *
+   * 앱들이 쓰던 `app.connectMicroservice(opts)` 는 마이크로서비스에 **빈
+   * ApplicationConfig** 를 주므로 `APP_INTERCEPTOR` 로 등록한 스키마 검증·재시도·DLQ
+   * 인터셉터가 소비 경로에 하나도 붙지 않는다. 아래 `현재 앱 배선` describe 가 그
+   * 상태를 실행 가능한 형태로 박아둔다. `startConsumer` 는 그것을 고친다.
+   */
+  it('스키마를 위반한 인바운드 메시지는 핸들러에 닿지 않고 DLQ 로 분류된다', async () => {
+    await broker.inject(TOPIC, {
+      messageId: 'msg-bad',
+      messageType: 'CartCreated',
+      messageVersion: 1,
+      messageKind: 'event',
+      correlationId: 'corr-bad',
+      timestamp: new Date().toISOString(),
+      occurredAt: new Date().toISOString(),
+      source: { service: 'other-service', aggregateType: 'Cart', aggregateId: 'cart-3' },
+      payload: { id: 'cart-3' }, // ← customerId·regionId·createdAt 누락
+    });
+
+    expect(calls).toHaveLength(0);
+
+    // DLQ 메시지가 **토픽에 걸린 핸들러 수만큼** 생긴다. 같은 토픽의 핸들러는
+    // 전부 파이프라인을 타고 각자 검증에서 터지기 때문이다 — 알려진 현재 동작이며,
+    // ADR-0029 §6("토픽당 한 번 파싱하고 타입으로 디스패치")이 이것을 없앤다.
+    // 여기 2 가 1 로 바뀌면 그 작업이 끝났다는 뜻이다.
+    const dlq = broker.envelopesOn<DLQMessage>(getDLQTopicName(TOPIC));
+    expect(dlq).toHaveLength(2);
+    expect(dlq.map((message) => message.error.name)).toEqual(['SchemaValidationError', 'SchemaValidationError']);
+    expect(dlq[0].originalTopic).toBe(TOPIC);
+    expect(broker.deliveryFailures).toHaveLength(0);
+  });
+
+  it('onModuleInit 을 두 번 부르지 않는다', () => {
+    // deferInitialization 을 쓰면서 초기화 플래그를 세우지 않으면 마이크로서비스의
+    // listen() 이 registerModules() 를 타 컨테이너 전체 훅이 재실행된다 (실측).
+    expect(moduleInitCount).toBe(1);
+  });
+});
+
+describe('startConsumer — 부팅 거부', () => {
+  beforeEach(() => {
+    moduleInitCount = 0;
+  });
+
+  it('@OnEvent 핸들러가 하나도 없으면 부팅을 거부한다', async () => {
+    const broker = new InMemoryBroker();
+    const moduleRef = await buildModule([], broker);
+    const app = moduleRef.createNestApplication({ logger: false });
+
+    await expect(
+      EventsModule.startConsumer(app, { groupId: 'spec-consumer', kafka, strategy: new InMemoryServer(broker) }),
+    ).rejects.toThrow(/controllers/);
+
+    await app.close();
+  });
+
+  it('계약 레지스트리에 없는 토픽을 구독하려 하면 부팅을 거부한다', async () => {
+    const broker = new InMemoryBroker();
+    const moduleRef = await buildModule([GhostConsumer], broker);
+    const app = moduleRef.createNestApplication({ logger: false });
+
+    await expect(
+      EventsModule.startConsumer(app, { groupId: 'spec-consumer', kafka, strategy: new InMemoryServer(broker) }),
+    ).rejects.toThrow(/nobody\.declared\.this\.v1.*GhostConsumer\.onGhost/s);
+
+    await app.close();
+  });
+});
+
+/**
+ * 옛 배선의 현재 상태를 실행 가능한 형태로 남긴다 (ADR-0029 §8).
+ *
+ * 이 describe 가 **초록이라는 사실 자체가 라이브 결함의 증거**다 — 스키마를 위반한
+ * 메시지가 검증을 통과해 핸들러까지 간다. 7개 소비 앱이 지금 이 상태다.
+ * 앱들이 `startConsumer` 로 이주하면 이 스펙은 삭제된다.
+ */
+describe('현재 앱 배선 (forConsumer + connectMicroservice) — 소비 인터셉터가 붙지 않는다', () => {
+  it('스키마 위반 메시지가 검증 없이 핸들러까지 도달한다', async () => {
+    const broker = new InMemoryBroker();
+    const moduleRef = await buildModule([CartConsumer], broker);
+    const app = moduleRef.createNestApplication({ logger: false });
+
+    // 앱들이 실제로 하는 그대로 — 두 번째 인자 없음
+    app.connectMicroservice({ strategy: new InMemoryServer(broker) });
+    await app.startAllMicroservices();
+    await app.init();
+
+    calls.length = 0;
+    await broker.inject(TOPIC, {
+      messageId: 'msg-bad-legacy',
+      messageType: 'CartCreated',
+      messageVersion: 1,
+      messageKind: 'event',
+      correlationId: 'corr-bad-legacy',
+      timestamp: new Date().toISOString(),
+      occurredAt: new Date().toISOString(),
+      source: { service: 'other-service', aggregateType: 'Cart', aggregateId: 'cart-9' },
+      payload: { id: 'cart-9' },
+    });
+
+    expect(calls).toHaveLength(1); // ← 검증되지 않은 채 도착했다
+    expect(broker.envelopesOn(getDLQTopicName(TOPIC))).toHaveLength(0);
+
+    await app.close();
+  });
+});


### PR DESCRIPTION
[ADR-0029](docs/adr/0029-events-module-registration-surfaces.md) Task 3. 소비 스트림 목록을 선언이 아니라 `@OnEvent` 데코레이터에서 **도출**하게 만든다.

## 무엇이 바뀌나

`EventsModule.startConsumer(app, { groupId })` — 구독 목록 인자가 없다. 컨테이너를 훑어 **구독 토픽 · 검증 스키마 맵 · 토픽 부트스트랩 목록**을 전부 파생하고, 두 가지를 부팅에서 거부한다:

- 계약 레지스트리(Task 1)에 없는 토픽 구독 → 어느 컨트롤러의 어느 메서드인지 지목하며 throw
- `@OnEvent` 핸들러 0개 → throw. `ServerKafka.bindEvents` 에 `registeredPatterns.length > 0` 가드가 있어 지금은 **subscribe 자체를 건너뛰고 로그도 안 남는다**

`forConsumer({streams})` 는 `@deprecated`. `subscribe.topics` 를 이제 아예 만들지 않는다 — 남겨두면 "이 목록이 구독을 결정한다"는 틀린 모델이 다시 자란다.

**앱 코드 변경 0.** 7개 앱은 여전히 `forConsumer` 를 쓰고 그대로 동작한다.

## 🔴 이 작업이 라이브 결함을 찾았다 (ADR-0029 §8)

`app.connectMicroservice(opts)` 를 두 번째 인자 없이 부르면 Nest 가 마이크로서비스에 **빈 `ApplicationConfig`** 를 준다 (`nest-application.js:128`). **7개 소비 앱 전부가 그렇게 부른다.** 따라서 `APP_INTERCEPTOR` 로 등록한

- `SchemaValidationInterceptor`
- `EventRetryInterceptor` (재시도 · DLQ · offset commit)
- `ChainContextInterceptor`

가 **소비 경로에 하나도 붙지 않는다.** 컨트롤러 레벨 `@UseInterceptors(EventTypeGuard)` 는 메타데이터에서 해석되므로 살아 있다 — 그래서 필터링만 동작하고 검증·재시도·DLQ 는 조용히 죽어 있었다.

하네스로 4가지 배선을 실행해 비교했고(ADR §8 표), 채택한 것은 **마이크로서비스 스코프 전역 인터셉터**다:

```ts
const microservice = app.connectMicroservice(opts, { deferInitialization: true });
microservice.useGlobalInterceptors(retry, schemaValidation, chainContext);
microservice.registerListeners();
microservice.setIsInitialized(true);
microservice.setIsInitHookCalled(true);
```

- `inheritAppConfig: true` 기각 — 앱의 HTTP 전역 파이프·필터·**가드**까지 RPC 핸들러에 얹힌다
- `deferInitialization` 단독 기각 — `listen()` 이 `registerModules()` 를 타 `onModuleInit` 이 **2회** 실행된다 (실측)

옛 배선의 현재 상태는 `start-consumer.spec.ts` 의 마지막 describe 에 실행 가능한 형태로 박아뒀다. **그 describe 가 초록이라는 사실 자체가 라이브 결함의 증거**다 — 스키마를 위반한 메시지가 검증 없이 핸들러까지 간다.

**옛 표면에 소급 적용하지 않았다.** 7개 앱에서 검증·DLQ 가 한 배포에 동시에 켜지면, 지금까지 검증 없이 통과하던 인바운드 payload 가 있을 경우 그 배포가 DLQ 폭탄이 된다. 앱별 이주(Task 5)에서 하나씩, 관찰 가능한 단위로 켠다.

## 부수 정정 — Task 2 의 결론 일부가 틀렸다

Task 2(#580)는 파싱 버그가 "core·analytics·search 에서 모든 메시지 재시도 3회 → DLQ 실패 → offset 미커밋 → 무한 재전달"을 일으킨다고 적었다. 그 세 인터셉터가 애초에 붙지 않으므로 **프로덕션 영향 범위는 0** 이었다. 수정 자체는 유효하다 — §8 배선이 켜지는 순간 그 경로가 살아나며 그때 이 버그가 없어야 한다. ADR Follow-up 3 에 정정을 남겼다.

## 설계 메모

- 도출은 Nest 자신의 `ListenerMetadataExplorer` 로 한다. 흉내낸 스캐너를 쓰면 "우리가 도출한 집합"과 "Nest 가 바인딩하는 집합"이 갈라질 수 있고, 그 어긋남이 정확히 이 워크스트림이 없애려는 무증상 결함이다.
- **컨트롤러만** 훑는다 — Nest 의 `setupListeners` 도 `module.controllers` 만 순회하므로 provider 의 `@OnEvent` 는 지금도 아무 일을 하지 않는다 (스펙으로 고정).
- 검증 **정책**(`validateOnConsume` 등)은 `EVENTS_CONSUMER_POLICY` 토큰으로 컨테이너에서 읽는다. 정책은 코드에서 도출할 수 없는 사실이라 선언이 맞고, 스트림 목록만 도출로 대체됐다.

## 배포

마이그레이션 0 / 시크릿 0 / env 0 / 이벤트 계약 변경 0 / 앱 코드 변경 0 → **배포 순서 제약 없음.** 다음 아무 배포에 묻어가면 된다.

## 검증

- `libs/events` + 계약 패키지 **16 suite / 145 tests 초록** (Task 2 대비 +2 suite / +16 tests)
- `npm run type-check` **164 = develop 기준선과 동일**
- **10개 앱 전부 `nest build` 초록**
- 신규 파일 eslint 초록 (`events.module.ts` 는 기존 부채 11 error / 4 warning 그대로)
- 전체 jest 실패 suite 집합이 develop 과 **동일** (18)