### PR TITLE
feat(events): 소비 핸들러 87개를 계약 도출 데코레이터로 이주 (ADR-0029 Task 5-A)

### DIFF
--- a/apps/analytics/src/datasets/memberships/ingest/membership-events.consumer.ts
+++ b/apps/analytics/src/datasets/memberships/ingest/membership-events.consumer.ts
@@ -1,13 +1,13 @@
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
 import { InjectTypedDb } from '@app/db/decorators';
-import { EventPayload, EventEnvelope, OnEvent } from '@app/events';
+import { EventPayload, EventEnvelope, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import { MembershipStatusChangedPayload } from '@packages/event-contracts/streams/membership.stream';
-import { DomainEvent } from '@packages/event-contracts/types';
 import { DbService } from '@app/db';
 import { analyticsSchema } from '../../../schema';
 import { MembershipFactsService } from '../facts/membership-facts.service';
 import { MembershipDimensionsService } from '../dimensions/membership-dimensions.service';
+import { MEMBERSHIP_STREAM } from '@packages/event-contracts/streams/membership.stream';
+import { EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 
 @Controller()
 @UseInterceptors(EventTypeGuard)
@@ -21,10 +21,10 @@ export class MembershipEventsConsumer {
     private readonly membershipDimensionsService: MembershipDimensionsService,
   ) {}
 
-  @OnEvent('membership.events.v1', 'MembershipStatusChanged')
+  @On(MEMBERSHIP_STREAM, 'MembershipStatusChanged')
   async onMembershipStatusChanged(
-    @EventEnvelope() envelope: DomainEvent<MembershipStatusChangedPayload>,
-    @EventPayload() payload: MembershipStatusChangedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof MEMBERSHIP_STREAM, 'MembershipStatusChanged'>,
+    @EventPayload() payload: EventPayloadOf<typeof MEMBERSHIP_STREAM, 'MembershipStatusChanged'>,
   ) {
     this.logger.log(`MembershipStatusChanged received: ${payload.userId} → ${payload.status}`);
     await this.dbService.run(async (tx) => {

--- a/apps/analytics/src/datasets/orders/ingest/order-events.consumer.ts
+++ b/apps/analytics/src/datasets/orders/ingest/order-events.consumer.ts
@@ -1,13 +1,7 @@
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
 import { InjectTypedDb } from '@app/db/decorators';
-import { EventPayload, EventEnvelope, OnEvent } from '@app/events';
+import { EventPayload, EventEnvelope, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import {
-  OrderCreatedPayload,
-  OrderCancelledPayload,
-  OrderRefundCreatedPayload,
-} from '@packages/event-contracts/streams/orders.stream';
-import { DomainEvent } from '@packages/event-contracts/types';
 import { OrderAggregatesService } from '../aggregates/order-aggregates.service';
 import { UserPurchaseAggregatesService } from '../aggregates/user-purchase-aggregates.service';
 import { ChannelAggregatesService } from '../aggregates/channel-aggregates.service';
@@ -17,6 +11,8 @@ import { OrderFactsService } from '../facts/order-facts.service';
 import { DbTx } from '../../../db.types';
 import { analyticsSchema } from '../../../schema';
 import { DbService } from '@app/db';
+import { ORDER_STREAM } from '@packages/event-contracts/streams/orders.stream';
+import { EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 
 @Controller()
 @UseInterceptors(EventTypeGuard)
@@ -42,10 +38,10 @@ export class OrderEventsConsumer {
     return tx ? fn(tx) : this.db.transaction(fn);
   }
 
-  @OnEvent('orders.events.v1', 'OrderCreated')
+  @On(ORDER_STREAM, 'OrderCreated')
   async onOrderCreated(
-    @EventEnvelope() envelope: DomainEvent<OrderCreatedPayload>,
-    @EventPayload() payload: OrderCreatedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof ORDER_STREAM, 'OrderCreated'>,
+    @EventPayload() payload: EventPayloadOf<typeof ORDER_STREAM, 'OrderCreated'>,
   ) {
     this.logger.log(`OrderCreated received: ${payload.orderId}`);
     await this.inTx(async (tx) => {
@@ -71,10 +67,10 @@ export class OrderEventsConsumer {
     this.logger.debug(`OrderCreated processed: ${payload.orderId} (${envelope.messageId})`);
   }
 
-  @OnEvent('orders.events.v1', 'OrderCancelled')
+  @On(ORDER_STREAM, 'OrderCancelled')
   async onOrderCancelled(
-    @EventEnvelope() envelope: DomainEvent<OrderCancelledPayload>,
-    @EventPayload() payload: OrderCancelledPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof ORDER_STREAM, 'OrderCancelled'>,
+    @EventPayload() payload: EventPayloadOf<typeof ORDER_STREAM, 'OrderCancelled'>,
   ) {
     this.logger.log(`OrderCancelled received: ${payload.orderId}`);
     await this.inTx(async (tx) => {
@@ -97,10 +93,10 @@ export class OrderEventsConsumer {
     });
   }
 
-  @OnEvent('orders.events.v1', 'OrderRefundCreated')
+  @On(ORDER_STREAM, 'OrderRefundCreated')
   async onOrderRefundCreated(
-    @EventEnvelope() envelope: DomainEvent<OrderRefundCreatedPayload>,
-    @EventPayload() payload: OrderRefundCreatedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof ORDER_STREAM, 'OrderRefundCreated'>,
+    @EventPayload() payload: EventPayloadOf<typeof ORDER_STREAM, 'OrderRefundCreated'>,
   ) {
     this.logger.log(`OrderRefundCreated received: ${payload.orderId}`);
     await this.inTx(async (tx) => {

--- a/apps/analytics/src/datasets/products/ingest/product-events.consumer.ts
+++ b/apps/analytics/src/datasets/products/ingest/product-events.consumer.ts
@@ -1,16 +1,9 @@
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { EventEnvelope, EventPayload, OnEvent } from '@app/events';
+import { EventEnvelope, EventPayload, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import {
-  ProductInventoryManagementChangedPayload,
-  ProductMasterActiveVersionChangedPayload,
-  ProductMasterDeletedPayload,
-  ProductVariantCreatedPayload,
-  ProductVariantDeletedPayload,
-  ProductVariantUpdatedPayload,
-} from '@packages/event-contracts/streams/product.stream';
-import { DomainEvent } from '@packages/event-contracts/types';
 import { ProductDimensionsService } from '../dimensions/product-dimensions.service';
+import { PRODUCT_STREAM } from '@packages/event-contracts/streams/product.stream';
+import { EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 
 @Controller()
 @UseInterceptors(EventTypeGuard)
@@ -19,60 +12,60 @@ export class ProductEventsConsumer {
 
   constructor(private readonly productDimensionsService: ProductDimensionsService) {}
 
-  @OnEvent('products.events.v1', 'ProductVariantCreated')
+  @On(PRODUCT_STREAM, 'ProductVariantCreated')
   async onVariantCreated(
-    @EventEnvelope() envelope: DomainEvent<ProductVariantCreatedPayload>,
-    @EventPayload() payload: ProductVariantCreatedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PRODUCT_STREAM, 'ProductVariantCreated'>,
+    @EventPayload() payload: EventPayloadOf<typeof PRODUCT_STREAM, 'ProductVariantCreated'>,
   ) {
     this.logger.log(`ProductVariantCreated received: ${payload.masterId}/${payload.variantId}`);
     await this.productDimensionsService.recordVariantCreated(payload);
     this.logger.debug(`ProductVariantCreated processed: ${payload.variantId} (${envelope.messageId})`);
   }
 
-  @OnEvent('products.events.v1', 'ProductVariantUpdated')
+  @On(PRODUCT_STREAM, 'ProductVariantUpdated')
   async onVariantUpdated(
-    @EventEnvelope() envelope: DomainEvent<ProductVariantUpdatedPayload>,
-    @EventPayload() payload: ProductVariantUpdatedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PRODUCT_STREAM, 'ProductVariantUpdated'>,
+    @EventPayload() payload: EventPayloadOf<typeof PRODUCT_STREAM, 'ProductVariantUpdated'>,
   ) {
     this.logger.log(`ProductVariantUpdated received: ${payload.masterId}/${payload.variantId}`);
     await this.productDimensionsService.recordVariantUpdated(payload);
     this.logger.debug(`ProductVariantUpdated processed: ${payload.variantId} (${envelope.messageId})`);
   }
 
-  @OnEvent('products.events.v1', 'ProductVariantDeleted')
+  @On(PRODUCT_STREAM, 'ProductVariantDeleted')
   async onVariantDeleted(
-    @EventEnvelope() envelope: DomainEvent<ProductVariantDeletedPayload>,
-    @EventPayload() payload: ProductVariantDeletedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PRODUCT_STREAM, 'ProductVariantDeleted'>,
+    @EventPayload() payload: EventPayloadOf<typeof PRODUCT_STREAM, 'ProductVariantDeleted'>,
   ) {
     this.logger.log(`ProductVariantDeleted received: ${payload.masterId}/${payload.variantId}`);
     await this.productDimensionsService.recordVariantDeleted(payload);
     this.logger.debug(`ProductVariantDeleted processed: ${payload.variantId} (${envelope.messageId})`);
   }
 
-  @OnEvent('products.events.v1', 'ProductInventoryManagementChanged')
+  @On(PRODUCT_STREAM, 'ProductInventoryManagementChanged')
   async onInventoryManagementChanged(
-    @EventEnvelope() envelope: DomainEvent<ProductInventoryManagementChangedPayload>,
-    @EventPayload() payload: ProductInventoryManagementChangedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PRODUCT_STREAM, 'ProductInventoryManagementChanged'>,
+    @EventPayload() payload: EventPayloadOf<typeof PRODUCT_STREAM, 'ProductInventoryManagementChanged'>,
   ) {
     this.logger.log(`ProductInventoryManagementChanged received: ${payload.masterId}`);
     await this.productDimensionsService.recordInventoryManagementChanged(payload);
     this.logger.debug(`ProductInventoryManagementChanged processed: ${payload.masterId} (${envelope.messageId})`);
   }
 
-  @OnEvent('products.events.v1', 'ProductMasterActiveVersionChanged')
+  @On(PRODUCT_STREAM, 'ProductMasterActiveVersionChanged')
   async onMasterActiveVersionChanged(
-    @EventEnvelope() envelope: DomainEvent<ProductMasterActiveVersionChangedPayload>,
-    @EventPayload() payload: ProductMasterActiveVersionChangedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PRODUCT_STREAM, 'ProductMasterActiveVersionChanged'>,
+    @EventPayload() payload: EventPayloadOf<typeof PRODUCT_STREAM, 'ProductMasterActiveVersionChanged'>,
   ) {
     this.logger.log(`ProductMasterActiveVersionChanged received: ${payload.masterId}`);
     await this.productDimensionsService.recordMasterActiveVersionChanged(payload);
     this.logger.debug(`ProductMasterActiveVersionChanged processed: ${payload.masterId} (${envelope.messageId})`);
   }
 
-  @OnEvent('products.events.v1', 'ProductMasterDeleted')
+  @On(PRODUCT_STREAM, 'ProductMasterDeleted')
   async onMasterDeleted(
-    @EventEnvelope() envelope: DomainEvent<ProductMasterDeletedPayload>,
-    @EventPayload() payload: ProductMasterDeletedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PRODUCT_STREAM, 'ProductMasterDeleted'>,
+    @EventPayload() payload: EventPayloadOf<typeof PRODUCT_STREAM, 'ProductMasterDeleted'>,
   ) {
     this.logger.log(`ProductMasterDeleted received: ${payload.masterId}`);
     await this.productDimensionsService.recordMasterDeleted(payload);

--- a/apps/analytics/src/main.ts
+++ b/apps/analytics/src/main.ts
@@ -66,14 +66,14 @@ async function bootstrap() {
     // that field: `bindEvents()` spreads `options.subscribe` and then sets
     // `topics: [...this.messageHandlers.keys()]` after the spread
     // (node_modules/@nestjs/microservices/server/server-kafka.js:92, v11.1.17). Since
-    // @OnEvent(topic, type) is EventPattern(topic) + metadata, the registered patterns
-    // ARE the topic strings, so the real subscription set comes from the @OnEvent
+    // @On(STREAM, type) expands to EventPattern(topic) + metadata, the registered
+    // patterns ARE the topic strings, so the real subscription set comes from the @On
     // decorators on controllers registered in analytics.module.ts.
     //
     // Concretely: PRODUCT_STREAM is absent from this array and products.events.v1 is
     // still subscribed, because ProductEventsConsumer is in `controllers` and declares
-    // six @OnEvent('products.events.v1', ...) handlers. (An earlier version of this
-    // comment claimed the opposite and was wrong — see docs/adr/0029.)
+    // six @On(PRODUCT_STREAM, ...) handlers. (An earlier version of this comment
+    // claimed the opposite and was wrong — see docs/adr/0029.)
     //
     // The list that does carry weight is the one passed to forConsumerModule() in
     // analytics.module.ts: it supplies the topic -> StreamConfig map used by

--- a/apps/channel-adapter/src/consumers/fulfillment-events.consumer.ts
+++ b/apps/channel-adapter/src/consumers/fulfillment-events.consumer.ts
@@ -9,18 +9,14 @@
  */
 
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { OnEvent, EventPayload, EventEnvelope } from '@app/events';
+import { EventPayload, EventEnvelope, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import {
-  FulfillmentShippedPayload,
-  FulfillmentCancelledPayload,
-  FulfillmentDeliveredPayload,
-  SalesOrderCancelledPayload,
-} from '@packages/event-contracts/streams';
-import { MessageEnvelope } from '@packages/event-contracts/types';
 import { DbService } from '@app/db';
 import { inboxEvents } from '../schema';
 import type { ChannelAdapterSchema } from '../types';
+import { FULFILLMENT_STREAM } from '@packages/event-contracts/streams/fulfillments.stream';
+import { CORE_ORDER_STREAM } from '@packages/event-contracts/streams/orders.stream';
+import { EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 
 @Controller()
 @UseInterceptors(EventTypeGuard)
@@ -37,10 +33,10 @@ export class FulfillmentEventsConsumer {
    * V1 이벤트는 FO 전체 완료의 Medusa 호환 projection만 담당한다.
    * 실제 외부 채널 발송은 ShipmentShipped consumer가 소유한다.
    */
-  @OnEvent('fulfillments.events.v1', 'FulfillmentShipped')
+  @On(FULFILLMENT_STREAM, 'FulfillmentShipped')
   async handleFulfillmentShipped(
-    @EventPayload() payload: FulfillmentShippedPayload,
-    @EventEnvelope() envelope: MessageEnvelope<FulfillmentShippedPayload>,
+    @EventPayload() payload: EventPayloadOf<typeof FULFILLMENT_STREAM, 'FulfillmentShipped'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof FULFILLMENT_STREAM, 'FulfillmentShipped'>,
   ) {
     this.logger.log(`🚚 [FulfillmentShipped] Received: fulfillmentId=${payload.fulfillmentId}`, {
       correlationId: envelope.correlationId,
@@ -78,10 +74,10 @@ export class FulfillmentEventsConsumer {
    * Core WMS에서 배송 완료가 확인되면 Medusa order metadata를 갱신합니다.
    * 네이버/쿠팡은 자체 배송 추적을 하므로 여기서는 Medusa projection만 처리합니다.
    */
-  @OnEvent('fulfillments.events.v1', 'FulfillmentDelivered')
+  @On(FULFILLMENT_STREAM, 'FulfillmentDelivered')
   async handleFulfillmentDelivered(
-    @EventPayload() payload: FulfillmentDeliveredPayload,
-    @EventEnvelope() envelope: MessageEnvelope<FulfillmentDeliveredPayload>,
+    @EventPayload() payload: EventPayloadOf<typeof FULFILLMENT_STREAM, 'FulfillmentDelivered'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof FULFILLMENT_STREAM, 'FulfillmentDelivered'>,
   ) {
     this.logger.log(`📦 [FulfillmentDelivered] Received: fulfillmentId=${payload.fulfillmentId}`, {
       correlationId: envelope.correlationId,
@@ -120,10 +116,10 @@ export class FulfillmentEventsConsumer {
    * V1 fulfillment cancellation은 외부 채널 명령을 소유하지 않는다.
    * 주문 취소 projection은 SalesOrderCancelled의 단일 채널 경로가 담당한다.
    */
-  @OnEvent('fulfillments.events.v1', 'FulfillmentCancelled')
+  @On(FULFILLMENT_STREAM, 'FulfillmentCancelled')
   async handleFulfillmentCancelled(
-    @EventPayload() payload: FulfillmentCancelledPayload,
-    @EventEnvelope() envelope: MessageEnvelope<FulfillmentCancelledPayload>,
+    @EventPayload() payload: EventPayloadOf<typeof FULFILLMENT_STREAM, 'FulfillmentCancelled'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof FULFILLMENT_STREAM, 'FulfillmentCancelled'>,
   ) {
     this.logger.log(`❌ [FulfillmentCancelled] Received: fulfillmentId=${payload.fulfillmentId}`, {
       correlationId: envelope.correlationId,
@@ -155,10 +151,10 @@ export class FulfillmentEventsConsumer {
    *
    * 이벤트 발행 경로: Core sales-orders.service → outbox → core.orders.events.v1 (outbox dispatcher)
    */
-  @OnEvent('core.orders.events.v1', 'SalesOrderCancelled')
+  @On(CORE_ORDER_STREAM, 'SalesOrderCancelled')
   async handleCoreOrderCancelled(
-    @EventPayload() payload: SalesOrderCancelledPayload,
-    @EventEnvelope() envelope: MessageEnvelope,
+    @EventPayload() payload: EventPayloadOf<typeof CORE_ORDER_STREAM, 'SalesOrderCancelled'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof CORE_ORDER_STREAM, 'SalesOrderCancelled'>,
   ): Promise<void> {
     const { orderId, cancellationScope } = payload;
     this.logger.log(`[SALES_ORDER_CANCELLED] Core 주문 취소 수신: orderId=${orderId}, scope=${cancellationScope}`, {

--- a/apps/channel-adapter/src/consumers/membership-event.consumer.ts
+++ b/apps/channel-adapter/src/consumers/membership-event.consumer.ts
@@ -1,12 +1,12 @@
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { OnEvent, EventPayload, EventEnvelope } from '@app/events';
+import { EventPayload, EventEnvelope, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
 import { DbService } from '@app/db';
-import { DomainEvent } from '@packages/event-contracts/types';
-import type { MembershipStatusChangedPayload } from '@packages/event-contracts/streams/membership.stream';
 import { processedEvents, inboxEvents } from '../schema';
 import { eq } from 'drizzle-orm';
 import type { ChannelAdapterSchema } from '../types';
+import { MEMBERSHIP_STREAM } from '@packages/event-contracts/streams/membership.stream';
+import { EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 
 /**
  * Membership Event Consumer
@@ -23,11 +23,11 @@ export class MembershipEventConsumer {
     this.logger.log('Membership Event Consumer 초기화 완료');
   }
 
-  @OnEvent('membership.events.v1', 'MembershipStatusChanged')
+  @On(MEMBERSHIP_STREAM, 'MembershipStatusChanged')
   async onMembershipStatusChanged(
     @EventEnvelope()
-    envelope: DomainEvent<MembershipStatusChangedPayload>,
-    @EventPayload() payload: MembershipStatusChangedPayload,
+    envelope: EnvelopeOf<typeof MEMBERSHIP_STREAM, 'MembershipStatusChanged'>,
+    @EventPayload() payload: EventPayloadOf<typeof MEMBERSHIP_STREAM, 'MembershipStatusChanged'>,
   ): Promise<void> {
     const startTime = Date.now();
     const { userId, status } = payload;

--- a/apps/channel-adapter/src/consumers/payment-events.consumer.ts
+++ b/apps/channel-adapter/src/consumers/payment-events.consumer.ts
@@ -11,14 +11,15 @@
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { HttpService } from '@nestjs/axios';
-import { OnEvent, EventPayload, EventEnvelope } from '@app/events';
+import { EventPayload, EventEnvelope, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import { MessageEnvelope } from '@packages/event-contracts/types';
+import { MessageEnvelope, EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 import { firstValueFrom } from 'rxjs';
 import { DbService } from '@app/db';
 import { eq, and } from 'drizzle-orm';
 import { wmsOrderMappings } from '../schema';
 import type { ChannelAdapterSchema } from '../types';
+import { PAYMENT_STREAM } from '@packages/event-contracts/streams/payment.stream';
 
 /** Medusa에 전달할 결제 이벤트 타입 목록 */
 const MEDUSA_PAYMENT_EVENT_TYPES = [
@@ -66,10 +67,10 @@ export class PaymentEventsConsumer {
    * PaymentCaptured — 결제 확정 이벤트.
    * Medusa에서 주문 결제 상태 업데이트에 사용.
    */
-  @OnEvent('payments.events.v1', 'PaymentCaptured')
+  @On(PAYMENT_STREAM, 'PaymentCaptured')
   async handlePaymentCaptured(
-    @EventPayload() payload: Record<string, unknown>,
-    @EventEnvelope() envelope: MessageEnvelope,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'PaymentCaptured'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'PaymentCaptured'>,
   ) {
     await this.forwardToMedusa(envelope);
   }
@@ -79,26 +80,30 @@ export class PaymentEventsConsumer {
   // (dot-notation)을 그대로 싣는다. EventTypeGuard 가 messageType 단위로 필터링하므로
   // 타입별 핸들러가 없으면 조용히 버려져 Medusa projection 이 끊긴다 (#407).
 
-  @OnEvent('payments.events.v1', 'payment.intent.created')
-  async handleIntentCreated(@EventEnvelope() envelope: MessageEnvelope) {
+  @On(PAYMENT_STREAM, 'payment.intent.created')
+  async handleIntentCreated(@EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'payment.intent.created'>) {
     await this.forwardToMedusa(envelope);
   }
 
-  @OnEvent('payments.events.v1', 'payment.intent.authorized')
-  async handleIntentAuthorized(@EventEnvelope() envelope: MessageEnvelope) {
+  @On(PAYMENT_STREAM, 'payment.intent.authorized')
+  async handleIntentAuthorized(
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'payment.intent.authorized'>,
+  ) {
     await this.forwardToMedusa(envelope);
   }
 
-  @OnEvent('payments.events.v1', 'payment.intent.captured')
-  async handleIntentCaptured(@EventEnvelope() envelope: MessageEnvelope) {
+  @On(PAYMENT_STREAM, 'payment.intent.captured')
+  async handleIntentCaptured(@EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'payment.intent.captured'>) {
     await this.forwardToMedusa(envelope);
   }
 
   /**
    * 무통장입금 입금 대기 진입 — Medusa 가 주문을 '입금확인중' 으로 선생성하도록 전달
    */
-  @OnEvent('payments.events.v1', 'payment.intent.awaiting_deposit')
-  async handleIntentAwaitingDeposit(@EventEnvelope() envelope: MessageEnvelope) {
+  @On(PAYMENT_STREAM, 'payment.intent.awaiting_deposit')
+  async handleIntentAwaitingDeposit(
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'payment.intent.awaiting_deposit'>,
+  ) {
     await this.forwardToMedusa(envelope);
   }
 
@@ -107,52 +112,58 @@ export class PaymentEventsConsumer {
    * 승인 전까지 WMS 수집/발송에서 제외하도록 전달. 거절 시 marker 해제 이벤트로 복원.
    * intentId 기반이라 별도 channelOrderId 보강 불필요(Medusa hook 이 intent→order 역추적).
    */
-  @OnEvent('payments.events.v1', 'payment.intent.refund_requested')
-  async handleIntentRefundRequested(@EventEnvelope() envelope: MessageEnvelope) {
+  @On(PAYMENT_STREAM, 'payment.intent.refund_requested')
+  async handleIntentRefundRequested(
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'payment.intent.refund_requested'>,
+  ) {
     await this.forwardToMedusa(envelope);
   }
 
-  @OnEvent('payments.events.v1', 'payment.intent.refund_request_rejected')
-  async handleIntentRefundRequestRejected(@EventEnvelope() envelope: MessageEnvelope) {
+  @On(PAYMENT_STREAM, 'payment.intent.refund_request_rejected')
+  async handleIntentRefundRequestRejected(
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'payment.intent.refund_request_rejected'>,
+  ) {
     await this.forwardToMedusa(envelope);
   }
 
   /** legacy 타입 — wallet GatewayEventType.INTENT_SUCCEEDED 가 backward compat 으로 남아 있음 */
-  @OnEvent('payments.events.v1', 'payment.intent.succeeded')
-  async handleIntentSucceeded(@EventEnvelope() envelope: MessageEnvelope) {
-    await this.forwardToMedusa(envelope);
-  }
-
-  @OnEvent('payments.events.v1', 'payment.intent.failed')
-  async handleIntentFailed(@EventEnvelope() envelope: MessageEnvelope) {
-    await this.forwardToMedusa(envelope);
-  }
-
-  @OnEvent('payments.events.v1', 'payment.intent.canceled')
-  async handleIntentCanceled(@EventEnvelope() envelope: MessageEnvelope) {
-    await this.forwardToMedusa(envelope);
-  }
-
-  @OnEvent('payments.events.v1', 'gateway.charge.captured')
-  async handleChargeCaptured(@EventEnvelope() envelope: MessageEnvelope) {
-    await this.forwardToMedusa(envelope);
-  }
-
-  @OnEvent('payments.events.v1', 'gateway.refund.succeeded')
-  async handleGatewayRefundSucceeded(
-    @EventPayload() payload: Record<string, unknown>,
-    @EventEnvelope() envelope: MessageEnvelope,
+  @On(PAYMENT_STREAM, 'payment.intent.succeeded')
+  async handleIntentSucceeded(
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'payment.intent.succeeded'>,
   ) {
-    await this.forwardRefundToMedusa(envelope, payload);
+    await this.forwardToMedusa(envelope);
+  }
+
+  @On(PAYMENT_STREAM, 'payment.intent.failed')
+  async handleIntentFailed(@EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'payment.intent.failed'>) {
+    await this.forwardToMedusa(envelope);
+  }
+
+  @On(PAYMENT_STREAM, 'payment.intent.canceled')
+  async handleIntentCanceled(@EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'payment.intent.canceled'>) {
+    await this.forwardToMedusa(envelope);
+  }
+
+  @On(PAYMENT_STREAM, 'gateway.charge.captured')
+  async handleChargeCaptured(@EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'gateway.charge.captured'>) {
+    await this.forwardToMedusa(envelope);
+  }
+
+  @On(PAYMENT_STREAM, 'gateway.refund.succeeded')
+  async handleGatewayRefundSucceeded(
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'gateway.refund.succeeded'>,
+  ) {
+    // gateway 환불 payload 에는 core orderId 가 없다 — intentId 기반이라 Medusa hook 이 역추적한다.
+    await this.forwardRefundToMedusa(envelope);
   }
 
   /**
    * PaymentAuthorized — 결제 승인 이벤트.
    */
-  @OnEvent('payments.events.v1', 'PaymentAuthorized')
+  @On(PAYMENT_STREAM, 'PaymentAuthorized')
   async handlePaymentAuthorized(
-    @EventPayload() payload: Record<string, unknown>,
-    @EventEnvelope() envelope: MessageEnvelope,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'PaymentAuthorized'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'PaymentAuthorized'>,
   ) {
     await this.forwardToMedusa(envelope);
   }
@@ -160,10 +171,10 @@ export class PaymentEventsConsumer {
   /**
    * PaymentFailed — 결제 실패 이벤트.
    */
-  @OnEvent('payments.events.v1', 'PaymentFailed')
+  @On(PAYMENT_STREAM, 'PaymentFailed')
   async handlePaymentFailed(
-    @EventPayload() payload: Record<string, unknown>,
-    @EventEnvelope() envelope: MessageEnvelope,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'PaymentFailed'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'PaymentFailed'>,
   ) {
     await this.forwardToMedusa(envelope);
   }
@@ -171,10 +182,10 @@ export class PaymentEventsConsumer {
   /**
    * PaymentCancelled — 결제 취소 이벤트.
    */
-  @OnEvent('payments.events.v1', 'PaymentCancelled')
+  @On(PAYMENT_STREAM, 'PaymentCancelled')
   async handlePaymentCancelled(
-    @EventPayload() payload: Record<string, unknown>,
-    @EventEnvelope() envelope: MessageEnvelope,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'PaymentCancelled'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'PaymentCancelled'>,
   ) {
     await this.forwardToMedusa(envelope);
   }
@@ -183,24 +194,24 @@ export class PaymentEventsConsumer {
    * RefundApproved — 환불 승인 이벤트.
    * channelOrderId를 조회해 Medusa hook에 함께 전달한다.
    */
-  @OnEvent('payments.events.v1', 'RefundApproved')
+  @On(PAYMENT_STREAM, 'RefundApproved')
   async handleRefundApproved(
-    @EventPayload() payload: Record<string, unknown>,
-    @EventEnvelope() envelope: MessageEnvelope,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'RefundApproved'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'RefundApproved'>,
   ) {
-    await this.forwardRefundToMedusa(envelope, payload);
+    await this.forwardRefundToMedusa(envelope, payload.orderId);
   }
 
   /**
    * PaymentRefundCompleted — 환불 완료 이벤트.
    * channelOrderId를 조회해 Medusa hook에 함께 전달한다 (order-level refund projection용).
    */
-  @OnEvent('payments.events.v1', 'PaymentRefundCompleted')
+  @On(PAYMENT_STREAM, 'PaymentRefundCompleted')
   async handlePaymentRefundCompleted(
-    @EventPayload() payload: Record<string, unknown>,
-    @EventEnvelope() envelope: MessageEnvelope,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'PaymentRefundCompleted'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'PaymentRefundCompleted'>,
   ) {
-    await this.forwardRefundToMedusa(envelope, payload);
+    await this.forwardRefundToMedusa(envelope, payload.orderId);
   }
 
   // ─── Medusa webhook delivery ────────────────────────────────────────────────
@@ -212,8 +223,12 @@ export class PaymentEventsConsumer {
    * channel-adapter가 wms_order_mappings를 보유하므로 여기서 변환한다.
    * 조회 실패는 Medusa 전달을 막지 않는다 — channelOrderId 없이 payment metadata만 갱신된다.
    */
-  private async forwardRefundToMedusa(envelope: MessageEnvelope, payload: Record<string, unknown>): Promise<void> {
-    const coreOrderId = payload?.orderId as string | undefined;
+  // 이 헬퍼가 payload 에서 실제로 쓰는 것은 orderId 하나뿐이므로 그것만 받는다. 계약에서 타입을 도출하고
+  // 나니 세 호출부의 payload 타입이 서로 다르고(RefundApprovedPayload · PaymentRefundCompletedPayload ·
+  // GatewayRefundEventPayload) **gateway.refund.succeeded 에는 orderId 가 아예 없다**는 사실이 드러났다
+  // (buildRefundEventPayload 는 refundId·chargeId·intentId 만 싣는다). 그 경로는 예전부터 조회를 건너뛰고
+  // 있었고 — payload.orderId 가 늘 undefined 였다 — 동작은 그대로다. 달라진 건 그것이 타입에 보인다는 것뿐이다.
+  private async forwardRefundToMedusa(envelope: MessageEnvelope, coreOrderId?: string): Promise<void> {
     let channelOrderId: string | undefined;
 
     if (coreOrderId) {
@@ -221,10 +236,7 @@ export class PaymentEventsConsumer {
         const [mapping] = await this.dbService.db
           .select({ channelOrderId: wmsOrderMappings.channelOrderId })
           .from(wmsOrderMappings)
-          .where(and(
-            eq(wmsOrderMappings.wmsOrderId, coreOrderId),
-            eq(wmsOrderMappings.salesChannel, 'medusa'),
-          ))
+          .where(and(eq(wmsOrderMappings.wmsOrderId, coreOrderId), eq(wmsOrderMappings.salesChannel, 'medusa')))
           .limit(1);
         channelOrderId = mapping?.channelOrderId ?? undefined;
       } catch (err) {
@@ -235,7 +247,7 @@ export class PaymentEventsConsumer {
 
     const enrichedPayload: Record<string, unknown> = channelOrderId
       ? { ...((envelope.payload as Record<string, unknown>) ?? {}), channelOrderId }
-      : (envelope.payload as Record<string, unknown>) ?? {};
+      : ((envelope.payload as Record<string, unknown>) ?? {});
 
     await this.forwardToMedusa(envelope, enrichedPayload);
   }

--- a/apps/channel-adapter/src/consumers/pim-category.consumer.ts
+++ b/apps/channel-adapter/src/consumers/pim-category.consumer.ts
@@ -1,14 +1,14 @@
 // PIM에서 카테고리 변경 이벤트가 발생하면 Inbox에 저장
 
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { OnEvent, EventPayload, EventEnvelope } from '@app/events';
+import { EventPayload, EventEnvelope, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import { DomainEvent } from '@packages/event-contracts/types';
-import { CategoryChangedPayload } from '@packages/event-contracts/streams/product.stream';
 import { DbService } from '@app/db';
 import { processedEvents, inboxEvents } from '../schema';
 import { eq } from 'drizzle-orm';
 import type { ChannelAdapterSchema } from '../types';
+import { PRODUCT_STREAM } from '@packages/event-contracts/streams/product.stream';
+import { EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 
 /**
  * PIM Category Event Consumer
@@ -35,10 +35,10 @@ export class PimCategoryConsumer {
    * @param envelope 이벤트 메타데이터 (correlationId, timestamp 등)
    * @param payload 이벤트 페이로드
    */
-  @OnEvent('products.events.v1', 'CategoryChanged')
+  @On(PRODUCT_STREAM, 'CategoryChanged')
   async onCategoryChanged(
-    @EventEnvelope() envelope: DomainEvent<CategoryChangedPayload>,
-    @EventPayload() payload: CategoryChangedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PRODUCT_STREAM, 'CategoryChanged'>,
+    @EventPayload() payload: EventPayloadOf<typeof PRODUCT_STREAM, 'CategoryChanged'>,
   ): Promise<void> {
     const startTime = Date.now();
     const { categoryId, changeType } = payload;

--- a/apps/channel-adapter/src/consumers/pim-product-event.consumer.ts
+++ b/apps/channel-adapter/src/consumers/pim-product-event.consumer.ts
@@ -1,13 +1,14 @@
 // PIM에서 publish/unpublish/rollback 이벤트가 발생하면 Inbox에 저장
 
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { OnEvent, EventPayload, EventEnvelope } from '@app/events';
+import { EventPayload, EventEnvelope, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import { DomainEvent } from '@packages/event-contracts/types';
+import { DomainEvent, EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 import {
   ProductMasterActiveVersionChangedPayload,
   ProductMasterDeletedPayload,
   ProductPublishOrigin,
+  PRODUCT_STREAM,
 } from '@packages/event-contracts/streams/product.stream';
 import { DbService } from '@app/db';
 import { processedEvents, inboxEvents } from '../schema';
@@ -15,7 +16,9 @@ import { and, eq, or } from 'drizzle-orm';
 import type { ChannelAdapterSchema } from '../types';
 import { createHash } from 'crypto';
 
-const PRODUCT_TOPIC = 'products.events.v1';
+// idempotencyKey · processed_events.source 에 쓰이는 토픽 문자열. 계약에서 읽는다 —
+// 생문자열로 두면 계약과 어긋나도 조용하다 (ADR-0029 §1).
+const PRODUCT_TOPIC = PRODUCT_STREAM.topic.topic;
 const ACTIVE_VERSION_CHANGED = 'ProductMasterActiveVersionChanged';
 const MASTER_DELETED = 'ProductMasterDeleted';
 
@@ -173,10 +176,10 @@ export class PimProductEventConsumer {
    * @param envelope 이벤트 메타데이터 (correlationId, timestamp 등)
    * @param payload 이벤트 페이로드
    */
-  @OnEvent('products.events.v1', 'ProductMasterActiveVersionChanged')
+  @On(PRODUCT_STREAM, 'ProductMasterActiveVersionChanged')
   async onProductMasterActiveVersionChanged(
-    @EventEnvelope() envelope: DomainEvent<ProductMasterActiveVersionChangedPayload>,
-    @EventPayload() payload: ProductMasterActiveVersionChangedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PRODUCT_STREAM, 'ProductMasterActiveVersionChanged'>,
+    @EventPayload() payload: EventPayloadOf<typeof PRODUCT_STREAM, 'ProductMasterActiveVersionChanged'>,
   ): Promise<void> {
     const startTime = Date.now();
     const { masterId, versionId, changeReason } = payload;
@@ -222,10 +225,10 @@ export class PimProductEventConsumer {
     }
   }
 
-  @OnEvent(PRODUCT_TOPIC, MASTER_DELETED)
+  @On(PRODUCT_STREAM, 'ProductMasterDeleted')
   async onProductMasterDeleted(
-    @EventEnvelope() envelope: DomainEvent<ProductMasterDeletedPayload>,
-    @EventPayload() payload: ProductMasterDeletedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PRODUCT_STREAM, 'ProductMasterDeleted'>,
+    @EventPayload() payload: EventPayloadOf<typeof PRODUCT_STREAM, 'ProductMasterDeleted'>,
   ): Promise<void> {
     const startTime = Date.now();
     const { masterId } = payload;

--- a/apps/channel-adapter/src/consumers/product-sellable-quantity.consumer.ts
+++ b/apps/channel-adapter/src/consumers/product-sellable-quantity.consumer.ts
@@ -1,12 +1,12 @@
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { OnEvent, EventEnvelope, EventPayload } from '@app/events';
+import { EventEnvelope, EventPayload, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import type { DomainEvent } from '@packages/event-contracts/types';
-import type { ProductSellableQuantityChangedPayload } from '@packages/event-contracts/streams/inventory.stream';
 import { DbService } from '@app/db';
 import { inboxEvents, processedEvents } from '../schema';
 import { eq } from 'drizzle-orm';
 import type { ChannelAdapterSchema } from '../types';
+import { INVENTORY_STREAM } from '@packages/event-contracts/streams/inventory.stream';
+import { EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 
 @Controller()
 @UseInterceptors(EventTypeGuard)
@@ -17,10 +17,10 @@ export class ProductSellableQuantityConsumer {
     this.logger.log('Product Sellable Quantity Consumer 초기화 완료');
   }
 
-  @OnEvent('inventory.events.v1', 'ProductSellableQuantityChanged')
+  @On(INVENTORY_STREAM, 'ProductSellableQuantityChanged')
   async onProductSellableQuantityChanged(
-    @EventEnvelope() envelope: DomainEvent<ProductSellableQuantityChangedPayload>,
-    @EventPayload() payload: ProductSellableQuantityChangedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof INVENTORY_STREAM, 'ProductSellableQuantityChanged'>,
+    @EventPayload() payload: EventPayloadOf<typeof INVENTORY_STREAM, 'ProductSellableQuantityChanged'>,
   ): Promise<void> {
     const startTime = Date.now();
     const idempotencyKey = `${payload.variantId}:${payload.calculatedAt}:ProductSellableQuantityChanged`;

--- a/apps/channel-adapter/src/consumers/shipment-events.consumer.ts
+++ b/apps/channel-adapter/src/consumers/shipment-events.consumer.ts
@@ -1,17 +1,9 @@
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
 import { DbService } from '@app/db';
-import { EventEnvelope, EventPayload, OnEvent } from '@app/events';
+import { EventEnvelope, EventPayload, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import {
-  FULFILLMENT_V2_STREAM,
-  FulfillmentProgressedPayload,
-  FulfillmentReopenedPayload,
-  SHIPMENT_STREAM,
-  ShipmentDeliveredPayload,
-  ShipmentDispatchRecalledPayload,
-  ShipmentShippedPayload,
-} from '@packages/event-contracts/streams';
-import { MessageEnvelope } from '@packages/event-contracts/types';
+import { FULFILLMENT_V2_STREAM, SHIPMENT_STREAM } from '@packages/event-contracts/streams';
+import { MessageEnvelope, EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 import { inboxEvents } from '../schema';
 import type { ChannelAdapterSchema } from '../types';
 
@@ -22,10 +14,10 @@ export class ShipmentEventsConsumer {
 
   constructor(private readonly dbService: DbService<ChannelAdapterSchema>) {}
 
-  @OnEvent('shipments.events.v1', 'ShipmentShipped')
+  @On(SHIPMENT_STREAM, 'ShipmentShipped')
   async handleShipmentShipped(
-    @EventPayload() payload: ShipmentShippedPayload,
-    @EventEnvelope() envelope: MessageEnvelope<ShipmentShippedPayload>,
+    @EventPayload() payload: EventPayloadOf<typeof SHIPMENT_STREAM, 'ShipmentShipped'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof SHIPMENT_STREAM, 'ShipmentShipped'>,
   ): Promise<void> {
     const validated = SHIPMENT_STREAM.events.ShipmentShipped.schema!.parse(payload);
     await this.insertInbox(
@@ -38,10 +30,10 @@ export class ShipmentEventsConsumer {
     );
   }
 
-  @OnEvent('shipments.events.v1', 'ShipmentDelivered')
+  @On(SHIPMENT_STREAM, 'ShipmentDelivered')
   async handleShipmentDelivered(
-    @EventPayload() payload: ShipmentDeliveredPayload,
-    @EventEnvelope() envelope: MessageEnvelope<ShipmentDeliveredPayload>,
+    @EventPayload() payload: EventPayloadOf<typeof SHIPMENT_STREAM, 'ShipmentDelivered'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof SHIPMENT_STREAM, 'ShipmentDelivered'>,
   ): Promise<void> {
     const validated = SHIPMENT_STREAM.events.ShipmentDelivered.schema!.parse(payload);
     await this.insertInbox(
@@ -54,10 +46,10 @@ export class ShipmentEventsConsumer {
     );
   }
 
-  @OnEvent('shipments.events.v1', 'ShipmentDispatchRecalled')
+  @On(SHIPMENT_STREAM, 'ShipmentDispatchRecalled')
   async handleShipmentDispatchRecalled(
-    @EventPayload() payload: ShipmentDispatchRecalledPayload,
-    @EventEnvelope() envelope: MessageEnvelope<ShipmentDispatchRecalledPayload>,
+    @EventPayload() payload: EventPayloadOf<typeof SHIPMENT_STREAM, 'ShipmentDispatchRecalled'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof SHIPMENT_STREAM, 'ShipmentDispatchRecalled'>,
   ): Promise<void> {
     const validated = SHIPMENT_STREAM.events.ShipmentDispatchRecalled.schema!.parse(payload);
     await this.insertInbox(
@@ -70,10 +62,10 @@ export class ShipmentEventsConsumer {
     );
   }
 
-  @OnEvent('fulfillments.events.v2', 'FulfillmentProgressed')
+  @On(FULFILLMENT_V2_STREAM, 'FulfillmentProgressed')
   async handleFulfillmentProgressed(
-    @EventPayload() payload: FulfillmentProgressedPayload,
-    @EventEnvelope() envelope: MessageEnvelope<FulfillmentProgressedPayload>,
+    @EventPayload() payload: EventPayloadOf<typeof FULFILLMENT_V2_STREAM, 'FulfillmentProgressed'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof FULFILLMENT_V2_STREAM, 'FulfillmentProgressed'>,
   ): Promise<void> {
     const validated = FULFILLMENT_V2_STREAM.events.FulfillmentProgressed.schema!.parse(payload);
     await this.insertInbox(
@@ -86,10 +78,10 @@ export class ShipmentEventsConsumer {
     );
   }
 
-  @OnEvent('fulfillments.events.v2', 'FulfillmentReopened')
+  @On(FULFILLMENT_V2_STREAM, 'FulfillmentReopened')
   async handleFulfillmentReopened(
-    @EventPayload() payload: FulfillmentReopenedPayload,
-    @EventEnvelope() envelope: MessageEnvelope<FulfillmentReopenedPayload>,
+    @EventPayload() payload: EventPayloadOf<typeof FULFILLMENT_V2_STREAM, 'FulfillmentReopened'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof FULFILLMENT_V2_STREAM, 'FulfillmentReopened'>,
   ): Promise<void> {
     const validated = FULFILLMENT_V2_STREAM.events.FulfillmentReopened.schema!.parse(payload);
     await this.insertInbox(

--- a/apps/channel-adapter/src/consumers/user-event.consumer.ts
+++ b/apps/channel-adapter/src/consumers/user-event.consumer.ts
@@ -1,16 +1,12 @@
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { OnEvent, EventPayload, EventEnvelope } from '@app/events';
+import { EventPayload, EventEnvelope, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
 import { DbService } from '@app/db';
-import { DomainEvent } from '@packages/event-contracts/types';
-import type {
-  Cafe24LinkedPayload,
-  Cafe24UnlinkedPayload,
-  UserEmailVerifiedPayload,
-} from '@packages/event-contracts/streams/user.stream';
 import { processedEvents, inboxEvents, cafe24MemberMappings } from '../schema';
 import { eq } from 'drizzle-orm';
 import type { ChannelAdapterSchema } from '../types';
+import { USER_STREAM } from '@packages/event-contracts/streams/user.stream';
+import { EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 
 /**
  * User Event Consumer
@@ -25,10 +21,10 @@ export class UserEventConsumer {
 
   constructor(private readonly dbService: DbService<ChannelAdapterSchema>) {}
 
-  @OnEvent('users.events.v1', 'UserEmailVerified')
+  @On(USER_STREAM, 'UserEmailVerified')
   async onUserEmailVerified(
-    @EventEnvelope() envelope: DomainEvent<UserEmailVerifiedPayload>,
-    @EventPayload() payload: UserEmailVerifiedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof USER_STREAM, 'UserEmailVerified'>,
+    @EventPayload() payload: EventPayloadOf<typeof USER_STREAM, 'UserEmailVerified'>,
   ): Promise<void> {
     const { userId } = payload;
     const idempotencyKey = envelope.messageId || `UserEmailVerified:${userId}`;
@@ -82,10 +78,10 @@ export class UserEventConsumer {
     }
   }
 
-  @OnEvent('users.events.v1', 'Cafe24Linked')
+  @On(USER_STREAM, 'Cafe24Linked')
   async onCafe24Linked(
-    @EventEnvelope() envelope: DomainEvent<Cafe24LinkedPayload>,
-    @EventPayload() payload: Cafe24LinkedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof USER_STREAM, 'Cafe24Linked'>,
+    @EventPayload() payload: EventPayloadOf<typeof USER_STREAM, 'Cafe24Linked'>,
   ): Promise<void> {
     const { userId, cafe24MemberId, email } = payload;
     const idempotencyKey = envelope.messageId || `Cafe24Linked:${userId}:${cafe24MemberId}`;
@@ -147,10 +143,10 @@ export class UserEventConsumer {
     }
   }
 
-  @OnEvent('users.events.v1', 'Cafe24Unlinked')
+  @On(USER_STREAM, 'Cafe24Unlinked')
   async onCafe24Unlinked(
-    @EventEnvelope() envelope: DomainEvent<Cafe24UnlinkedPayload>,
-    @EventPayload() payload: Cafe24UnlinkedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof USER_STREAM, 'Cafe24Unlinked'>,
+    @EventPayload() payload: EventPayloadOf<typeof USER_STREAM, 'Cafe24Unlinked'>,
   ): Promise<void> {
     const { userId, cafe24MemberId } = payload;
     const idempotencyKey = envelope.messageId || `Cafe24Unlinked:${userId}:${cafe24MemberId}`;

--- a/apps/core/src/modules/sales-order/consumers/order-events.consumer.spec.ts
+++ b/apps/core/src/modules/sales-order/consumers/order-events.consumer.spec.ts
@@ -9,7 +9,8 @@ import type {
   OrderModifiedPayload,
   OrderRefundCreatedPayload,
 } from '@packages/event-contracts';
-import type { MessageEnvelope } from '@packages/event-contracts/types';
+import type { EnvelopeOf } from '@packages/event-contracts/types';
+import { ORDER_STREAM } from '@packages/event-contracts/streams/orders.stream';
 import 'reflect-metadata';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { RETRY_POLICY_METADATA } from '@app/events';
@@ -126,7 +127,7 @@ describe('OrderEventsConsumer', () => {
     };
   }
 
-  const envelope = { messageId: 'msg-1', correlationId: 'corr-1' } as MessageEnvelope<OrderCreatedPayload>;
+  const envelope = { messageId: 'msg-1', correlationId: 'corr-1' } as EnvelopeOf<typeof ORDER_STREAM, 'OrderCreated'>;
 
   it('새 SO + status=confirmed → createFromEvent 호출, grant 호출, orderEvents insert', async () => {
     const mocks = makeMocks();
@@ -242,7 +243,7 @@ describe('OrderEventsConsumer', () => {
     const cancelledEnvelope = {
       messageId: 'cancel-msg-1',
       correlationId: 'corr-1',
-    } as MessageEnvelope<OrderCancelledPayload>;
+    } as EnvelopeOf<typeof ORDER_STREAM, 'OrderCancelled'>;
     mocks.salesOrders.getOne.mockResolvedValue({ id: payload.orderId, status: 'cancelled' } as any);
 
     await consumer.handleOrderCancelled(payload, cancelledEnvelope);
@@ -278,7 +279,7 @@ describe('OrderEventsConsumer', () => {
     const cancelledEnvelope = {
       messageId: 'cancel-msg-missing-1',
       correlationId: 'corr-1',
-    } as MessageEnvelope<OrderCancelledPayload>;
+    } as EnvelopeOf<typeof ORDER_STREAM, 'OrderCancelled'>;
     mocks.salesOrders.getOne.mockResolvedValue(undefined as any);
 
     await expect(consumer.handleOrderCancelled(payload, cancelledEnvelope)).rejects.toThrow(
@@ -325,7 +326,7 @@ describe('OrderEventsConsumer', () => {
     const modifiedEnvelope = {
       messageId: 'modified-msg-1',
       correlationId: 'corr-1',
-    } as MessageEnvelope<OrderModifiedPayload>;
+    } as EnvelopeOf<typeof ORDER_STREAM, 'OrderModified'>;
     mocks.salesOrders.getOne.mockResolvedValue({ id: payload.orderId, status: 'pending' } as any);
 
     await consumer.handleOrderModified(payload, modifiedEnvelope);
@@ -356,7 +357,7 @@ describe('OrderEventsConsumer', () => {
     const refundEnvelope = {
       messageId: 'refund-msg-1',
       correlationId: 'corr-1',
-    } as MessageEnvelope<OrderRefundCreatedPayload>;
+    } as EnvelopeOf<typeof ORDER_STREAM, 'OrderRefundCreated'>;
     mocks.salesOrders.getOne.mockResolvedValue({ id: payload.orderId, status: 'pending' } as any);
 
     await consumer.handleOrderRefundCreated(payload, refundEnvelope);
@@ -400,7 +401,7 @@ describe('OrderEventsConsumer', () => {
     const refundEnvelope = {
       messageId: 'refund-msg-REDELIVERED',
       correlationId: 'corr-1',
-    } as MessageEnvelope<OrderRefundCreatedPayload>;
+    } as EnvelopeOf<typeof ORDER_STREAM, 'OrderRefundCreated'>;
     mocks.salesOrders.getOne.mockResolvedValue({ id: payload.orderId, status: 'pending' } as any);
     // 동일 (sourceId, relationName, targetExternalRef) 링크가 이전 전달에서 이미 기록돼 있음
     mocks.businessLinkRows.push({ id: 'existing-link-1' });
@@ -429,7 +430,7 @@ describe('OrderEventsConsumer', () => {
     const refundEnvelope = {
       messageId: 'refund-msg-missing-1',
       correlationId: 'corr-1',
-    } as MessageEnvelope<OrderRefundCreatedPayload>;
+    } as EnvelopeOf<typeof ORDER_STREAM, 'OrderRefundCreated'>;
     mocks.salesOrders.getOne.mockResolvedValue(undefined as any);
 
     await expect(consumer.handleOrderRefundCreated(payload, refundEnvelope)).rejects.toThrow(

--- a/apps/core/src/modules/sales-order/consumers/order-events.consumer.ts
+++ b/apps/core/src/modules/sales-order/consumers/order-events.consumer.ts
@@ -1,21 +1,16 @@
 import { Controller, Logger, NotFoundException, BadRequestException, UseInterceptors } from '@nestjs/common';
 import { InjectTypedDb } from '@app/db/decorators';
 import { DbService } from '@app/db';
-import { OnEvent, EventPayload, EventEnvelope, RetryPolicy } from '@app/events';
+import { EventPayload, EventEnvelope, RetryPolicy, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import type {
-  OrderCreatedPayload,
-  OrderCancelledPayload,
-  OrderModifiedPayload,
-  OrderRefundCreatedPayload,
-} from '@packages/event-contracts';
-import { MessageEnvelope } from '@packages/event-contracts/types';
 import { SalesOrdersService } from '../services/sales-orders.service';
 import { LibraryService } from '../../library/services/library.service';
 import { FulfillmentOrderCreationBacklogService } from '../../fulfillment/backlog/fulfillment-order-creation-backlog.service';
 import { FulfillmentWorkflowGate } from '../../fulfillment/services/fulfillment-workflow-gate.service';
 import { wmsTables, wmsSchema, DbTx } from '../../inventory/schema/inventory.schema';
 import { and, eq } from 'drizzle-orm';
+import { ORDER_STREAM } from '@packages/event-contracts/streams/orders.stream';
+import { EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 
 /**
  * Order 이벤트 컨슈머
@@ -66,11 +61,11 @@ export class OrderEventsConsumer {
     return false;
   }
 
-  @OnEvent('orders.events.v1', 'OrderCreated')
+  @On(ORDER_STREAM, 'OrderCreated')
   @RetryPolicy({ maxRetries: 5, backoff: 'exponential', initialDelayMs: 1000, maxDelayMs: 15000 })
   async handleOrderCreated(
-    @EventPayload() payload: OrderCreatedPayload,
-    @EventEnvelope() envelope: MessageEnvelope<OrderCreatedPayload>,
+    @EventPayload() payload: EventPayloadOf<typeof ORDER_STREAM, 'OrderCreated'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof ORDER_STREAM, 'OrderCreated'>,
   ) {
     this.logger.log(`[OrderCreated] Received: ${payload.orderId} from ${payload.salesChannel}`, {
       correlationId: envelope.correlationId,
@@ -120,11 +115,11 @@ export class OrderEventsConsumer {
     }
   }
 
-  @OnEvent('orders.events.v1', 'OrderCancelled')
+  @On(ORDER_STREAM, 'OrderCancelled')
   @RetryPolicy({ nonRetryableErrors: [NotFoundException, BadRequestException] })
   async handleOrderCancelled(
-    @EventPayload() payload: OrderCancelledPayload,
-    @EventEnvelope() envelope: MessageEnvelope<OrderCancelledPayload>,
+    @EventPayload() payload: EventPayloadOf<typeof ORDER_STREAM, 'OrderCancelled'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof ORDER_STREAM, 'OrderCancelled'>,
   ) {
     this.logger.log(`[OrderCancelled] Received: orderId=${payload.orderId}, reason=${payload.reason}`, {
       correlationId: envelope.correlationId,
@@ -171,10 +166,10 @@ export class OrderEventsConsumer {
     }
   }
 
-  @OnEvent('orders.events.v1', 'OrderModified')
+  @On(ORDER_STREAM, 'OrderModified')
   async handleOrderModified(
-    @EventPayload() payload: OrderModifiedPayload,
-    @EventEnvelope() envelope: MessageEnvelope<OrderModifiedPayload>,
+    @EventPayload() payload: EventPayloadOf<typeof ORDER_STREAM, 'OrderModified'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof ORDER_STREAM, 'OrderModified'>,
   ) {
     this.logger.log(`[OrderModified] Received: orderId=${payload.orderId}`, {
       correlationId: envelope.correlationId,
@@ -207,11 +202,11 @@ export class OrderEventsConsumer {
     }
   }
 
-  @OnEvent('orders.events.v1', 'OrderRefundCreated')
+  @On(ORDER_STREAM, 'OrderRefundCreated')
   @RetryPolicy({ nonRetryableErrors: [NotFoundException] })
   async handleOrderRefundCreated(
-    @EventPayload() payload: OrderRefundCreatedPayload,
-    @EventEnvelope() envelope: MessageEnvelope<OrderRefundCreatedPayload>,
+    @EventPayload() payload: EventPayloadOf<typeof ORDER_STREAM, 'OrderRefundCreated'>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof ORDER_STREAM, 'OrderRefundCreated'>,
   ) {
     this.logger.log(`[OrderRefundCreated] Received: orderId=${payload.orderId}, refundId=${payload.refundId}`, {
       correlationId: envelope.correlationId,

--- a/apps/membership/src/consumers/__tests__/billing-result.consumer.spec.ts
+++ b/apps/membership/src/consumers/__tests__/billing-result.consumer.spec.ts
@@ -1,4 +1,25 @@
 import { BillingResultConsumer } from '../billing-result.consumer';
+import { PAYMENT_STREAM } from '@packages/event-contracts/streams/payment.stream';
+import type { EventPayloadOf } from '@packages/event-contracts/types';
+
+type IntentCanceledPayload = EventPayloadOf<typeof PAYMENT_STREAM, 'payment.intent.canceled'>;
+
+/**
+ * 계약이 요구하는 공통 필드를 채운다. 이 테스트가 보는 것은 subscriberType/subscriberRef 라우팅뿐이지만,
+ * payload 타입을 계약에서 도출한 뒤로는 나머지 필드도 실제 발행 형태를 갖춰야 한다 — 예전 로컬
+ * 인터페이스가 느슨해서 3필드 stub 이 통과했을 뿐이다 (ADR-0029 §4).
+ */
+function intentPayload(overrides: Partial<IntentCanceledPayload>): IntentCanceledPayload {
+  return {
+    intentId: 'intent-0',
+    userId: 'user-1',
+    status: 'CANCELED',
+    payableAmount: 4990,
+    currency: 'KRW',
+    occurredAt: '2026-08-09T00:00:00.000Z',
+    ...overrides,
+  };
+}
 
 function makeConsumer() {
   const billingOutcomeHandler = {
@@ -13,18 +34,18 @@ function makeConsumer() {
 describe('BillingResultConsumer.onIntentCanceled', () => {
   it('멤버십 정기결제 취소 이벤트면 handleCanceled 로 선점을 해제한다', async () => {
     const { consumer, billingOutcomeHandler } = makeConsumer();
-    await consumer.onIntentCanceled({
-      intentId: 'intent-1',
-      subscriberType: 'MEMBERSHIP',
-      subscriberRef: 'contract-1',
-    });
+    await consumer.onIntentCanceled(
+      intentPayload({ intentId: 'intent-1', subscriberType: 'MEMBERSHIP', subscriberRef: 'contract-1' }),
+    );
     expect(billingOutcomeHandler.handleCanceled).toHaveBeenCalledWith('contract-1', 'intent-1');
   });
 
   it('subscriberType 이 MEMBERSHIP 이 아니거나 subscriberRef 가 없으면 무시한다', async () => {
     const { consumer, billingOutcomeHandler } = makeConsumer();
-    await consumer.onIntentCanceled({ intentId: 'intent-2', subscriberType: 'ORDER', subscriberRef: 'x' });
-    await consumer.onIntentCanceled({ intentId: 'intent-3', subscriberType: 'MEMBERSHIP' });
+    await consumer.onIntentCanceled(
+      intentPayload({ intentId: 'intent-2', subscriberType: 'ORDER', subscriberRef: 'x' }),
+    );
+    await consumer.onIntentCanceled(intentPayload({ intentId: 'intent-3', subscriberType: 'MEMBERSHIP' }));
     expect(billingOutcomeHandler.handleCanceled).not.toHaveBeenCalled();
   });
 });

--- a/apps/membership/src/consumers/__tests__/membership-checkout.consumer.spec.ts
+++ b/apps/membership/src/consumers/__tests__/membership-checkout.consumer.spec.ts
@@ -1,6 +1,23 @@
 import { MembershipCheckoutConsumer } from '../membership-checkout.consumer';
 import { SubscriptionService } from '../../services/subscription.service';
 import { ActiveSubscriptionExistsException } from '../../shared/exceptions/subscription.exceptions';
+import { PAYMENT_STREAM } from '@packages/event-contracts/streams/payment.stream';
+import type { EventPayloadOf } from '@packages/event-contracts/types';
+
+type IntentCapturedPayload = EventPayloadOf<typeof PAYMENT_STREAM, 'payment.intent.captured'>;
+
+/** 이 테스트가 보는 것은 metadata.type 분기뿐이지만, 계약이 요구하는 공통 필드는 채운다. */
+function capturedPayload(overrides: Partial<IntentCapturedPayload>): IntentCapturedPayload {
+  return {
+    intentId: 'i1',
+    userId: 'user-1',
+    status: 'CAPTURED',
+    payableAmount: 4990,
+    currency: 'KRW',
+    occurredAt: '2026-08-09T00:00:00.000Z',
+    ...overrides,
+  };
+}
 
 describe('MembershipCheckoutConsumer', () => {
   let consumer: MembershipCheckoutConsumer;
@@ -12,32 +29,32 @@ describe('MembershipCheckoutConsumer', () => {
   });
 
   it('멤버십 결제가 아니면 무시한다', async () => {
-    await consumer.onIntentCaptured({ intentId: 'i1', metadata: { type: 'ORDER' } });
+    await consumer.onIntentCaptured(capturedPayload({ metadata: { type: 'ORDER' } }));
     expect(confirmCheckoutIntent).not.toHaveBeenCalled();
   });
 
   it('metadata 가 없으면 무시한다', async () => {
-    await consumer.onIntentCaptured({ intentId: 'i1', metadata: null });
+    await consumer.onIntentCaptured(capturedPayload({ metadata: null }));
     expect(confirmCheckoutIntent).not.toHaveBeenCalled();
   });
 
   it('멤버십 결제면 구독 생성을 호출한다', async () => {
     confirmCheckoutIntent.mockResolvedValue({ contractId: 'c1' });
-    await consumer.onIntentCaptured({ intentId: 'i1', metadata: { type: 'MEMBERSHIP_FEE' } });
+    await consumer.onIntentCaptured(capturedPayload({ metadata: { type: 'MEMBERSHIP_FEE' } }));
     expect(confirmCheckoutIntent).toHaveBeenCalledWith('i1');
   });
 
   it('이미 구독이 있으면 멱등하게 스킵한다', async () => {
     confirmCheckoutIntent.mockRejectedValue(new ActiveSubscriptionExistsException());
     await expect(
-      consumer.onIntentCaptured({ intentId: 'i1', metadata: { type: 'MEMBERSHIP_FEE' } }),
+      consumer.onIntentCaptured(capturedPayload({ metadata: { type: 'MEMBERSHIP_FEE' } })),
     ).resolves.toBeUndefined();
   });
 
   it('그 외 에러는 재던진다(재시도/DLQ 대상)', async () => {
     confirmCheckoutIntent.mockRejectedValue(new Error('boom'));
-    await expect(
-      consumer.onIntentCaptured({ intentId: 'i1', metadata: { type: 'MEMBERSHIP_FEE' } }),
-    ).rejects.toThrow('boom');
+    await expect(consumer.onIntentCaptured(capturedPayload({ metadata: { type: 'MEMBERSHIP_FEE' } }))).rejects.toThrow(
+      'boom',
+    );
   });
 });

--- a/apps/membership/src/consumers/__tests__/membership-refund.consumer.spec.ts
+++ b/apps/membership/src/consumers/__tests__/membership-refund.consumer.spec.ts
@@ -1,4 +1,23 @@
 import { MembershipRefundConsumer } from '../membership-refund.consumer';
+import { PAYMENT_STREAM } from '@packages/event-contracts/streams/payment.stream';
+import type { EventPayloadOf } from '@packages/event-contracts/types';
+
+type RefundSucceededPayload = EventPayloadOf<typeof PAYMENT_STREAM, 'gateway.refund.succeeded'>;
+
+/** 이 테스트가 보는 것은 intentId/amount 뿐이지만, 계약이 요구하는 공통 필드는 채운다. */
+function refundPayload(overrides: Partial<RefundSucceededPayload>): RefundSucceededPayload {
+  return {
+    refundId: 'r0',
+    chargeId: 'ch0',
+    intentId: 'intent_0',
+    userId: 'user-1',
+    status: 'SUCCEEDED',
+    amount: 0,
+    currency: 'KRW',
+    occurredAt: '2026-08-09T00:00:00.000Z',
+    ...overrides,
+  };
+}
 
 /**
  * 결제관리에서 건 환불 이벤트가 멤버십 계약에 어떻게 반영되는지.
@@ -29,7 +48,7 @@ describe('MembershipRefundConsumer', () => {
       eligibleRefundAmount: 4990,
     });
 
-    await consumer.onRefundSucceeded({ intentId: 'intent_1', amount: 4990, refundId: 'r1' });
+    await consumer.onRefundSucceeded(refundPayload({ intentId: 'intent_1', amount: 4990, refundId: 'r1' }));
 
     expect(refundEventHandler.handleRefundCompleted).toHaveBeenCalledWith(
       expect.objectContaining({ contractId: 'c1', amount: 4990 }),
@@ -45,7 +64,7 @@ describe('MembershipRefundConsumer', () => {
       eligibleRefundAmount: null,
     });
 
-    await consumer.onRefundSucceeded({ intentId: 'intent_1', amount: 1000, refundId: 'r1' });
+    await consumer.onRefundSucceeded(refundPayload({ intentId: 'intent_1', amount: 1000, refundId: 'r1' }));
 
     // 자격 회수 판단은 voidByPaymentIntent 가 (전액인지 보고) 따로 한다.
     expect(subscriptionService.voidByPaymentIntent).toHaveBeenCalledWith('intent_1', '결제 환불', 1000);
@@ -61,7 +80,7 @@ describe('MembershipRefundConsumer', () => {
       eligibleRefundAmount: 4990,
     });
 
-    await consumer.onRefundSucceeded({ intentId: 'intent_1', amount: 4990 });
+    await consumer.onRefundSucceeded(refundPayload({ intentId: 'intent_1', amount: 4990 }));
 
     expect(refundEventHandler.handleRefundCompleted).not.toHaveBeenCalled();
   });

--- a/apps/membership/src/consumers/billing-result.consumer.ts
+++ b/apps/membership/src/consumers/billing-result.consumer.ts
@@ -1,7 +1,9 @@
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { OnEvent, EventPayload } from '@app/events';
+import { EventPayload, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
 import { BillingOutcomeHandler } from '../services/billing/billing-outcome.handler';
+import { PAYMENT_STREAM } from '@packages/event-contracts/streams/payment.stream';
+import { EventPayloadOf } from '@packages/event-contracts/types';
 
 interface IntentEventPayload {
   intentId: string;
@@ -19,8 +21,10 @@ export class BillingResultConsumer {
 
   constructor(private readonly billingOutcomeHandler: BillingOutcomeHandler) {}
 
-  @OnEvent('payments.events.v1', 'payment.intent.authorized')
-  async onIntentAuthorized(@EventPayload() payload: IntentEventPayload) {
+  @On(PAYMENT_STREAM, 'payment.intent.authorized')
+  async onIntentAuthorized(
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'payment.intent.authorized'>,
+  ) {
     if (payload.subscriberType !== 'MEMBERSHIP' || !payload.subscriberRef) return;
 
     const contractId = payload.subscriberRef;
@@ -29,8 +33,8 @@ export class BillingResultConsumer {
     await this.billingOutcomeHandler.handleSuccess(contractId, payload.payableAmount ?? null, payload.intentId);
   }
 
-  @OnEvent('payments.events.v1', 'payment.intent.failed')
-  async onIntentFailed(@EventPayload() payload: IntentEventPayload) {
+  @On(PAYMENT_STREAM, 'payment.intent.failed')
+  async onIntentFailed(@EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'payment.intent.failed'>) {
     if (payload.subscriberType !== 'MEMBERSHIP' || !payload.subscriberRef) return;
 
     const contractId = payload.subscriberRef;
@@ -47,8 +51,8 @@ export class BillingResultConsumer {
   // CMS 정산대기 intent 가 취소되면 wallet 은 canceled 만 발행한다. 이를 처리하지 않으면 billingInProgress
   // 선점이 풀리지 않아 계약이 이후 청구/만료에서 영구 제외된다(Finding 2). 성공/실패와 동일하게 subscriberRef 로
   // 계약을 라우팅한다 — wallet 취소/만료 경로가 intent.metadata 의 subscriberRef/Type 을 payload 에 실어준다.
-  @OnEvent('payments.events.v1', 'payment.intent.canceled')
-  async onIntentCanceled(@EventPayload() payload: IntentEventPayload) {
+  @On(PAYMENT_STREAM, 'payment.intent.canceled')
+  async onIntentCanceled(@EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'payment.intent.canceled'>) {
     if (payload.subscriberType !== 'MEMBERSHIP' || !payload.subscriberRef) return;
 
     const contractId = payload.subscriberRef;

--- a/apps/membership/src/consumers/invoice-result.consumer.ts
+++ b/apps/membership/src/consumers/invoice-result.consumer.ts
@@ -1,14 +1,9 @@
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { OnEvent, EventPayload } from '@app/events';
+import { EventPayload, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import {
-  InvoicePaidPayload,
-  InvoicePaymentFailedPayload,
-  InvoiceUncollectiblePayload,
-  InvoiceVoidedPayload,
-  MandateRejectedPayload,
-} from '@packages/event-contracts/streams/payment.stream';
 import { InvoiceOutcomeHandler } from '../services/billing/invoice-outcome.handler';
+import { PAYMENT_STREAM } from '@packages/event-contracts/streams/payment.stream';
+import { EventPayloadOf } from '@packages/event-contracts/types';
 
 /**
  * ADR-0027 §4-2. wallet 인보이스 결과 이벤트 컨슈머 — 인보이스 경로(billing_path=INVOICE)의
@@ -41,8 +36,8 @@ export class InvoiceResultConsumer {
     return true;
   }
 
-  @OnEvent('payments.events.v1', 'invoice.paid')
-  async onInvoicePaid(@EventPayload() payload: InvoicePaidPayload) {
+  @On(PAYMENT_STREAM, 'invoice.paid')
+  async onInvoicePaid(@EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'invoice.paid'>) {
     if (!this.isForMembership('invoice.paid', payload)) return;
     if (!payload.periodEnd) {
       this.logger.warn(`[InvoiceResult] invoice.paid 드롭: periodEnd 누락 (ref=${payload.subscriberRef})`);
@@ -61,8 +56,10 @@ export class InvoiceResultConsumer {
     );
   }
 
-  @OnEvent('payments.events.v1', 'invoice.payment_failed')
-  async onInvoicePaymentFailed(@EventPayload() payload: InvoicePaymentFailedPayload) {
+  @On(PAYMENT_STREAM, 'invoice.payment_failed')
+  async onInvoicePaymentFailed(
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'invoice.payment_failed'>,
+  ) {
     if (!this.isForMembership('invoice.payment_failed', payload)) return;
 
     this.logger.log(
@@ -78,8 +75,10 @@ export class InvoiceResultConsumer {
     );
   }
 
-  @OnEvent('payments.events.v1', 'invoice.uncollectible')
-  async onInvoiceUncollectible(@EventPayload() payload: InvoiceUncollectiblePayload) {
+  @On(PAYMENT_STREAM, 'invoice.uncollectible')
+  async onInvoiceUncollectible(
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'invoice.uncollectible'>,
+  ) {
     if (!this.isForMembership('invoice.uncollectible', payload)) return;
 
     this.logger.warn(
@@ -92,8 +91,8 @@ export class InvoiceResultConsumer {
     );
   }
 
-  @OnEvent('payments.events.v1', 'invoice.voided')
-  async onInvoiceVoided(@EventPayload() payload: InvoiceVoidedPayload) {
+  @On(PAYMENT_STREAM, 'invoice.voided')
+  async onInvoiceVoided(@EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'invoice.voided'>) {
     if (!this.isForMembership('invoice.voided', payload)) return;
 
     this.logger.warn(
@@ -102,8 +101,8 @@ export class InvoiceResultConsumer {
     await this.invoiceOutcomeHandler.handleVoided(payload.subscriberRef, payload.invoiceId, payload.reason ?? null);
   }
 
-  @OnEvent('payments.events.v1', 'mandate.rejected')
-  async onMandateRejected(@EventPayload() payload: MandateRejectedPayload) {
+  @On(PAYMENT_STREAM, 'mandate.rejected')
+  async onMandateRejected(@EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'mandate.rejected'>) {
     if (!this.isForMembership('mandate.rejected', payload)) return;
 
     this.logger.warn(

--- a/apps/membership/src/consumers/membership-checkout.consumer.ts
+++ b/apps/membership/src/consumers/membership-checkout.consumer.ts
@@ -1,8 +1,10 @@
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { OnEvent, EventPayload } from '@app/events';
+import { EventPayload, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
 import { SubscriptionService } from '../services/subscription.service';
 import { ActiveSubscriptionExistsException } from '../shared/exceptions/subscription.exceptions';
+import { PAYMENT_STREAM } from '@packages/event-contracts/streams/payment.stream';
+import { EventPayloadOf } from '@packages/event-contracts/types';
 
 interface CapturedEventPayload {
   intentId: string;
@@ -25,8 +27,8 @@ export class MembershipCheckoutConsumer {
 
   constructor(private readonly subscriptionService: SubscriptionService) {}
 
-  @OnEvent('payments.events.v1', 'payment.intent.captured')
-  async onIntentCaptured(@EventPayload() payload: CapturedEventPayload) {
+  @On(PAYMENT_STREAM, 'payment.intent.captured')
+  async onIntentCaptured(@EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'payment.intent.captured'>) {
     if (payload.metadata?.type !== 'MEMBERSHIP_FEE') return;
 
     this.logger.log(`[MembershipCheckout] CAPTURED 멤버십 결제 감지: intentId=${payload.intentId}`);

--- a/apps/membership/src/consumers/membership-refund.consumer.ts
+++ b/apps/membership/src/consumers/membership-refund.consumer.ts
@@ -1,9 +1,11 @@
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { OnEvent, EventPayload } from '@app/events';
+import { EventPayload, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
 import { SubscriptionService } from '../services/subscription.service';
 import { SubscriptionContractReader } from '../services/subscription/subscription-contract.reader';
 import { RefundEventHandler } from '../services/refund-event-handler.service';
+import { PAYMENT_STREAM } from '@packages/event-contracts/streams/payment.stream';
+import { EventPayloadOf } from '@packages/event-contracts/types';
 
 interface RefundEventPayload {
   intentId?: string;
@@ -31,8 +33,8 @@ export class MembershipRefundConsumer {
     private readonly refundEventHandler: RefundEventHandler,
   ) {}
 
-  @OnEvent('payments.events.v1', 'gateway.refund.succeeded')
-  async onRefundSucceeded(@EventPayload() payload: RefundEventPayload) {
+  @On(PAYMENT_STREAM, 'gateway.refund.succeeded')
+  async onRefundSucceeded(@EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'gateway.refund.succeeded'>) {
     if (!payload.intentId) return;
 
     this.logger.log(`[MembershipRefund] 환불 성공 감지: intentId=${payload.intentId}`);

--- a/apps/notification/src/dispatcher/handlers/order-event.consumer.ts
+++ b/apps/notification/src/dispatcher/handlers/order-event.consumer.ts
@@ -1,14 +1,14 @@
 // apps/notification/src/dispatcher/handlers/order-event.consumer.ts
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { OnEvent, EventPayload, EventEnvelope } from '@app/events';
+import { EventPayload, EventEnvelope, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import { OrderCreatedPayload, OrderPaymentCompletedPayload } from '@packages/event-contracts/streams/orders.stream';
-import { DomainEvent } from '@packages/event-contracts/types';
 import { NotificationDispatcherService } from '../services/notification-dispatcher.service';
 import { EventMappingService } from '../../shared/services/event-mapping.service';
 import { NotificationCategory } from '../../shared/enums';
 import { SendNotificationDto } from '../dto/send-notification.dto';
-import { formatAmount, formatOrderTotal } from '../../shared/utils/template-helpers';
+import { formatOrderTotal } from '../../shared/utils/template-helpers';
+import { ORDER_STREAM } from '@packages/event-contracts/streams/orders.stream';
+import { EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 
 /**
  * Order Service 이벤트 컨슈머
@@ -27,10 +27,10 @@ export class OrderEventConsumer {
     private readonly eventMappingService: EventMappingService,
   ) {}
 
-  @OnEvent('orders.events.v1', 'OrderCreated')
+  @On(ORDER_STREAM, 'OrderCreated')
   async onOrderCreated(
-    @EventEnvelope() envelope: DomainEvent<OrderCreatedPayload>,
-    @EventPayload() payload: OrderCreatedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof ORDER_STREAM, 'OrderCreated'>,
+    @EventPayload() payload: EventPayloadOf<typeof ORDER_STREAM, 'OrderCreated'>,
   ) {
     this.logger.log(`[Event] Received OrderCreated: ${payload.orderId} (correlationId: ${envelope.correlationId})`);
     try {
@@ -72,10 +72,10 @@ export class OrderEventConsumer {
     }
   }
 
-  @OnEvent('orders.events.v1', 'OrderPaymentCompleted')
+  @On(ORDER_STREAM, 'OrderPaymentCompleted')
   async onPaymentCompleted(
-    @EventEnvelope() envelope: DomainEvent<OrderPaymentCompletedPayload>,
-    @EventPayload() payload: OrderPaymentCompletedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof ORDER_STREAM, 'OrderPaymentCompleted'>,
+    @EventPayload() payload: EventPayloadOf<typeof ORDER_STREAM, 'OrderPaymentCompleted'>,
   ) {
     this.logger.log(
       `[Event] Received OrderPaymentCompleted: ${payload.orderId} (correlationId: ${envelope.correlationId})`,

--- a/apps/notification/src/dispatcher/handlers/user-event.consumer.ts
+++ b/apps/notification/src/dispatcher/handlers/user-event.consumer.ts
@@ -1,17 +1,13 @@
 // apps/notification/src/dispatcher/handlers/user-event.consumer.ts
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { OnEvent, EventPayload, EventEnvelope } from '@app/events';
+import { EventPayload, EventEnvelope, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import {
-  UserVerificationPayload,
-  UserVerificationCodePayload,
-  UserPasswordChangedPayload,
-} from '@packages/event-contracts/streams/user.stream';
-import { DomainEvent } from '@packages/event-contracts/types';
 import { NotificationDispatcherService } from '../services/notification-dispatcher.service';
 import { EventMappingService } from '../../shared/services/event-mapping.service';
 import { NotificationCategory } from '../../shared/enums';
 import { SendNotificationDto } from '../dto/send-notification.dto';
+import { USER_STREAM } from '@packages/event-contracts/streams/user.stream';
+import { EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 
 /**
  * User Service 이벤트 컨슈머
@@ -29,10 +25,10 @@ export class UserEventConsumer {
     private readonly eventMappingService: EventMappingService,
   ) {}
 
-  @OnEvent('users.events.v1', 'UserVerification')
+  @On(USER_STREAM, 'UserVerification')
   async onUserVerification(
-    @EventEnvelope() envelope: DomainEvent<UserVerificationPayload>,
-    @EventPayload() payload: UserVerificationPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof USER_STREAM, 'UserVerification'>,
+    @EventPayload() payload: EventPayloadOf<typeof USER_STREAM, 'UserVerification'>,
   ) {
     this.logger.log(`[Event] Received UserVerification: ${payload.userId} (correlationId: ${envelope.correlationId})`);
     try {
@@ -67,10 +63,10 @@ export class UserEventConsumer {
     }
   }
 
-  @OnEvent('users.events.v1', 'UserVerificationCode')
+  @On(USER_STREAM, 'UserVerificationCode')
   async onUserVerificationCode(
-    @EventEnvelope() envelope: DomainEvent<UserVerificationCodePayload>,
-    @EventPayload() payload: UserVerificationCodePayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof USER_STREAM, 'UserVerificationCode'>,
+    @EventPayload() payload: EventPayloadOf<typeof USER_STREAM, 'UserVerificationCode'>,
   ) {
     this.logger.log(
       `[Event] Received UserVerificationCode: ${payload.userId} (correlationId: ${envelope.correlationId})`,
@@ -104,10 +100,10 @@ export class UserEventConsumer {
     }
   }
 
-  @OnEvent('users.events.v1', 'UserPasswordChanged')
+  @On(USER_STREAM, 'UserPasswordChanged')
   async onUserPasswordChanged(
-    @EventEnvelope() envelope: DomainEvent<UserPasswordChangedPayload>,
-    @EventPayload() payload: UserPasswordChangedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof USER_STREAM, 'UserPasswordChanged'>,
+    @EventPayload() payload: EventPayloadOf<typeof USER_STREAM, 'UserPasswordChanged'>,
   ) {
     this.logger.log(
       `[Event] Received UserPasswordChanged: ${payload.userId} (correlationId: ${envelope.correlationId})`,
@@ -140,6 +136,4 @@ export class UserEventConsumer {
       throw error;
     }
   }
-
-
 }

--- a/apps/notification/src/dispatcher/handlers/wallet-event.consumer.ts
+++ b/apps/notification/src/dispatcher/handlers/wallet-event.consumer.ts
@@ -1,31 +1,14 @@
 // apps/notification/src/dispatcher/handlers/wallet-event.consumer.ts
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { OnEvent, EventPayload, EventEnvelope } from '@app/events';
+import { EventPayload, EventEnvelope, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import {
-  PaymentAuthorizedPayload,
-  PaymentCapturedPayload,
-  PaymentFailedPayload,
-  PaymentCancelledPayload,
-  PaymentRefundRequestPayload,
-  PaymentRefundCompletedPayload,
-  RefundApprovedPayload,
-  RefundRejectedPayload,
-  RefundFailedPayload,
-  PointsEarnedPayload,
-  PointsRedeemedPayload,
-  PointsCancelledPayload,
-  PointsExpiredPayload,
-  TaxInvoiceIssuedPayload,
-  TaxInvoiceFailedPayload,
-  TaxInvoiceCancelledPayload,
-} from '@packages/event-contracts/streams';
-import { DomainEvent } from '@packages/event-contracts/types';
 import { NotificationDispatcherService } from '../services/notification-dispatcher.service';
 import { EventMappingService } from '../../shared/services/event-mapping.service';
 import { NotificationCategory } from '../../shared/enums';
 import { SendNotificationDto } from '../dto/send-notification.dto';
 import { formatAmount, formatDueDate } from '../../shared/utils/template-helpers';
+import { PAYMENT_STREAM } from '@packages/event-contracts/streams/payment.stream';
+import { EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 
 /**
  * Payment Service 이벤트 컨슈머
@@ -74,10 +57,10 @@ export class WalletEventConsumer {
 
   // ===== Payment 이벤트 =====
 
-  @OnEvent('payments.events.v1', 'PaymentAuthorized')
+  @On(PAYMENT_STREAM, 'PaymentAuthorized')
   async onPaymentAuthorized(
-    @EventEnvelope() envelope: DomainEvent<PaymentAuthorizedPayload>,
-    @EventPayload() payload: PaymentAuthorizedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'PaymentAuthorized'>,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'PaymentAuthorized'>,
   ) {
     this.logger.log(
       `[Event] Received PaymentAuthorized: ${payload.intentId} (correlationId: ${envelope.correlationId})`,
@@ -115,10 +98,10 @@ export class WalletEventConsumer {
     }
   }
 
-  @OnEvent('payments.events.v1', 'PaymentCaptured')
+  @On(PAYMENT_STREAM, 'PaymentCaptured')
   async onPaymentCaptured(
-    @EventEnvelope() envelope: DomainEvent<PaymentCapturedPayload>,
-    @EventPayload() payload: PaymentCapturedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'PaymentCaptured'>,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'PaymentCaptured'>,
   ) {
     this.logger.log(
       `[Event] Received PaymentCaptured: ${payload.paymentId} (correlationId: ${envelope.correlationId})`,
@@ -154,10 +137,10 @@ export class WalletEventConsumer {
     }
   }
 
-  @OnEvent('payments.events.v1', 'PaymentFailed')
+  @On(PAYMENT_STREAM, 'PaymentFailed')
   async onPaymentFailed(
-    @EventEnvelope() envelope: DomainEvent<PaymentFailedPayload>,
-    @EventPayload() payload: PaymentFailedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'PaymentFailed'>,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'PaymentFailed'>,
   ) {
     this.logger.log(`[Event] Received PaymentFailed: ${payload.intentId} (correlationId: ${envelope.correlationId})`);
     try {
@@ -194,10 +177,10 @@ export class WalletEventConsumer {
     }
   }
 
-  @OnEvent('payments.events.v1', 'PaymentCancelled')
+  @On(PAYMENT_STREAM, 'PaymentCancelled')
   async onPaymentCancelled(
-    @EventEnvelope() envelope: DomainEvent<PaymentCancelledPayload>,
-    @EventPayload() payload: PaymentCancelledPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'PaymentCancelled'>,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'PaymentCancelled'>,
   ) {
     this.logger.log(
       `[Event] Received PaymentCancelled: ${payload.intentId} (correlationId: ${envelope.correlationId})`,
@@ -237,10 +220,10 @@ export class WalletEventConsumer {
 
   // ===== Refund 이벤트 =====
 
-  @OnEvent('payments.events.v1', 'PaymentRefundRequest')
+  @On(PAYMENT_STREAM, 'PaymentRefundRequest')
   async onPaymentRefundRequest(
-    @EventEnvelope() envelope: DomainEvent<PaymentRefundRequestPayload>,
-    @EventPayload() payload: PaymentRefundRequestPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'PaymentRefundRequest'>,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'PaymentRefundRequest'>,
   ) {
     this.logger.log(
       `[Event] Received PaymentRefundRequest: ${payload.refundId} (correlationId: ${envelope.correlationId})`,
@@ -276,10 +259,10 @@ export class WalletEventConsumer {
     }
   }
 
-  @OnEvent('payments.events.v1', 'PaymentRefundCompleted')
+  @On(PAYMENT_STREAM, 'PaymentRefundCompleted')
   async onPaymentRefundCompleted(
-    @EventEnvelope() envelope: DomainEvent<PaymentRefundCompletedPayload>,
-    @EventPayload() payload: PaymentRefundCompletedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'PaymentRefundCompleted'>,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'PaymentRefundCompleted'>,
   ) {
     this.logger.log(
       `[Event] Received PaymentRefundCompleted: ${payload.refundId} (correlationId: ${envelope.correlationId})`,
@@ -319,10 +302,10 @@ export class WalletEventConsumer {
     }
   }
 
-  @OnEvent('payments.events.v1', 'RefundApproved')
+  @On(PAYMENT_STREAM, 'RefundApproved')
   async onRefundApproved(
-    @EventEnvelope() envelope: DomainEvent<RefundApprovedPayload>,
-    @EventPayload() payload: RefundApprovedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'RefundApproved'>,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'RefundApproved'>,
   ) {
     this.logger.log(`[Event] Received RefundApproved: ${payload.refundId} (correlationId: ${envelope.correlationId})`);
     try {
@@ -358,10 +341,10 @@ export class WalletEventConsumer {
     }
   }
 
-  @OnEvent('payments.events.v1', 'RefundRejected')
+  @On(PAYMENT_STREAM, 'RefundRejected')
   async onRefundRejected(
-    @EventEnvelope() envelope: DomainEvent<RefundRejectedPayload>,
-    @EventPayload() payload: RefundRejectedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'RefundRejected'>,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'RefundRejected'>,
   ) {
     this.logger.log(`[Event] Received RefundRejected: ${payload.refundId} (correlationId: ${envelope.correlationId})`);
     try {
@@ -398,10 +381,10 @@ export class WalletEventConsumer {
     }
   }
 
-  @OnEvent('payments.events.v1', 'RefundFailed')
+  @On(PAYMENT_STREAM, 'RefundFailed')
   async onRefundFailed(
-    @EventEnvelope() envelope: DomainEvent<RefundFailedPayload>,
-    @EventPayload() payload: RefundFailedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'RefundFailed'>,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'RefundFailed'>,
   ) {
     this.logger.log(`[Event] Received RefundFailed: ${payload.refundId} (correlationId: ${envelope.correlationId})`);
     try {
@@ -441,10 +424,10 @@ export class WalletEventConsumer {
 
   // ===== Point 이벤트 =====
 
-  @OnEvent('payments.events.v1', 'PointsEarned')
+  @On(PAYMENT_STREAM, 'PointsEarned')
   async onPointsEarned(
-    @EventEnvelope() envelope: DomainEvent<PointsEarnedPayload>,
-    @EventPayload() payload: PointsEarnedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'PointsEarned'>,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'PointsEarned'>,
   ) {
     this.logger.log(`[Event] Received PointsEarned: ${payload.pointId} (correlationId: ${envelope.correlationId})`);
     try {
@@ -478,10 +461,10 @@ export class WalletEventConsumer {
     }
   }
 
-  @OnEvent('payments.events.v1', 'PointsRedeemed')
+  @On(PAYMENT_STREAM, 'PointsRedeemed')
   async onPointsRedeemed(
-    @EventEnvelope() envelope: DomainEvent<PointsRedeemedPayload>,
-    @EventPayload() payload: PointsRedeemedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'PointsRedeemed'>,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'PointsRedeemed'>,
   ) {
     this.logger.log(`[Event] Received PointsRedeemed: ${payload.pointId} (correlationId: ${envelope.correlationId})`);
     try {
@@ -515,10 +498,10 @@ export class WalletEventConsumer {
     }
   }
 
-  @OnEvent('payments.events.v1', 'PointsCancelled')
+  @On(PAYMENT_STREAM, 'PointsCancelled')
   async onPointsCancelled(
-    @EventEnvelope() envelope: DomainEvent<PointsCancelledPayload>,
-    @EventPayload() payload: PointsCancelledPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'PointsCancelled'>,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'PointsCancelled'>,
   ) {
     this.logger.log(`[Event] Received PointsCancelled: ${payload.pointId} (correlationId: ${envelope.correlationId})`);
     try {
@@ -552,10 +535,10 @@ export class WalletEventConsumer {
     }
   }
 
-  @OnEvent('payments.events.v1', 'PointsExpired')
+  @On(PAYMENT_STREAM, 'PointsExpired')
   async onPointsExpired(
-    @EventEnvelope() envelope: DomainEvent<PointsExpiredPayload>,
-    @EventPayload() payload: PointsExpiredPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'PointsExpired'>,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'PointsExpired'>,
   ) {
     this.logger.log(`[Event] Received PointsExpired: ${payload.pointId} (correlationId: ${envelope.correlationId})`);
     try {
@@ -591,10 +574,10 @@ export class WalletEventConsumer {
 
   // ===== Tax Invoice 이벤트 =====
 
-  @OnEvent('payments.events.v1', 'TaxInvoiceIssued')
+  @On(PAYMENT_STREAM, 'TaxInvoiceIssued')
   async onTaxInvoiceIssued(
-    @EventEnvelope() envelope: DomainEvent<TaxInvoiceIssuedPayload>,
-    @EventPayload() payload: TaxInvoiceIssuedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'TaxInvoiceIssued'>,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'TaxInvoiceIssued'>,
   ) {
     this.logger.log(
       `[Event] Received TaxInvoiceIssued: ${payload.invoiceId} (correlationId: ${envelope.correlationId})`,
@@ -633,10 +616,10 @@ export class WalletEventConsumer {
     }
   }
 
-  @OnEvent('payments.events.v1', 'TaxInvoiceFailed')
+  @On(PAYMENT_STREAM, 'TaxInvoiceFailed')
   async onTaxInvoiceFailed(
-    @EventEnvelope() envelope: DomainEvent<TaxInvoiceFailedPayload>,
-    @EventPayload() payload: TaxInvoiceFailedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'TaxInvoiceFailed'>,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'TaxInvoiceFailed'>,
   ) {
     this.logger.log(
       `[Event] Received TaxInvoiceFailed: ${payload.invoiceId} (correlationId: ${envelope.correlationId})`,
@@ -673,10 +656,10 @@ export class WalletEventConsumer {
     }
   }
 
-  @OnEvent('payments.events.v1', 'TaxInvoiceCancelled')
+  @On(PAYMENT_STREAM, 'TaxInvoiceCancelled')
   async onTaxInvoiceCancelled(
-    @EventEnvelope() envelope: DomainEvent<TaxInvoiceCancelledPayload>,
-    @EventPayload() payload: TaxInvoiceCancelledPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'TaxInvoiceCancelled'>,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'TaxInvoiceCancelled'>,
   ) {
     this.logger.log(
       `[Event] Received TaxInvoiceCancelled: ${payload.invoiceId} (correlationId: ${envelope.correlationId})`,
@@ -720,10 +703,10 @@ export class WalletEventConsumer {
    * 수신자(email)와 계좌 정보는 반드시 이벤트 payload 로 와야 한다 —
    * notification 에는 wallet intent 조회 경로가 없다.
    */
-  @OnEvent('payments.events.v1', 'payment.intent.awaiting_deposit')
+  @On(PAYMENT_STREAM, 'payment.intent.awaiting_deposit')
   async onIntentAwaitingDeposit(
-    @EventEnvelope() envelope: DomainEvent<Record<string, any>>,
-    @EventPayload() payload: Record<string, any>,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PAYMENT_STREAM, 'payment.intent.awaiting_deposit'>,
+    @EventPayload() payload: EventPayloadOf<typeof PAYMENT_STREAM, 'payment.intent.awaiting_deposit'>,
   ) {
     this.logger.log(
       `[Event] Received IntentAwaitingDeposit: ${payload.intentId} (correlationId: ${envelope.correlationId})`,

--- a/apps/search/src/product-events.consumer.ts
+++ b/apps/search/src/product-events.consumer.ts
@@ -1,15 +1,15 @@
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { EventEnvelope, EventPayload, OnEvent } from '@app/events';
+import { EventEnvelope, EventPayload, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
 import {
   ProductMasterActiveVersionChangedPayload,
-  ProductMasterDeletedPayload,
   ProductSnapshot,
+  PRODUCT_STREAM,
 } from '@packages/event-contracts/streams/product.stream';
-import { DomainEvent } from '@packages/event-contracts/types';
 import { ProductIndexService } from './product-index.service';
 import { SearchProductDocument } from './types/product-document.type';
 import { compactText } from './utils/text.utils';
+import { EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 
 @Controller()
 @UseInterceptors(EventTypeGuard)
@@ -18,11 +18,11 @@ export class ProductEventsConsumer {
 
   constructor(private readonly productIndexService: ProductIndexService) {}
 
-  @OnEvent('products.events.v1', 'ProductMasterActiveVersionChanged')
+  @On(PRODUCT_STREAM, 'ProductMasterActiveVersionChanged')
   async onProductMasterActiveVersionChanged(
     @EventEnvelope()
-    envelope: DomainEvent<ProductMasterActiveVersionChangedPayload>,
-    @EventPayload() payload: ProductMasterActiveVersionChangedPayload,
+    envelope: EnvelopeOf<typeof PRODUCT_STREAM, 'ProductMasterActiveVersionChanged'>,
+    @EventPayload() payload: EventPayloadOf<typeof PRODUCT_STREAM, 'ProductMasterActiveVersionChanged'>,
   ): Promise<void> {
     this.logger.log(`ProductMasterActiveVersionChanged received: ${payload.masterId} (${payload.changeReason})`);
 
@@ -48,10 +48,10 @@ export class ProductEventsConsumer {
     }
   }
 
-  @OnEvent('products.events.v1', 'ProductMasterDeleted')
+  @On(PRODUCT_STREAM, 'ProductMasterDeleted')
   async onProductMasterDeleted(
-    @EventEnvelope() envelope: DomainEvent<ProductMasterDeletedPayload>,
-    @EventPayload() payload: ProductMasterDeletedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof PRODUCT_STREAM, 'ProductMasterDeleted'>,
+    @EventPayload() payload: EventPayloadOf<typeof PRODUCT_STREAM, 'ProductMasterDeleted'>,
   ): Promise<void> {
     this.logger.log(`ProductMasterDeleted received: ${payload.masterId}`);
     try {

--- a/apps/search/src/review-events.consumer.ts
+++ b/apps/search/src/review-events.consumer.ts
@@ -1,8 +1,8 @@
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { EventEnvelope, EventPayload, OnEvent } from '@app/events';
+import { EventEnvelope, EventPayload, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import { ProductReviewStatsChangedPayload } from '@packages/event-contracts/streams/ugc.stream';
-import { DomainEvent } from '@packages/event-contracts/types';
+import { UGC_EVENT_STREAM } from '@packages/event-contracts/streams/ugc.stream';
+import { EnvelopeOf, EventPayloadOf } from '@packages/event-contracts/types';
 import { ProductIndexService } from './product-index.service';
 
 @Controller()
@@ -12,10 +12,10 @@ export class ReviewEventsConsumer {
 
   constructor(private readonly productIndexService: ProductIndexService) {}
 
-  @OnEvent('ugc.events.v1', 'ProductReviewStatsChanged')
+  @On(UGC_EVENT_STREAM, 'ProductReviewStatsChanged')
   async onProductReviewStatsChanged(
-    @EventEnvelope() envelope: DomainEvent<ProductReviewStatsChangedPayload>,
-    @EventPayload() payload: ProductReviewStatsChangedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof UGC_EVENT_STREAM, 'ProductReviewStatsChanged'>,
+    @EventPayload() payload: EventPayloadOf<typeof UGC_EVENT_STREAM, 'ProductReviewStatsChanged'>,
   ): Promise<void> {
     this.logger.log(
       `ProductReviewStatsChanged: productId=${payload.productId} reviewCount=${payload.reviewCount} bayesianScore=${payload.bayesianReviewScore} (${envelope.messageId})`,

--- a/apps/wallet/src/consumers/billing-charge.consumer.ts
+++ b/apps/wallet/src/consumers/billing-charge.consumer.ts
@@ -1,8 +1,7 @@
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { OnEvent, EventPayload, EventEnvelope } from '@app/events';
+import { EventPayload, EventEnvelope, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import { BillingChargePayload } from '@packages/event-contracts/streams/wallet-command.stream';
-import { DomainEvent } from '@packages/event-contracts/types';
+import { BillingChargePayload, WALLET_COMMAND_STREAM } from '@packages/event-contracts/streams/wallet-command.stream';
 import { DbService } from '@app/db';
 import { randomBytes, randomUUID } from 'node:crypto';
 import { and, eq, sql } from 'drizzle-orm';
@@ -20,6 +19,7 @@ import {
 } from '../messaging/gateway-event.builder';
 import { buildOutboxInsertValues } from '../messaging/outbox-event.util';
 import { PaymentProvider, ChargeResult } from '../providers/payment-provider.interface';
+import { EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 
 const DEFAULT_INTENT_EXPIRY_MINUTES = 60 * 24; // 24 hours
 
@@ -38,10 +38,10 @@ export class BillingChargeConsumer {
     private readonly stateTransitionService: StateTransitionService,
   ) {}
 
-  @OnEvent('wallet.commands.v1', 'BillingCharge')
+  @On(WALLET_COMMAND_STREAM, 'BillingCharge')
   async onBillingCharge(
-    @EventEnvelope() envelope: DomainEvent<BillingChargePayload>,
-    @EventPayload() payload: BillingChargePayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof WALLET_COMMAND_STREAM, 'BillingCharge'>,
+    @EventPayload() payload: EventPayloadOf<typeof WALLET_COMMAND_STREAM, 'BillingCharge'>,
   ) {
     const correlationId = envelope.correlationId ?? `billing-charge:${payload.idempotencyKey}`;
 

--- a/apps/wallet/src/consumers/ugc-command.consumer.ts
+++ b/apps/wallet/src/consumers/ugc-command.consumer.ts
@@ -1,9 +1,9 @@
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { OnEvent, EventPayload, EventEnvelope } from '@app/events';
+import { EventPayload, EventEnvelope, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import { EarnPointsRequestedPayload } from '@packages/event-contracts/streams/ugc.stream';
-import { DomainEvent } from '@packages/event-contracts/types';
 import { PointsAdminService } from '../admin/points-admin.service';
+import { UGC_COMMAND_STREAM } from '@packages/event-contracts/streams/ugc.stream';
+import { EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 
 @Controller()
 @UseInterceptors(EventTypeGuard)
@@ -12,10 +12,10 @@ export class UgcCommandConsumer {
 
   constructor(private readonly pointsAdminService: PointsAdminService) {}
 
-  @OnEvent('ugc.commands.v1', 'EarnPointsRequested')
+  @On(UGC_COMMAND_STREAM, 'EarnPointsRequested')
   async onEarnPointsRequested(
-    @EventEnvelope() envelope: DomainEvent<EarnPointsRequestedPayload>,
-    @EventPayload() payload: EarnPointsRequestedPayload,
+    @EventEnvelope() envelope: EnvelopeOf<typeof UGC_COMMAND_STREAM, 'EarnPointsRequested'>,
+    @EventPayload() payload: EventPayloadOf<typeof UGC_COMMAND_STREAM, 'EarnPointsRequested'>,
   ) {
     this.logger.log(
       `[Event] Received EarnPointsRequested: reviewId=${payload.reviewId}, userId=${payload.userId}, amount=${payload.amount} (correlationId: ${envelope.correlationId})`,

--- a/apps/wallet/src/invoices/invoice-command.consumer.ts
+++ b/apps/wallet/src/invoices/invoice-command.consumer.ts
@@ -1,7 +1,7 @@
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
-import { OnEvent, EventPayload } from '@app/events';
+import { EventPayload, On } from '@app/events';
 import { EventTypeGuard } from '@app/events/guards/event-type.guard';
-import { CreateInvoicePayload, VoidInvoicePayload } from '@packages/event-contracts/streams/wallet-command.stream';
+import { CreateInvoicePayload, WALLET_COMMAND_STREAM } from '@packages/event-contracts/streams/wallet-command.stream';
 import { DbService } from '@app/db';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import { randomUUID } from 'node:crypto';
@@ -11,6 +11,7 @@ import { BillingMethodService } from '../billing/billing-method.service';
 import { InvoiceOutcomeService } from './invoice-outcome.service';
 import { buildOutboxInsertValues } from '../messaging/outbox-event.util';
 import { INVOICE_AGGREGATE_TYPE, InvoiceEventType, invoicePartitionKey } from './invoice-event.builder';
+import { EventPayloadOf } from '@packages/event-contracts/types';
 
 const DEFAULT_MAX_ATTEMPTS = 3;
 const DEFAULT_RETRY_INTERVAL_HOURS = 72;
@@ -31,8 +32,8 @@ export class InvoiceCommandConsumer {
     private readonly invoiceOutcomeService: InvoiceOutcomeService,
   ) {}
 
-  @OnEvent('wallet.commands.v1', 'CreateInvoice')
-  async onCreateInvoice(@EventPayload() payload: CreateInvoicePayload) {
+  @On(WALLET_COMMAND_STREAM, 'CreateInvoice')
+  async onCreateInvoice(@EventPayload() payload: EventPayloadOf<typeof WALLET_COMMAND_STREAM, 'CreateInvoice'>) {
     this.logger.log(
       `[CreateInvoice] Received: subscriberRef=${payload.subscriberRef}, period=${payload.periodStart}~${payload.periodEnd}, key=${payload.idempotencyKey}`,
     );
@@ -160,8 +161,8 @@ export class InvoiceCommandConsumer {
     );
   }
 
-  @OnEvent('wallet.commands.v1', 'VoidInvoice')
-  async onVoidInvoice(@EventPayload() payload: VoidInvoicePayload) {
+  @On(WALLET_COMMAND_STREAM, 'VoidInvoice')
+  async onVoidInvoice(@EventPayload() payload: EventPayloadOf<typeof WALLET_COMMAND_STREAM, 'VoidInvoice'>) {
     // ATTEMPTING 은 출금이 이미 나갔을 수 있어 무효화하지 않는다(CMS 환불 불가) — 정산 결과가 반영된다.
     const voided = await this.dbService.db
       .update(invoices)

--- a/docs/adr/0029-events-module-registration-surfaces.md
+++ b/docs/adr/0029-events-module-registration-surfaces.md
@@ -93,6 +93,16 @@ async onVerified(@Payload() payload: EventPayloadOf<typeof USER_STREAM, 'UserEma
 - **payload 파라미터 데코레이터는 기존 `@EventPayload()` 를 그대로 쓴다.** 위 예시의 `@Payload()` 는 채택하지 않았다 — `@nestjs/microservices` 가 이미 `Payload` 라는 이름으로 **다른 것**(파싱된 메시지 전체)을 export 하고 있고, `@app/events` 는 `export *` 로 데코레이터를 공개하므로 같은 이름이 import 경로에 따라 다른 뜻을 갖게 된다. 그건 이 ADR 이 없애려는 실패 모드를 이름 공간에서 재생산하는 것이다. 도출되는 것은 데코레이터 이름이 아니라 **타입**이므로(`EventPayloadOf<typeof S, 'K'>`) §4 의 목적은 그대로 달성된다.
 - **`EnvelopeOf<S, K>` 를 계약 패키지에 추가했다.** 소비 핸들러 87개 중 75개가 `@EventEnvelope() envelope: DomainEvent<XPayload>` 를 함께 받는다(실측). `DomainEvent<EventPayloadOf<typeof S, 'K'>>` 를 매번 손으로 조합하게 두면 이주 시 옛 손수 타입이 그대로 살아남는다.
 
+**`@On` 은 계약에 없는 이벤트를 소비할 수 없다 — 그래서 이주가 계약의 구멍을 드러낸다 (2026-08-09, Follow-up 5 후반부).**
+
+`@OnEvent('payments.events.v1', 'gateway.refund.succeeded')` 는 생문자열 두 개라 계약과 무관하게 컴파일되고 부팅된다. `@On(PAYMENT_STREAM, 'gateway.refund.succeeded')` 는 `EventKeysOf` 에 없으면 **컴파일 에러**이고, `as any` 로 빠져나가도 데코레이터 평가 시점에 던진다. 즉 이주는 "소비 중인데 계약에 없는 이벤트"를 전수로 노출시킨다.
+
+실제로 노출됐다. 이주 착수 시점에 소비 핸들러 87개 중 **5개가 계약에 없는 이벤트를 구독하고 있었다** — `payment.intent.refund_requested` · `payment.intent.refund_request_rejected` · `gateway.charge.captured` · `gateway.refund.succeeded` (channel-adapter 4 + membership 1). 넷 다 죽은 코드가 아니라 `apps/wallet/src/messaging/gateway-event.builder.ts` 가 실제로 발행하는 라이브 이벤트다. `PAYMENT_STREAM` 이 `payment.intent.*` 8종은 계약화하면서 이 4종을 빠뜨린 것이다.
+
+`deriveConsumerConfig` 는 이것을 잡지 못한다 — **토픽** 단위로만 레지스트리를 확인하기 때문이다(`consumer-discovery.ts`). 토픽은 `payments.events.v1` 로 등록돼 있으므로 통과한다. 이벤트명 단위의 구멍은 `@On` 만이 드러낸다. 이는 §3 의 "레지스트리에 없는 토픽 → 부팅 거부" 가 이벤트명 층위에서도 성립해야 함을 뜻하며, 데코레이터 이주가 그 역할을 대신한다.
+
+**해소는 계약을 채우는 쪽이다** — 소비 중인 이벤트가 계약에 없으면 틀린 것은 소비자가 아니라 계약이다(§1: 계약의 소유자는 `packages/event-contracts`). 다만 **스키마는 관대하게(전 필드 optional + passthrough) 둔다.** `PaymentIntentEventSchema` 가 이미 같은 이유로 그렇게 돼 있다: 계약 등록만으로 소비 검증이 켜지면 그 순간이 라이브 트래픽의 DLQ 폭탄이 된다. 검증을 조이는 결정은 payload 를 실제로 샘플링한 뒤 앱별 이주(Follow-up 5 / 플랜 Task 5-C)에서 내린다. 이 원칙 덕분에 **데코레이터 이주는 계약을 채우면서도 동작 중립을 유지한다.**
+
 **`@On` 이 핸들러 시그니처를 타입으로 강제하지는 않는다.** 검토했고 기각했다. 파라미터 데코레이터 순서가 앱마다 다르고(envelope-우선 45 · payload-우선 20 · payload-only 12 · envelope-only 10, 실측), 이 레포는 `strictFunctionTypes` 가 꺼져 있어 `TypedPropertyDescriptor` 제약이 반공변으로 걸리지도 않는다. 따라서 `@On(S, 'A')` 와 `@EventPayload() p: EventPayloadOf<typeof S, 'B'>` 가 어긋나는 것은 여전히 컴파일을 통과한다 — 이벤트명 **오타**는 잡히지만 이벤트명 **불일치**는 잡히지 않는다. 이를 닫으려면 "명시적으로 하지 않는 것" 의 핸들러 레코드 형태가 필요하며, 그 판단은 바뀌지 않았다.
 
 ### 5. 발행 경로를 하나의 인터페이스로 통합한다
@@ -236,6 +246,8 @@ microservice.setIsInitHookCalled(true);
    착수 당시 근거(보존): 원래 마지막에 두려던 것을 앞으로 당겼다. 발행→소비를 브로커 없이 검증할 방법이 **아예 없어서**(`libs/events/src` 소스 29 / 스펙 5, 페이크 트랜스포트 0) 어댑터가 없으면 이후 모든 단계가 자기 증거를 남기지 못하고, 여러 세션에 걸친 작업에서 다음 작업자는 앞 단계가 무엇을 보장했는지 알 수 없기 때문이다. **검증 도구를 먼저 만들고 나머지를 그 위에 얹는다** — 그 판단은 결과로 정당화됐다.
 4. ~~`startConsumer(app)` 도입 + `forConsumer` 의 `streams` deprecated. 앱 수정 없이 동작해야 한다.~~ **완료 (2026-08-09).** 소비 집합은 `@OnEvent` 데코레이터에서 도출되고, 레지스트리에 없는 토픽·핸들러 0개는 부팅을 거부한다. 도출 과정에서 §8 과 아래 10번을 발견했다.
 5. `@On` / `@InjectPublisher` 를 기존 데코레이터와 병행 도입, 앱별 이주 (7개 앱 = 7 PR). ⚠️ **§8 에 따라 이주는 동작 중립이 아니다** — 그 앱에서 스키마 검증·재시도·DLQ 가 처음으로 켜진다.
+
+   **앱별 데코레이터 이주 완료 (2026-08-09).** 7개 앱 · 소비 핸들러 **87개 전량**이 `@On` + `EventPayloadOf`/`EnvelopeOf` 로 옮겨졌고 `@OnEvent` 호출은 0건이다. `main.ts` 는 손대지 않았으므로 **이 단계는 동작 중립**이다 — §8 의 라이브 구멍은 배선 이주(플랜 Task 5-B) 전까지 그대로 남는다. 이주 중 계약의 구멍 두 종류가 드러났다(위 §4 의 "`@On` 은 계약에 없는 이벤트를 소비할 수 없다" 참조). 회귀 방지는 `scripts/events/event-handler-contract-audit.js` (`npm run audit:event-handlers`) 가 맡는다 — `@On` 의 이벤트 키와 payload/envelope 도출 키의 불일치는 타입이 끝내 잡지 못하므로, 이 게이트는 이주 종료 후에도 남긴다. **`@InjectStreamPublisher` → `@InjectPublisher` 는 아직 0건**(21곳): 발행 쪽 표면이라 Follow-up 6 에서 발행 경로를 통합할 때 함께 옮긴다.
 
    **전반부(데코레이터 도입) 완료 (2026-08-09).** `@On` · `@InjectPublisher` · `PublisherFor` · `EnvelopeOf` 가 옛 표면과 **병행**으로 존재한다. `@On` 은 `@OnEvent` 과 **바이트 단위로 같은 메타데이터**를 남기고(스펙이 메타데이터 키 집합과 값을 전수 비교한다), `@InjectPublisher` 는 `EventsModule.getPublisherToken` 과 같은 토큰을 만든다 — 토큰 형식은 `publishers/publisher-token.ts` 한 곳으로 모았다. 따라서 한 앱 안에서 두 표면을 섞어 써도 되고, 앱 이주는 파일 단위로 쪼갤 수 있다. 앱 이주(후반부)는 아직 0개다. 위 §4 의 두 가지 이행 차이도 참조.
 6. 공용 outbox 에 `idempotencyKey`·`partitionKey`·enqueue 시점 검증 추가 후 앱 자체 판본 5벌 회수. **core 의 두 벌은 import 경로만 다른 동일 파일이므로 이 작업과 무관하게 지금 하나로 합칠 수 있다.**

--- a/docs/superpowers/plans/2026-08-09-events-module-registration.md
+++ b/docs/superpowers/plans/2026-08-09-events-module-registration.md
@@ -215,38 +215,73 @@ Nest 는 수신 `value` 를 `KafkaParser.decode` 로 **JSON 파싱해서** 넘�
 
 ---
 
-## Task 5: 앱별 이주 (7 PR)
+## Task 5: 앱별 이주 — 스위치 3개로 분해한다
 
-**앱 하나 = PR 하나 = 세션 하나.** 순서는 위험도 역순 — 작은 앱부터 배워서 큰 앱으로 간다.
+**앱 하나를 이주시키면 독립적인 스위치 3개가 동시에 켜진다.** 위험 프로파일이 완전히 다르므로 한 PR 에 묶지 않는다. 묶으면 C 때문에 롤백할 때 멀쩡한 A 까지 되돌아가고, 각 PR 의 blast radius 가 불분명해진다.
 
-권장 순서와 규모 (핸들러 / 발행 / outbox):
+| 스위치 | 무엇이 바뀌나 | 위험 |
+|---|---|---|
+| **A. 데코레이터** | 없음 — Task 4 가 런타임 동등성을 실행 증거로 고정 | 0 (단, 핸들러 87개 수작업 함정) |
+| **B. 배선** (`startConsumer`) | 재시도·DLQ·chain-context 가 **처음으로** 붙는다 | 낮음 — 오히려 이득 |
+| **C. 검증 정책** (`validateOnConsume`) | 스키마 검증이 **처음으로** 켜진다 | **여기가 진짜 게이트** |
 
-- [ ] 5a. `search` (3 / — / —)
-- [ ] 5b. `wallet` (4 / — / —)
-- [ ] 5c. `core` (4 / 8 / 25)
-- [ ] 5d. `analytics` (11 / — / —)
-- [ ] 5e. `membership` (11 / 4 / 1)
-- [ ] 5f. `notification` (22 / — / 1)
-- [ ] 5g. `channel-adapter` (34 / 8 / 10) — **마지막.** 유일하게 `forConsumerModule` 을 호출하지 않는 앱이라 이주 시 처음으로 소비 측 zod 검증이 켜진다
+### 앱별로 C 가 무엇을 바꾸는가 (실측)
 
-각 앱에서:
+| 앱 | 현재 정책 | C 가 바꾸는 것 | DLQ 관측 |
+|---|---|---|---|
+| `core` (4 핸들러) | 기본 `true` | 검증 ON | ✅ Alloy 스크레이프 |
+| `analytics` (11) | 기본 `true` | 검증 ON | ❌ |
+| `search` (3) | 기본 `true` | 검증 ON | ❌ |
+| **`channel-adapter` (34)** | **정책 없음 → 기본 `true`** | 검증 ON, 외부 유래 payload | ❌ |
+| `notification` (22) | 명시 `false` | **없음 (no-op)** | ❌ |
+| `membership` (11) | 명시 `false` | **없음 (no-op)** | ❌ |
+| `wallet` (4) | 명시 `false` | **없음 (no-op)** | ❌ |
 
-- [ ] `main.ts` 를 `startConsumer(app, { groupId })` 로 교체 (streams 인자 제거)
-- [ ] `@OnEvent` → `@On`, `@InjectStreamPublisher` → `@InjectPublisher` 로 이주. payload/envelope 주석도 `EventPayloadOf` / `EnvelopeOf` 로 — **이벤트명을 사람이 맞춰야 한다** (Task 4 경고 참조)
+**⚠️ channel-adapter 함정 — 누락으로 터진다.** `forConsumerModule` 을 호출하지 않으므로 `EVENTS_CONSUMER_POLICY` 프로바이더가 없고, `consumer-interceptors.ts:59` 의 `optionalGet` 이 `undefined` 를 반환해 `DEFAULT_SCHEMA_VALIDATION_OPTIONS` 의 `validateOnConsume: true` 가 먹는다. **아무 조치 없이 이주하면 B 와 C 가 같은 PR 에서 동시에 켜진다** — 선택이 아니라 누락으로. 이주 시 `validateOnConsume: false` 를 **명시**할 것.
+
+**관측성 제약.** `dlq/dlq.metrics.ts:10` — Alloy 는 Core `/metrics` 만 스크레이프한다. **core 외 6개 앱은 DLQ 카운터가 돌아도 아무도 보지 않는다.** C 를 core 밖에서 먼저 켜는 것은 눈 감고 켜는 것이다.
+
+---
+
+### Task 5-A: 데코레이터 일괄 이주 (위험 0)
+
+- [ ] **AST 게이트 스크립트를 먼저 만든다.** `@On(S,'A')` + `@EventPayload() p: EventPayloadOf<typeof S,'B'>` 는 컴파일된다 — 파라미터 데코레이터 순서가 4가지(envelope-우선 45 · payload-우선 20 · payload-only 12 · envelope-only 10)이고 `strictFunctionTypes` 도 꺼져 있어 타입으로 막을 수 없다. 핸들러 87개를 사람 눈으로 맞추면 실수가 난다. 핸들러마다 `@On` 의 이벤트 키와 `EventPayloadOf<…, K>` 의 K 일치를 단언하고 불일치면 exit 1. **선례: `scripts/security/route-authz-audit.js`**
+- [ ] 게이트를 켠 채 7개 앱의 `@OnEvent` → `@On`, `@InjectStreamPublisher` → `@InjectPublisher`, payload/envelope 타입을 `EventPayloadOf` / `EnvelopeOf` 로 이주
+- [ ] `npm run type-check` 기준선(164) · 10개 앱 `nest build` 초록 · AST 게이트 exit 0
+- [ ] 스크립트는 이주 종료 후 버리거나 CI 게이트로 남긴다 (착수 시 결정)
+
+`main.ts` 는 건드리지 않는다. Task 4 가 두 표면 혼재를 실행으로 검증했으므로 앱 단위·파일 단위로 쪼개도 안전하다.
+
+### Task 5-B: 배선 켜기 (`startConsumer`) — 앱별
+
+- [ ] **선행 확인 1건.** 지금 핸들러가 throw 하면 실제로 어떻게 되는지(재전달 루프인지 Nest 가 삼키는지)를 Task 2 하네스로 재현해 확정한다. B 의 before/after 를 말할 수 있어야 한다
+- [ ] 각 앱: `main.ts` 를 `startConsumer(app, { groupId })` 로 교체 (streams 인자 제거)
+- [ ] **검증이 기본 ON 으로 넘어가는 앱은 이 PR 에서 `validateOnConsume: false` 를 명시**해 B 와 C 를 분리한다 (core · analytics · search · **channel-adapter**)
+- [ ] 그 앱 핸들러의 idempotency 확인 — 재시도가 처음으로 실재하게 된다
 - [ ] `nest build <app>` · `npm run type-check` 초록
-- [ ] 커밋 · 푸시 · **배포 후 다음 앱으로**
 
-**⚠️ 이주는 동작 중립이 아니다 — 7개 앱 전부에 해당 (Task 3 발견, ADR-0029 §8).**
+B 는 위험을 더하는 게 아니라 **없던 탈출구를 만드는 쪽에 가깝다.** `EventRetryInterceptor` 의 의미론은 "최종 실패 → DLQ 전송 후 에러 삼킴 → offset commit" 인데 지금은 그게 안 붙어 있어 독약 메시지에 탈출구가 없다.
 
-원래 이 경고는 5g(channel-adapter) 에만 붙어 있었다. Task 3 이 밝혀낸 바에 따르면 **7개 앱 모두** 지금 소비 측 스키마 검증·재시도·DLQ 가 적용되지 않고 있다 — `app.connectMicroservice(opts)` 가 빈 `ApplicationConfig` 를 만들기 때문이다. `startConsumer` 로 이주하는 순간 그 앱에서 이 셋이 **처음으로 켜진다.**
+### Task 5-C: 검증 켜기 — 앱별, 게이트
 
-따라서 각 앱 이주 PR 은 다음을 포함해야 한다:
+- [ ] notification · membership · wallet 은 **해당 없음** — 명시 `false` 가 정상 상태다. 5-A + 5-B 로 종결
+- [ ] 나머지 4개 앱: 인바운드 payload 가 실제로 zod 스키마를 만족하는지 **먼저** 확인 (스테이징 샘플링 또는 5-B 상태에서 로그 관찰)
+- [ ] core 를 먼저 켜고 DLQ 대시보드로 관찰한다 — **유일하게 관측 가능한 앱**
+- [ ] core 밖으로 나가기 전에 DLQ 관측 범위를 넓힐지, 로그 기반으로 갈지 결정한다
+- [ ] `validateOnConsume` 명시를 걷어내거나 `true` 로 전환
 
-- [ ] 그 앱의 `validateOnConsume` 선언 확인. `false` 를 명시한 앱(notification·membership·wallet)은 검증이 계속 꺼진 채 이주하므로 위험이 낮다. 명시하지 않은 앱(core·analytics·search = 기본값 `true`)과 `forConsumerModule` 자체가 없는 앱(channel-adapter)은 **이주가 곧 검증 활성화**다.
-- [ ] 검증이 새로 켜지는 앱은 인바운드 payload 가 실제로 zod 스키마를 만족하는지 먼저 확인한다. 확인 없이 이주하면 **이주 자체가 DLQ 폭탄이 된다.** 확인 방법은 착수 시 결정 — 스테이징 트래픽 샘플링 또는 `validateOnConsume: false` 로 먼저 붙이고 로그만 관찰.
-- [ ] 재시도·DLQ 가 새로 켜지는 것은 **전 앱 공통**이다. 지금까지 핸들러 에러는 아무 분류 없이 Nest 기본 경로로 갔다. 이주 후에는 `@RetryPolicy` 분류 → backoff 재시도 → DLQ 로 흐른다. 그 앱의 핸들러가 idempotent 한지 확인한다 (재시도가 처음으로 실재하게 된다).
+### 권장 순서
 
-**완료 기준:** 7개 앱 전부 `startConsumer` 를 쓰고, `forConsumer` 호출이 0건이다.
+```
+5-A   데코레이터 일괄 (7앱)                    위험 0 · AST 게이트
+5-B   notification · membership · wallet       C 가 no-op → 여기서 종결
+5-B   core  →  5-C core                        관측 가능한 유일한 앱. 여기서 C 를 배운다
+5-B+C search → analytics                       작다. core 가 패턴을 증명한 뒤
+5-B   channel-adapter (validateOnConsume:false 명시)
+5-C   channel-adapter                          payload 샘플링 후, 마지막
+```
+
+**완료 기준:** 7개 앱 전부 `startConsumer` 를 쓰고, `forConsumer` 호출이 0건이며, `@OnEvent` 호출이 0건이다. `start-consumer.spec.ts` 의 "옛 배선" describe 를 삭제한다 (그게 초록이라는 사실이 라이브 결함의 증거였다).
 
 ---
 

--- a/docs/superpowers/plans/2026-08-09-events-module-registration.md
+++ b/docs/superpowers/plans/2026-08-09-events-module-registration.md
@@ -245,12 +245,30 @@ Nest 는 수신 `value` 를 `KafkaParser.decode` 로 **JSON 파싱해서** 넘�
 
 ### Task 5-A: 데코레이터 일괄 이주 (위험 0)
 
-- [ ] **AST 게이트 스크립트를 먼저 만든다.** `@On(S,'A')` + `@EventPayload() p: EventPayloadOf<typeof S,'B'>` 는 컴파일된다 — 파라미터 데코레이터 순서가 4가지(envelope-우선 45 · payload-우선 20 · payload-only 12 · envelope-only 10)이고 `strictFunctionTypes` 도 꺼져 있어 타입으로 막을 수 없다. 핸들러 87개를 사람 눈으로 맞추면 실수가 난다. 핸들러마다 `@On` 의 이벤트 키와 `EventPayloadOf<…, K>` 의 K 일치를 단언하고 불일치면 exit 1. **선례: `scripts/security/route-authz-audit.js`**
-- [ ] 게이트를 켠 채 7개 앱의 `@OnEvent` → `@On`, `@InjectStreamPublisher` → `@InjectPublisher`, payload/envelope 타입을 `EventPayloadOf` / `EnvelopeOf` 로 이주
-- [ ] `npm run type-check` 기준선(164) · 10개 앱 `nest build` 초록 · AST 게이트 exit 0
-- [ ] 스크립트는 이주 종료 후 버리거나 CI 게이트로 남긴다 (착수 시 결정)
+- [x] **AST 게이트 스크립트를 먼저 만든다.** `@On(S,'A')` + `@EventPayload() p: EventPayloadOf<typeof S,'B'>` 는 컴파일된다 — 파라미터 데코레이터 순서가 4가지(envelope-우선 45 · payload-우선 20 · payload-only 12 · envelope-only 10)이고 `strictFunctionTypes` 도 꺼져 있어 타입으로 막을 수 없다. 핸들러 87개를 사람 눈으로 맞추면 실수가 난다. 핸들러마다 `@On` 의 이벤트 키와 `EventPayloadOf<…, K>` 의 K 일치를 단언하고 불일치면 exit 1. **선례: `scripts/security/route-authz-audit.js`**
+- [x] 게이트를 켠 채 7개 앱의 `@OnEvent` → `@On`, ~~`@InjectStreamPublisher` → `@InjectPublisher`~~(아래 참조), payload/envelope 타입을 `EventPayloadOf` / `EnvelopeOf` 로 이주
+- [x] `npm run type-check` 기준선(164) · 10개 앱 `nest build` 초록 · AST 게이트 exit 0
+- [x] 스크립트는 이주 종료 후 버리거나 CI 게이트로 남긴다 (착수 시 결정) → **남긴다.** 아래 참조
 
 `main.ts` 는 건드리지 않는다. Task 4 가 두 표면 혼재를 실행으로 검증했으므로 앱 단위·파일 단위로 쪼개도 안전하다.
+
+**완료 (2026-08-09).** 브랜치 `docs/plan-task5-split`.
+
+- 게이트는 `scripts/events/event-handler-contract-audit.js`. **CI 게이트로 남긴다** — 이주가 끝나도 새 핸들러는 계속 추가되고, 이 게이트가 막는 불일치는 타입이 끝내 잡지 못하는 종류다. 검사는 5종: `LEGACY`(`@OnEvent` 잔량) · `UNDERIVED`(손수 단 payload/envelope 주석) · `STREAM_MISMATCH` · `EVENT_MISMATCH` · `WRONG_DERIVED_TYPE`(`@EventEnvelope` 에 `EventPayloadOf`). **5종 전부를 일부러 어긋뜨려 exit 1 을 확인했다** — 초록불이 무엇을 뜻하는지 모르는 게이트를 남기지 않기 위해서다.
+- 게이트는 **순수 구문 검사**다. `@On` 의 스트림·이벤트가 실재하는지는 검사하지 않는다 — `EventKeysOf` 가 컴파일에서, `@On` 의 런타임 가드가 부팅에서 이미 잡는다. 여기서 또 검사하면 계약 로딩이라는 두 번째 진실이 생긴다.
+- 87개 전량 이주. 파일 상수로 이벤트명을 쓰는 곳(`@OnEvent(PRODUCT_TOPIC, MASTER_DELETED)`)이 있어 게이트는 **같은 파일의 문자열 상수를 푼다**. 못 풀면 그 핸들러만 조용히 감사 밖으로 빠지는데, 그건 이 게이트가 없애려는 실패 모드 그 자체다.
+- `@InjectStreamPublisher` → `@InjectPublisher` 는 **하지 않았다.** 그건 소비가 아니라 발행 쪽 표면이고(21곳: core 7 · user-service 7 · channel-adapter 3 · membership 2 · ugc-service 2), 이 게이트가 검사하지 않는다. Task 6 이 발행 경로(`publish`/`enqueue` 통합)를 손대므로 거기서 같이 옮기는 편이 PR 경계가 깔끔하다. **워크스트림 완료 기준에는 그대로 남아 있다.**
+
+**🔴 이주가 계약의 구멍 두 종류를 드러냈다 — `@OnEvent` 로는 영원히 안 보이는 것들이다.**
+
+1. **계약에 없는 이벤트를 5개 핸들러가 구독하고 있었다.** `payment.intent.refund_requested` · `payment.intent.refund_request_rejected` · `gateway.charge.captured` · `gateway.refund.succeeded` (channel-adapter 4 + membership 1). 넷 다 `apps/wallet/src/messaging/gateway-event.builder.ts` 가 실제로 발행하는 라이브 이벤트인데 `PAYMENT_STREAM` 에 빠져 있었다. `deriveConsumerConfig` 는 **토픽** 단위로만 확인하므로 이걸 못 잡는다. `PAYMENT_STREAM` 에 추가했고, **스키마는 기존 `PaymentIntentEventSchema` 선례대로 관대하게(전 필드 optional + passthrough)** 뒀다 — 계약 등록만으로 소비검증이 켜지면 그게 곧 DLQ 폭탄이다. 검증을 조이는 결정은 5-C 몫.
+2. **`PaymentIntentEventPayload` 가 소비자가 실제로 읽는 필드를 빠뜨리고 있었다.** membership 이 `errorCode`/`errorMessage`(billing-result) 와 `metadata.type`(membership-checkout) 을 읽는데 계약에 없어 각자 로컬 인터페이스를 다시 선언해 두고 있었다. 발행측 실재를 확인하고(`direct-billing-charge.service.ts:214` · `invoice-executor.service.ts:489` · `bank-transfer-admin.service.ts:178`) 계약에 optional 로 추가했다.
+
+**부수 발견 — `gateway.refund.succeeded` 에는 `orderId` 가 없다.** channel-adapter 의 `forwardRefundToMedusa` 가 `payload.orderId` 로 channelOrderId 를 보강하는데, 그 경로만 payload 에 `orderId` 가 아예 없어 **예전부터 조회를 건너뛰고 있었다**(`Record<string, unknown>` 이라 `undefined` 가 조용히 통과). 동작은 그대로 두고 헬퍼 시그니처를 `coreOrderId?: string` 으로 좁혀 사실이 타입에 보이게 했다.
+
+- **스펙 3개가 부분 payload 를 넘기고 있었다** (membership billing-result · membership-checkout · membership-refund). 옛 로컬 인터페이스가 느슨해서 3필드 stub 이 통과했을 뿐이다. 계약 필수 필드를 채우는 팩토리를 각 스펙에 넣었다.
+- 검증: `npm run type-check` **164 — develop 기준선과 file:line:code 집합 완전 동일**(신규 0 · 소멸 0) · **10개 앱 전부 `nest build` 초록** · AST 게이트 exit 0 · `libs/events`+계약 패키지 **17 suite / 151 tests 초록** · 변경 파일 eslint **150 → 143 error**(신규 0, 감소는 미사용 파라미터 제거분) · 전체 jest 실패 suite 집합이 develop 과 동일.
+- **5-B 에 넘기는 사실:** `main.ts` 는 한 줄도 안 건드렸다. 7개 앱 전부 여전히 `forConsumer` + 하이브리드 `connectMicroservice` 를 쓰므로 **§8 의 라이브 구멍(검증·재시도·DLQ 미적용)은 그대로다.** 이 PR 은 동작 중립이다.
 
 ### Task 5-B: 배선 켜기 (`startConsumer`) — 앱별
 

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "lint:admin-web": "cd apps/admin-web && npm run lint",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "type-check:scoped": "tsc -p tsconfig.spec-scope.json --noEmit",
+    "audit:event-handlers": "node scripts/events/event-handler-contract-audit.js",
     "membership:backfill:last-payment-intent": "./scripts/with-ipv4.sh node apps/membership/scripts/backfill-last-payment-intent.js",
     "migrate:auth": "./scripts/with-ipv4.sh ts-node -r tsconfig-paths/register libs/authorization/scripts/migrate-auth-schema.ts",
     "migrate:backfill": "./scripts/with-ipv4.sh dotenv -e apps/channel-adapter/.env.migration -- ts-node -r tsconfig-paths/register apps/channel-adapter/scripts/backfill-v2.ts",

--- a/packages/event-contracts/streams/payment.stream.ts
+++ b/packages/event-contracts/streams/payment.stream.ts
@@ -380,6 +380,47 @@ export interface PaymentIntentEventPayload {
   subscriberRef?: string;
   subscriberType?: string;
   purpose?: string;
+  /**
+   * 인텐트의 자유형 metadata. 무통장 입금확인 경로(bank-transfer-admin.service.ts)가 통째로 실어 보내며,
+   * membership 은 `type === 'MEMBERSHIP_FEE'` 로 멤버십 결제를 식별한다.
+   */
+  metadata?: { type?: string; [key: string]: unknown } | null;
+  /** 실패/취소 경로에서 charge 결과로부터 승격되는 오류 정보 */
+  errorCode?: string;
+  errorMessage?: string;
+  [key: string]: unknown;
+}
+
+// ==========================================
+// gateway.* — wallet 이 charge/refund 단위로 발행하는 도트-표기 이벤트.
+// 발행측은 buildChargeEventPayload / buildRefundEventPayload (apps/wallet/src/messaging/gateway-event.builder.ts).
+// 소비: channel-adapter(gateway.charge.captured·gateway.refund.succeeded → Medusa 전달),
+//       membership(gateway.refund.succeeded → 구독 회수).
+// payment.intent.* 와 같은 이유로 확장 필드를 passthrough 로 보존한다.
+// ==========================================
+
+export interface GatewayChargeEventPayload {
+  chargeId: string;
+  intentId: string;
+  userId: string;
+  status: string;
+  operation: string;
+  amount: number;
+  currency: string;
+  providerTransactionId: string | null;
+  occurredAt: string;
+  [key: string]: unknown;
+}
+
+export interface GatewayRefundEventPayload {
+  refundId: string;
+  chargeId: string;
+  intentId: string;
+  userId: string;
+  status: string;
+  amount: number;
+  currency: string;
+  occurredAt: string;
   [key: string]: unknown;
 }
 
@@ -750,8 +791,42 @@ const PaymentIntentEventSchema = z
     subscriberRef: z.string().optional(),
     subscriberType: z.string().optional(),
     purpose: z.string().optional(),
+    metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+    errorCode: z.string().optional(),
+    errorMessage: z.string().optional(),
   })
   .catchall(z.unknown()) as unknown as z.ZodType<PaymentIntentEventPayload>;
+
+// gateway.charge.* / gateway.refund.* 공통 스키마.
+// 위 payment.intent.* 와 같은 이유로 관대하게 둔다 — 이 계열도 계약화 이전부터 라이브로 흐르고 있었고,
+// 계약 등록만으로 소비검증이 켜지면 그 순간이 DLQ 폭탄이 된다 (ADR-0029 §8·플랜 Task 5-C).
+// 검증을 조이는 결정은 앱별 이주(5-C)에서 payload 를 실제로 샘플링한 뒤에 한다.
+const GatewayChargeEventSchema = z
+  .object({
+    chargeId: z.string().optional(),
+    intentId: z.string().optional(),
+    userId: z.string().optional(),
+    status: z.string().optional(),
+    operation: z.string().optional(),
+    amount: z.number().optional(),
+    currency: z.string().optional(),
+    providerTransactionId: z.string().nullable().optional(),
+    occurredAt: z.string().optional(),
+  })
+  .catchall(z.unknown()) as unknown as z.ZodType<GatewayChargeEventPayload>;
+
+const GatewayRefundEventSchema = z
+  .object({
+    refundId: z.string().optional(),
+    chargeId: z.string().optional(),
+    intentId: z.string().optional(),
+    userId: z.string().optional(),
+    status: z.string().optional(),
+    amount: z.number().optional(),
+    currency: z.string().optional(),
+    occurredAt: z.string().optional(),
+  })
+  .catchall(z.unknown()) as unknown as z.ZodType<GatewayRefundEventPayload>;
 
 export const PAYMENT_STREAM = stream({
   topic: 'payments.events.v1',
@@ -868,6 +943,25 @@ export const PAYMENT_STREAM = stream({
     'payment.intent.awaiting_deposit': event<'payment.intent.awaiting_deposit', PaymentIntentEventPayload>(
       'payment.intent.awaiting_deposit',
       PaymentIntentEventSchema,
+    ),
+    // 무통장 환불 '신청'/'거절' — Medusa 주문의 refund_status marker 를 달고 해제한다.
+    'payment.intent.refund_requested': event<'payment.intent.refund_requested', PaymentIntentEventPayload>(
+      'payment.intent.refund_requested',
+      PaymentIntentEventSchema,
+    ),
+    'payment.intent.refund_request_rejected': event<
+      'payment.intent.refund_request_rejected',
+      PaymentIntentEventPayload
+    >('payment.intent.refund_request_rejected', PaymentIntentEventSchema),
+
+    // --- Gateway Charge/Refund Events (wallet outbox dispatcher, 도트 표기) ---
+    'gateway.charge.captured': event<'gateway.charge.captured', GatewayChargeEventPayload>(
+      'gateway.charge.captured',
+      GatewayChargeEventSchema,
+    ),
+    'gateway.refund.succeeded': event<'gateway.refund.succeeded', GatewayRefundEventPayload>(
+      'gateway.refund.succeeded',
+      GatewayRefundEventSchema,
     ),
   },
 });

--- a/scripts/events/event-handler-contract-audit.js
+++ b/scripts/events/event-handler-contract-audit.js
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+/**
+ * 이벤트 소비 핸들러의 **계약 도출 일관성** 전수 감사 (ADR-0029 §4, 플랜 Task 5-A).
+ *
+ * 무엇을 막는가 — `@On` 은 이벤트명 *오타*는 잡지만 *불일치*는 못 잡는다:
+ *
+ *   @On(PAYMENT_STREAM, 'PaymentCaptured')
+ *   async h(@EventPayload() p: EventPayloadOf<typeof PAYMENT_STREAM, 'PaymentFailed'>) {}
+ *   //                                                              ^^^^^^^^^^^^^^^ 컴파일된다
+ *
+ * 파라미터 데코레이터 순서가 앱마다 4가지이고(envelope-우선 45 · payload-우선 20 ·
+ * payload-only 12 · envelope-only 10, 2026-08-09 실측) 이 레포는 `strictFunctionTypes` 가
+ * 꺼져 있어 `TypedPropertyDescriptor` 제약이 반공변으로 걸리지 않는다. 즉 타입으로 막을
+ * 방법이 없고, 핸들러 87개를 사람 눈으로 맞추면 반드시 샌다. 그 자리를 이 게이트가 막는다.
+ *
+ * 왜 AST 인가 — 여러 줄 데코레이터(`@On(\n  STREAM,\n  'Event',\n)`)와 여러 줄 파라미터
+ * 주석이 흔해 정규식은 핸들러를 통째로 놓친다. 선례: `scripts/security/route-authz-audit.js`
+ * (정규식 집계로 무방비 쓰기를 105건으로 과소집계했다가 실제 207건이었다).
+ *
+ * 이 게이트는 **순수 구문 검사**다. `@On` 의 스트림·이벤트가 실재하는지는 검사하지 않는다 —
+ * 그건 `EventKeysOf` 가 컴파일 시점에, `@On` 의 런타임 가드가 부팅 시점에 이미 잡는다.
+ * 여기서 또 검사하면 계약 로딩이라는 두 번째 진실이 생긴다.
+ *
+ * 사용법:
+ *   node scripts/events/event-handler-contract-audit.js                  # 전체 앱
+ *   node scripts/events/event-handler-contract-audit.js core membership  # 특정 앱
+ *   node scripts/events/event-handler-contract-audit.js --json           # 기계 판독용
+ *   node scripts/events/event-handler-contract-audit.js --allow-legacy   # 이주 중: @OnEvent 잔량 허용
+ *
+ * 종료 코드: 발견이 하나라도 있으면 1.
+ */
+const ts = require('typescript');
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const REPO = path.resolve(__dirname, '..', '..');
+
+/** 계약에서 도출되는 파라미터 타입. 왼쪽 데코레이터에는 오른쪽 제네릭만 허용된다. */
+const DERIVED_TYPE_FOR = {
+  EventPayload: 'EventPayloadOf',
+  EventEnvelope: 'EnvelopeOf',
+};
+
+const decoratorsOf = (node) =>
+  (ts.getDecorators(node) ?? []).map((d) => {
+    const e = d.expression;
+    return ts.isCallExpression(e)
+      ? { name: e.expression.getText(), args: [...e.arguments] }
+      : { name: e.getText(), args: [] };
+  });
+
+/**
+ * 파일 안의 `const NAME = 'literal'` 를 모은다.
+ *
+ * `@On(PRODUCT_STREAM, MASTER_DELETED)` 처럼 이벤트명을 파일 상수로 뽑아 쓰는 곳이 있다
+ * (channel-adapter 의 pim-product-event.consumer.ts). 상수를 못 풀면 그 핸들러만 조용히
+ * 감사 밖으로 빠지므로 — 이 게이트가 없애려는 실패 모드 그 자체다 — 같은 파일 상수는 푼다.
+ */
+function collectStringConsts(source) {
+  const consts = new Map();
+  const visit = (node) => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      let init = node.initializer;
+      // `'x' as const` 를 벗긴다
+      while (ts.isAsExpression(init)) init = init.expression;
+      if (ts.isStringLiteral(init)) consts.set(node.name.text, init.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return consts;
+}
+
+/** 이벤트명 인자를 문자열로 푼다. 풀 수 없으면 undefined. */
+function resolveEventName(node, consts) {
+  if (!node) return undefined;
+  let n = node;
+  while (ts.isAsExpression(n)) n = n.expression;
+  if (ts.isStringLiteral(n)) return n.text;
+  if (ts.isIdentifier(n)) return consts.get(n.text);
+  return undefined;
+}
+
+/**
+ * `EventPayloadOf<typeof PAYMENT_STREAM, 'PaymentCaptured'>` 를 분해한다.
+ * 도출 타입이 아니면 null.
+ */
+function parseDerivedType(typeNode) {
+  if (!typeNode || !ts.isTypeReferenceNode(typeNode)) return null;
+
+  const name = typeNode.typeName.getText();
+  if (name !== 'EventPayloadOf' && name !== 'EnvelopeOf') return null;
+
+  const args = typeNode.typeArguments ?? [];
+  if (args.length !== 2) return { kind: name, stream: undefined, event: undefined };
+
+  // 1번째: `typeof STREAM`
+  const streamArg = args[0];
+  const stream =
+    ts.isTypeQueryNode(streamArg) ? streamArg.exprName.getText() : undefined;
+
+  // 2번째: `'EventName'`
+  const eventArg = args[1];
+  const event =
+    ts.isLiteralTypeNode(eventArg) && ts.isStringLiteral(eventArg.literal) ? eventArg.literal.text : undefined;
+
+  return { kind: name, stream, event };
+}
+
+function scanFile(rel) {
+  const abs = path.join(REPO, rel);
+  const source = ts.createSourceFile(abs, fs.readFileSync(abs, 'utf8'), ts.ScriptTarget.Latest, true);
+  const consts = collectStringConsts(source);
+  const findings = [];
+  const handlers = [];
+
+  const lineOf = (node) => source.getLineAndCharacterOfPosition(node.getStart()).line + 1;
+
+  const visit = (node) => {
+    if (ts.isMethodDeclaration(node)) {
+      const ds = decoratorsOf(node);
+      const handler = ds.find((d) => d.name === 'On' || d.name === 'OnEvent');
+      if (handler) {
+        const where = `${rel}:${lineOf(node)}`;
+        const method = `${node.parent && node.parent.name ? node.parent.name.getText() : '?'}.${node.name.getText()}`;
+
+        if (handler.name === 'OnEvent') {
+          handlers.push({ where, method, migrated: false });
+          findings.push({
+            code: 'LEGACY',
+            where,
+            method,
+            detail: '@OnEvent 은 토픽·이벤트명이 생문자열이다. @On(STREAM, "Event") 로 이주하라 (ADR-0029 §4).',
+          });
+        } else {
+          const streamArg = handler.args[0];
+          const stream = streamArg && ts.isIdentifier(streamArg) ? streamArg.text : streamArg?.getText();
+          const event = resolveEventName(handler.args[1], consts);
+          handlers.push({ where, method, migrated: true, stream, event });
+
+          if (event === undefined) {
+            findings.push({
+              code: 'UNRESOLVED_EVENT',
+              where,
+              method,
+              detail: `@On 의 이벤트명을 정적으로 풀 수 없다 (${handler.args[1]?.getText() ?? '<없음>'}). ` +
+                '리터럴이거나 같은 파일의 문자열 상수여야 이 게이트가 검사할 수 있다.',
+            });
+          }
+
+          for (const param of node.parameters) {
+            const pd = decoratorsOf(param);
+            const marker = pd.find((d) => DERIVED_TYPE_FOR[d.name]);
+            if (!marker) continue;
+
+            const expectedKind = DERIVED_TYPE_FOR[marker.name];
+            const derived = parseDerivedType(param.type);
+            const paramName = param.name.getText();
+
+            if (!derived) {
+              findings.push({
+                code: 'UNDERIVED',
+                where,
+                method,
+                detail:
+                  `@${marker.name}() ${paramName}: ${param.type ? param.type.getText().replace(/\s+/g, ' ') : '<타입 없음>'} — ` +
+                  `${expectedKind}<typeof ${stream ?? 'STREAM'}, '${event ?? 'Event'}'> 로 도출하라. ` +
+                  '손으로 단 주석은 계약과 어긋나도 조용하다.',
+              });
+              continue;
+            }
+
+            if (derived.kind !== expectedKind) {
+              findings.push({
+                code: 'WRONG_DERIVED_TYPE',
+                where,
+                method,
+                detail: `@${marker.name}() ${paramName} 에 ${derived.kind} 가 쓰였다 — ${expectedKind} 여야 한다.`,
+              });
+              continue;
+            }
+
+            if (derived.stream === undefined || derived.event === undefined) {
+              findings.push({
+                code: 'UNRESOLVED_DERIVED',
+                where,
+                method,
+                detail: `@${marker.name}() ${paramName} 의 ${derived.kind}<...> 인자를 정적으로 풀 수 없다. ` +
+                  `${expectedKind}<typeof STREAM, 'EventName'> 형태여야 한다.`,
+              });
+              continue;
+            }
+
+            if (stream !== undefined && derived.stream !== stream) {
+              findings.push({
+                code: 'STREAM_MISMATCH',
+                where,
+                method,
+                detail: `@On 은 ${stream} 인데 @${marker.name}() ${paramName} 은 ${derived.stream} 에서 도출한다.`,
+              });
+            }
+
+            if (event !== undefined && derived.event !== event) {
+              findings.push({
+                code: 'EVENT_MISMATCH',
+                where,
+                method,
+                detail:
+                  `@On(${stream}, '${event}') 인데 @${marker.name}() ${paramName} 은 '${derived.event}' 에서 도출한다. ` +
+                  '둘 중 하나가 틀렸고, 타입은 이것을 잡지 못한다.',
+              });
+            }
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(source);
+  return { findings, handlers };
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const json = argv.includes('--json');
+  const allowLegacy = argv.includes('--allow-legacy');
+  const apps = argv.filter((a) => !a.startsWith('--'));
+
+  const scope = apps.length ? apps.map((a) => `apps/${a}`).join(' ') : 'apps';
+  let files = [];
+  try {
+    files = execSync(`grep -rlE "@(On|OnEvent)\\(" ${scope} --include=*.ts | grep -v '\\.spec\\.' | sort`, {
+      cwd: REPO,
+      encoding: 'utf8',
+    })
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+  } catch {
+    files = [];
+  }
+
+  const findings = [];
+  const handlers = [];
+  for (const rel of files) {
+    const result = scanFile(rel);
+    findings.push(...result.findings);
+    handlers.push(...result.handlers);
+  }
+
+  const reported = allowLegacy ? findings.filter((f) => f.code !== 'LEGACY') : findings;
+  const legacy = findings.filter((f) => f.code === 'LEGACY').length;
+  const migrated = handlers.filter((h) => h.migrated).length;
+
+  if (json) {
+    console.log(JSON.stringify({ handlers: handlers.length, migrated, legacy, findings: reported }, null, 2));
+  } else {
+    console.log(`이벤트 핸들러 ${handlers.length}개 (파일 ${files.length}) — @On ${migrated} / @OnEvent ${legacy}`);
+    if (reported.length === 0) {
+      console.log('발견 없음.');
+    } else {
+      const byCode = new Map();
+      for (const f of reported) byCode.set(f.code, [...(byCode.get(f.code) ?? []), f]);
+      for (const [code, list] of byCode) {
+        console.log(`\n[${code}] ${list.length}건`);
+        for (const f of list) console.log(`  ${f.where}  ${f.method}\n    ${f.detail}`);
+      }
+    }
+    if (allowLegacy && legacy > 0) console.log(`\n(--allow-legacy: @OnEvent 잔량 ${legacy}건 무시)`);
+  }
+
+  process.exit(reported.length > 0 ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
ADR-0029 Task 5-A. 앱 이주의 **세 스위치 중 A 하나만** 담는다 — 데코레이터 교체는 동작 중립이므로, 배선(5-B)·검증(5-C)과 롤백 단위를 분리한다.

## 무엇이 들어있나

- 7개 앱 소비 핸들러 **87개** 전량을 `@OnEvent('topic','Event')` → `@On(STREAM,'Event')` 로, payload/envelope 주석을 `EventPayloadOf`/`EnvelopeOf` 로 이주
- AST 게이트 `npm run audit:event-handlers` — 이주 후에도 CI 게이트로 유지
- 계약 구멍 2종 수선 (아래)

`main.ts` 는 건드리지 않는다 → **동작 중립.** ADR-0029 §8 의 라이브 구멍(검증·재시도·DLQ 미적용)은 5-B 까지 그대로다. 유일한 `main.ts` 변경은 `apps/analytics/src/main.ts` 의 **주석 문구**(데코레이터 이름 갱신)뿐이다.

## 왜 AST 게이트가 필요한가

`@On(S,'A')` 와 `@EventPayload() p: EventPayloadOf<typeof S,'B'>` 의 불일치는 **컴파일을 통과한다.** 파라미터 데코레이터 순서가 4가지(envelope-우선 45 · payload-우선 20 · payload-only 12 · envelope-only 10)이고 이 레포는 `strictFunctionTypes` 가 꺼져 있어 타입으로 막을 수 없다. 검사 5종(LEGACY·UNDERIVED·STREAM_MISMATCH·EVENT_MISMATCH·WRONG_DERIVED_TYPE)을 **전부 일부러 어긋뜨려 exit 1 을 확인**했다.

## 이주가 드러낸 계약 구멍

1. **계약에 없는 이벤트를 5개 핸들러가 구독 중이었다** — `payment.intent.refund_requested` · `payment.intent.refund_request_rejected` · `gateway.charge.captured` · `gateway.refund.succeeded`. 넷 다 wallet 의 `gateway-event.builder` 가 실제로 발행하는 라이브 이벤트인데 `PAYMENT_STREAM` 에 없었다. `deriveConsumerConfig` 는 토픽 단위로만 확인하므로 못 잡는다. 계약에 추가하되 스키마는 선례대로 **관대하게**(전 필드 optional + passthrough) — 여기서 조이면 그게 곧 5-C 의 DLQ 폭탄이다.
2. **`PaymentIntentEventPayload` 가 소비자가 실제로 읽는 필드를 빠뜨리고 있었다** — membership 이 `errorCode`/`errorMessage`/`metadata.type` 을 읽으며 로컬 인터페이스를 재선언 중이었다. 발행측 실재 확인 후 optional 로 추가.

**부수 발견:** `gateway.refund.succeeded` payload 에 `orderId` 가 없어 channel-adapter 의 `channelOrderId` 보강이 예전부터 그 경로에서만 no-op 이었다. 동작은 그대로 두고 헬퍼 시그니처만 좁혀 사실이 타입에 보이게 했다.

## 계약 변경은 순수 additive

`git diff develop..HEAD -- packages/event-contracts/` 의 **삭제 라인 0건**. 앱이 독립 배포되므로 옛 계약으로 발행하는 producer 가 남아 있어도 소비 검증이 깨지지 않는다 — 이것이 5-C 정적 증명의 전제이기도 하다.

## 검증

- `npm run type-check` **164** — develop 기준선과 file:line:code 집합 동일 (신규 0)
- 10개 앱 `nest build` 초록
- `npm run audit:event-handlers` exit 0
- `libs/events`+계약 **17 suite / 151 tests** 초록
- 전체 jest 실패 suite **18 = develop 동일** (통과 3013)
- 변경 파일 eslint 150 → 143 error (신규 0)

마이그레이션 0 / 시크릿 0 / env 0 → **배포 순서 제약 없음.**

## 후속

- 5-B(배선) · 5-C(core 검증)는 **별도 PR**. 5-A 머지 후 순차로 올린다
- `@InjectStreamPublisher` → `@InjectPublisher` (21곳)는 발행 표면이라 **Task 6** 으로 미뤘다
- 새로 추가한 4개 이벤트의 느슨한 스키마는 추적이 필요하다 — `audit:consume-validation --gate` 는 "계약에 있음"으로 집계하므로 잡지 못한다