### PR TITLE
feat(events): 계약에서 도출하는 @On / @InjectPublisher 추가 (ADR-0029 Task 4)

### DIFF
--- a/docs/adr/0029-events-module-registration-surfaces.md
+++ b/docs/adr/0029-events-module-registration-surfaces.md
@@ -88,6 +88,13 @@ async onVerified(@Payload() payload: EventPayloadOf<typeof USER_STREAM, 'UserEma
 
 `@InjectStreamPublisher('orders.events.v1') p: StreamPublisher<OrderEvents>` 의 **문자열과 제네릭 두 사실**이 하나로 줄고, payload 타입이 계약에서 도출되어 손으로 단 주석과 스키마가 어긋날 수 없게 된다.
 
+**이행 시 위 스케치에서 두 가지가 달라졌다 (2026-08-09, Follow-up 5 전반부).**
+
+- **payload 파라미터 데코레이터는 기존 `@EventPayload()` 를 그대로 쓴다.** 위 예시의 `@Payload()` 는 채택하지 않았다 — `@nestjs/microservices` 가 이미 `Payload` 라는 이름으로 **다른 것**(파싱된 메시지 전체)을 export 하고 있고, `@app/events` 는 `export *` 로 데코레이터를 공개하므로 같은 이름이 import 경로에 따라 다른 뜻을 갖게 된다. 그건 이 ADR 이 없애려는 실패 모드를 이름 공간에서 재생산하는 것이다. 도출되는 것은 데코레이터 이름이 아니라 **타입**이므로(`EventPayloadOf<typeof S, 'K'>`) §4 의 목적은 그대로 달성된다.
+- **`EnvelopeOf<S, K>` 를 계약 패키지에 추가했다.** 소비 핸들러 87개 중 75개가 `@EventEnvelope() envelope: DomainEvent<XPayload>` 를 함께 받는다(실측). `DomainEvent<EventPayloadOf<typeof S, 'K'>>` 를 매번 손으로 조합하게 두면 이주 시 옛 손수 타입이 그대로 살아남는다.
+
+**`@On` 이 핸들러 시그니처를 타입으로 강제하지는 않는다.** 검토했고 기각했다. 파라미터 데코레이터 순서가 앱마다 다르고(envelope-우선 45 · payload-우선 20 · payload-only 12 · envelope-only 10, 실측), 이 레포는 `strictFunctionTypes` 가 꺼져 있어 `TypedPropertyDescriptor` 제약이 반공변으로 걸리지도 않는다. 따라서 `@On(S, 'A')` 와 `@EventPayload() p: EventPayloadOf<typeof S, 'B'>` 가 어긋나는 것은 여전히 컴파일을 통과한다 — 이벤트명 **오타**는 잡히지만 이벤트명 **불일치**는 잡히지 않는다. 이를 닫으려면 "명시적으로 하지 않는 것" 의 핸들러 레코드 형태가 필요하며, 그 판단은 바뀌지 않았다.
+
 ### 5. 발행 경로를 하나의 인터페이스로 통합한다
 
 ```ts
@@ -229,6 +236,8 @@ microservice.setIsInitHookCalled(true);
    착수 당시 근거(보존): 원래 마지막에 두려던 것을 앞으로 당겼다. 발행→소비를 브로커 없이 검증할 방법이 **아예 없어서**(`libs/events/src` 소스 29 / 스펙 5, 페이크 트랜스포트 0) 어댑터가 없으면 이후 모든 단계가 자기 증거를 남기지 못하고, 여러 세션에 걸친 작업에서 다음 작업자는 앞 단계가 무엇을 보장했는지 알 수 없기 때문이다. **검증 도구를 먼저 만들고 나머지를 그 위에 얹는다** — 그 판단은 결과로 정당화됐다.
 4. ~~`startConsumer(app)` 도입 + `forConsumer` 의 `streams` deprecated. 앱 수정 없이 동작해야 한다.~~ **완료 (2026-08-09).** 소비 집합은 `@OnEvent` 데코레이터에서 도출되고, 레지스트리에 없는 토픽·핸들러 0개는 부팅을 거부한다. 도출 과정에서 §8 과 아래 10번을 발견했다.
 5. `@On` / `@InjectPublisher` 를 기존 데코레이터와 병행 도입, 앱별 이주 (7개 앱 = 7 PR). ⚠️ **§8 에 따라 이주는 동작 중립이 아니다** — 그 앱에서 스키마 검증·재시도·DLQ 가 처음으로 켜진다.
+
+   **전반부(데코레이터 도입) 완료 (2026-08-09).** `@On` · `@InjectPublisher` · `PublisherFor` · `EnvelopeOf` 가 옛 표면과 **병행**으로 존재한다. `@On` 은 `@OnEvent` 과 **바이트 단위로 같은 메타데이터**를 남기고(스펙이 메타데이터 키 집합과 값을 전수 비교한다), `@InjectPublisher` 는 `EventsModule.getPublisherToken` 과 같은 토큰을 만든다 — 토큰 형식은 `publishers/publisher-token.ts` 한 곳으로 모았다. 따라서 한 앱 안에서 두 표면을 섞어 써도 되고, 앱 이주는 파일 단위로 쪼갤 수 있다. 앱 이주(후반부)는 아직 0개다. 위 §4 의 두 가지 이행 차이도 참조.
 6. 공용 outbox 에 `idempotencyKey`·`partitionKey`·enqueue 시점 검증 추가 후 앱 자체 판본 5벌 회수. **core 의 두 벌은 import 경로만 다른 동일 파일이므로 이 작업과 무관하게 지금 하나로 합칠 수 있다.**
 7. 옛 표면(`forRoot`/`forConsumerModule`/`forConsumer`) 제거 — contract phase.
 8. channel-adapter 가 `forConsumerModule` 을 호출하지 않는 현재 상태는 이 ADR 이 시행되기 전까지 남는 실재 구멍이다 — 소비 측 zod 검증이 없다. 4번 이전에 단독으로 메울지, 이주에 묶을지 결정한다.

--- a/docs/superpowers/plans/2026-08-09-events-module-registration.md
+++ b/docs/superpowers/plans/2026-08-09-events-module-registration.md
@@ -189,13 +189,29 @@ Nest 는 수신 `value` 를 `KafkaParser.decode` 로 **JSON 파싱해서** 넘�
 
 기존 `@OnEvent` / `@InjectStreamPublisher` 와 **병행**한다. 아직 아무 앱도 고치지 않는다.
 
-- [ ] `@On(STREAM, 'EventName')` — 이벤트명을 `EventKeysOf` 로 좁힌다
-- [ ] `@Payload()` + `EventPayloadOf<typeof STREAM, 'EventName'>` 로 payload 타입이 계약에서 도출되게 한다
-- [ ] `@InjectPublisher(STREAM)` + `PublisherFor<typeof STREAM>` — 문자열 토큰과 제네릭 두 사실을 하나로
-- [ ] 타입 레벨 스펙: 잘못된 이벤트명이 컴파일 에러가 되는지 (`@ts-expect-error`)
-- [ ] `npm run type-check` 초록 · 커밋 · 푸시
+- [x] `@On(STREAM, 'EventName')` — 이벤트명을 `EventKeysOf` 로 좁힌다
+- [x] ~~`@Payload()`~~ 기존 `@EventPayload()` + `EventPayloadOf<typeof STREAM, 'EventName'>` 로 payload 타입이 계약에서 도출되게 한다
+- [x] `@InjectPublisher(STREAM)` + `PublisherFor<typeof STREAM>` — 문자열 토큰과 제네릭 두 사실을 하나로
+- [x] 타입 레벨 스펙: 잘못된 이벤트명이 컴파일 에러가 되는지 (`@ts-expect-error`)
+- [x] `npm run type-check` 초록 · 커밋 · 푸시
 
 **완료 기준:** 새 데코레이터가 존재하고 타입이 도출되며, 옛 데코레이터도 그대로 동작한다.
+
+**완료 (2026-08-09).** 브랜치 `feat/events-typed-decorators`.
+
+- 새 표면 4개: `@On` · `@InjectPublisher` · `PublisherFor<S>` · `EnvelopeOf<S, K>`. 옛 표면(`@OnEvent` · `@InjectStreamPublisher`)은 한 줄도 안 건드렸고 **앱 코드 변경 0**.
+- **`@Payload()` 는 채택하지 않았다.** ADR §4 스케치가 그렇게 적혀 있었지만 `@nestjs/microservices` 가 이미 `Payload` 로 **다른 것**(메시지 전체)을 export 한다. `@app/events` 는 `export *` 라 같은 이름이 import 경로에 따라 다른 뜻이 되고, 그건 이 워크스트림이 없애려는 실패 모드를 이름 공간에서 재생산하는 것이다. 도출되는 것은 데코레이터 이름이 아니라 **타입**이므로 §4 의 목적은 그대로 달성된다. **ADR §4 를 먼저 고쳤다.**
+- **`EnvelopeOf<S, K>` 를 계약 패키지에 추가했다** (ADR §4 에도 기록). 소비 핸들러 87개 중 **75개**가 `@EventEnvelope() envelope: DomainEvent<XPayload>` 를 함께 받는다(실측). 이 조합을 매번 손으로 쓰게 두면 이주해도 옛 손수 타입이 그대로 살아남는다.
+- **런타임 동등성이 스펙으로 고정됐다.** `@On` 이 남기는 메타데이터를 `@OnEvent` 과 **키 집합·값 전수 비교**하고, 인메모리 하네스(Task 2)로 `@InjectPublisher` → 발행 → `@On` 핸들러 왕복을 실제로 돌린다. "같아 보인다"가 아니라 실행 증거다. 그래서 앱 이주는 **파일 단위로** 쪼갤 수 있다.
+- Publisher 토큰 형식(`STREAM_PUBLISHER_${topic}`)을 `publishers/publisher-token.ts` 한 곳으로 모으고 `EventsModule.getPublisherToken` 이 그것을 부르게 했다 — 두 벌이면 어긋남이 무증상 DI 실패로 나온다.
+- 타입을 우회한 호출(`as any`)은 **데코레이터 평가 시점 = 부팅**에 던진다. 계약에 없는 이벤트명 · 토픽 없는 객체 둘 다.
+
+**⚠️ Task 5 에 넘기는 사실 — `@On` 은 이벤트명 *오타*를 잡지만 *불일치*는 못 잡는다.**
+
+`@On(S, 'A')` + `@EventPayload() p: EventPayloadOf<typeof S, 'B'>` 는 여전히 컴파일된다. 핸들러 시그니처를 타입으로 강제하는 안을 검토하고 기각했다: 파라미터 데코레이터 순서가 앱마다 다르고(**envelope-우선 45 · payload-우선 20 · payload-only 12 · envelope-only 10**, 실측 87개), 이 레포는 `strictFunctionTypes` 가 꺼져 있어 `TypedPropertyDescriptor` 제약이 반공변으로 걸리지도 않는다. **이주할 때 payload/envelope 주석의 이벤트명을 사람이 맞춰야 한다** — 기계가 안 잡아준다.
+
+- 검증: `libs/events`+계약 패키지 **17 suite / 151 tests 초록**(Task 3 대비 +1 suite / +6 tests) · `npm run type-check` **164 = develop 기준선과 동일** · **10개 앱 전부 `nest build` 초록** · 신규 파일 eslint 초록, 손댄 기존 파일(`decorators.ts` 4 · `events.module.ts` 15)은 메시지 집합이 develop 과 동일 · 전체 jest 실패 suite **18 = develop 과 동일**(3013 통과).
+- `@ts-expect-error` 단언이 살아 있음을 확인했다 — 하나를 지우면 `tsc` 가 `TS2345: '"NoSuchEvent"' is not assignable to '"OrderCreated" | "OrderCancelled"'` 로 실패한다(실행 확인). 쓸모없어진 directive 는 `TS2578` 로 스스로 드러나므로 이 단언들은 썩어도 조용하지 않다.
 
 ---
 
@@ -216,7 +232,7 @@ Nest 는 수신 `value` 를 `KafkaParser.decode` 로 **JSON 파싱해서** 넘�
 각 앱에서:
 
 - [ ] `main.ts` 를 `startConsumer(app, { groupId })` 로 교체 (streams 인자 제거)
-- [ ] `@OnEvent` → `@On`, `@InjectStreamPublisher` → `@InjectPublisher` 로 이주
+- [ ] `@OnEvent` → `@On`, `@InjectStreamPublisher` → `@InjectPublisher` 로 이주. payload/envelope 주석도 `EventPayloadOf` / `EnvelopeOf` 로 — **이벤트명을 사람이 맞춰야 한다** (Task 4 경고 참조)
 - [ ] `nest build <app>` · `npm run type-check` 초록
 - [ ] 커밋 · 푸시 · **배포 후 다음 앱으로**
 

--- a/libs/events/src/consumers/decorators.ts
+++ b/libs/events/src/consumers/decorators.ts
@@ -8,6 +8,7 @@ import { applyDecorators, SetMetadata, createParamDecorator, ExecutionContext } 
 import { EventPattern, Payload, Ctx } from '@nestjs/microservices';
 import { KafkaContext } from '@nestjs/microservices';
 import { MessageEnvelope, DomainEvent, DomainCommand } from '@packages/event-contracts/types';
+import type { EventKeysOf, StreamConfig, StreamEventTypes } from '@packages/event-contracts/types';
 
 export const STREAM_EVENT_METADATA = 'STREAM_EVENT_METADATA';
 export const EVENT_TYPE_FILTER = 'EVENT_TYPE_FILTER';
@@ -75,6 +76,55 @@ export function StreamEventHandler(
  */
 export function OnEvent(topic: string, eventType: string) {
   return applyDecorators(EventPattern(topic), SetMetadata(EVENT_TYPE_FILTER, eventType));
+}
+
+/**
+ * 계약에서 토픽·이벤트명을 도출하는 핸들러 데코레이터 (ADR-0029 §4)
+ *
+ * `@OnEvent('products.events.v1', 'ProductMasterDeleted')` 는 **두 개의 생문자열**이다.
+ * 토픽은 계약이 이미 알고 있고(`STREAM.topic.topic`), 이벤트명은 계약이 가진 키 집합에
+ * 속해야 한다. `@On` 은 토픽을 계약에서 읽고 이벤트명을 `EventKeysOf` 로 좁혀,
+ * 오타가 **컴파일 에러**가 되게 한다.
+ *
+ * 런타임 동작은 `@OnEvent` 과 **완전히 같다** — `EventPattern(topic)` +
+ * `SetMetadata(EVENT_TYPE_FILTER, eventName)`. 따라서 `EventTypeGuard` · 소비 집합
+ * 도출(`consumer-discovery.ts`) · Nest 의 바인딩이 전부 그대로 동작하며, 두 데코레이터를
+ * 한 앱에서 섞어 써도 된다 (앱별 이주 중에는 실제로 섞인다).
+ *
+ * @example
+ * @Controller()
+ * @UseInterceptors(EventTypeGuard)
+ * export class ProductEventsConsumer {
+ *   @On(PRODUCT_STREAM, 'ProductMasterDeleted')
+ *   async onDeleted(
+ *     @EventEnvelope() envelope: EnvelopeOf<typeof PRODUCT_STREAM, 'ProductMasterDeleted'>,
+ *     @EventPayload() payload: EventPayloadOf<typeof PRODUCT_STREAM, 'ProductMasterDeleted'>,
+ *   ): Promise<void> {}
+ * }
+ */
+export function On<S extends StreamConfig<StreamEventTypes>, K extends EventKeysOf<S> & string>(
+  stream: S,
+  eventName: K,
+) {
+  const topic = stream?.topic?.topic;
+
+  if (typeof topic !== 'string' || topic.length === 0) {
+    throw new Error(
+      `@On(): 스트림에 토픽이 없다 (${JSON.stringify(topic)}). ` +
+        'packages/event-contracts 의 stream() 으로 만든 StreamConfig 를 넘겨야 한다.',
+    );
+  }
+
+  // 타입 단계에서 이미 좁혀지지만, `as any` 로 빠져나온 호출은 데코레이터 평가 시점
+  // (= 부팅)에 죽인다. 조용히 통과하면 그 핸들러는 영원히 실행되지 않는다.
+  if (!Object.prototype.hasOwnProperty.call(stream.events, eventName)) {
+    throw new Error(
+      `@On(): ${topic} 계약에 "${String(eventName)}" 이벤트가 없다. ` +
+        `사용 가능한 이벤트: ${Object.keys(stream.events).join(', ')}`,
+    );
+  }
+
+  return OnEvent(topic, eventName);
 }
 
 /**

--- a/libs/events/src/consumers/typed-decorators.spec.ts
+++ b/libs/events/src/consumers/typed-decorators.spec.ts
@@ -1,0 +1,288 @@
+/**
+ * 타입 도출 데코레이터 `@On` / `@InjectPublisher` (ADR-0029 §4, 플랜 Task 4)
+ *
+ * 증명해야 할 것이 둘이다:
+ *
+ * 1. **런타임이 옛 표면과 같다.** `@On` 은 `@OnEvent` 과 동일한 메타데이터를 남기고,
+ *    `@InjectPublisher` 는 `@InjectStreamPublisher` 와 동일한 토큰을 만든다. 그래야
+ *    앱별 이주(Task 5) 중 한 앱 안에서 두 표면이 섞여도 안전하다. 이건 Task 2 하네스로
+ *    실제 발행→소비 왕복을 돌려서 확인한다 — 메타데이터만 비교하면 "같아 보인다"에서 끝난다.
+ * 2. **타입이 계약에서 도출된다.** 잘못된 이벤트명·payload 는 컴파일 에러다.
+ *    타입 단계 단언은 `@ts-expect-error` 로 하며, 그 검사는 `npm run type-check` 가 강제한다
+ *    (불필요한 `@ts-expect-error` 는 그 자체가 에러라 단언이 썩으면 바로 드러난다).
+ */
+
+import { Controller, INestMicroservice, Injectable, UseInterceptors } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { z } from 'zod';
+import { event, stream } from '@packages/event-contracts/types';
+import type { EnvelopeOf, EventPayloadOf } from '@packages/event-contracts/types';
+import { EventsModule } from '../events.module';
+import { EventEnvelope, EventPayload, On, OnEvent } from './decorators';
+import { EventTypeGuard } from '../guards/event-type.guard';
+import { InjectPublisher, PublisherFor } from '../publishers/inject-publisher';
+import { getPublisherToken } from '../publishers/publisher-token';
+import { EVENT_TRANSPORT } from '../transport/transport.port';
+import { InMemoryBroker } from '../transport/in-memory.broker';
+import { InMemoryTransport } from '../transport/in-memory.transport';
+import { InMemoryServer } from '../transport/in-memory.server';
+
+// ===== 하네스 전용 계약 =====
+// 실제 스트림을 쓰지 않는다 — `streams/index.ts` 밖이므로 STREAM_REGISTRY 에도 영향이 없다.
+
+const OrderCreatedSchema = z.object({
+  orderId: z.string(),
+  amount: z.number().int().positive(),
+});
+
+const TYPED_STREAM = stream({
+  topic: 'harness.typed.v1',
+  partitions: 1,
+  aggregateType: 'TypedHarness',
+  events: {
+    OrderCreated: event('OrderCreated', OrderCreatedSchema),
+    OrderCancelled: event<'OrderCancelled', { orderId: string; reason: string }>('OrderCancelled'),
+  },
+});
+
+// ===== 관찰 기록 =====
+
+interface HandlerCall {
+  handler: string;
+  payload: unknown;
+  messageId: string;
+}
+
+const calls: HandlerCall[] = [];
+
+@Controller()
+@UseInterceptors(EventTypeGuard)
+class TypedConsumer {
+  /**
+   * 토픽 문자열이 없다. 이벤트명은 계약의 키 집합으로 좁혀진다.
+   * payload·envelope 주석도 손으로 쓴 타입이 아니라 계약에서 도출된다.
+   */
+  @On(TYPED_STREAM, 'OrderCreated')
+  onCreated(
+    @EventEnvelope() envelope: EnvelopeOf<typeof TYPED_STREAM, 'OrderCreated'>,
+    @EventPayload() payload: EventPayloadOf<typeof TYPED_STREAM, 'OrderCreated'>,
+  ): void {
+    // payload 가 계약 타입이라는 것의 실증 — `.orderId`/`.amount` 가 타입에서 나온다
+    calls.push({
+      handler: 'onCreated',
+      payload: { orderId: payload.orderId, amount: payload.amount },
+      messageId: envelope.messageId,
+    });
+  }
+
+  @On(TYPED_STREAM, 'OrderCancelled')
+  onCancelled(
+    @EventEnvelope() envelope: EnvelopeOf<typeof TYPED_STREAM, 'OrderCancelled'>,
+    @EventPayload() payload: EventPayloadOf<typeof TYPED_STREAM, 'OrderCancelled'>,
+  ): void {
+    calls.push({
+      handler: 'onCancelled',
+      payload: { orderId: payload.orderId, reason: payload.reason },
+      messageId: envelope.messageId,
+    });
+  }
+}
+
+/**
+ * 생성자 주입도 계약 하나에서 나온다 — 토큰 문자열과 제네릭 두 사실이 하나로 줄었다.
+ */
+@Injectable()
+class TypedOrderService {
+  constructor(@InjectPublisher(TYPED_STREAM) private readonly orders: PublisherFor<typeof TYPED_STREAM>) {}
+
+  async createOrder(orderId: string, amount: number): Promise<void> {
+    await this.orders.publishEvent({
+      eventType: 'OrderCreated',
+      aggregateId: orderId,
+      payload: { orderId, amount },
+    });
+  }
+
+  async cancelOrder(orderId: string, reason: string): Promise<void> {
+    await this.orders.publishEvent({
+      eventType: 'OrderCancelled',
+      aggregateId: orderId,
+      payload: { orderId, reason },
+    });
+  }
+}
+
+describe('@On / @InjectPublisher — 계약에서 도출하는 등록 표면', () => {
+  let app: INestMicroservice;
+  let broker: InMemoryBroker;
+  let orders: TypedOrderService;
+
+  beforeAll(async () => {
+    process.env.KAFKA_BOOTSTRAP_TOPICS = 'false';
+
+    broker = new InMemoryBroker();
+    const kafka = { clientId: 'typed-harness', brokers: ['unused:9092'] };
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        EventsModule.forRoot({ streams: [TYPED_STREAM], serviceName: 'typed-harness', kafka }),
+        EventsModule.forConsumerModule({ streams: [TYPED_STREAM], groupId: 'typed-harness-consumer', kafka }),
+      ],
+      controllers: [TypedConsumer],
+      providers: [TypedOrderService],
+    })
+      .overrideProvider(EVENT_TRANSPORT)
+      .useValue(new InMemoryTransport(broker))
+      .compile();
+
+    app = moduleRef.createNestMicroservice({
+      strategy: new InMemoryServer(broker),
+      logger: false,
+    });
+    await app.listen();
+
+    orders = app.get(TypedOrderService);
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  beforeEach(() => {
+    calls.length = 0;
+    broker.reset();
+  });
+
+  describe('런타임 동등성', () => {
+    it('@InjectPublisher 로 주입한 publisher 가 @On 핸들러까지 왕복한다', async () => {
+      await orders.createOrder('order-1', 12_000);
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toMatchObject({
+        handler: 'onCreated',
+        payload: { orderId: 'order-1', amount: 12_000 },
+      });
+      expect(calls[0].messageId).toEqual(expect.any(String));
+
+      const published = broker.envelopesOn(TYPED_STREAM.topic.topic);
+      expect(published).toHaveLength(1);
+      expect(published[0]).toMatchObject({
+        messageType: 'OrderCreated',
+        source: { service: 'typed-harness', aggregateType: 'TypedHarness', aggregateId: 'order-1' },
+      });
+    });
+
+    it('EventTypeGuard 가 @On 의 eventType 메타데이터로도 그대로 필터링한다', async () => {
+      await orders.cancelOrder('order-2', 'out-of-stock');
+
+      // 두 핸들러가 같은 토픽에 걸려 있고 둘 다 파이프라인을 타지만 하나만 실행된다
+      expect(calls.map((call) => call.handler)).toEqual(['onCancelled']);
+      expect(calls[0].payload).toEqual({ orderId: 'order-2', reason: 'out-of-stock' });
+    });
+
+    it('@On 이 남기는 메타데이터가 @OnEvent 과 완전히 같다', () => {
+      class ViaOn {
+        @On(TYPED_STREAM, 'OrderCreated')
+        handle(): void {}
+      }
+
+      class ViaOnEvent {
+        @OnEvent('harness.typed.v1', 'OrderCreated')
+        handle(): void {}
+      }
+
+      // `proto.handle` 를 직접 읽으면 unbound-method 규칙에 걸린다. 여기서 원하는 것은
+      // 호출이 아니라 메타데이터가 붙은 함수 객체 자체다.
+      const handlerOf = (proto: object): object => Reflect.get(proto, 'handle') as object;
+
+      const onHandler = handlerOf(ViaOn.prototype);
+      const onEventHandler = handlerOf(ViaOnEvent.prototype);
+
+      const onKeys = Reflect.getMetadataKeys(onHandler).sort();
+      const onEventKeys = Reflect.getMetadataKeys(onEventHandler).sort();
+
+      // 키 집합이 같아야 한다 — 하나라도 빠지면 Nest 의 바인딩이나 EventTypeGuard 가 갈라진다
+      expect(onKeys).toEqual(onEventKeys);
+      expect(onKeys.length).toBeGreaterThan(0);
+
+      for (const key of onKeys) {
+        expect(Reflect.getMetadata(key, onHandler)).toEqual(Reflect.getMetadata(key, onEventHandler));
+      }
+    });
+
+    it('@InjectPublisher 의 토큰이 @InjectStreamPublisher 와 같다', () => {
+      expect(getPublisherToken(TYPED_STREAM.topic.topic)).toBe(
+        EventsModule.getPublisherToken(TYPED_STREAM.topic.topic),
+      );
+
+      // 같은 토큰이므로 계약으로 뽑은 publisher 와 문자열로 뽑은 publisher 가 같은 인스턴스다
+      expect(app.get(getPublisherToken(TYPED_STREAM.topic.topic))).toBe(
+        app.get(EventsModule.getPublisherToken('harness.typed.v1')),
+      );
+    });
+  });
+
+  describe('런타임 거부 — 타입을 우회한 호출', () => {
+    it('계약에 없는 이벤트명은 데코레이터 평가(= 부팅) 시점에 던진다', () => {
+      expect(() => On(TYPED_STREAM, 'NoSuchEvent' as never)).toThrow(/계약에 "NoSuchEvent" 이벤트가 없다/);
+    });
+
+    it('토픽이 없는 객체를 넘기면 던진다', () => {
+      const notAStream = { events: { OrderCreated: {} }, aggregateType: 'X', topic: { topic: '' } };
+
+      expect(() => On(notAStream as never, 'OrderCreated' as never)).toThrow(/스트림에 토픽이 없다/);
+      expect(() => InjectPublisher(notAStream as never)).toThrow(/스트림에 토픽이 없다/);
+    });
+  });
+});
+
+/**
+ * ===== 타입 단계 단언 =====
+ *
+ * 실행하지 않는다. 데코레이터를 평가하면 위의 런타임 가드가 던지기 때문이고,
+ * 여기서 증명하려는 것은 런타임이 아니라 **컴파일 결과**다. `@ts-expect-error` 가
+ * 붙은 줄이 실제로 에러가 아니게 되면 `npm run type-check` 가 "unused directive" 로
+ * 실패하므로, 이 단언들은 썩어도 조용하지 않다.
+ */
+function compileTimeAssertions(): void {
+  // 올바른 이벤트명은 통과한다
+  On(TYPED_STREAM, 'OrderCreated');
+  On(TYPED_STREAM, 'OrderCancelled');
+
+  // @ts-expect-error — 계약에 없는 이벤트명은 EventKeysOf 로 걸러진다
+  On(TYPED_STREAM, 'NoSuchEvent');
+
+  // payload 타입이 계약에서 도출된다 (= any 가 아니다)
+  const good: EventPayloadOf<typeof TYPED_STREAM, 'OrderCreated'> = { orderId: 'o-1', amount: 1 };
+  void good;
+
+  // @ts-expect-error — amount 는 number 이므로 문자열은 거부된다
+  const wrongPayloadType: EventPayloadOf<typeof TYPED_STREAM, 'OrderCreated'> = { orderId: 'o-1', amount: '1' };
+  void wrongPayloadType;
+
+  // @ts-expect-error — OrderCancelled 의 payload 는 reason 을 요구한다 (이벤트별로 다른 타입)
+  const wrongEventPayload: EventPayloadOf<typeof TYPED_STREAM, 'OrderCancelled'> = { orderId: 'o-1' };
+  void wrongEventPayload;
+
+  // envelope 타입도 도출된다
+  const envelope: EnvelopeOf<typeof TYPED_STREAM, 'OrderCreated'> = undefined as never;
+  const amount: number = envelope.payload.amount;
+  void amount;
+
+  // publisher 도 계약으로 좁혀진다
+  const publisher: PublisherFor<typeof TYPED_STREAM> = undefined as never;
+  void publisher.publishEvent({
+    eventType: 'OrderCreated',
+    aggregateId: 'o-1',
+    payload: { orderId: 'o-1', amount: 1 },
+  });
+
+  void publisher.publishEvent({
+    // @ts-expect-error — 계약에 없는 이벤트는 발행할 수 없다
+    eventType: 'NoSuchEvent',
+    aggregateId: 'o-1',
+    payload: { orderId: 'o-1', amount: 1 },
+  });
+}
+
+void compileTimeAssertions;

--- a/libs/events/src/events.module.ts
+++ b/libs/events/src/events.module.ts
@@ -23,6 +23,7 @@ import {
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ClsModule } from 'nestjs-cls';
 import { StreamPublisher } from './publishers/stream-publisher.service';
+import { getPublisherToken } from './publishers/publisher-token';
 import { DLQHandler } from './dlq/dlq-handler.service';
 import { SchemaValidationInterceptor } from './interceptors/schema-validation.interceptor';
 import { ChainContextInterceptor } from './interceptors/chain-context.interceptor';
@@ -561,7 +562,7 @@ export class EventsModule {
    * private readonly orderPublisher: StreamPublisher<OrderEvents>
    */
   static getPublisherToken(topicName: string): string {
-    return `STREAM_PUBLISHER_${topicName}`;
+    return getPublisherToken(topicName);
   }
 
   /**

--- a/libs/events/src/index.ts
+++ b/libs/events/src/index.ts
@@ -23,6 +23,9 @@ export * from './transport/in-memory.server';
 
 // Publisher
 export * from './publishers/stream-publisher.service';
+// 계약에서 도출하는 주입 표면 (ADR-0029 §4) — @InjectStreamPublisher 와 병행
+export * from './publishers/publisher-token';
+export * from './publishers/inject-publisher';
 
 // Consumer Decorators & Guards
 export * from './consumers/decorators';

--- a/libs/events/src/publishers/inject-publisher.ts
+++ b/libs/events/src/publishers/inject-publisher.ts
@@ -1,0 +1,50 @@
+/**
+ * 계약에서 도출하는 Publisher 주입 (ADR-0029 §4)
+ *
+ * 옛 표면은 같은 사실을 두 번 적게 만든다:
+ *
+ * ```ts
+ * @InjectStreamPublisher('orders.events.v1') p: StreamPublisher<OrderEvents>
+ * //                      ^^^^^^^^^^^^^^^^^ 토큰(문자열)     ^^^^^^^^^^^ 이벤트 타입(제네릭)
+ * ```
+ *
+ * 둘 다 `ORDER_STREAM` 하나에서 나온다. 어긋나면 컴파일은 통과하고 런타임에
+ * 잘못된 publisher 가 주입되거나 DI 가 실패한다. `@InjectPublisher(ORDER_STREAM)` +
+ * `PublisherFor<typeof ORDER_STREAM>` 은 두 사실을 하나로 줄인다.
+ */
+
+import { Inject } from '@nestjs/common';
+import type { StreamConfig, StreamEventTypes } from '@packages/event-contracts/types';
+import type { StreamPublisher } from './stream-publisher.service';
+import { getPublisherToken } from './publisher-token';
+
+/**
+ * 스트림 계약에서 도출한 `StreamPublisher` 타입.
+ *
+ * @example
+ * constructor(
+ *   @InjectPublisher(ORDER_STREAM) private readonly orders: PublisherFor<typeof ORDER_STREAM>,
+ * ) {}
+ */
+export type PublisherFor<S extends StreamConfig<any>> =
+  S extends StreamConfig<infer TEvents extends StreamEventTypes> ? StreamPublisher<TEvents> : never;
+
+/**
+ * 스트림 계약으로 publisher 를 주입한다. 토큰은 계약의 토픽에서 도출된다.
+ *
+ * 런타임 동작은 `@InjectStreamPublisher(topic)` 과 같다 — 같은 토큰을 만든다.
+ * 따라서 한 앱 안에서 두 표면을 섞어 써도 되고, `forRoot({streams})` 에 그 스트림이
+ * 들어 있기만 하면 provider 는 이미 존재한다.
+ */
+export function InjectPublisher<TEvents extends StreamEventTypes>(stream: StreamConfig<TEvents>) {
+  const topic = stream?.topic?.topic;
+
+  if (typeof topic !== 'string' || topic.length === 0) {
+    throw new Error(
+      `@InjectPublisher(): 스트림에 토픽이 없다 (${JSON.stringify(topic)}). ` +
+        'packages/event-contracts 의 stream() 으로 만든 StreamConfig 를 넘겨야 한다.',
+    );
+  }
+
+  return Inject(getPublisherToken(topic));
+}

--- a/libs/events/src/publishers/publisher-token.ts
+++ b/libs/events/src/publishers/publisher-token.ts
@@ -1,0 +1,11 @@
+/**
+ * Publisher DI 토큰
+ *
+ * `EventsModule.forRoot({streams})` 가 스트림당 하나씩 등록하는 `StreamPublisher`
+ * provider 의 토큰 형식. `EventsModule.getPublisherToken` 과 `@InjectPublisher` 가
+ * 같은 문자열을 만들어야 하므로 형식은 여기 한 곳에만 둔다 — 두 벌이 되는 순간
+ * 어긋남이 무증상 DI 실패로 나타난다.
+ */
+export function getPublisherToken(topicName: string): string {
+  return `STREAM_PUBLISHER_${topicName}`;
+}

--- a/packages/event-contracts/types/stream-builder.ts
+++ b/packages/event-contracts/types/stream-builder.ts
@@ -6,6 +6,7 @@
 
 import type { EventType, StreamConfig, StreamEventTypes } from './stream-config.types';
 import type { ZodSchema } from './schema-validation.types';
+import type { DomainEvent } from './envelope.types';
 
 /**
  * 타입 안전한 이벤트 정의 헬퍼
@@ -101,6 +102,20 @@ export type EventPayloadOf<TStream extends StreamConfig<any>, K extends EventKey
       ? TPayload
       : never
     : never;
+
+/**
+ * Stream에서 특정 이벤트의 Envelope 타입 추출
+ *
+ * 소비 핸들러의 `@EventEnvelope()` 파라미터 주석이 계약에서 도출되게 한다.
+ * `DomainEvent<EventPayloadOf<...>>` 를 매번 손으로 조합하는 대신 쓴다 —
+ * 이 조합이 앱 전체에서 75곳에 나온다 (2026-08-09 실측).
+ *
+ * @example
+ * async onCreated(@EventEnvelope() envelope: EnvelopeOf<typeof ORDER_STREAM, 'OrderCreated'>) {}
+ */
+export type EnvelopeOf<TStream extends StreamConfig<any>, K extends EventKeysOf<TStream>> = DomainEvent<
+  EventPayloadOf<TStream, K>
+>;
 
 /**
  * Stream에서 특정 이벤트의 MessageType 추출


### PR DESCRIPTION
[ADR-0029](../blob/develop/docs/adr/0029-events-module-registration-surfaces.md) §4 · [플랜](../blob/develop/docs/superpowers/plans/2026-08-09-events-module-registration.md) Task 4.

## 왜

`@OnEvent('products.events.v1', 'ProductMasterDeleted')` 은 **생문자열 두 개**다. 토픽은 계약(`PRODUCT_STREAM.topic.topic`)이 이미 알고 있고, 이벤트명은 계약이 가진 키 집합에 속해야 한다. `@InjectStreamPublisher('orders.events.v1') p: StreamPublisher<OrderEvents>` 도 같은 사실(스트림)을 **문자열 토큰과 제네릭**으로 두 번 적는다. 어긋나도 컴파일은 통과한다.

## 무엇

새 표면 4개를 옛 표면과 **병행**으로 추가한다. **앱 코드 변경 0 · 마이그레이션 0 · 배포 요구 없음.**

| 새 표면 | 대체 대상 |
|---|---|
| `@On(STREAM, 'EventName')` | `@OnEvent(topic, eventName)` |
| `@InjectPublisher(STREAM)` | `@InjectStreamPublisher(topic)` |
| `PublisherFor<typeof STREAM>` | `StreamPublisher<XEvents>` |
| `EnvelopeOf<S, K>` | `DomainEvent<XPayload>` (핸들러 87개 중 75개가 쓴다) |

## 런타임 동등성이 증거로 고정됐다

앱 이주 중에는 한 앱 안에서 두 표면이 섞인다. 그래서 "같아 보인다"로는 부족하다.

- `@On` 이 남기는 메타데이터를 `@OnEvent` 과 **키 집합·값 전수 비교**
- Task 2 인메모리 하네스로 `@InjectPublisher` → 발행 → `@On` 핸들러 **왕복 실행**
- `EventTypeGuard` 필터링이 `@On` 의 메타데이터로도 그대로 동작
- 토큰 형식(`STREAM_PUBLISHER_${topic}`)을 `publishers/publisher-token.ts` 한 곳으로 모으고 `EventsModule.getPublisherToken` 이 그것을 부른다

타입을 우회한 호출(`as any`)은 **데코레이터 평가 시점 = 부팅**에 던진다 — 조용히 통과하면 그 핸들러는 영원히 실행되지 않는다.

## ADR 을 먼저 고친 부분

ADR §4 스케치의 `@Payload()` 는 **채택하지 않았다.** `@nestjs/microservices` 가 이미 `Payload` 라는 이름으로 다른 것(파싱된 메시지 전체)을 export 하고, `@app/events` 는 `export *` 라 같은 이름이 import 경로에 따라 다른 뜻이 된다 — 이 워크스트림이 없애려는 실패 모드를 이름 공간에서 재생산하는 것이다. 기존 `@EventPayload()` 를 유지했다. **도출되는 것은 데코레이터 이름이 아니라 타입**이므로 §4 의 목적은 그대로 달성된다. ADR §4 · Follow-up 5 에 기록.

## ⚠️ Task 5 로 넘어가는 한계

`@On` 은 이벤트명 **오타**를 잡지만 **불일치**는 못 잡는다 — `@On(S, 'A')` + `@EventPayload() p: EventPayloadOf<typeof S, 'B'>` 는 여전히 컴파일된다.

핸들러 시그니처를 타입으로 강제하는 안을 검토하고 기각했다: 파라미터 데코레이터 순서가 앱마다 다르고(**envelope-우선 45 · payload-우선 20 · payload-only 12 · envelope-only 10**, 실측 87개), 이 레포는 `strictFunctionTypes` 가 꺼져 있어 `TypedPropertyDescriptor` 제약이 반공변으로 걸리지도 않는다. 이주 시 **사람이 이벤트명을 맞춰야 한다.**

## 검증

- `libs/events` + 계약 패키지 **17 suite / 151 tests 초록** (Task 3 대비 +1 suite / +6 tests)
- `npm run type-check` **164 = develop 기준선과 동일** (file:line:code 집합 동일)
- **10개 앱 전부 `nest build` 초록**
- 전체 jest 실패 suite **18 = develop 과 동일** (3013 통과)
- 신규 파일 eslint 초록. 손댄 기존 파일(`decorators.ts` · `events.module.ts`)은 메시지 집합이 develop 과 동일 (기존 부채 그대로)
- `@ts-expect-error` 단언이 살아 있음을 실행 확인 — 하나를 지우면 `tsc` 가 `TS2345: '"NoSuchEvent"' is not assignable to '"OrderCreated" | "OrderCancelled"'` 로 실패한다. 쓸모없어진 directive 는 `TS2578` 로 스스로 드러난다.

## 배포

**요구 없음.** 순수 추가이고 아무도 호출하지 않는다 — 다음 아무 배포에 묻어가면 된다 (플랜 Global Constraints 표).