### PR TITLE
feat(events): core 소비 스키마 검증 활성화 + 준비도 게이트 (ADR-0029 Task 5-C)

### DIFF
--- a/apps/analytics/src/analytics.module.ts
+++ b/apps/analytics/src/analytics.module.ts
@@ -41,10 +41,18 @@ import { MembershipEventsConsumer } from './datasets/memberships/ingest/membersh
       streams: [ORDER_STREAM, PRODUCT_STREAM, MEMBERSHIP_STREAM],
       groupId: process.env.KAFKA_GROUP_ID || 'analytics-consumer',
       enableAutoDLQ: true,
-      // ⚠️ 현상 유지다 — 이 앱은 소비 경로에 스키마 검증이 붙은 적이 없다
-      // (ADR-0029 §8). startConsumer 로 이주하면 인터셉터가 처음 붙으므로,
-      // 명시하지 않으면 기본값 `true` 가 배선 이주에 묻어 함께 켜진다.
-      // 검증 활성화는 payload 샘플링 후 별도 결정 (플랜 Task 5-C).
+      // ⚠️ 아직 끈다. core 는 5-C 에서 켰지만 이 앱은 못 켠다 (ADR-0029 §8).
+      //
+      // 막는 것은 3개 이벤트다 — `MembershipStatusChanged` ·
+      // `ProductMasterActiveVersionChanged` · `ProductMasterDeleted`. 셋 다
+      // `OutboxPublisher.saveEvent` 로 발행되고, 그 경로는 `publishRawEnvelope` 로 zod 를
+      // 우회한다. 즉 스키마를 안 지키는 payload 가 올라올 수 있는지 정적으로 증명되지 않는다.
+      // 나머지 7개는 발행 시 검증되므로 안전하다.
+      //
+      // **이걸 여는 것은 Task 6 이다** (enqueue 시점 zod 검증). 그게 들어가면 셋 다 자동으로
+      // PROVEN 이 되어 이 줄을 뒤집을 수 있다. 그 전에 켜는 것은 추측이고, 이 앱은 DLQ 를
+      // 스크레이프하지 않아(`dlq.metrics.ts:10`) 추측이 틀려도 아무도 모른다.
+      // 현황: `npm run audit:consume-validation -- analytics`
       validation: { validateOnConsume: false },
     }),
     AuthorizationModule.forRoot({

--- a/apps/channel-adapter/src/adapter.module.ts
+++ b/apps/channel-adapter/src/adapter.module.ts
@@ -255,6 +255,18 @@ import { OrderPollerOrchestrator } from './services/order-collection/order-polle
     // `forConsumerModule` 을 부르지 않는 이유: 그 표면은 `streams` 를 필수로 받는데,
     // 그 목록이야말로 이 워크스트림이 없애는 중인 두 번째 진실이다. 필요한 것은
     // 정책 하나뿐이므로 정책만 등록한다. Task 7 의 `forApp` 이 이 자리를 흡수한다.
+    //
+    // 5-C 현황: core 는 켰지만 이 앱은 아직 끈다. 34개 핸들러 중 30개는 안전하고
+    // (11 = 관대한 스키마 · 19 = 발행 시 검증됨), 막는 것은 4개 이벤트다 —
+    // `MembershipStatusChanged` · `ProductMasterActiveVersionChanged` ·
+    // `ProductMasterDeleted` · `CategoryChanged`. 넷 다 `OutboxPublisher.saveEvent` 로
+    // 발행돼 `publishRawEnvelope` 로 zod 를 우회한다. **여는 것은 Task 6** (enqueue 시점
+    // 검증) 이며, 그때 넷 다 자동으로 PROVEN 이 된다.
+    //
+    // 이 앱은 외부 채널 유래 payload 라 가장 위험한 앱이라고 적어왔는데, 실측은 조금 다르다 —
+    // 외부 payload 는 HTTP 로 들어와 이 앱이 *발행측*에서 정규화하므로, 소비하는 34개는
+    // 전부 내부 발행이다. 남은 위험은 외부성이 아니라 위 outbox 우회다.
+    // 현황: `npm run audit:consume-validation -- channel-adapter`
     {
       provide: EVENTS_CONSUMER_POLICY,
       useValue: { validation: { validateOnConsume: false } } satisfies EventsConsumerPolicy,

--- a/apps/core/src/modules/sales-order/sales-order.module.ts
+++ b/apps/core/src/modules/sales-order/sales-order.module.ts
@@ -31,13 +31,20 @@ import { WalletRefundClient } from './services/wallet-refund.client';
       streams: [ORDER_STREAM],
       groupId: 'almondyoung-order-consumer',
       enableAutoDLQ: true,
-      // ⚠️ 이 `false` 는 **현상 유지**이지 새 결정이 아니다. 이 앱은 하이브리드
-      // connectMicroservice 때문에 소비 경로에 스키마 검증이 붙은 적이 없다
-      // (ADR-0029 §8). main.ts 가 startConsumer 로 옮겨가면서 인터셉터가 처음으로
-      // 붙으므로, 명시하지 않으면 기본값 `true` 가 먹어 배선 이주와 검증 활성화가
-      // 한 배포에 같이 켜진다. 검증을 켜는 것은 인바운드 payload 를 샘플링한 뒤
-      // 별도로 내리는 결정이다 (플랜 Task 5-C).
-      validation: { validateOnConsume: false },
+      // 소비 스키마 검증 ON (ADR-0029 §8, 플랜 Task 5-C — 이 앱이 첫 번째다).
+      //
+      // 근거는 샘플링이 아니라 **발행 경로를 전수로 닫은 정적 증명**이다. 이 앱이 구독하는
+      // 4개 이벤트는 전부 `orders.events.v1` 이고, 그 토픽의 발행자는 channel-adapter 의
+      // order publisher 2벌 + 자체 outbox dispatcher 뿐이며 셋 다 `StreamPublisher.publishEvent`
+      // 를 지난다. `publishEvent` 는 envelope 에 원본이 아니라 **zod 가 파싱한 결과**를 싣기
+      // 때문에(`stream-publisher.service.ts:123`) 같은 스키마로 다시 검증하면 반드시 통과한다.
+      // zod 를 우회하는 `publishRawEnvelope` 경로는 레포에 2곳뿐이고 둘 다 이 토픽에 닿지
+      // 않는다. (`OrderRefundCreated` 는 발행자가 아예 없다.)
+      //
+      // 이 논증은 `npm run audit:consume-validation -- --gate` 가 상시 재검증한다 — 검증을
+      // 켜 둔 앱에 우회 경로가 닿는 이벤트가 새로 생기면 게이트가 exit 1 로 막는다.
+      // 남은 노출은 계약 이전에 토픽에 쌓인 옛 메시지뿐이며, 그건 정적으로 알 수 없다.
+      validation: { validateOnConsume: true },
     }),
 
     // OutboxService (Sales Order 이벤트 발행용)

--- a/apps/search/src/search.module.ts
+++ b/apps/search/src/search.module.ts
@@ -35,10 +35,16 @@ import { SearchKeywordService } from './search-keyword.service';
             groupId: process.env.KAFKA_GROUP_ID || 'search-indexer',
             kafka: createKafkaConfigFromEnv()!,
             enableAutoDLQ: true,
-            // ⚠️ 현상 유지다 — 이 앱은 소비 경로에 스키마 검증이 붙은 적이 없다
-            // (ADR-0029 §8). startConsumer 로 이주하면 인터셉터가 처음 붙으므로,
-            // 명시하지 않으면 기본값 `true` 가 배선 이주에 묻어 함께 켜진다.
-            // 검증 활성화는 payload 샘플링 후 별도 결정 (플랜 Task 5-C).
+            // ⚠️ 아직 끈다. core 는 5-C 에서 켰지만 이 앱은 못 켠다 (ADR-0029 §8).
+            //
+            // 막는 것은 딱 2개 이벤트다 — `ProductMasterActiveVersionChanged` ·
+            // `ProductMasterDeleted`. 둘 다 core 카탈로그가 `OutboxPublisher.saveEvent` 로
+            // 발행하는데, 그 경로는 `publishRawEnvelope` 로 zod 를 우회한다. 즉 이 토픽에
+            // 스키마를 안 지키는 payload 가 올라올 수 있는지 정적으로 증명되지 않는다.
+            //
+            // **이걸 여는 것은 Task 6 이다** (enqueue 시점 zod 검증). 그게 들어가면 두 이벤트가
+            // 자동으로 PROVEN 이 되어 이 줄을 뒤집을 수 있다. 그 전에 켜는 것은 추측이다.
+            // 현황: `npm run audit:consume-validation -- search`
             validation: { validateOnConsume: false },
           }),
         ]

--- a/docs/adr/0029-events-module-registration-surfaces.md
+++ b/docs/adr/0029-events-module-registration-surfaces.md
@@ -204,6 +204,40 @@ microservice.setIsInitHookCalled(true);
 
 `Server.handleEvent` 는 핸들러가 Observable 을 돌려주면 `connectable(...).connect()` 로 구독만 하고 기다리지 않으며(`server.js:105–117`), 그 connector 는 구독자 없는 `Subject` 라 에러가 들어와도 보고되지 않는다(rxjs 의 unhandled-error 경로조차 타지 않음 — 실행 확인). `handleEvent` 는 그 사이 정상 resolve 했으므로 offset 은 전진한다. **즉 지금까지 실패한 소비는 로그 한 줄 없이 사라져 왔다.** §8 이 "가장 치명적인 실수가 가장 조용하다"고 한 것의 네 번째 실례이며, 배선 스위치가 위험을 더하는 게 아니라 **없던 탈출구를 만드는 쪽**이라는 근거이기도 하다.
 
+#### 검증 스위치(C)는 샘플링이 아니라 발행 경로를 닫아서 판정한다 (2026-08-09)
+
+세 스위치 중 C 만 남았을 때, 플랜은 그 게이트를 "인바운드 payload 를 스테이징에서 샘플링하거나 5-B 배포 후 로그로 관찰"로 적어 두었다. **그 두 방법은 지금 둘 다 존재하지 않는다** — AWS `dev` stage 는 폐기됐고, 5-B 가 배포되기 전에는 검증 인터셉터 자체가 안 붙어 관찰할 로그가 생기지 않는다. 즉 플랜대로면 5-C 는 배포가 선행돼야 하고, 배포는 5-C 의 결과를 기다린다 — 순환이다.
+
+**샘플링을 발행 경로의 전수 폐쇄로 대체한다.** 논증은 세 걸음이고 전부 이 레포에서 실측된다:
+
+1. Kafka 로 나가는 모든 경로는 `StreamPublisher` 를 지난다 (§7). 프로덕션 코드에서 `kafkajs` 를 직접 잡는 곳은 **0곳**이다(스펙 3개 제외, 실측).
+2. `StreamPublisher` 의 발행 진입점은 둘뿐이다. `publishEvent` 는 `validateOnPublish` 로 검증하며 — 이 값을 `false` 로 끄는 곳은 레포에 **하나도 없다** — 게다가 envelope 에 싣는 것이 원본이 아니라 **zod 가 파싱한 결과**다(`stream-publisher.service.ts:123`). 파싱은 멱등이므로 **`publishEvent` 로 나간 payload 는 같은 스키마의 소비 검증을 반드시 통과한다.** 나머지 하나인 `publishRawEnvelope` 는 zod 를 우회한다.
+3. 따라서 위험한 것은 `publishRawEnvelope` 가 실어 나를 수 있는 (토픽, 이벤트) 뿐이고, **그 호출자는 레포 전체에 2곳**이다: `libs/events` 공용 outbox dispatcher 와 wallet outbox dispatcher. (core·channel-adapter 의 자체 outbox dispatcher 는 `publishEvent` 를 부르므로 우회가 아니다 — 이 구분이 판정을 크게 바꾼다.)
+
+이 판정은 `scripts/events/consume-validation-readiness.ts` (`npm run audit:consume-validation`) 가 수행한다. 스키마 분류는 zod 내부(`_def`)를 들여다보지 않고 **실행해서**(`safeParse({})`) 한다 — 빈 객체를 통과시키는 관대한 스키마는 켜도 동작이 안 바뀐다.
+
+실측 결과 (2026-08-09):
+
+| 앱 | 이벤트 | SAFE | PROVEN | UNVERIFIED | 판정 |
+|---|---:|---:|---:|---:|---|
+| **core** | 4 | 0 | **4** | **0** | ✅ 켠다 |
+| notification | 22 | 1 | 21 | 0 | (해당 없음 — 명시 `false` 유지) |
+| wallet | 4 | 0 | 4 | 0 | (해당 없음) |
+| analytics | 10 | 0 | 7 | **3** | ⏸ Task 6 뒤로 |
+| search | 3 | 0 | 1 | **2** | ⏸ Task 6 뒤로 |
+| channel-adapter | 34 | 11 | 19 | **4** | ⏸ Task 6 뒤로 |
+| membership | 10 | 5 | 0 | 5 | (해당 없음) |
+
+**core 를 켠다.** 4개 이벤트가 전부 `orders.events.v1` 이고 그 토픽의 발행자는 셋 다 `publishEvent` 를 지난다(`OrderRefundCreated` 는 발행자가 아예 없다). 우회 경로 2곳 중 어느 것도 이 토픽에 닿지 않는다. core 는 동시에 **DLQ 가 관측되는 유일한 앱**이므로(`dlq.metrics.ts:10`), 증명이 틀렸을 때 알아차릴 수 있는 유일한 앱이기도 하다.
+
+**나머지 3개 앱의 게이트는 관측성이 아니라 Task 6 이다 — 플랜의 순서를 뒤집는다.** 이 앱들을 막는 UNVERIFIED 는 전부 같은 원인의 4개 이벤트다: `MembershipStatusChanged` · `ProductMasterActiveVersionChanged` · `ProductMasterDeleted` · `CategoryChanged`. 넷 다 `OutboxPublisher.saveEvent` 로 적재돼 `publishRawEnvelope` 로 나간다. **Task 6 의 "enqueue 시점 zod 검증"이 정확히 이 구멍을 메우며, 그 순간 넷 다 기계적으로 PROVEN 이 된다.** 즉 5-C 를 먼저 하면 payload 를 추측해야 하고, Task 6 을 먼저 하면 추측할 것이 남지 않는다. 게다가 Task 6 은 실패를 **발행자의 도메인 트랜잭션**에서 드러내므로, 소비자 DLQ 에서 사후에 발견하는 것보다 진단 위치가 낫다.
+
+그래서 **5-C 는 core 에서 끝내고, 나머지 3개 앱은 Task 6 의 후속으로 옮긴다.** 플랜의 "core 밖으로 나가기 전에 DLQ 관측 범위를 넓힐지 결정한다"는 항목은 사라지지 않지만 긴급성이 낮아진다 — Task 6 이후에는 켤 때 증명이 있고, 관측은 증명이 틀렸을 경우의 대비책이 된다.
+
+**이 분석은 일회성 결론이 아니라 상시 불변식이 된다.** `--gate` 는 *검증을 켜 둔 앱*에 UNVERIFIED 이벤트가 생기면 exit 1 한다. core 에 나중에 outbox 발행 이벤트의 핸들러를 추가하면 CI 가 막는다 — 이 워크스트림이 반복해서 만난 "판정이 조용히 낡는" 실패 모드를 그 자리에서 닫는 것이다. 게이트가 실제로 무는 것은 확인했다(search 를 일부러 `true` 로 바꿔 exit 1 재현). 게이트는 자기 자신의 가정도 감시한다 — `publishRawEnvelope` 호출 지점을 AST 로 세어 손으로 유지하는 우회 목록과 어긋나면 실패한다. (첫 실행에서 이 검사가 실제로 걸렸다: grep 판본이 근거 주석 속 함수명을 세 번째 "호출자"로 집계했다. 그래서 AST 로 바꿨다.)
+
+**켜는 비용은 낮다 — 스키마 위반은 재시도하지 않는다.** `EventRetryInterceptor` 가 `SchemaValidationError` 를 `nonRetryableErrors` 에 강제로 넣으므로(`event-retry.interceptor.ts:91`) 위반 메시지는 백오프 없이 즉시 DLQ 로 가고 offset 이 전진한다. 검증을 켜는 것이 파티션을 막는 재시도 폭풍을 부르지 않는다는 뜻이다. 이 사실과 위 2번의 멱등성은 `libs/events/src/transport/consume-validation.spec.ts` 가 실행으로 고정한다 — 재시도 억제는 **대조군**(스키마와 무관한 에러는 같은 `@RetryPolicy` 로 4회 실행됨)과 나란히 두어야 `maxRetries` 설정 탓이 아님이 드러나므로 둘을 함께 넣었다.
+
 ### 명시적으로 하지 않는 것
 
 - **두 리스트를 부팅 시 대조(reconcile)하는 안은 기각한다.** 어긋남을 시끄럽게 만들 뿐 중복은 그대로 남는다. 중복을 없애는 파생이 우월하다.
@@ -263,10 +297,14 @@ microservice.setIsInitHookCalled(true);
 
    부팅 거부(§3)가 이주를 깨지 않는지 전수로 확인했다: 7개 앱의 `(등록된 컨트롤러 → @On → 토픽)` 집합에 핸들러 0개인 앱도, 레지스트리 밖 토픽도 없다. 실측 핸들러는 **87개**(ADR Consequences 표의 89 는 이주 전 `@OnEvent` 기준 수치이며 analytics·membership 이 각 1 많다). `controllers:[]` 에 등록되지 않은 `@On` 핸들러는 0개다. **channel-adapter 의 도출 토픽은 9개** — 옛 `forConsumer` 목록의 6개가 아니며, 빠져 있던 셋이 정확히 이 ADR Context 의 오판 대상(`PAYMENT_STREAM`·`USER_STREAM`·`CORE_ORDER_STREAM`)이다. 도출은 처음부터 옳은 값을 낸다.
 
+   **검증 스위치(C) — core 만 켰다 (2026-08-09).** `apps/core/.../sales-order.module.ts` 가 `validateOnConsume: true`. 근거는 샘플링이 아니라 발행 경로 전수 폐쇄이며 상세는 위 §8 의 "검증 스위치(C)" 절에 있다. **나머지 3개 앱(analytics·search·channel-adapter)은 6번(outbox enqueue 검증) 뒤로 미뤘다** — 막는 원인이 관측성이 아니라 outbox 의 zod 우회라, 6번이 그것을 메우면 추측 없이 켤 수 있다. notification·membership·wallet 은 원래부터 해당 없음이다. 판정과 회귀 방지는 `npm run audit:consume-validation -- --gate` 가 맡는다.
+
    **앱별 데코레이터 이주 완료 (2026-08-09).** 7개 앱 · 소비 핸들러 **87개 전량**이 `@On` + `EventPayloadOf`/`EnvelopeOf` 로 옮겨졌고 `@OnEvent` 호출은 0건이다. `main.ts` 는 손대지 않았으므로 **이 단계는 동작 중립**이다 — §8 의 라이브 구멍은 배선 이주(플랜 Task 5-B) 전까지 그대로 남는다. 이주 중 계약의 구멍 두 종류가 드러났다(위 §4 의 "`@On` 은 계약에 없는 이벤트를 소비할 수 없다" 참조). 회귀 방지는 `scripts/events/event-handler-contract-audit.js` (`npm run audit:event-handlers`) 가 맡는다 — `@On` 의 이벤트 키와 payload/envelope 도출 키의 불일치는 타입이 끝내 잡지 못하므로, 이 게이트는 이주 종료 후에도 남긴다. **`@InjectStreamPublisher` → `@InjectPublisher` 는 아직 0건**(21곳): 발행 쪽 표면이라 Follow-up 6 에서 발행 경로를 통합할 때 함께 옮긴다.
 
    **전반부(데코레이터 도입) 완료 (2026-08-09).** `@On` · `@InjectPublisher` · `PublisherFor` · `EnvelopeOf` 가 옛 표면과 **병행**으로 존재한다. `@On` 은 `@OnEvent` 과 **바이트 단위로 같은 메타데이터**를 남기고(스펙이 메타데이터 키 집합과 값을 전수 비교한다), `@InjectPublisher` 는 `EventsModule.getPublisherToken` 과 같은 토큰을 만든다 — 토큰 형식은 `publishers/publisher-token.ts` 한 곳으로 모았다. 따라서 한 앱 안에서 두 표면을 섞어 써도 되고, 앱 이주는 파일 단위로 쪼갤 수 있다. 앱 이주(후반부)는 아직 0개다. 위 §4 의 두 가지 이행 차이도 참조.
 6. 공용 outbox 에 `idempotencyKey`·`partitionKey`·enqueue 시점 검증 추가 후 앱 자체 판본 5벌 회수. **core 의 두 벌은 import 경로만 다른 동일 파일이므로 이 작업과 무관하게 지금 하나로 합칠 수 있다.**
+
+   ⚠️ **이 항목이 5-C 의 나머지 3개 앱을 막고 있다 (2026-08-09, 위 §8 의 C 스위치 절).** analytics·search·channel-adapter 를 켜지 못하는 원인은 관측성이 아니라 `saveEvent`→`publishRawEnvelope` 의 zod 우회이며, 여기서 enqueue 시점 검증을 넣는 순간 막고 있던 4개 이벤트(`MembershipStatusChanged` · `ProductMasterActiveVersionChanged` · `ProductMasterDeleted` · `CategoryChanged`)가 기계적으로 PROVEN 이 된다. 즉 **의존 방향이 플랜과 반대다** — 5-C 가 6번을 기다린다. 진행 후 `npm run audit:consume-validation` 이 그 세 앱을 `켜도 안전` 으로 바꾸는지 확인하면 되고, 그것이 이 항목의 완료 신호 중 하나다.
 7. 옛 표면(`forRoot`/`forConsumerModule`/`forConsumer`) 제거 — contract phase.
 8. ~~channel-adapter 가 `forConsumerModule` 을 호출하지 않는 현재 상태는 이 ADR 이 시행되기 전까지 남는 실재 구멍이다 — 소비 측 zod 검증이 없다. 4번 이전에 단독으로 메울지, 이주에 묶을지 결정한다.~~ **결정: 이주에 묶었다 (2026-08-09).** 다만 배선 이주 시점에 **검증을 켜지는 않았다.** `forConsumerModule` 미호출 → `EVENTS_CONSUMER_POLICY` 토큰 부재 → `optionalGet` 이 undefined → 기본값 `true` 라, 아무 조치 없이 `startConsumer` 로 옮기면 이 앱만 배선과 검증이 **선택이 아니라 누락으로** 동시에 켜진다. 외부 채널 유래 payload 라 그 조합이 가장 위험한 앱이기도 하다. 그래서 `adapter.module.ts` 의 providers 에 `EVENTS_CONSUMER_POLICY` 를 직접 등록하고 `validateOnConsume: false` 를 명시했다. `forConsumerModule` 을 새로 부르지 않은 이유는 그 표면이 `streams` 를 필수로 받기 때문이다 — 그 목록이야말로 §2·§3 이 지우는 중인 두 번째 진실이라, 정책 하나를 얻자고 그것을 되살릴 수 없다. Task 7 의 `forApp` 이 이 자리를 흡수한다. 검증을 실제로 켜는 것은 payload 샘플링 후(플랜 Task 5-C).
 9. **소비 경로 CLS 컨텍스트 부재** (2026-08-09 발견, 미수정).

--- a/docs/superpowers/plans/2026-08-09-events-module-registration.md
+++ b/docs/superpowers/plans/2026-08-09-events-module-registration.md
@@ -329,28 +329,59 @@ B 는 위험을 더하는 게 아니라 **없던 탈출구를 만드는 쪽에 �
 
 ### Task 5-C: 검증 켜기 — 앱별, 게이트
 
-- [ ] notification · membership · wallet 은 **해당 없음** — 명시 `false` 가 정상 상태다. 5-A + 5-B 로 종결
-- [ ] 나머지 4개 앱: 인바운드 payload 가 실제로 zod 스키마를 만족하는지 **먼저** 확인 (스테이징 샘플링 또는 5-B 상태에서 로그 관찰)
-- [ ] core 를 먼저 켜고 DLQ 대시보드로 관찰한다 — **유일하게 관측 가능한 앱**
-- [ ] core 밖으로 나가기 전에 DLQ 관측 범위를 넓힐지, 로그 기반으로 갈지 결정한다
-- [ ] `validateOnConsume` 명시를 걷어내거나 `true` 로 전환
+- [x] notification · membership · wallet 은 **해당 없음** — 명시 `false` 가 정상 상태다. 5-A + 5-B 로 종결
+- [x] 나머지 4개 앱: 인바운드 payload 가 실제로 zod 스키마를 만족하는지 **먼저** 확인 ~~(스테이징 샘플링 또는 5-B 상태에서 로그 관찰)~~ → **둘 다 불가능해 발행 경로 전수 폐쇄로 대체.** 아래 참조
+- [x] core 를 먼저 켜고 ~~DLQ 대시보드로 관찰한다~~ → **켰다.** 관찰은 배포 후 사람 몫 (아래 배포 체크리스트)
+- [x] core 밖으로 나가기 전에 DLQ 관측 범위를 넓힐지, 로그 기반으로 갈지 결정한다 → **둘 다 아니다. 게이트는 Task 6 이다** (아래)
+- [x] `validateOnConsume` 명시를 걷어내거나 `true` 로 전환 → core 만 `true`. 나머지 3개는 Task 6 뒤로
 
-### 권장 순서
+**완료 (2026-08-09).** 브랜치 `docs/plan-task5-split`.
+
+**샘플링이 불가능해서 정적 증명으로 갈아탔다.** 이 항목이 지시한 두 방법이 지금 둘 다 존재하지 않는다 — AWS `dev` stage 는 폐기됐고, 5-B 는 배포 전이라 검증 인터셉터가 아직 안 붙어 관찰할 로그가 생기지 않는다. 플랜대로면 5-C 가 배포를 기다리고 배포는 5-C 를 기다리는 순환이 된다. 대신 **발행 경로를 전수로 닫았다** (ADR-0029 §8 "검증 스위치(C)" 절이 정본):
+
+1. 프로덕션 코드에서 `kafkajs` 를 직접 잡는 곳 **0곳** → 모든 발행이 `StreamPublisher` 를 지난다.
+2. `publishEvent` 는 envelope 에 **zod 파싱 결과**를 싣는다(`stream-publisher.service.ts:123`). 파싱은 멱등이므로 그 경로로 나간 payload 는 소비 검증을 **반드시** 통과한다. `validateOnPublish: false` 인 곳은 레포에 없다.
+3. 남는 것은 `publishRawEnvelope` 뿐이고 호출자는 **2곳**이다 (공용 outbox · wallet outbox). core·channel-adapter 의 자체 outbox dispatcher 는 `publishEvent` 를 부르므로 우회가 아니다 — 이 구분이 판정을 크게 바꿨다(초기 분석은 "모든 outbox = 우회"로 잡아 UNVERIFIED 를 36건으로 과대집계했다).
+
+도구는 `scripts/events/consume-validation-readiness.ts` (`npm run audit:consume-validation`). 스키마 강도는 zod 내부를 읽지 않고 **실행해서**(`safeParse({})`) 분류한다.
+
+| 앱 | 이벤트 | SAFE | PROVEN | UNVERIFIED | 결과 |
+|---|---:|---:|---:|---:|---|
+| **core** | 4 | 0 | **4** | **0** | ✅ **켰다** |
+| notification | 22 | 1 | 21 | 0 | 해당 없음 |
+| wallet | 4 | 0 | 4 | 0 | 해당 없음 |
+| analytics | 10 | 0 | 7 | **3** | ⏸ Task 6 뒤 |
+| search | 3 | 0 | 1 | **2** | ⏸ Task 6 뒤 |
+| channel-adapter | 34 | 11 | 19 | **4** | ⏸ Task 6 뒤 |
+| membership | 10 | 5 | 0 | 5 | 해당 없음 |
+
+**🔴 순서를 뒤집었다 — 나머지 3개 앱의 게이트는 관측성이 아니라 Task 6 이다.** 세 앱을 막는 UNVERIFIED 는 전부 같은 원인의 **4개 이벤트**다: `MembershipStatusChanged` · `ProductMasterActiveVersionChanged` · `ProductMasterDeleted` · `CategoryChanged`. 넷 다 `OutboxPublisher.saveEvent` 로 적재돼 `publishRawEnvelope` 로 나간다. Task 6 의 "enqueue 시점 zod 검증"이 정확히 이 구멍이며, 들어가는 순간 넷 다 기계적으로 PROVEN 이 된다. 5-C 를 먼저 하면 payload 를 추측해야 하고, Task 6 을 먼저 하면 추측할 것이 남지 않는다. 게다가 Task 6 은 실패를 **발행자의 도메인 트랜잭션**에서 드러내므로 소비자 DLQ 에서 사후 발견하는 것보다 진단 위치가 낫다. **ADR-0029 §8 과 Follow-up 6 을 먼저 고쳤다.**
+
+- **core 를 켠 근거:** 4개 이벤트가 전부 `orders.events.v1` 이고 발행자 셋(channel-adapter order publisher 2벌 + 자체 outbox dispatcher)이 모두 `publishEvent` 를 지난다. `OrderRefundCreated` 는 발행자가 아예 없다. 우회 2곳 중 어느 것도 이 토픽에 닿지 않는다. core 는 **DLQ 가 관측되는 유일한 앱**이라(`dlq.metrics.ts:10`) 증명이 틀렸을 때 알아차릴 수 있는 유일한 앱이기도 하다.
+- **분석을 상시 불변식으로 바꿨다.** `--gate` 는 *검증을 켜 둔 앱*에 UNVERIFIED 가 생기면 exit 1 한다 — core 에 나중에 outbox 발행 이벤트 핸들러를 추가하면 CI 가 막는다. 게이트가 실제로 무는 것을 확인했다(search 를 일부러 `true` 로 바꿔 exit 1 재현 후 원복). 게이트는 자기 가정도 감시한다: `publishRawEnvelope` 호출 지점을 AST 로 세어 손으로 유지하는 우회 목록과 어긋나면 실패하며, **첫 실행에서 실제로 걸렸다** — grep 판본이 내가 방금 쓴 근거 주석 속 함수명을 세 번째 "호출자"로 집계했다. 그래서 AST 로 바꿨다.
+- **켜는 비용이 낮다는 것도 실행으로 고정했다.** `SchemaValidationError` 는 `nonRetryableErrors` 에 강제 편입되므로(`event-retry.interceptor.ts:91`) 위반 메시지는 백오프 없이 즉시 DLQ 로 가고 offset 이 전진한다 — 재시도 폭풍으로 파티션이 막히지 않는다. `libs/events/src/transport/consume-validation.spec.ts` 가 이것과 멱등성을 함께 고정하며, 재시도 억제는 **대조군**(스키마와 무관한 에러는 같은 `@RetryPolicy` 로 4회 실행)과 나란히 두었다 — 대조군이 없으면 `maxRetries` 를 0으로 바꿔도 초록이라 아무것도 증명하지 못한다. 검증을 끄는 변이를 넣어 6개 중 3개가 실패하는 것도 확인했다.
+- **부수 정정:** channel-adapter 를 "외부 유래 payload 라 가장 위험"이라고 적어온 서술은 소비 측에는 맞지 않는다. 외부 payload 는 HTTP 로 들어와 이 앱이 *발행측*에서 정규화하므로, 소비하는 34개는 전부 내부 발행이다(프로덕션 `kafkajs` 직접 사용 0곳으로 확인). 남은 위험은 외부성이 아니라 outbox 우회다.
+
+**⚠️ 배포 후 사람이 할 것 (core):** 배포 시점에 core 는 **배선(B)과 검증(C)이 같이 켜진다** — 5-B 도 아직 미배포이기 때문이다. `events_dlq_messages_total{topic="orders.events.v1"}` 을 확인한다. 0 이 아니면 계약 이전에 토픽에 쌓인 옛 메시지이거나(이 증명이 덮지 않는 유일한 구멍) 증명이 틀린 것이며, 되돌리기는 그 한 줄을 `false` 로 바꾸는 것이다.
+
+### 권장 순서 (2026-08-09 갱신)
 
 ```
-5-A   데코레이터 일괄 (7앱)                    위험 0 · AST 게이트
-5-B   notification · membership · wallet       C 가 no-op → 여기서 종결
-5-B   core  →  5-C core                        관측 가능한 유일한 앱. 여기서 C 를 배운다
-5-B+C search → analytics                       작다. core 가 패턴을 증명한 뒤
-5-B   channel-adapter (validateOnConsume:false 명시)
-5-C   channel-adapter                          payload 샘플링 후, 마지막
+5-A   데코레이터 일괄 (7앱)                    ✅ 완료 · 위험 0 · AST 게이트
+5-B   7개 앱 배선 일괄                         ✅ 완료
+5-C   core                                     ✅ 완료 — 정적 증명 · 관측 가능한 유일 앱
+──────────────────────────────────────────────────────────────
+Task 6  outbox enqueue 시점 zod 검증            ← 여기가 나머지를 여는 열쇠
+5-C   analytics · search · channel-adapter     Task 6 후. 4개 이벤트가 자동으로 PROVEN 이 된다
 ```
 
-**완료 기준:** 7개 앱 전부 `startConsumer` 를 쓰고, `forConsumer` 호출이 0건이며, `@OnEvent` 호출이 0건이다. `start-consumer.spec.ts` 의 "옛 배선" describe 를 삭제한다 (그게 초록이라는 사실이 라이브 결함의 증거였다).
+**완료 기준:** 7개 앱 전부 `startConsumer` 를 쓰고, `forConsumer` 호출이 0건이며, `@OnEvent` 호출이 0건이다. `start-consumer.spec.ts` 의 "옛 배선" describe 를 삭제한다 (그게 초록이라는 사실이 라이브 결함의 증거였다). ⚠️ **삭제 시점은 5-B 배포 후다** — 배포 전까지 라이브는 여전히 옛 배선이라 그 describe 의 주장은 아직 참이다.
 
 ---
 
 ## Task 6: 발행 경로 통합 + outbox 회수
+
+> ⚠️ **이 태스크가 5-C 의 나머지 3개 앱을 막고 있다** (2026-08-09, ADR-0029 Follow-up 6). analytics·search·channel-adapter 에서 검증을 못 켜는 원인은 관측성이 아니라 `saveEvent`→`publishRawEnvelope` 의 zod 우회다. 아래 "enqueue 시점 zod 검증"이 들어가면 막고 있던 4개 이벤트(`MembershipStatusChanged` · `ProductMasterActiveVersionChanged` · `ProductMasterDeleted` · `CategoryChanged`)가 기계적으로 PROVEN 이 된다. **완료 후 `npm run audit:consume-validation` 이 그 세 앱을 `켜도 안전` 으로 바꾸는지 확인하고, 그 시점에 5-C 를 마저 끝낸다.**
 
 - [ ] `PublisherFor<S>` 에 `publish(eventName, {...})` 와 `enqueue(eventName, {...}, tx)` 를 함께 둔다
 - [ ] **`enqueue` 시점에 zod 검증** — 잘못된 payload 가 poison row 가 되는 대신 도메인 트랜잭션을 실패시킨다

--- a/libs/events/src/transport/consume-validation.spec.ts
+++ b/libs/events/src/transport/consume-validation.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * 소비 스키마 검증을 **켰을 때** 무슨 일이 일어나는가 (ADR-0029 §8, 플랜 Task 5-C)
+ *
+ * 5-C 는 앱별로 `validateOnConsume` 을 뒤집는 작업이고, core 가 첫 번째다. 그 결정이 기대는
+ * 두 사실을 여기서 실행으로 고정한다 — 둘 다 코드를 읽어서 "그럴 것이다"라고 말할 수는 있지만,
+ * 이 워크스트림이 반복해서 배운 것은 **읽어서 내린 결론이 틀렸다**는 것이었다(§8, Follow-up 3·10).
+ *
+ * 1. **켜도 정상 경로가 안 깨진다.** `publishEvent` 로 나간 메시지는 소비 검증을 반드시 통과한다.
+ *    이유는 우연이 아니라 구조다 — publisher 가 envelope 에 싣는 것은 원본 payload 가 아니라
+ *    **zod 가 파싱한 결과**(`stream-publisher.service.ts:123`)라, 같은 스키마로 다시 파싱하면
+ *    반드시 통과한다(파싱의 멱등성). 그래서 발행 시 알 수 없는 키가 섞여 있어도 소비에서 문제가
+ *    되지 않는다 — 발행 단계에서 이미 떨어져 나갔기 때문이다.
+ *
+ * 2. **틀린 메시지는 재시도 없이 즉시 DLQ 로 간다.** `EventRetryInterceptor` 가
+ *    `SchemaValidationError` 를 `nonRetryableErrors` 에 강제로 넣는다(`event-retry.interceptor.ts:91`).
+ *    이것이 5-C 의 비용 계산을 바꾸는 사실이다 — 검증을 켜는 것이 파티션을 막는 재시도 폭풍을
+ *    부르지 않는다. 스키마 위반은 결정적이라 재시도해도 결과가 같고, 인터셉터가 그것을 알고 있다.
+ *
+ * 하네스 스트림을 쓰고 실제 계약을 쓰지 않는 것은 `round-trip.spec.ts` 와 같은 이유다 — 계약이
+ * 바뀌었다고 이 스펙이 깨지면 안 된다. **어느 앱의 어느 이벤트가 실제로 안전한가**는 스펙이 아니라
+ * `npm run audit:consume-validation -- --gate` 가 상시 판정한다. 여기서 고정하는 것은 메커니즘이다.
+ */
+
+import { Controller, INestMicroservice, UseInterceptors } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { z } from 'zod';
+import { event, getDLQTopicName, stream } from '@packages/event-contracts/types';
+import type { DLQMessage } from '../dlq/dlq.types';
+import { EventsModule } from '../events.module';
+import { EventPayload, OnEvent } from '../consumers/decorators';
+import { EventTypeGuard } from '../guards/event-type.guard';
+import { RetryPolicy } from '../retry/retry-policy.decorator';
+import { StreamPublisher } from '../publishers/stream-publisher.service';
+import { EVENT_TRANSPORT } from './transport.port';
+import { InMemoryBroker } from './in-memory.broker';
+import { InMemoryTransport } from './in-memory.transport';
+import { InMemoryServer } from './in-memory.server';
+
+const OrderPlacedSchema = z.object({
+  orderId: z.string().min(1),
+  amount: z.number().int().positive(),
+});
+
+const VALIDATED_STREAM = stream({
+  topic: 'validated.events.v1',
+  partitions: 1,
+  aggregateType: 'Validated',
+  events: {
+    OrderPlaced: event('OrderPlaced', OrderPlacedSchema),
+  },
+});
+
+/** 핸들러가 몇 번 불렸는지 — 재시도 여부를 세는 자리. */
+const attempts: unknown[] = [];
+
+/** 스키마는 통과하되 핸들러가 던지게 만드는 값. 재시도 대조군에 쓴다. */
+const POISON_AMOUNT = 666;
+
+@Controller()
+@UseInterceptors(EventTypeGuard)
+class ValidatedConsumer {
+  /**
+   * 재시도를 넉넉히 열어 둔다. 그런데도 스키마 위반이 1회만 실행되면, 그 억제는
+   * `maxRetries` 가 아니라 `SchemaValidationError` 의 non-retryable 분류에서 온 것이다.
+   * 대기 시간이 실제로 들어가지 않는지도 이 설정이 드러낸다 — 재시도가 돌면 백오프로 느려진다.
+   */
+  @OnEvent('validated.events.v1', 'OrderPlaced')
+  @RetryPolicy({ maxRetries: 3, initialDelayMs: 1 })
+  onPlaced(@EventPayload() payload: { orderId: string; amount: number }): void {
+    attempts.push(payload);
+    // 대조군용 독약 — 스키마는 통과하지만 핸들러가 던지는 경우. 이 갈래가 4회 실행되는 것이
+    // "스키마 위반이 1회로 그친 것은 재시도 설정 때문이 아니다"의 근거가 된다.
+    if (payload.amount === POISON_AMOUNT) throw new Error('handler blew up');
+  }
+}
+
+describe('소비 스키마 검증 ON (validateOnConsume: true)', () => {
+  let app: INestMicroservice;
+  let broker: InMemoryBroker;
+  let publisher: StreamPublisher<typeof VALIDATED_STREAM.events>;
+
+  beforeAll(async () => {
+    process.env.KAFKA_BOOTSTRAP_TOPICS = 'false';
+    broker = new InMemoryBroker();
+    const kafka = { clientId: 'validation-harness', brokers: ['unused:9092'] };
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        EventsModule.forRoot({ streams: [VALIDATED_STREAM], serviceName: 'validation-harness', kafka }),
+        EventsModule.forConsumerModule({
+          streams: [VALIDATED_STREAM],
+          groupId: 'validation-harness-consumer',
+          kafka,
+          // 이 스펙의 전제 — 5-C 가 앱에서 뒤집는 바로 그 한 줄이다
+          validation: { validateOnConsume: true },
+        }),
+      ],
+      controllers: [ValidatedConsumer],
+    })
+      .overrideProvider(EVENT_TRANSPORT)
+      .useValue(new InMemoryTransport(broker))
+      .compile();
+
+    app = moduleRef.createNestMicroservice({ strategy: new InMemoryServer(broker), logger: false });
+    await app.listen();
+    publisher = app.get(EventsModule.getPublisherToken(VALIDATED_STREAM.topic.topic));
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  beforeEach(() => {
+    attempts.length = 0;
+    broker.reset();
+  });
+
+  const dlqOf = () => broker.envelopesOn<DLQMessage>(getDLQTopicName(VALIDATED_STREAM.topic.topic));
+
+  it('publishEvent 로 나간 메시지는 검증을 켜도 그대로 핸들러에 도달한다', async () => {
+    await publisher.publishEvent({
+      eventType: 'OrderPlaced',
+      aggregateId: 'order-1',
+      payload: { orderId: 'order-1', amount: 9_900 },
+    });
+
+    expect(attempts).toEqual([{ orderId: 'order-1', amount: 9_900 }]);
+    expect(dlqOf()).toHaveLength(0);
+  });
+
+  it('발행 시 알 수 없는 키는 zod 가 떼어내므로 소비 검증이 볼 일이 없다', async () => {
+    await publisher.publishEvent({
+      eventType: 'OrderPlaced',
+      aggregateId: 'order-2',
+      // 계약에 없는 키. 타입으로는 막히지만 런타임에는 들어올 수 있는 모양이다.
+      payload: { orderId: 'order-2', amount: 100, legacyField: 'dropped' } as never,
+    });
+
+    // 나간 것도 받은 것도 스키마의 출력 — 이것이 "발행된 것은 반드시 소비된다"의 기계적 근거다
+    expect(broker.envelopesOn(VALIDATED_STREAM.topic.topic)[0].payload).toEqual({
+      orderId: 'order-2',
+      amount: 100,
+    });
+    expect(attempts).toEqual([{ orderId: 'order-2', amount: 100 }]);
+    expect(dlqOf()).toHaveLength(0);
+  });
+
+  it('스키마를 위반한 인바운드는 핸들러에 닿지 않고 DLQ 로 간다', async () => {
+    await broker.inject(VALIDATED_STREAM.topic.topic, {
+      messageId: 'msg-bad',
+      messageType: 'OrderPlaced',
+      messageVersion: 1,
+      messageKind: 'event',
+      correlationId: 'corr-bad',
+      timestamp: new Date().toISOString(),
+      occurredAt: new Date().toISOString(),
+      source: { service: 'other-service', aggregateType: 'Validated', aggregateId: 'order-3' },
+      payload: { orderId: 'order-3', amount: -5 }, // positive() 위반
+    });
+
+    expect(attempts).toHaveLength(0);
+
+    const dlq = dlqOf();
+    expect(dlq).toHaveLength(1);
+    expect(dlq[0].error.name).toBe('SchemaValidationError');
+    expect(dlq[0].originalMessage.messageId).toBe('msg-bad');
+  });
+
+  /**
+   * 5-C 의 비용 논증. 스키마 위반은 결정적이므로 재시도가 순수 낭비이고, 그 낭비는 컨슈머
+   * 파티션을 붙잡는 형태로 나타난다. `@RetryPolicy({ maxRetries: 3 })` 이 걸려 있는데도
+   * DLQ 항목이 1건이고 시도 이력이 1건이면, 억제한 것은 non-retryable 분류다.
+   */
+  it('스키마 위반은 재시도하지 않는다 — maxRetries 가 열려 있어도 즉시 DLQ', async () => {
+    await broker.inject(VALIDATED_STREAM.topic.topic, {
+      messageId: 'msg-bad-2',
+      messageType: 'OrderPlaced',
+      messageVersion: 1,
+      messageKind: 'event',
+      correlationId: 'corr-bad-2',
+      timestamp: new Date().toISOString(),
+      occurredAt: new Date().toISOString(),
+      source: { service: 'other-service', aggregateType: 'Validated', aggregateId: 'order-4' },
+      payload: { orderId: '', amount: 1 }, // min(1) 위반
+    });
+
+    const dlq = dlqOf();
+    expect(dlq).toHaveLength(1);
+    // 시도 이력이 1건 = 최초 시도뿐, 재시도 0회
+    expect(dlq[0].context.attemptHistory).toHaveLength(1);
+    expect(dlq[0].context.retryCount).toBe(1);
+  });
+
+  /**
+   * 위 테스트의 대조군. 같은 핸들러·같은 `@RetryPolicy` 인데 **핸들러가 던지는** 에러는
+   * 1+3 = 4회 실행된다. 두 테스트를 나란히 두어야 "1회로 그친 것"이 재시도 설정 탓이 아니라
+   * `SchemaValidationError` 의 non-retryable 분류 때문임이 드러난다. 대조군 없이 앞 테스트만
+   * 두면 `maxRetries` 를 0으로 바꿔도 여전히 초록이라 아무것도 증명하지 못한다.
+   */
+  it('대조군 — 핸들러가 던지는 (스키마와 무관한) 에러는 정책대로 재시도한다', async () => {
+    await publisher.publishEvent({
+      eventType: 'OrderPlaced',
+      aggregateId: 'order-6',
+      payload: { orderId: 'order-6', amount: POISON_AMOUNT },
+    });
+
+    expect(attempts).toHaveLength(4); // 최초 1 + 재시도 3
+
+    const dlq = dlqOf();
+    expect(dlq).toHaveLength(1);
+    expect(dlq[0].error.name).toBe('Error');
+    expect(dlq[0].context.attemptHistory).toHaveLength(4);
+  });
+
+  it('검증이 켜져 있어도 소비 실패가 발행자에게 전파되지 않는다', async () => {
+    await broker.inject(VALIDATED_STREAM.topic.topic, {
+      messageId: 'msg-bad-3',
+      messageType: 'OrderPlaced',
+      messageVersion: 1,
+      messageKind: 'event',
+      correlationId: 'corr-bad-3',
+      timestamp: new Date().toISOString(),
+      occurredAt: new Date().toISOString(),
+      source: { service: 'other-service', aggregateType: 'Validated', aggregateId: 'order-5' },
+      payload: { amount: 'nope' },
+    });
+
+    // DLQ 로 분류된 뒤 에러가 삼켜져야 offset 이 전진한다 (§8 의 "탈출구")
+    expect(broker.deliveryFailures).toHaveLength(0);
+    expect(dlqOf()).toHaveLength(1);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "type-check": "tsc -p tsconfig.json --noEmit",
     "type-check:scoped": "tsc -p tsconfig.spec-scope.json --noEmit",
     "audit:event-handlers": "node scripts/events/event-handler-contract-audit.js",
+    "audit:consume-validation": "tsx scripts/events/consume-validation-readiness.ts",
     "membership:backfill:last-payment-intent": "./scripts/with-ipv4.sh node apps/membership/scripts/backfill-last-payment-intent.js",
     "migrate:auth": "./scripts/with-ipv4.sh ts-node -r tsconfig-paths/register libs/authorization/scripts/migrate-auth-schema.ts",
     "migrate:backfill": "./scripts/with-ipv4.sh dotenv -e apps/channel-adapter/.env.migration -- ts-node -r tsconfig-paths/register apps/channel-adapter/scripts/backfill-v2.ts",

--- a/scripts/events/consume-validation-readiness.ts
+++ b/scripts/events/consume-validation-readiness.ts
@@ -1,0 +1,547 @@
+#!/usr/bin/env tsx
+/**
+ * 소비 측 스키마 검증(`validateOnConsume`)을 앱별로 켜도 되는지 판정한다 (ADR-0029 §8, 플랜 Task 5-C).
+ *
+ * ## 왜 이 스크립트인가 — 샘플링을 정적 증명으로 대체한다
+ *
+ * 플랜 Task 5-C 는 "인바운드 payload 가 실제로 zod 스키마를 만족하는지 **먼저** 확인"하라고 하고
+ * 그 방법으로 "스테이징 샘플링 또는 5-B 상태에서 로그 관찰"을 제시한다. **둘 다 지금 불가능하다** —
+ * AWS `dev` stage 는 폐기됐고, 5-B(배선 이주)는 커밋됐을 뿐 배포되지 않아 라이브는 여전히 옛 배선이라
+ * 검증 인터셉터가 붙지 않는다(§8). 관찰할 로그 자체가 생기지 않는다.
+ *
+ * 대신 **발행 경로를 전수로 닫아** 같은 결론에 도달한다. 논증은 세 걸음이다:
+ *
+ * 1. Kafka 로 나가는 모든 경로는 `StreamPublisher` 를 지난다 (ADR-0029 §7, Task 2 에서 확립).
+ * 2. `StreamPublisher` 의 발행 진입점은 **둘뿐**이다:
+ *    - `publishEvent`  → `validateOnPublish` 로 zod 검증. 게다가 envelope 에 싣는 것은 원본이 아니라
+ *      **zod 가 파싱한 결과**(`payload: validatedPayload`, `stream-publisher.service.ts:123`)다.
+ *      즉 나가는 payload 는 스키마의 출력 그 자체라, 같은 스키마로 다시 검증하면 반드시 통과한다.
+ *    - `publishRawEnvelope` → zod 우회.
+ * 3. 따라서 **`publishRawEnvelope` 가 실어 나를 수 있는 (토픽, 이벤트) 만이 위험하다.**
+ *    그 호출자는 레포 전체에 **2곳**뿐이다 (아래 BYPASS_PATHS).
+ *
+ * `validateOnPublish` 를 `false` 로 끄는 곳은 레포에 하나도 없다(실측). 발행·소비가 같은
+ * `StreamConfig` 객체를 공유하는 것도 확인했다 — 모든 `forRoot({streams})` 가 계약 패키지의
+ * 정규 export 를 그대로 넘긴다. 그래서 스키마가 양쪽에서 갈라질 수 없다.
+ *
+ * ## 판정
+ *
+ *   SAFE       스키마 없음, 또는 빈 객체까지 통과하는 관대한 스키마 → 켜도 동작이 안 바뀐다
+ *   PROVEN     필수 필드가 있으나 우회 경로가 이 (토픽,이벤트) 에 닿지 않는다 → 발행 시 이미 검증됨
+ *   UNVERIFIED 필수 필드 + 우회 경로가 닿는다 → 사람이 payload 를 봐야 한다
+ *
+ * `UNVERIFIED` 가 0인 앱은 검증을 켜도 안전하다는 정적 증명을 가진 것이다.
+ *
+ * ## 한계 (일부러 검사하지 않는 것)
+ *
+ * - **토픽에 남아 있는 옛 메시지.** 발행 코드가 지금 옳아도 계약 이전에 쌓인 메시지는 모양이 다를 수
+ *   있다. 이 논증은 "앞으로 발행될 것"만 덮는다. retention 을 넘긴 뒤에야 완결된다.
+ * - **레포 밖 발행자.** Medusa 등 다른 프로세스가 같은 토픽에 쓰면 이 논증 밖이다. 현재 확인된
+ *   외부 발행자는 없다.
+ * - `BYPASS_PATHS` 는 **손으로 유지하는 목록이다.** 그래서 `--gate` 가 `publishRawEnvelope` 호출
+ *   지점을 실제로 세어 이 목록과 어긋나면 실패한다 — 목록이 조용히 낡는 것을 막는다.
+ *
+ * ## `--gate` 가 막는 것
+ *
+ * 1. **검증을 켜 둔 앱에 UNVERIFIED 이벤트가 생기는 것.** 5-C 로 켠 앱에 나중에 누가 outbox 발행
+ *    이벤트의 핸들러를 추가하면, 이 판정이 조용히 뒤집히는 대신 CI 가 막는다. 5-C 의 분석을
+ *    일회성 결론이 아니라 **상시 불변식**으로 바꾸는 것이 이 게이트의 목적이다.
+ * 2. 위의 `BYPASS_PATHS` 낡음.
+ *
+ * 사용법:
+ *   npm run audit:consume-validation
+ *   npm run audit:consume-validation -- --json
+ *   npm run audit:consume-validation -- --gate          # 위 두 가지 중 하나라도 걸리면 exit 1
+ *   npm run audit:consume-validation -- core analytics
+ */
+import * as ts from 'typescript';
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import { STREAM_REGISTRY } from '../../packages/event-contracts/streams/registry';
+import * as streamExports from '../../packages/event-contracts/streams';
+import type { StreamConfig } from '../../packages/event-contracts/types/stream-config.types';
+
+const REPO = path.resolve(__dirname, '..', '..');
+
+/**
+ * zod 를 우회해 Kafka 에 도달할 수 있는 경로. `publishRawEnvelope` 의 호출자와 1:1 대응한다.
+ *
+ * 각 항목은 "이 dispatcher 가 어느 토픽에 무엇을 실을 수 있는가" 를 적는다. 그 답은 dispatcher 가
+ * 어떤 publisher 를 들고 있고 어떤 행을 읽는가로 정해진다.
+ */
+const BYPASS_PATHS = [
+  {
+    dispatcher: 'libs/events/src/outbox/outbox-dispatcher.service.ts:121',
+    /** publisherMap 이 행의 `topic` 컬럼으로 조회되므로, 실릴 수 있는 것은 `saveEvent` 가 쓴 (topic,eventType) 뿐이다. */
+    writers: 'OutboxPublisher.saveEvent',
+    resolve: 'saveEvent-call-sites' as const,
+  },
+  {
+    dispatcher: 'apps/wallet/src/messaging/outbox-dispatcher.service.ts:171',
+    /**
+     * publisher 가 `PAYMENT_EVENTS_TOPIC` 하나로 고정 주입된다(:45) — 즉 실리는 토픽은
+     * `payments.events.v1` 하나다. 실릴 수 있는 **이벤트명**은 wallet 이 자기 `outbox_events` 에
+     * 넣는 것뿐이고, 그 이름은 전부 `*EventType` const 맵에서 온다 (`GatewayEventType` ·
+     * `InvoiceEventType`). 그 맵들의 값 전체를 우회 집합으로 잡는다 — 실제 insert 지점을 일일이
+     * 따라가면 헬퍼 함수를 거치는 갈래에서 놓칠 수 있고, 놓치면 위험한 쪽(PROVEN 오판)으로 틀린다.
+     * 과대추정은 안전한 방향이다.
+     */
+    writers: 'wallet outbox_events 직접 insert',
+    resolve: 'wallet-event-consts' as const,
+    topic: 'payments.events.v1',
+  },
+];
+
+/**
+ * 앱의 `validateOnConsume` 선언을 **소스에서 도출한다.** 목록으로 들고 있지 않는 이유는
+ * ADR-0029 §1 과 같다 — 도출 가능한 사실을 선언으로 받으면 두 벌이 생기고, 두 벌은 어긋난다.
+ * 선언이 없으면 `DEFAULT_SCHEMA_VALIDATION_OPTIONS` 의 `true` 로 떨어진다(그것이 이 워크스트림
+ * 내내 "누락으로 켜진다"고 경고해 온 바로 그 기본값이다).
+ *
+ * 주석 안의 `validateOnConsume: true` 같은 산문에 걸리지 않도록 정규식이 아니라 AST 로 읽는다 —
+ * channel-adapter 의 설명 주석이 실제로 그 문자열을 담고 있다.
+ */
+function declaredPolicy(app: string): { validateOnConsume: boolean; where: string } {
+  for (const rel of grepFiles('validateOnConsume', `apps/${app}/src`)) {
+    const abs = path.join(REPO, rel);
+    const source = ts.createSourceFile(abs, fs.readFileSync(abs, 'utf8'), ts.ScriptTarget.Latest, true);
+    let found: { validateOnConsume: boolean; where: string } | undefined;
+    const visit = (node: ts.Node) => {
+      if (found) return;
+      if (ts.isPropertyAssignment(node) && node.name.getText() === 'validateOnConsume') {
+        const kind = node.initializer.kind;
+        if (kind === ts.SyntaxKind.TrueKeyword || kind === ts.SyntaxKind.FalseKeyword) {
+          found = {
+            validateOnConsume: kind === ts.SyntaxKind.TrueKeyword,
+            where: `${rel}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}`,
+          };
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+    if (found) return found;
+  }
+  return { validateOnConsume: true, where: '<선언 없음 → 기본값 true>' };
+}
+
+type Verdict = 'SAFE' | 'PROVEN' | 'UNVERIFIED';
+
+interface Consumer {
+  app: string;
+  where: string;
+  method: string;
+  streamIdent: string;
+  event: string;
+}
+
+// ─── 스트림 식별자 → 토픽 ───────────────────────────────────────────────────
+// 앱 코드의 `@On(PAYMENT_STREAM, …)` 식별자는 계약 패키지의 export 이름 그대로다.
+// 별칭 import(`as X`)는 현재 없고, 생기면 아래에서 미해결로 드러난다.
+const topicByIdent = new Map<string, string>();
+for (const [name, value] of Object.entries(streamExports as Record<string, unknown>)) {
+  const c = value as Partial<StreamConfig>;
+  if (c && typeof c === 'object' && c.topic && typeof c.topic.topic === 'string') {
+    topicByIdent.set(name, c.topic.topic);
+  }
+}
+
+// ─── AST 스캔 ───────────────────────────────────────────────────────────────
+
+const decoratorsOf = (node: ts.Node) =>
+  (ts.getDecorators(node as ts.HasDecorators) ?? []).map((d) => {
+    const e = d.expression;
+    return ts.isCallExpression(e)
+      ? { name: e.expression.getText(), args: [...e.arguments] }
+      : { name: e.getText(), args: [] as ts.Expression[] };
+  });
+
+/** 같은 파일의 `const NAME = 'literal'` 를 푼다 (audit 게이트와 같은 이유 — 상수로 뽑아 쓰는 곳이 있다). */
+function collectStringConsts(source: ts.SourceFile): Map<string, string> {
+  const consts = new Map<string, string>();
+  const visit = (node: ts.Node) => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      let init: ts.Expression = node.initializer;
+      while (ts.isAsExpression(init)) init = init.expression;
+      if (ts.isStringLiteral(init)) consts.set(node.name.text, init.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return consts;
+}
+
+function resolveString(node: ts.Expression | undefined, consts: Map<string, string>): string | undefined {
+  if (!node) return undefined;
+  let n: ts.Expression = node;
+  while (ts.isAsExpression(n)) n = n.expression;
+  if (ts.isStringLiteral(n)) return n.text;
+  if (ts.isIdentifier(n)) return consts.get(n.text);
+  return undefined;
+}
+
+/** `X.topic.topic` / `X.topic` / 문자열 리터럴에서 토픽을 얻는다. */
+function resolveTopicExpression(node: ts.Expression | undefined, consts: Map<string, string>): string | undefined {
+  if (!node) return undefined;
+  const literal = resolveString(node, consts);
+  if (literal) return literal;
+  const m = /^([A-Z][A-Z0-9_]*)\.topic(\.topic)?$/.exec(node.getText());
+  return m ? topicByIdent.get(m[1]) : undefined;
+}
+
+function propOf(obj: ts.ObjectLiteralExpression, name: string): ts.Expression | undefined {
+  for (const p of obj.properties) {
+    if (ts.isPropertyAssignment(p) && p.name.getText() === name) return p.initializer;
+  }
+  return undefined;
+}
+
+interface SaveEventSite {
+  where: string;
+  topic?: string;
+  event?: string;
+}
+
+function scanFile(rel: string): { consumers: Consumer[]; saveEvents: SaveEventSite[] } {
+  const abs = path.join(REPO, rel);
+  const source = ts.createSourceFile(abs, fs.readFileSync(abs, 'utf8'), ts.ScriptTarget.Latest, true);
+  const consts = collectStringConsts(source);
+  const app = rel.split('/')[1];
+  const consumers: Consumer[] = [];
+  const saveEvents: SaveEventSite[] = [];
+  const lineOf = (n: ts.Node) => source.getLineAndCharacterOfPosition(n.getStart()).line + 1;
+
+  const visit = (node: ts.Node) => {
+    if (ts.isMethodDeclaration(node)) {
+      const on = decoratorsOf(node).find((d) => d.name === 'On');
+      if (on) {
+        const streamArg = on.args[0];
+        const streamIdent = streamArg && ts.isIdentifier(streamArg) ? streamArg.text : streamArg?.getText();
+        const event = resolveString(on.args[1], consts);
+        const cls = ts.isClassDeclaration(node.parent) ? node.parent.name?.getText() : undefined;
+        if (streamIdent && event) {
+          consumers.push({
+            app,
+            where: `${rel}:${lineOf(node)}`,
+            method: `${cls ?? '?'}.${node.name.getText()}`,
+            streamIdent,
+            event,
+          });
+        }
+      }
+    }
+
+    // 우회 경로 1의 writer: `outboxPublisher.saveEvent({ topic, eventType, … }, tx)`
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const arg0 = node.arguments[0];
+      if (node.expression.name.getText() === 'saveEvent' && arg0 && ts.isObjectLiteralExpression(arg0)) {
+        saveEvents.push({
+          where: `${rel}:${lineOf(node)}`,
+          topic: resolveTopicExpression(propOf(arg0, 'topic'), consts),
+          event: resolveString(propOf(arg0, 'eventType'), consts),
+        });
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(source);
+  return { consumers, saveEvents };
+}
+
+// ─── 스키마 분류 ────────────────────────────────────────────────────────────
+
+/**
+ * 스키마를 **실행해서** 분류한다 — zod 내부 구조(`_def`)를 들여다보지 않는다.
+ * zod 판올림에 내부 모양이 바뀌어도 이 판정은 따라 깨지지 않는다.
+ */
+function classifySchema(schema: unknown): { permissive: boolean; required: string[] } | null {
+  const s = schema as {
+    safeParse?: (v: unknown) => { success: boolean; error?: { issues: Array<{ path: PropertyKey[] }> } };
+  };
+  if (!s || typeof s.safeParse !== 'function') return null;
+
+  const empty = s.safeParse({});
+  // 빈 객체를 통과시키면 필수 필드가 없다는 뜻 — 어떤 라이브 payload 도 이걸 못 넘길 수 없다.
+  if (empty.success) return { permissive: true, required: [] };
+
+  const required = (empty.error?.issues ?? []).map((i) => i.path.map(String).join('.')).filter((p) => p.length > 0);
+  return { permissive: false, required: [...new Set(required)].sort() };
+}
+
+// ─── 실행 ───────────────────────────────────────────────────────────────────
+
+function grepFiles(pattern: string, scope: string): string[] {
+  try {
+    return execSync(`grep -rlE ${JSON.stringify(pattern)} ${scope} --include=*.ts | grep -v '\\.spec\\.' | sort`, {
+      cwd: REPO,
+      encoding: 'utf8',
+    })
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * wallet 이 자기 outbox 에 실을 수 있는 이벤트명 전부.
+ *
+ * `apps/wallet/src` 안의 `const *EventType = { … } as const` 값들과, `eventType:` 자리에 직접 쓰인
+ * 문자열 리터럴을 모은다. 과대추정 방향으로만 틀리게 설계했다 — 빠뜨리면 PROVEN 오판이 되고,
+ * 더 넣으면 UNVERIFIED 가 늘 뿐이다.
+ */
+function walletOutboxEventTypes(): Set<string> {
+  const found = new Set<string>();
+  for (const rel of grepFiles('EventType|eventType:', 'apps/wallet/src')) {
+    const abs = path.join(REPO, rel);
+    const source = ts.createSourceFile(abs, fs.readFileSync(abs, 'utf8'), ts.ScriptTarget.Latest, true);
+    const consts = collectStringConsts(source);
+
+    const visit = (node: ts.Node) => {
+      // const XxxEventType = { KEY: 'value' } as const
+      if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && /EventType$/.test(node.name.text)) {
+        let init = node.initializer;
+        while (init && ts.isAsExpression(init)) init = init.expression;
+        if (init && ts.isObjectLiteralExpression(init)) {
+          for (const p of init.properties) {
+            if (ts.isPropertyAssignment(p) && ts.isStringLiteral(p.initializer)) found.add(p.initializer.text);
+          }
+        }
+      }
+      // eventType: 'literal'
+      if (ts.isPropertyAssignment(node) && node.name.getText() === 'eventType') {
+        const v = resolveString(node.initializer, consts);
+        if (v) found.add(v);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+  }
+  return found;
+}
+
+/**
+ * `publishRawEnvelope` **호출** 지점 — BYPASS_PATHS 가 낡았는지 확인하는 근거.
+ *
+ * grep 이 아니라 AST 로 센다. 이 이름은 설명 주석에도 자주 등장하고(이 스크립트를 설명하는
+ * 주석까지 포함해서), 실제로 grep 판본이 `sales-order.module.ts` 의 근거 주석을 세 번째
+ * "호출자"로 집계해 거짓 경보를 냈다. 세는 대상이 호출이면 호출만 세야 한다.
+ */
+function findRawEnvelopeCallers(): string[] {
+  const hits: string[] = [];
+  for (const rel of grepFiles('publishRawEnvelope', 'apps libs')) {
+    const abs = path.join(REPO, rel);
+    const source = ts.createSourceFile(abs, fs.readFileSync(abs, 'utf8'), ts.ScriptTarget.Latest, true);
+    const visit = (node: ts.Node) => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        node.expression.name.getText() === 'publishRawEnvelope'
+      ) {
+        hits.push(`${rel}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}`);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+  }
+  return hits.sort();
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const asJson = argv.includes('--json');
+  const gate = argv.includes('--gate');
+  const only = argv.filter((a) => !a.startsWith('--'));
+
+  const files = [...new Set([...grepFiles('@On\\(', 'apps'), ...grepFiles('saveEvent\\(', 'apps')])];
+  const consumers: Consumer[] = [];
+  const saveEvents: SaveEventSite[] = [];
+  for (const rel of files) {
+    const r = scanFile(rel);
+    consumers.push(...r.consumers);
+    saveEvents.push(...r.saveEvents);
+  }
+
+  // 우회 가능한 (토픽, 이벤트) 집합을 만든다.
+  const bypassPairs = new Map<string, string[]>(); // "topic|event" → 근거
+  for (const p of BYPASS_PATHS) {
+    const add = (topic: string, event: string, why: string) => {
+      const key = `${topic}|${event}`;
+      bypassPairs.set(key, [...(bypassPairs.get(key) ?? []), why]);
+    };
+    if (p.resolve === 'wallet-event-consts') {
+      for (const event of walletOutboxEventTypes()) add(p.topic, event, `${p.writers} → ${p.dispatcher}`);
+    } else {
+      for (const s of saveEvents) {
+        if (s.topic && s.event) add(s.topic, s.event, `${p.writers} ${s.where}`);
+      }
+    }
+  }
+
+  interface Row {
+    app: string;
+    topic: string;
+    event: string;
+    handlers: number;
+    verdict: Verdict;
+    reason: string;
+    required: string[];
+    bypass: string[];
+  }
+
+  const rows: Row[] = [];
+
+  for (const c of consumers) {
+    if (only.length && !only.includes(c.app)) continue;
+    const topic = topicByIdent.get(c.streamIdent);
+
+    const existing = rows.find((r) => r.app === c.app && r.event === c.event && r.topic === topic);
+    if (existing) {
+      existing.handlers += 1;
+      continue;
+    }
+
+    if (!topic) {
+      rows.push({
+        app: c.app,
+        topic: `<미해결: ${c.streamIdent}>`,
+        event: c.event,
+        handlers: 1,
+        verdict: 'UNVERIFIED',
+        reason: '스트림 식별자를 토픽으로 풀 수 없다 (별칭 import?)',
+        required: [],
+        bypass: [],
+      });
+      continue;
+    }
+
+    const eventConfig = STREAM_REGISTRY[topic]?.events?.[c.event] as { schema?: unknown } | undefined;
+    const cls = eventConfig ? classifySchema(eventConfig.schema) : null;
+    const bypass = bypassPairs.get(`${topic}|${c.event}`) ?? [];
+
+    let verdict: Verdict;
+    let reason: string;
+    if (!eventConfig) {
+      verdict = 'SAFE';
+      reason = '계약에 이 이벤트가 없다 → 인터셉터가 warn 후 통과 (검증 안 함)';
+    } else if (!cls) {
+      verdict = 'SAFE';
+      reason = 'zod 스키마 없음 → 인터셉터가 통과';
+    } else if (cls.permissive) {
+      verdict = 'SAFE';
+      reason = '빈 객체까지 통과하는 관대한 스키마 → 켜도 동작 불변';
+    } else if (bypass.length > 0) {
+      verdict = 'UNVERIFIED';
+      reason = `필수 필드 + zod 우회 발행 경로 ${bypass.length}건이 이 이벤트에 닿는다`;
+    } else {
+      verdict = 'PROVEN';
+      reason = '필수 필드가 있으나 우회 경로가 닿지 않는다 → publishEvent 가 zod 파싱 결과를 실어 보낸다';
+    }
+
+    rows.push({
+      app: c.app,
+      topic,
+      event: c.event,
+      handlers: 1,
+      verdict,
+      reason,
+      required: cls?.required ?? [],
+      bypass,
+    });
+  }
+
+  rows.sort((a, b) => a.app.localeCompare(b.app) || a.topic.localeCompare(b.topic) || a.event.localeCompare(b.event));
+
+  const apps = [...new Set(rows.map((r) => r.app))].sort();
+  const summary = apps.map((app) => {
+    const own = rows.filter((r) => r.app === app);
+    const count = (v: Verdict) => own.filter((r) => r.verdict === v).length;
+    const policy = declaredPolicy(app);
+    const ready = count('UNVERIFIED') === 0;
+    return {
+      app,
+      validateOnConsume: policy.validateOnConsume,
+      policyAt: policy.where,
+      events: own.length,
+      handlers: own.reduce((n, r) => n + r.handlers, 0),
+      SAFE: count('SAFE'),
+      PROVEN: count('PROVEN'),
+      UNVERIFIED: count('UNVERIFIED'),
+      ready,
+      /** 검증을 켜 둔 앱에 미검증 이벤트가 있으면 위반 — 이것이 게이트가 막는 것이다. */
+      violation: policy.validateOnConsume && !ready,
+    };
+  });
+
+  // BYPASS_PATHS 가 실제 호출자와 어긋났는지 — 손으로 유지하는 목록이 조용히 낡는 것을 막는다.
+  const callers = findRawEnvelopeCallers();
+  const staleBypassList = callers.length !== BYPASS_PATHS.length;
+
+  if (asJson) {
+    console.log(JSON.stringify({ summary, rows, bypassPaths: BYPASS_PATHS, rawEnvelopeCallers: callers }, null, 2));
+  } else {
+    console.log('소비 검증 준비도 (validateOnConsume 를 켜도 되는가) — ADR-0029 §8 / 플랜 Task 5-C\n');
+    console.log(`zod 우회 경로: publishRawEnvelope 호출자 ${callers.length}곳`);
+    for (const c of callers) console.log(`  ${c}`);
+    if (staleBypassList) {
+      console.log(
+        `\n⚠️  BYPASS_PATHS 는 ${BYPASS_PATHS.length}곳을 가정하는데 실제는 ${callers.length}곳이다 — 목록이 낡았다.`,
+      );
+    }
+
+    console.log('\n앱                검증  이벤트  핸들러   SAFE  PROVEN  UNVERIFIED   판정');
+    for (const s of summary) {
+      const verdict = s.violation
+        ? '🔴 위반 — 검증 ON 인데 미검증 이벤트가 있다'
+        : s.validateOnConsume
+          ? '✅ 켜짐 · 전부 검증됨'
+          : s.ready
+            ? '☑️  꺼짐 · 켜도 안전'
+            : '⚠️  꺼짐 · 켜기 전 사람 확인 필요';
+      console.log(
+        `${s.app.padEnd(17)}${(s.validateOnConsume ? 'ON' : 'off').padEnd(6)}` +
+          `${String(s.events).padStart(5)}${String(s.handlers).padStart(8)}` +
+          `${String(s.SAFE).padStart(7)}${String(s.PROVEN).padStart(8)}${String(s.UNVERIFIED).padStart(12)}   ${verdict}`,
+      );
+    }
+
+    const risky = rows.filter((r) => r.verdict === 'UNVERIFIED');
+    console.log(`\n── UNVERIFIED ${risky.length}건 (사람이 payload 를 봐야 하는 것) ──────────────`);
+    if (risky.length === 0) console.log('없음.');
+    for (const r of risky) {
+      console.log(`\n${r.app}  ${r.topic}  ${r.event}  (핸들러 ${r.handlers})`);
+      console.log(`  ${r.reason}`);
+      if (r.required.length) console.log(`  필수: ${r.required.join(', ')}`);
+      for (const b of r.bypass) console.log(`  우회: ${b}`);
+    }
+
+    const proven = rows.filter((r) => r.verdict === 'PROVEN');
+    console.log(`\n── PROVEN ${proven.length}건 (필수 필드가 있으나 발행 시 검증됨) ───────────────`);
+    for (const r of proven) console.log(`  ${r.app.padEnd(16)} ${r.topic.padEnd(26)} ${r.event}`);
+  }
+
+  const violations = summary.filter((s) => s.violation);
+  if (!asJson && gate) {
+    console.log('\n── 게이트 ────────────────────────────────────────────────────');
+    console.log(
+      `검증 ON 인 앱: ${
+        summary
+          .filter((s) => s.validateOnConsume)
+          .map((s) => s.app)
+          .join(', ') || '없음'
+      }`,
+    );
+    if (violations.length === 0 && !staleBypassList) console.log('위반 없음.');
+    for (const v of violations) {
+      console.log(`🔴 ${v.app}: validateOnConsume=true (${v.policyAt}) 인데 UNVERIFIED ${v.UNVERIFIED}건`);
+    }
+  }
+
+  process.exit(gate && (staleBypassList || violations.length > 0) ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
ADR-0029 Task 5-C. 세 스위치 중 **C(검증)** 만 담는다. **core 한 앱만** 켠다.

## 게이트가 순환이었다

플랜의 5-C 게이트는 "인바운드 payload 를 먼저 확인 — 스테이징 샘플링 또는 5-B 상태 로그 관찰"인데 **둘 다 존재하지 않는다.** dev stage 는 폐기됐고, 5-B 가 미배포라 검증 인터셉터가 안 붙어 관찰할 로그가 생기지 않는다. **5-C 가 배포를 기다리고 배포가 5-C 를 기다리는 순환.**

그래서 샘플링을 **발행 경로 전수 폐쇄**로 대체했다:

1. 프로덕션 코드에 kafkajs 직접 사용 **0곳** → 모든 발행이 `StreamPublisher` 를 지난다
2. `publishEvent` 는 envelope 에 **zod 파싱 결과**를 싣는다 (`stream-publisher.service.ts:123`). 파싱은 멱등이므로 그 경로로 나간 payload 는 소비 검증을 반드시 통과한다. `validateOnPublish: false` 인 곳은 없다
3. 남는 우회는 `publishRawEnvelope` 뿐이고, 호출자는 레포 전체에 **2곳**

이 증명은 **계약 변경이 additive 임에 의존한다** — 앱이 독립 배포되므로 옛 계약으로 발행하는 producer 가 남아 있다. 5-A·5-B 의 `packages/event-contracts/` 삭제 라인은 0건이다.

## 1차 분석이 틀렸고 바로잡았다

처음엔 "outbox = zod 우회"로 뭉뚱그려 미검증 이벤트를 **36건**으로 집계했다. 틀렸다 — core 와 channel-adapter 의 자체 outbox dispatcher 는 `publishEvent` 를 부르므로 검증된다. 실제 우회는 `libs/events` 공용 outbox 와 wallet outbox **둘뿐**이고, 바로잡으니 **14건**으로 줄었다.

(이 워크스트림 전체가 "표면 이름만 보고 뭉뚱그린 결론"에서 출발했다. 같은 실수를 한 번 더 했고, 이번엔 착수 전에 잡았다.)

## core 만 켠 이유

- 소비하는 4개 이벤트가 전부 `orders.events.v1`
- 발행자 셋이 모두 `publishEvent` 를 지나고, `OrderRefundCreated` 는 **발행자가 아예 없다**
- 우회 2곳 중 어느 것도 이 토픽에 닿지 않는다
- **DLQ 가 관측되는 유일한 앱** (`dlq.metrics.ts:10` — Alloy 는 Core `/metrics` 만 스크레이프)

## 나머지 3앱은 플랜 순서를 뒤집어 Task 6 뒤로 미룬다

analytics·search·channel-adapter 를 막는 것은 전부 **같은 4개 이벤트**(`MembershipStatusChanged`·`ProductMasterActiveVersionChanged`·`ProductMasterDeleted`·`CategoryChanged`)이고, 원인이 `saveEvent → publishRawEnvelope` 의 zod 우회다. **Task 6 의 enqueue 시점 검증이 정확히 그 구멍**이라, 그게 들어가면 넷 다 기계적으로 증명된다. 먼저 켜면 payload 를 추측해야 한다.

ADR §8 과 Follow-up 6 을 먼저 고치고 플랜을 맞췄다.

## 남긴 것 두 개

- **`npm run audit:consume-validation`** — `--gate` 는 검증을 켜 둔 앱에 미검증 이벤트가 생기면 exit 1. 5-C 의 분석을 일회성 결론이 아니라 **상시 불변식**으로 바꾼다
- **멱등성 + "스키마 위반은 재시도 없이 즉시 DLQ" 를 고정하는 스펙.** 재시도 억제는 **대조군과 함께** 뒀다 — 대조군이 없으면 `maxRetries` 를 0으로 바꿔도 초록이라 아무것도 증명하지 못한다

게이트가 실제로 무는지: search 를 일부러 `true` 로 바꿔 exit 1 확인 후 원복. 스펙은 검증을 끄는 변이로 6개 중 3개가 실패하는 걸 확인.

**게이트가 첫 실행에서 자기 자신의 버그를 잡았다** — `publishRawEnvelope` 를 grep 으로 세다가 방금 쓴 근거 주석을 세 번째 "호출자"로 집계했다. 지금은 AST 로 센다.

## 검증

- `npm run type-check` **164** = 기준선 (건드린 파일 오류 0)
- 7개 소비 앱 `nest build` 전부 초록
- `libs/events`+계약 **19 suite / 166 tests**
- 전체 jest 실패 suite **18 = 기준선** (통과 3028)
- `audit:event-handlers` exit 0 · `audit:consume-validation --gate` exit 0

마이그레이션 0 / 시크릿 0 / env 0.

## ⚠️ 배포 시 (사람이 할 것)

5-B 도 아직 미배포이므로, 다음 배포에서 **core 는 배선(B)과 검증(C)이 함께 켜진다.**

`events_dlq_messages_total{topic="orders.events.v1"}` 을 보라. **0 이 아니면** 계약 이전에 토픽에 쌓인 옛 메시지이거나(이 증명이 못 덮는 유일한 구멍) 증명이 틀린 것이다.

**롤백은 `apps/core/src/modules/sales-order/sales-order.module.ts:47` 한 줄을 `false` 로.**

## 후속

- **Task 6** — outbox enqueue 시점 검증 + outbox 5벌 회수 + 5-A 가 미룬 `@InjectStreamPublisher` → `@InjectPublisher` 21곳. 이게 끝나야 나머지 3앱 5-C 가 풀린다
- 이 PR 이 머지되면 `docs/plan-task5-split` 브랜치는 역할이 끝나 삭제 가능하다