### PR TITLE
feat(events): enqueue 시점 zod 검증 + 발행 경로 우회 제거 (ADR-0029 Task 6-A)

### DIFF
--- a/apps/analytics/src/analytics.module.ts
+++ b/apps/analytics/src/analytics.module.ts
@@ -41,17 +41,16 @@ import { MembershipEventsConsumer } from './datasets/memberships/ingest/membersh
       streams: [ORDER_STREAM, PRODUCT_STREAM, MEMBERSHIP_STREAM],
       groupId: process.env.KAFKA_GROUP_ID || 'analytics-consumer',
       enableAutoDLQ: true,
-      // ⚠️ 아직 끈다. core 는 5-C 에서 켰지만 이 앱은 못 켠다 (ADR-0029 §8).
+      // ⚠️ 아직 끈다 — 그러나 **막는 이유는 사라졌다** (ADR-0029 §5, 플랜 Task 6-A).
       //
-      // 막는 것은 3개 이벤트다 — `MembershipStatusChanged` ·
-      // `ProductMasterActiveVersionChanged` · `ProductMasterDeleted`. 셋 다
-      // `OutboxPublisher.saveEvent` 로 발행되고, 그 경로는 `publishRawEnvelope` 로 zod 를
-      // 우회한다. 즉 스키마를 안 지키는 payload 가 올라올 수 있는지 정적으로 증명되지 않는다.
-      // 나머지 7개는 발행 시 검증되므로 안전하다.
+      // 이 앱을 막던 3개 이벤트(`MembershipStatusChanged` ·
+      // `ProductMasterActiveVersionChanged` · `ProductMasterDeleted`)는 아웃박스로 나가면서
+      // zod 를 우회했다. 6-A 가 적재(`enqueue`)와 발행(`publishStoredEnvelope`) 양쪽에 문을
+      // 달아 그 우회를 없앴고, 셋 다 PROVEN 이 됐다 — 10/10 이 검증된 발행 경로만 탄다.
       //
-      // **이걸 여는 것은 Task 6 이다** (enqueue 시점 zod 검증). 그게 들어가면 셋 다 자동으로
-      // PROVEN 이 되어 이 줄을 뒤집을 수 있다. 그 전에 켜는 것은 추측이고, 이 앱은 DLQ 를
-      // 스크레이프하지 않아(`dlq.metrics.ts:10`) 추측이 틀려도 아무도 모른다.
+      // 남은 것은 **이 한 줄을 뒤집는 결정**뿐이고 그건 5-C 의 마지막 조각이다. 이 앱은 DLQ 를
+      // 스크레이프하지 않으므로(`dlq.metrics.ts:10`) 켠 뒤 증명이 틀렸을 때 알아차릴 수단이
+      // core 뿐이라는 점을 감안해 결정한다.
       // 현황: `npm run audit:consume-validation -- analytics`
       validation: { validateOnConsume: false },
     }),

--- a/apps/channel-adapter/src/adapter.module.ts
+++ b/apps/channel-adapter/src/adapter.module.ts
@@ -256,12 +256,11 @@ import { OrderPollerOrchestrator } from './services/order-collection/order-polle
     // 그 목록이야말로 이 워크스트림이 없애는 중인 두 번째 진실이다. 필요한 것은
     // 정책 하나뿐이므로 정책만 등록한다. Task 7 의 `forApp` 이 이 자리를 흡수한다.
     //
-    // 5-C 현황: core 는 켰지만 이 앱은 아직 끈다. 34개 핸들러 중 30개는 안전하고
-    // (11 = 관대한 스키마 · 19 = 발행 시 검증됨), 막는 것은 4개 이벤트다 —
-    // `MembershipStatusChanged` · `ProductMasterActiveVersionChanged` ·
-    // `ProductMasterDeleted` · `CategoryChanged`. 넷 다 `OutboxPublisher.saveEvent` 로
-    // 발행돼 `publishRawEnvelope` 로 zod 를 우회한다. **여는 것은 Task 6** (enqueue 시점
-    // 검증) 이며, 그때 넷 다 자동으로 PROVEN 이 된다.
+    // 5-C 현황: 아직 끄지만 **막는 이유는 사라졌다** (플랜 Task 6-A). 이 앱을 막던 4개
+    // 이벤트(`MembershipStatusChanged` · `ProductMasterActiveVersionChanged` ·
+    // `ProductMasterDeleted` · `CategoryChanged`)는 아웃박스로 나가며 zod 를 우회했는데,
+    // 6-A 가 적재·발행 양쪽에 문을 달아 그 우회를 없앴다. 34개가 전부 SAFE(11) 또는
+    // PROVEN(23) 이다. 남은 것은 이 한 줄을 뒤집는 결정뿐이며 그건 5-C 의 마지막 조각이다.
     //
     // 이 앱은 외부 채널 유래 payload 라 가장 위험한 앱이라고 적어왔는데, 실측은 조금 다르다 —
     // 외부 payload 는 HTTP 로 들어와 이 앱이 *발행측*에서 정규화하므로, 소비하는 34개는

--- a/apps/core/src/modules/catalog/core/categories/categories.service.spec.ts
+++ b/apps/core/src/modules/catalog/core/categories/categories.service.spec.ts
@@ -1,11 +1,4 @@
-jest.mock(
-  '@packages/event-contracts/streams/product.stream',
-  () => ({
-    PRODUCT_STREAM: { topic: { topic: 'products.events.v1' }, aggregateType: 'Product' },
-  }),
-  { virtual: true },
-);
-
+import { PRODUCT_STREAM } from '@packages/event-contracts/streams/product.stream';
 import { ProductCategoriesService } from './categories.service';
 
 describe('ProductCategoriesService Medusa projection outbox events', () => {
@@ -44,8 +37,8 @@ describe('ProductCategoriesService Medusa projection outbox events', () => {
     const db = {
       run: jest.fn(async (callback: (trx: typeof tx) => Promise<unknown>, t?: typeof tx) => callback(t ?? tx)),
     };
-    const outboxPublisher = {
-      saveEvent: jest.fn().mockResolvedValue(undefined),
+    const productPublisher = {
+      enqueue: jest.fn().mockResolvedValue(undefined),
     };
 
     const projectionSnapshotAssembler = {
@@ -55,22 +48,20 @@ describe('ProductCategoriesService Medusa projection outbox events', () => {
     const service = new (ProductCategoriesService as any)(
       db,
       projectionSnapshotAssembler,
-      outboxPublisher,
+      productPublisher,
     ) as ProductCategoriesService;
 
-    return { service, tx, outboxPublisher, projectionSnapshotAssembler };
+    return { service, tx, productPublisher, projectionSnapshotAssembler };
   }
 
   it('enqueues CategoryChanged through the transactional outbox using the category transaction', async () => {
-    const { service, tx, outboxPublisher } = makeService();
+    const { service, tx, productPublisher } = makeService();
 
     await service.updateCategory('cat-1', { name: 'Updated Lip' } as any);
 
-    expect(outboxPublisher.saveEvent).toHaveBeenCalledWith(
+    expect(productPublisher.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
-        topic: 'products.events.v1',
         eventType: 'CategoryChanged',
-        aggregateType: 'Product',
         aggregateId: 'cat-1',
         payload: expect.objectContaining({
           categoryId: 'cat-1',
@@ -114,7 +105,7 @@ describe('ProductCategoriesService 상품-카테고리 변경 시 프로젝션 �
     const db = {
       run: jest.fn(async (callback: (trx: unknown) => Promise<unknown>, t?: unknown) => callback(t ?? tx)),
     };
-    const outboxPublisher = { saveEvent: jest.fn().mockResolvedValue(undefined) };
+    const productPublisher = { enqueue: jest.fn().mockResolvedValue(undefined) };
     const projectionSnapshotAssembler = {
       assembleActiveVersionSnapshot: jest.fn().mockResolvedValue({
         snapshot: { name: '아몬드 립' },
@@ -126,14 +117,14 @@ describe('ProductCategoriesService 상품-카테고리 변경 시 프로젝션 �
     const service = new (ProductCategoriesService as any)(
       db,
       projectionSnapshotAssembler,
-      outboxPublisher,
+      productPublisher,
     ) as ProductCategoriesService;
 
-    return { service, outboxPublisher, projectionSnapshotAssembler };
+    return { service, productPublisher, projectionSnapshotAssembler };
   }
 
-  const productEvents = (outboxPublisher: { saveEvent: jest.Mock }) =>
-    outboxPublisher.saveEvent.mock.calls.filter(
+  const productEvents = (productPublisher: { enqueue: jest.Mock }) =>
+    productPublisher.enqueue.mock.calls.filter(
       ([params]) => params.eventType === 'ProductMasterActiveVersionChanged',
     );
 
@@ -143,11 +134,11 @@ describe('ProductCategoriesService 상품-카테고리 변경 시 프로젝션 �
       [{ versionId: 'v1', masterId: 'm1', version: 1 }], // 활성 버전
       [], // 기존 연결 없음
     ]);
-    const { service, outboxPublisher } = makeService(tx);
+    const { service, productPublisher } = makeService(tx);
 
     await service.addProductsToCategory(['v1'], 'cat-2');
 
-    const events = productEvents(outboxPublisher);
+    const events = productEvents(productPublisher);
     expect(events).toHaveLength(1);
     expect(events[0][0]).toEqual(
       expect.objectContaining({
@@ -171,11 +162,11 @@ describe('ProductCategoriesService 상품-카테고리 변경 시 프로젝션 �
       [{ versionId: 'v1', masterId: 'm1', version: 1 }],
       [{ masterId: 'm1', versionId: 'v1', categoryId: 'cat-2' }], // 이미 연결됨
     ]);
-    const { service, outboxPublisher } = makeService(tx);
+    const { service, productPublisher } = makeService(tx);
 
     await service.addProductsToCategory(['v1'], 'cat-2');
 
-    expect(productEvents(outboxPublisher)).toHaveLength(0);
+    expect(productEvents(productPublisher)).toHaveLength(0);
   });
 
   it('moveProductsToCategory: 이동한 활성 버전을 재발행한다', async () => {
@@ -183,11 +174,11 @@ describe('ProductCategoriesService 상품-카테고리 변경 시 프로젝션 �
       [{ id: 'cat-2' }],
       [{ versionId: 'v1', masterId: 'm1', version: 1 }],
     ]);
-    const { service, outboxPublisher } = makeService(tx);
+    const { service, productPublisher } = makeService(tx);
 
     await service.moveProductsToCategory(['v1'], 'cat-2');
 
-    const events = productEvents(outboxPublisher);
+    const events = productEvents(productPublisher);
     expect(events).toHaveLength(1);
     expect(events[0][0].payload).toEqual(expect.objectContaining({ masterId: 'm1', versionId: 'v1' }));
   });
@@ -199,14 +190,14 @@ describe('ProductCategoriesService 상품-카테고리 변경 시 프로젝션 �
       [{ masterId: 'm1', versionId: 'v1', categoryId: 'cat-1' }], // 상품 연결
       [{ masterId: 'm1', versionId: 'v1' }], // 그중 활성 버전
     ]);
-    const { service, outboxPublisher } = makeService(tx);
+    const { service, productPublisher } = makeService(tx);
 
     await service.deleteCategory('cat-1');
 
     expect(
-      outboxPublisher.saveEvent.mock.calls.filter(([params]) => params.eventType === 'CategoryChanged'),
+      productPublisher.enqueue.mock.calls.filter(([params]) => params.eventType === 'CategoryChanged'),
     ).toHaveLength(1);
-    const events = productEvents(outboxPublisher);
+    const events = productEvents(productPublisher);
     expect(events).toHaveLength(1);
     expect(events[0][0].aggregateId).toBe('m1');
   });
@@ -220,14 +211,14 @@ describe('ProductCategoriesService 상품-카테고리 변경 시 프로젝션 �
       ],
       [],
     ]);
-    const { service, outboxPublisher, projectionSnapshotAssembler } = makeService(tx);
+    const { service, productPublisher, projectionSnapshotAssembler } = makeService(tx);
     projectionSnapshotAssembler.assembleActiveVersionSnapshot
       .mockRejectedValueOnce(new Error('활성 variant 없음'))
       .mockResolvedValueOnce({ snapshot: { name: 'ok' }, categoryIds: ['cat-2'], primaryCategoryId: null });
 
     await expect(service.addProductsToCategory(['v1', 'v2'], 'cat-2')).resolves.toBeUndefined();
 
-    const events = productEvents(outboxPublisher);
+    const events = productEvents(productPublisher);
     expect(events).toHaveLength(1);
     expect(events[0][0].aggregateId).toBe('m2');
   });
@@ -267,13 +258,13 @@ describe('ProductCategoriesService 멤버십 전용 카테고리 지정', () => 
     const db = {
       run: jest.fn(async (callback: (trx: unknown) => Promise<unknown>, t?: unknown) => callback(t ?? tx)),
     };
-    const outboxPublisher = { saveEvent: jest.fn().mockResolvedValue(undefined) };
+    const productPublisher = { enqueue: jest.fn().mockResolvedValue(undefined) };
     const service = new (ProductCategoriesService as any)(
       db,
       { assembleActiveVersionSnapshot: jest.fn() },
-      outboxPublisher,
+      productPublisher,
     ) as ProductCategoriesService;
-    return { service, outboxPublisher, setSpy };
+    return { service, productPublisher, setSpy };
   }
 
   it('기존 display_settings 를 보존한 채 멤버십 전용 플래그만 병합한다', async () => {
@@ -289,11 +280,11 @@ describe('ProductCategoriesService 멤버십 전용 카테고리 지정', () => 
   });
 
   it('플래그가 CategoryChanged 스냅샷으로 전달된다', async () => {
-    const { service, outboxPublisher } = makeService({ showOnMainCategory: true });
+    const { service, productPublisher } = makeService({ showOnMainCategory: true });
 
     await service.updateCategory('cat-1', { isVisibleToMembersOnly: true } as any);
 
-    const [params] = outboxPublisher.saveEvent.mock.calls.find(
+    const [params] = productPublisher.enqueue.mock.calls.find(
       ([p]: [{ eventType: string }]) => p.eventType === 'CategoryChanged',
     );
     expect(params.payload.category.displaySettings).toEqual(
@@ -348,13 +339,13 @@ describe('ProductCategoriesService 조상/자손 이벤트', () => {
     };
     queue.push(rows.descendants ?? [], rows.ancestors ?? []);
     const db = { run: jest.fn(async (cb: (t: unknown) => Promise<unknown>, t?: unknown) => cb(t ?? tx)) };
-    const outboxPublisher = { saveEvent: jest.fn().mockResolvedValue(undefined) };
+    const productPublisher = { enqueue: jest.fn().mockResolvedValue(undefined) };
     const service = new (ProductCategoriesService as any)(
       db,
       { assembleActiveVersionSnapshot: jest.fn() },
-      outboxPublisher,
+      productPublisher,
     ) as ProductCategoriesService;
-    return { service, outboxPublisher };
+    return { service, productPublisher };
   }
 
   it('멤버십 전용 변경 시 자손 카테고리 이벤트도 발행한다', async () => {
@@ -376,11 +367,11 @@ describe('ProductCategoriesService 조상/자손 이벤트', () => {
       createdAt: new Date('2026-07-27T00:00:00.000Z'),
       updatedAt: new Date('2026-07-27T00:00:00.000Z'),
     };
-    const { service, outboxPublisher } = makeService({ descendants: [descendant] });
+    const { service, productPublisher } = makeService({ descendants: [descendant] });
 
     await service.updateCategory('cat-2', { isVisibleToMembersOnly: true } as any);
 
-    const ids = outboxPublisher.saveEvent.mock.calls
+    const ids = productPublisher.enqueue.mock.calls
       .filter(([p]: [{ eventType: string }]) => p.eventType === 'CategoryChanged')
       .map(([p]: [{ aggregateId: string }]) => p.aggregateId);
     expect(ids).toContain('cat-2');
@@ -418,18 +409,83 @@ describe('ProductCategoriesService 레거시 path 대응', () => {
       insert: jest.fn(() => ({ values: jest.fn().mockResolvedValue(undefined) })),
     };
     const db = { run: jest.fn(async (cb: (t: unknown) => Promise<unknown>, t?: unknown) => cb(t ?? tx)) };
-    const outboxPublisher = { saveEvent: jest.fn().mockResolvedValue(undefined) };
+    const productPublisher = { enqueue: jest.fn().mockResolvedValue(undefined) };
     const service = new (ProductCategoriesService as any)(
       db,
       { assembleActiveVersionSnapshot: jest.fn() },
-      outboxPublisher,
+      productPublisher,
     ) as ProductCategoriesService;
 
     await expect(service.updateCategory(legacy.id, { name: '브랜드' } as any)).resolves.toBeDefined();
 
-    const event = outboxPublisher.saveEvent.mock.calls.find(
+    const event = productPublisher.enqueue.mock.calls.find(
       ([p]: [{ eventType: string }]) => p.eventType === 'CategoryChanged',
     );
     expect(event[0].payload.ancestors).toEqual([]);
+  });
+});
+
+
+/**
+ * ADR-0029 §5 이후 `CategoryChanged` 는 **적재 시점에 zod 파싱을 탄다.** 그 전까지 이 스키마는
+ * 런타임에서 한 번도 실행된 적이 없었다 — 이 이벤트의 발행자는 아웃박스뿐이었고 아웃박스에는
+ * 검증이 없었기 때문이다.
+ *
+ * 손실 여부를 함께 보는 이유가 이 이벤트에서 특히 크다. zod object 는 미선언 키를 **조용히**
+ * 떼어내는데, `ancestors` 가 정확히 그런 키였다(payload 인터페이스에는 있고 스키마에는 없었다).
+ * channel-adapter 의 Medusa 카테고리 동기화가 그 배열로 부모를 먼저 보장하므로
+ * (`pim-medusa-sync.service.ts:662`), 조용한 손실은 자식 카테고리가 최상위로 붙는 버그가 된다.
+ */
+describe('ProductCategoriesService CategoryChanged 계약 적합성', () => {
+  const CHILD_ID = '019fa2dc-670f-7018-ab1e-f46df45ff8aa';
+  const PARENT_ID = '019fa2dc-670f-7018-ab1e-f46df45ff8bb';
+
+  function row(overrides: Record<string, unknown>) {
+    return {
+      description: null,
+      level: 0,
+      sortOrder: 0,
+      isActive: true,
+      visibility: true,
+      imageUrl: null,
+      displaySettings: null,
+      seoConfig: null,
+      templateConfig: null,
+      createdAt: new Date('2026-07-27T00:00:00.000Z'),
+      updatedAt: new Date('2026-07-27T00:00:00.000Z'),
+      ...overrides,
+    };
+  }
+
+  it('조상까지 포함한 payload 가 계약을 손실 없이 통과한다', async () => {
+    const child = row({ id: CHILD_ID, name: '자식', slug: 'child', parentId: PARENT_ID, level: 1, path: 'p/c' });
+    const parent = row({ id: PARENT_ID, name: '부모', slug: 'parent', parentId: null, path: 'p' });
+
+    // 이름만 바꾸므로 display_settings 를 읽지 않는다. select 순서는 조상(parentId 체인) 뿐이다.
+    const queue: unknown[][] = [[parent], []];
+    const tx = {
+      select: jest.fn(() => ({ from: () => ({ where: () => Promise.resolve(queue.shift() ?? []) }) })),
+      update: jest.fn(() => ({ set: () => ({ where: () => ({ returning: () => [child] }) }) })),
+      delete: jest.fn(() => ({ where: jest.fn().mockResolvedValue(undefined) })),
+      insert: jest.fn(() => ({ values: jest.fn().mockResolvedValue(undefined) })),
+    };
+    const db = { run: jest.fn(async (cb: (t: unknown) => Promise<unknown>, t?: unknown) => cb(t ?? tx)) };
+    const productPublisher = { enqueue: jest.fn().mockResolvedValue(undefined) };
+    const service = new (ProductCategoriesService as any)(
+      db,
+      { assembleActiveVersionSnapshot: jest.fn() },
+      productPublisher,
+    ) as ProductCategoriesService;
+
+    await service.updateCategory(CHILD_ID, { name: '자식' } as any);
+
+    const [{ payload }] = productPublisher.enqueue.mock.calls.find(
+      ([p]: [{ eventType: string }]) => p.eventType === 'CategoryChanged',
+    );
+
+    expect(payload.ancestors).toHaveLength(1);
+
+    const parsed = PRODUCT_STREAM.events.CategoryChanged.schema!.parse(payload);
+    expect(parsed).toEqual(payload);
   });
 });

--- a/apps/core/src/modules/catalog/core/categories/categories.service.ts
+++ b/apps/core/src/modules/catalog/core/categories/categories.service.ts
@@ -36,7 +36,7 @@ import {
 import { ProjectionSnapshotAssembler } from '../products/assemblers/projection-snapshot.assembler';
 import { eq, isNull, like, inArray, and, or, sql, asc } from 'drizzle-orm';
 import { RowList } from 'postgres';
-import { OutboxPublisher } from '@app/events';
+import { InjectPublisher, type PublisherFor } from '@app/events';
 import { PRODUCT_STREAM } from '@packages/event-contracts/streams/product.stream';
 import type {
   CategoryChangedPayload,
@@ -54,7 +54,8 @@ export class ProductCategoriesService {
   constructor(
     @InjectDb() private readonly db: DbService<PimSchema>,
     private readonly projectionSnapshotAssembler: ProjectionSnapshotAssembler,
-    private readonly outboxPublisher: OutboxPublisher,
+    @InjectPublisher(PRODUCT_STREAM)
+    private readonly productPublisher: PublisherFor<typeof PRODUCT_STREAM>,
   ) {}
 
   private getClient(tx?: DbTransaction): DbClient {
@@ -896,16 +897,7 @@ export class ProductCategoriesService {
       ancestors: snapshot ? await this.buildAncestorSnapshots(snapshot, tx) : undefined,
     };
 
-    await this.outboxPublisher.saveEvent(
-      {
-        topic: PRODUCT_STREAM.topic.topic,
-        eventType: 'CategoryChanged',
-        aggregateType: PRODUCT_STREAM.aggregateType,
-        aggregateId: categoryId,
-        payload,
-      },
-      tx,
-    );
+    await this.productPublisher.enqueue({ eventType: 'CategoryChanged', aggregateId: categoryId, payload }, tx);
   }
 
   /**
@@ -951,11 +943,9 @@ export class ProductCategoriesService {
         continue;
       }
 
-      await this.outboxPublisher.saveEvent(
+      await this.productPublisher.enqueue(
         {
-          topic: PRODUCT_STREAM.topic.topic,
           eventType: 'ProductMasterActiveVersionChanged',
-          aggregateType: PRODUCT_STREAM.aggregateType,
           aggregateId: masterId,
           payload: {
             masterId,

--- a/apps/core/src/modules/catalog/core/products/assemblers/projection-snapshot.assembler.spec.ts
+++ b/apps/core/src/modules/catalog/core/products/assemblers/projection-snapshot.assembler.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
+import { PRODUCT_STREAM } from '@packages/event-contracts/streams/product.stream';
 import { ProjectionSnapshotAssembler } from './projection-snapshot.assembler';
 
 type CategoryFixture = {
@@ -316,5 +317,42 @@ describe('ProjectionSnapshotAssembler', () => {
     await expect(assembler.assembleActiveVersionSnapshot('master-1', 'version-1', {} as any)).rejects.toThrow(
       'Multiple primary categories',
     );
+  });
+
+  /**
+   * 이 조립 결과는 `ProductMasterActiveVersionChanged` 의 payload 로 들어가고, ADR-0029 §5 이후
+   * **적재 시점에 zod 파싱을 탄다.** 그 전까지 이 스키마는 런타임에서 한 번도 실행된 적이 없었다 —
+   * 이 이벤트의 발행자는 아웃박스뿐이었고 아웃박스에는 검증이 없었기 때문이다.
+   *
+   * 그래서 두 가지를 함께 본다:
+   * - **통과하는가** — 통과하지 못하면 상품 게시 트랜잭션이 통째로 실패한다.
+   * - **손실이 없는가** — zod object 는 미선언 키를 조용히 떼어내므로, 통과만 봐서는
+   *   소비자가 쓰던 필드가 사라진 것을 알 수 없다. 이 워크스트림이 없애려는 무증상 실패다.
+   */
+  it('조립 결과는 ProductMasterActiveVersionChanged 계약을 손실 없이 통과한다', async () => {
+    const { assembler } = makeAssembler({
+      categories: [category({ id: 'cat-lip', isPrimary: true, thumbnailFileId: 'file-category' })],
+      variants: [{ id: 'variant-active', status: 'active', variantName: 'Red', isDefault: true, optionValueIds: [] }],
+      images: [{ id: 'image-1', fileId: 'file-primary', isPrimary: true, sortOrder: 1 }],
+    });
+
+    const assembly = await assembler.assembleActiveVersionSnapshot('master-1', 'version-1', {} as any);
+
+    // product-versions.service.ts `_emitActiveVersionChangedEvent` 가 만드는 payload 그대로
+    const payload = {
+      masterId: 'master-1',
+      versionId: 'version-1',
+      name: assembly.snapshot.name,
+      previousActiveVersionId: null,
+      categoryIds: assembly.categoryIds,
+      primaryCategoryId: assembly.primaryCategoryId,
+      changeReason: 'published' as const,
+      changedAt: new Date('2026-08-09T00:00:00.000Z').toISOString(),
+      snapshot: assembly.snapshot,
+    };
+
+    const parsed = PRODUCT_STREAM.events.ProductMasterActiveVersionChanged.schema!.parse(payload);
+
+    expect(parsed).toEqual(payload);
   });
 });

--- a/apps/core/src/modules/catalog/core/products/services/product-masters.service.spec.ts
+++ b/apps/core/src/modules/catalog/core/products/services/product-masters.service.spec.ts
@@ -18,9 +18,7 @@ describe('ProductMastersService Medusa projection outbox events', () => {
   function makeService() {
     const productPublisher = {
       publishEvent: jest.fn().mockResolvedValue(undefined),
-    };
-    const outboxPublisher = {
-      saveEvent: jest.fn().mockResolvedValue(undefined),
+      enqueue: jest.fn().mockResolvedValue(undefined),
     };
     const productSellableQuantity = {
       recalculateAndPublishForMaster: jest.fn().mockResolvedValue([]),
@@ -29,7 +27,6 @@ describe('ProductMastersService Medusa projection outbox events', () => {
     const service = new ProductMastersService(
       { run: (fn: any, t?: any) => (t ? fn(t) : fn(undefined)) } as any,
       productPublisher as any,
-      outboxPublisher as any,
       {} as any,
       {} as any,
       {} as any,
@@ -38,7 +35,7 @@ describe('ProductMastersService Medusa projection outbox events', () => {
       null,
     );
 
-    return { service, productPublisher, outboxPublisher, productSellableQuantity };
+    return { service, productPublisher, productSellableQuantity };
   }
 
   it('passes the delete transaction to the ProductMasterDeleted outbox enqueue', async () => {
@@ -82,16 +79,15 @@ describe('ProductMastersService Medusa projection outbox events', () => {
   });
 
   it('enqueues ProductMasterDeleted through the transactional outbox and does not publish directly to Kafka', async () => {
-    const { service, productPublisher, outboxPublisher } = makeService();
+    const { service, productPublisher } = makeService();
     const tx = {} as any;
 
     await (service as any)._emitMasterDeletedEvent('master-1', tx);
 
-    expect(outboxPublisher.saveEvent).toHaveBeenCalledWith(
+    // 토픽·aggregateType 은 계약에서 도출되므로 호출부에 없다 (ADR-0029 §5)
+    expect(productPublisher.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
-        topic: 'products.events.v1',
         eventType: 'ProductMasterDeleted',
-        aggregateType: 'Product',
         aggregateId: 'master-1',
         payload: expect.objectContaining({
           masterId: 'master-1',
@@ -126,9 +122,7 @@ describe('ProductMastersService hardDelete purchase constraint cleanup', () => {
   function makeService() {
     const productPublisher = {
       publishEvent: jest.fn().mockResolvedValue(undefined),
-    };
-    const outboxPublisher = {
-      saveEvent: jest.fn().mockResolvedValue(undefined),
+      enqueue: jest.fn().mockResolvedValue(undefined),
     };
     const productSellableQuantity = {
       recalculateAndPublishForMaster: jest.fn().mockResolvedValue([]),
@@ -137,7 +131,6 @@ describe('ProductMastersService hardDelete purchase constraint cleanup', () => {
     return new ProductMastersService(
       { run: (fn: any, t?: any) => (t ? fn(t) : fn(undefined)) } as any,
       productPublisher as any,
-      outboxPublisher as any,
       {} as any,
       {} as any,
       {} as any,
@@ -277,9 +270,7 @@ describe('ProductMastersService.createMaster ownership', () => {
   function makeService() {
     const productPublisher = {
       publishEvent: jest.fn().mockResolvedValue(undefined),
-    };
-    const outboxPublisher = {
-      saveEvent: jest.fn().mockResolvedValue(undefined),
+      enqueue: jest.fn().mockResolvedValue(undefined),
     };
     const productSellableQuantity = {
       recalculateAndPublishForMaster: jest.fn().mockResolvedValue([]),
@@ -288,7 +279,6 @@ describe('ProductMastersService.createMaster ownership', () => {
     const service = new ProductMastersService(
       { run: (fn: any, t?: any) => (t ? fn(t) : fn(undefined)) } as any,
       productPublisher as any,
-      outboxPublisher as any,
       {} as any,
       {} as any,
       {} as any,
@@ -297,7 +287,7 @@ describe('ProductMastersService.createMaster ownership', () => {
       null,
     );
 
-    return { service, productPublisher, outboxPublisher, productSellableQuantity };
+    return { service, productPublisher, productSellableQuantity };
   }
 
   it('records the creating user as draft owner and creator on the initial version', async () => {

--- a/apps/core/src/modules/catalog/core/products/services/product-masters.service.ts
+++ b/apps/core/src/modules/catalog/core/products/services/product-masters.service.ts
@@ -9,7 +9,7 @@ import {
 } from '@nestjs/common';
 import { DbService, InjectDb } from '@app/db';
 import { ConflictError } from '@app/shared';
-import { InjectStreamPublisher, OutboxPublisher, StreamPublisher } from '@app/events';
+import { InjectStreamPublisher, StreamPublisher } from '@app/events';
 import { PRODUCT_STREAM, ProductEvents } from '@packages/event-contracts';
 import {
   ProductMaster,
@@ -110,7 +110,6 @@ export class ProductMastersService {
 
     @InjectStreamPublisher(PRODUCT_STREAM.topic.topic)
     private readonly productPublisher: StreamPublisher<ProductEvents>,
-    private readonly outboxPublisher: OutboxPublisher,
 
     @Inject(forwardRef(() => ProductVersionsService))
     private readonly productVersionsService: ProductVersionsService,
@@ -1013,11 +1012,9 @@ export class ProductMastersService {
    * Emit ProductMasterDeleted event
    */
   private async _emitMasterDeletedEvent(masterId: string, tx: DbTransaction): Promise<void> {
-    await this.outboxPublisher.saveEvent(
+    await this.productPublisher.enqueue(
       {
-        topic: PRODUCT_STREAM.topic.topic,
         eventType: 'ProductMasterDeleted',
-        aggregateType: PRODUCT_STREAM.aggregateType,
         aggregateId: masterId,
         payload: {
           masterId,

--- a/apps/core/src/modules/catalog/core/products/services/product-versions.service.spec.ts
+++ b/apps/core/src/modules/catalog/core/products/services/product-versions.service.spec.ts
@@ -24,9 +24,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
   function makeService() {
     const productPublisher = {
       publishEvent: jest.fn().mockResolvedValue(undefined),
-    };
-    const outboxPublisher = {
-      saveEvent: jest.fn().mockResolvedValue(undefined),
+      enqueue: jest.fn().mockResolvedValue(undefined),
     };
     const projectionSnapshotAssembler = {
       assembleActiveVersionSnapshot: jest.fn(),
@@ -48,7 +46,6 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
     const service = new ProductVersionsService(
       { run: (fn: any, t?: any) => (t ? fn(t) : fn(undefined)) } as any,
       productPublisher as any,
-      outboxPublisher as any,
       pricingValidator as any,
       {} as any,
       projectionSnapshotAssembler as any,
@@ -61,7 +58,6 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
     return {
       service,
       productPublisher,
-      outboxPublisher,
       projectionSnapshotAssembler,
       pricingValidator,
       priceCacheService,
@@ -71,7 +67,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
   }
 
   it('enqueues ProductMasterActiveVersionChanged through the transactional outbox using the provided tx', async () => {
-    const { service, productPublisher, outboxPublisher, projectionSnapshotAssembler } = makeService();
+    const { service, productPublisher, projectionSnapshotAssembler } = makeService();
     const tx = {} as any;
     const snapshot = {
       masterId: 'master-1',
@@ -111,11 +107,9 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
     );
 
     expect(projectionSnapshotAssembler.assembleActiveVersionSnapshot).toHaveBeenCalledWith('master-1', 'version-2', tx);
-    expect(outboxPublisher.saveEvent).toHaveBeenCalledWith(
+    expect(productPublisher.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
-        topic: 'products.events.v1',
         eventType: 'ProductMasterActiveVersionChanged',
-        aggregateType: 'Product',
         aggregateId: 'master-1',
         payload: expect.objectContaining({
           masterId: 'master-1',
@@ -139,7 +133,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
   });
 
   it('임포트 게시면 payload 에 origin 과 importSessionId 를 싣는다', async () => {
-    const { service, outboxPublisher, projectionSnapshotAssembler } = makeService();
+    const { service, productPublisher, projectionSnapshotAssembler } = makeService();
     projectionSnapshotAssembler.assembleActiveVersionSnapshot.mockResolvedValue({
       snapshot: null,
       categoryIds: [],
@@ -154,7 +148,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
       { origin: 'bulk_import', importSessionId: 'session-1' },
     );
 
-    expect(outboxPublisher.saveEvent).toHaveBeenCalledWith(
+    expect(productPublisher.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
         payload: expect.objectContaining({
           origin: 'bulk_import',
@@ -166,7 +160,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
   });
 
   it('단건 게시면 origin 키 자체가 payload 에 없다', async () => {
-    const { service, outboxPublisher, projectionSnapshotAssembler } = makeService();
+    const { service, productPublisher, projectionSnapshotAssembler } = makeService();
     projectionSnapshotAssembler.assembleActiveVersionSnapshot.mockResolvedValue({
       snapshot: null,
       categoryIds: [],
@@ -182,13 +176,13 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
 
     // `origin: undefined` 로도 통과하지 않도록 키 존재 자체를 본다 —
     // 단건 경로의 payload 는 이 스테이지 전후로 바이트 단위로 같아야 한다.
-    const [{ payload }] = outboxPublisher.saveEvent.mock.calls[0];
+    const [{ payload }] = productPublisher.enqueue.mock.calls[0];
     expect(Object.prototype.hasOwnProperty.call(payload, 'origin')).toBe(false);
     expect(Object.prototype.hasOwnProperty.call(payload, 'importSessionId')).toBe(false);
   });
 
   it('uses the caller-provided active changeReason instead of inferring rollback from previous active version', async () => {
-    const { service, outboxPublisher, projectionSnapshotAssembler } = makeService();
+    const { service, productPublisher, projectionSnapshotAssembler } = makeService();
     const tx = {} as any;
     const snapshot = {
       masterId: 'master-1',
@@ -225,7 +219,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
       tx,
     );
 
-    expect(outboxPublisher.saveEvent).toHaveBeenCalledWith(
+    expect(productPublisher.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
         payload: expect.objectContaining({
           versionId: 'version-2',
@@ -240,7 +234,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
   });
 
   it('fails published/rollback events before enqueueing when the projection snapshot cannot be assembled', async () => {
-    const { service, outboxPublisher, projectionSnapshotAssembler } = makeService();
+    const { service, productPublisher, projectionSnapshotAssembler } = makeService();
     const tx = {} as any;
     projectionSnapshotAssembler.assembleActiveVersionSnapshot.mockRejectedValue(new Error('snapshot unavailable'));
 
@@ -257,11 +251,11 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
       ),
     ).rejects.toThrow('snapshot unavailable');
 
-    expect(outboxPublisher.saveEvent).not.toHaveBeenCalled();
+    expect(productPublisher.enqueue).not.toHaveBeenCalled();
   });
 
   it('enqueues unpublished events without a snapshot, active version id, or category projection', async () => {
-    const { service, outboxPublisher, projectionSnapshotAssembler } = makeService();
+    const { service, productPublisher, projectionSnapshotAssembler } = makeService();
     const tx = {} as any;
 
     await (service as any)._emitActiveVersionChangedEvent(
@@ -279,7 +273,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
     );
 
     expect(projectionSnapshotAssembler.assembleActiveVersionSnapshot).not.toHaveBeenCalled();
-    expect(outboxPublisher.saveEvent).toHaveBeenCalledWith(
+    expect(productPublisher.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
         payload: expect.objectContaining({
           masterId: 'master-1',
@@ -299,7 +293,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
   it('publishes a draft with validation, price cache, active transition, snapshot enqueue, and sellable recalculation in order', async () => {
     const {
       service,
-      outboxPublisher,
+      productPublisher,
       projectionSnapshotAssembler,
       pricingValidator,
       priceCacheService,
@@ -364,7 +358,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
         primaryCategoryId: null,
       };
     });
-    outboxPublisher.saveEvent.mockImplementation(async () => order.push('saveOutbox'));
+    productPublisher.enqueue.mockImplementation(async () => order.push('saveOutbox'));
     productSellableQuantity.recalculateAndPublishForVariants.mockImplementation(async () =>
       order.push('recalculateSellableQuantity'),
     );
@@ -385,7 +379,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
       'saveOutbox',
       'recalculateSellableQuantity',
     ]);
-    expect(outboxPublisher.saveEvent).toHaveBeenCalledWith(
+    expect(productPublisher.enqueue).toHaveBeenCalledWith(
       expect.objectContaining({
         payload: expect.objectContaining({
           changeReason: 'published',
@@ -562,7 +556,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
   });
 
   it('updateRequiresMembership: active 버전의 구매 제약을 upsert 하고 이벤트를 1회 발행한다', async () => {
-    const { service, outboxPublisher, projectionSnapshotAssembler, purchaseConstraints } = makeService();
+    const { service, productPublisher, projectionSnapshotAssembler, purchaseConstraints } = makeService();
     projectionSnapshotAssembler.assembleActiveVersionSnapshot.mockResolvedValue({
       snapshot: { name: 'N' },
       categoryIds: [],
@@ -579,8 +573,8 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
       { requiresMembership: true, lifetimeQuantityLimit: null },
       tx,
     );
-    expect(outboxPublisher.saveEvent).toHaveBeenCalledTimes(1);
-    expect(outboxPublisher.saveEvent.mock.calls[0][0].payload.changeReason).toBe('published');
+    expect(productPublisher.enqueue).toHaveBeenCalledTimes(1);
+    expect(productPublisher.enqueue.mock.calls[0][0].payload.changeReason).toBe('published');
   });
 
   it('updateRequiresMembership: 기존 lifetimeQuantityLimit 을 보존한다', async () => {
@@ -604,7 +598,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
   });
 
   it('updateExposurePolicy: 제공된 플래그만 set 하고 이벤트를 published로 1회 발행한다', async () => {
-    const { service, outboxPublisher, projectionSnapshotAssembler } = makeService();
+    const { service, productPublisher, projectionSnapshotAssembler } = makeService();
     projectionSnapshotAssembler.assembleActiveVersionSnapshot.mockResolvedValue({
       snapshot: { name: 'N' },
       categoryIds: [],
@@ -631,8 +625,8 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
       isMembershipOnly: false, // deprecated 컬럼 미러
     });
     expect(setArg.isOverseas).toBeUndefined(); // 미제공 플래그는 건드리지 않음
-    expect(outboxPublisher.saveEvent).toHaveBeenCalledTimes(1);
-    const [event, txArg] = outboxPublisher.saveEvent.mock.calls[0];
+    expect(productPublisher.enqueue).toHaveBeenCalledTimes(1);
+    const [event, txArg] = productPublisher.enqueue.mock.calls[0];
     expect(event.payload.changeReason).toBe('published');
     expect(txArg).toBe(tx);
   });
@@ -642,15 +636,12 @@ describe('ProductVersionsService copy mappings', () => {
   function makeService() {
     const productPublisher = {
       publishEvent: jest.fn().mockResolvedValue(undefined),
-    };
-    const outboxPublisher = {
-      saveEvent: jest.fn().mockResolvedValue(undefined),
+      enqueue: jest.fn().mockResolvedValue(undefined),
     };
 
     return new ProductVersionsService(
       { run: (fn: any, t?: any) => (t ? fn(t) : fn(undefined)) } as any,
       productPublisher as any,
-      outboxPublisher as any,
       {} as any,
       {} as any,
       {} as any,
@@ -731,8 +722,7 @@ describe('ProductVersionsService productCode publish validation', () => {
   function makeService() {
     return new ProductVersionsService(
       {} as any,
-      { publishEvent: jest.fn() } as any,
-      { saveEvent: jest.fn() } as any,
+      { publishEvent: jest.fn(), enqueue: jest.fn() } as any,
       {} as any,
       {} as any,
       {} as any,
@@ -776,8 +766,7 @@ describe('ProductVersionsService digital asset-link publish guard', () => {
   function makeService(variantAssetLinkService: any) {
     return new ProductVersionsService(
       {} as any,
-      { publishEvent: jest.fn() } as any,
-      { saveEvent: jest.fn() } as any,
+      { publishEvent: jest.fn(), enqueue: jest.fn() } as any,
       {} as any,
       {} as any,
       {} as any,
@@ -857,15 +846,12 @@ describe('ProductVersionsService deleteDraftVersion purchase constraint cleanup'
   function makeService() {
     const productPublisher = {
       publishEvent: jest.fn().mockResolvedValue(undefined),
-    };
-    const outboxPublisher = {
-      saveEvent: jest.fn().mockResolvedValue(undefined),
+      enqueue: jest.fn().mockResolvedValue(undefined),
     };
 
     return new ProductVersionsService(
       { run: (fn: any, t?: any) => (t ? fn(t) : fn(undefined)) } as any,
       productPublisher as any,
-      outboxPublisher as any,
       {} as any,
       {} as any,
       {} as any,
@@ -1063,7 +1049,6 @@ describe('ProductVersionsService.getMyDraftVersions', () => {
   function makeBareService() {
     return new ProductVersionsService(
       { run: (fn: any, t?: any) => (t ? fn(t) : fn(undefined)) } as any,
-      {} as any,
       {} as any,
       {} as any,
       {} as any,

--- a/apps/core/src/modules/catalog/core/products/services/product-versions.service.ts
+++ b/apps/core/src/modules/catalog/core/products/services/product-versions.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
 import { DbService, InjectDb } from '@app/db';
 import { NotFoundError, ConflictError } from '@app/shared';
-import { InjectStreamPublisher, OutboxPublisher, StreamPublisher } from '@app/events';
+import { InjectStreamPublisher, StreamPublisher } from '@app/events';
 import { ProductEvents, PRODUCT_STREAM } from '@packages/event-contracts';
 import type { ProductPublishOrigin } from '@packages/event-contracts/streams/product.stream';
 import { PricingValidatorService } from '../../pricing/pricing-validator.service';
@@ -66,7 +66,6 @@ export class ProductVersionsService {
     @InjectDb() private readonly db: DbService<PimSchema>,
     @InjectStreamPublisher(PRODUCT_STREAM.topic.topic)
     private readonly productPublisher: StreamPublisher<ProductEvents>,
-    private readonly outboxPublisher: OutboxPublisher,
     private readonly pricingValidator: PricingValidatorService,
     private readonly productReadAssembler: ProductReadAssembler,
     private readonly projectionSnapshotAssembler: ProjectionSnapshotAssembler,
@@ -1026,11 +1025,9 @@ export class ProductVersionsService {
     const categoryIds = assembly?.categoryIds ?? [];
     const primaryCategoryId = assembly?.primaryCategoryId ?? null;
 
-    await this.outboxPublisher.saveEvent(
+    await this.productPublisher.enqueue(
       {
-        topic: PRODUCT_STREAM.topic.topic,
         eventType: 'ProductMasterActiveVersionChanged',
-        aggregateType: PRODUCT_STREAM.aggregateType,
         aggregateId: newVersion.masterId,
         payload: {
           masterId: newVersion.masterId,

--- a/apps/core/src/modules/catalog/operations/bulk-session/services/bulk-session-merge.integration.spec.ts
+++ b/apps/core/src/modules/catalog/operations/bulk-session/services/bulk-session-merge.integration.spec.ts
@@ -9,7 +9,7 @@
 jest.mock(
   '@packages/event-contracts',
   () => ({
-    PRODUCT_STREAM: { topic: { topic: 'products.events.v1' }, aggregateType: 'Product' },
+    PRODUCT_STREAM: { topic: { topic: 'products.events.v1' }, aggregateType: 'Product', events: {} },
   }),
   { virtual: true },
 );
@@ -21,7 +21,8 @@ import * as postgres from 'postgres';
 import { drizzle, PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { eq } from 'drizzle-orm';
 import { DbService } from '@app/db';
-import { OutboxPublisher } from '@app/events';
+import { OutboxPublisher, StreamPublisher } from '@app/events';
+import { PRODUCT_STREAM } from '@packages/event-contracts';
 import { DbTransaction } from '../../../catalog.types';
 import {
   catalogSchema,
@@ -143,8 +144,19 @@ describeIfDb('일괄 세션 병합 시나리오 (실 Postgres)', () => {
     const snapshotAssembler = new ProjectionSnapshotAssembler(versionLoader, optionLoader, tagLoader, priceCache);
     // OutboxPublisher 는 스키마 제네릭을 받지 않는(기본값 Record<string, never>) DbService 를
     // 받는다 — 우리 dbService 의 실제 동작(db/run)엔 무관하고 순수 타입 불일치라 캐스팅한다.
+    // 카테고리 서비스는 이제 아웃박스가 아니라 publisher 를 받는다 (ADR-0029 §5) —
+    // `enqueue` 는 transport 를 쓰지 않으므로 전송 스텁으로 충분하다.
     const outbox = new OutboxPublisher(dbService as unknown as DbService);
-    categories = new ProductCategoriesService(dbService, snapshotAssembler, outbox);
+    const productPublisher = new StreamPublisher(
+      { send: async () => undefined },
+      PRODUCT_STREAM,
+      'core-integration-spec',
+      undefined,
+      undefined,
+      undefined,
+      outbox,
+    );
+    categories = new ProductCategoriesService(dbService, snapshotAssembler, productPublisher);
     // 이 스위트는 §F1(브랜드/셀러 병합) 회귀 잠금이지 품목 판매정책 프리필 검증이 아니다
     // — 실 ProductSkuMappingService 는 inventory BC 의 무거운 의존성 그래프(SharedModule
     // 등)를 끌고 오므로, 여기서는 빈 배치 응답 스텁만 채운다. base/current 양쪽 renderMaster

--- a/apps/core/src/modules/catalog/operations/bulk-session/services/form-export-snapshot.integration.spec.ts
+++ b/apps/core/src/modules/catalog/operations/bulk-session/services/form-export-snapshot.integration.spec.ts
@@ -35,7 +35,8 @@ import { PricingValidatorService } from '../../../core/pricing/pricing-validator
 import { PricingCalculatorService } from '../../../core/pricing/pricing-calculator.service';
 import { VariantPriceCacheService } from '../../../core/pricing/variant-price-cache.service';
 import { ProductCategoriesService } from '../../../core/categories/categories.service';
-import { OutboxPublisher } from '@app/events';
+import { OutboxPublisher, StreamPublisher } from '@app/events';
+import { PRODUCT_STREAM } from '@packages/event-contracts/streams/product.stream';
 import { ProductSkuMappingService } from '../../../../product-matching/services/product-sku-mapping.service';
 import { PRICING_SENTINEL } from './form-export.sheets';
 import { FormExportSnapshotReader } from './form-export.snapshot.reader';
@@ -99,8 +100,19 @@ describeIfDb('FormExportSnapshotReader (실 Postgres)', () => {
     const snapshotAssembler = new ProjectionSnapshotAssembler(versionLoader, optionLoader, tagLoader, priceCache);
     // OutboxPublisher 는 스키마 제네릭을 받지 않는(기본값 Record<string, never>) DbService 를
     // 받는다 — 우리 dbService 의 실제 동작(db/run)엔 무관하고 순수 타입 불일치라 캐스팅한다.
+    // 카테고리 서비스는 이제 아웃박스가 아니라 publisher 를 받는다 (ADR-0029 §5) —
+    // `enqueue` 는 transport 를 쓰지 않으므로 전송 스텁으로 충분하다.
     const outbox = new OutboxPublisher(dbService as unknown as DbService);
-    const categories = new ProductCategoriesService(dbService, snapshotAssembler, outbox);
+    const productPublisher = new StreamPublisher(
+      { send: async () => undefined },
+      PRODUCT_STREAM,
+      'core-integration-spec',
+      undefined,
+      undefined,
+      undefined,
+      outbox,
+    );
+    const categories = new ProductCategoriesService(dbService, snapshotAssembler, productPublisher);
     // 이 스위트는 필드명/가격 센티넬/이미지 키 등 리더 자체의 매핑을 검증하지, 품목 판매정책
     // 우선순위(그건 product-sku-mapping.service.spec.ts 와 form-export.snapshot.reader.spec.ts
     // 의 renderMaster 스위트 몫이다)를 검증하지 않는다. 실 ProductSkuMappingService 는

--- a/apps/core/src/modules/sales-order/sales-order.module.ts
+++ b/apps/core/src/modules/sales-order/sales-order.module.ts
@@ -38,8 +38,8 @@ import { WalletRefundClient } from './services/wallet-refund.client';
       // order publisher 2벌 + 자체 outbox dispatcher 뿐이며 셋 다 `StreamPublisher.publishEvent`
       // 를 지난다. `publishEvent` 는 envelope 에 원본이 아니라 **zod 가 파싱한 결과**를 싣기
       // 때문에(`stream-publisher.service.ts:123`) 같은 스키마로 다시 검증하면 반드시 통과한다.
-      // zod 를 우회하는 `publishRawEnvelope` 경로는 레포에 2곳뿐이고 둘 다 이 토픽에 닿지
-      // 않는다. (`OrderRefundCreated` 는 발행자가 아예 없다.)
+      // (`OrderRefundCreated` 는 발행자가 아예 없다.) Task 6-A 이후로는 이 앱만의 논증이
+      // 아니라 레포 전체의 불변식이다 — zod 를 우회하는 발행 경로가 하나도 남지 않았다.
       //
       // 이 논증은 `npm run audit:consume-validation -- --gate` 가 상시 재검증한다 — 검증을
       // 켜 둔 앱에 우회 경로가 닿는 이벤트가 새로 생기면 게이트가 exit 1 로 막는다.

--- a/apps/membership/src/services/membership-event.publisher.ts
+++ b/apps/membership/src/services/membership-event.publisher.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { InjectStreamPublisher, StreamPublisher, OutboxPublisher, type DbTx } from '@app/events';
+import { InjectStreamPublisher, StreamPublisher, type DbTx } from '@app/events';
 import {
   MEMBERSHIP_STREAM,
   type MembershipEvents,
@@ -13,7 +13,6 @@ export class MembershipEventPublisher {
   constructor(
     @InjectStreamPublisher(MEMBERSHIP_STREAM.topic.topic)
     private readonly publisher: StreamPublisher<MembershipEvents>,
-    private readonly outboxPublisher: OutboxPublisher,
   ) {}
 
   async publishStatusChanged(payload: MembershipStatusChangedPayload): Promise<void> {
@@ -32,15 +31,6 @@ export class MembershipEventPublisher {
    * 실제 Kafka 발행은 OutboxDispatcher 가 재시도하며 담당한다.
    */
   async saveStatusChanged(payload: MembershipStatusChangedPayload, tx: DbTx): Promise<void> {
-    await this.outboxPublisher.saveEvent(
-      {
-        topic: MEMBERSHIP_STREAM.topic.topic,
-        eventType: 'MembershipStatusChanged',
-        aggregateType: MEMBERSHIP_STREAM.aggregateType,
-        aggregateId: payload.userId,
-        payload,
-      },
-      tx,
-    );
+    await this.publisher.enqueue({ eventType: 'MembershipStatusChanged', aggregateId: payload.userId, payload }, tx);
   }
 }

--- a/apps/search/src/search.module.ts
+++ b/apps/search/src/search.module.ts
@@ -35,15 +35,12 @@ import { SearchKeywordService } from './search-keyword.service';
             groupId: process.env.KAFKA_GROUP_ID || 'search-indexer',
             kafka: createKafkaConfigFromEnv()!,
             enableAutoDLQ: true,
-            // ⚠️ 아직 끈다. core 는 5-C 에서 켰지만 이 앱은 못 켠다 (ADR-0029 §8).
+            // ⚠️ 아직 끈다 — 그러나 **막는 이유는 사라졌다** (ADR-0029 §5, 플랜 Task 6-A).
             //
-            // 막는 것은 딱 2개 이벤트다 — `ProductMasterActiveVersionChanged` ·
-            // `ProductMasterDeleted`. 둘 다 core 카탈로그가 `OutboxPublisher.saveEvent` 로
-            // 발행하는데, 그 경로는 `publishRawEnvelope` 로 zod 를 우회한다. 즉 이 토픽에
-            // 스키마를 안 지키는 payload 가 올라올 수 있는지 정적으로 증명되지 않는다.
-            //
-            // **이걸 여는 것은 Task 6 이다** (enqueue 시점 zod 검증). 그게 들어가면 두 이벤트가
-            // 자동으로 PROVEN 이 되어 이 줄을 뒤집을 수 있다. 그 전에 켜는 것은 추측이다.
+            // 이 앱을 막던 2개 이벤트(`ProductMasterActiveVersionChanged` ·
+            // `ProductMasterDeleted`)는 core 카탈로그가 아웃박스로 내보내며 zod 를 우회했다.
+            // 6-A 가 적재·발행 양쪽에 문을 달아 그 우회를 없앴고 둘 다 PROVEN 이 됐다.
+            // 남은 것은 이 한 줄을 뒤집는 결정뿐이며 그건 5-C 의 마지막 조각이다.
             // 현황: `npm run audit:consume-validation -- search`
             validation: { validateOnConsume: false },
           }),

--- a/apps/wallet/src/messaging/outbox-dispatcher.service.ts
+++ b/apps/wallet/src/messaging/outbox-dispatcher.service.ts
@@ -168,7 +168,10 @@ export class OutboxDispatcherService {
       payload: event.payload,
     };
 
-    await this.publisher.publishRawEnvelope(envelope, event.partitionKey);
+    // 검증을 탄다 (ADR-0029 §5). wallet 은 아웃박스 행을 테이블에 직접 insert 하므로
+    // `StreamPublisher.enqueue` 의 적재 시점 검증을 받지 않는다 — 그 앱에서 이 줄이 유일한
+    // zod 게이트다. 스키마 위반은 발행되지 않고 `markFailure` 로 백오프 후 DEAD_LETTER 로 남는다.
+    await this.publisher.publishStoredEnvelope(envelope, event.partitionKey);
 
     this.logger.debug(
       `Outbox dispatched to Kafka: id=${event.id}, eventType=${event.eventType}, partitionKey=${event.partitionKey}`,

--- a/docs/adr/0029-events-module-registration-surfaces.md
+++ b/docs/adr/0029-events-module-registration-surfaces.md
@@ -108,13 +108,20 @@ async onVerified(@Payload() payload: EventPayloadOf<typeof USER_STREAM, 'UserEma
 ### 5. 발행 경로를 하나의 인터페이스로 통합한다
 
 ```ts
-await this.orders.publish('OrderCreated', { aggregateId, payload });        // 즉시
-await this.orders.enqueue('OrderCreated', { aggregateId, payload }, tx);    // outbox
+await this.orders.publishEvent({ eventType: 'OrderCreated', aggregateId, payload });     // 즉시
+await this.orders.enqueue({ eventType: 'OrderCreated', aggregateId, payload }, tx);      // outbox
 ```
 
 같은 객체·같은 타입 도출·같은 검증. 다른 것은 배달 방식뿐이다. 공용 outbox 에 `idempotencyKey`·`partitionKey` 를 넣어 앱 자체 판본과 기능 동등하게 만든 뒤 5벌을 회수한다.
 
 **검증은 `enqueue` 시점에, 도메인 트랜잭션 안에서** 수행한다. 잘못된 payload 가 poison row 로 남는 대신 비즈니스 연산을 즉시 실패시킨다. `publishRawEnvelope` 의 zod 우회는 제거한다.
+
+**이행 완료 (2026-08-09, Task 6-A).** 스케치에서 세 가지가 달라졌고, 하나가 추가됐다.
+
+- **인자 모양은 `publishEvent` 를 그대로 따른다** — 위 스케치의 `enqueue('OrderCreated', {…}, tx)` 가 아니라 `enqueue({ eventType, aggregateId, payload }, tx)` 다. "다른 것은 배달 방식뿐"이라는 §5 의 주장은 두 메서드가 **같은 파라미터 타입**(`PublishEventParams`)을 받을 때만 참이고, 인자 배치를 다르게 두면 그 문장이 문서에서만 참이 된다. envelope 조립·검증은 `buildEventEnvelope` 하나로 합쳐 두 메서드가 공유한다.
+- **적재 대상은 port 로 받는다** — `OutboxWriter`(`outbox/outbox-writer.port.ts`). publisher 가 drizzle 을 알면 §7 의 seam 이 무너지고, 스펙이 DB 없이 적재를 관찰할 수 없다. `forRoot({ enableOutbox: true })` 인 앱에서만 주입되며, 켜지 않은 앱에서 `enqueue` 를 부르면 던진다(조용히 삼키는 것보다 낫다).
+- **`publishRawEnvelope` 는 이름째 없앴다** — `publishStoredEnvelope` 로 대체하고 검증을 넣었다. 이름을 남기면 "raw = 검증 안 함"이라는 옛 모델이 이름 안에서 계속 산다. 이 문은 `enqueue` 를 지나지 않은 행(이 변경 이전에 적재된 PENDING 행, 테이블에 직접 insert 하는 wallet 판본)에 실제로 문다.
+- **`publishCommand` 에도 검증을 넣었다 (스케치에 없던 것).** 이 메서드는 §8 의 "발행 경로 전수 폐쇄" 논증이 **놓친 네 번째 경로**였다 — `publishEvent` 와 `publishRawEnvelope` 만 세었고 커맨드는 세지 않았다. 호출자는 `ugc-service` 1곳(`EarnPointsRequested` → wallet 소비)뿐이라 실해는 없었지만, 그 논증이 "wallet 은 켜도 안전"이라고 판정한 근거에는 구멍이 있었다. 지금은 `sendMessage` 를 부르는 세 메서드가 전부 검증한다.
 
 ### 6. 토픽당 한 번 파싱하고 타입으로 디스패치한다
 
@@ -234,6 +241,26 @@ microservice.setIsInitHookCalled(true);
 
 그래서 **5-C 는 core 에서 끝내고, 나머지 3개 앱은 Task 6 의 후속으로 옮긴다.** 플랜의 "core 밖으로 나가기 전에 DLQ 관측 범위를 넓힐지 결정한다"는 항목은 사라지지 않지만 긴급성이 낮아진다 — Task 6 이후에는 켤 때 증명이 있고, 관측은 증명이 틀렸을 경우의 대비책이 된다.
 
+**Task 6-A 이후 이 표는 전부 뒤집혔다 (2026-08-09).** 적재·발행 양쪽 문이 생겨 zod 우회 경로가 0이 되면서 **UNVERIFIED 14건이 0건**이 됐다 — 7개 앱 전부 `켜도 안전` 이다(core 는 이미 켜져 있다).
+
+| 앱 | 이벤트 | SAFE | PROVEN | UNVERIFIED | 판정 |
+|---|---:|---:|---:|---:|---|
+| **core** | 4 | 0 | 4 | 0 | ✅ 켜짐 |
+| analytics | 10 | 0 | 10 | 0 | ☑️ 켜도 안전 |
+| channel-adapter | 34 | 11 | 23 | 0 | ☑️ 켜도 안전 |
+| membership | 10 | 5 | 5 | 0 | ☑️ 켜도 안전 |
+| notification | 22 | 1 | 21 | 0 | ☑️ 켜도 안전 |
+| search | 3 | 0 | 3 | 0 | ☑️ 켜도 안전 |
+| wallet | 4 | 0 | 4 | 0 | ☑️ 켜도 안전 |
+
+**membership 의 원인은 나머지 셋과 달랐다.** 5-C 가 "같은 4개 이벤트가 세 앱을 막는다"고 정리했을 때 membership 은 논외였는데, 실측하면 그 5건은 `saveEvent` 가 아니라 **wallet 이 자기 outbox 테이블에 직접 insert 하는 행**(`invoice.*` · `mandate.rejected`)에서 왔다. 즉 6-A 의 `enqueue` 문이 아니라 **`publishStoredEnvelope` 문**이 그것을 닫는다. 두 문을 다 달았기 때문에 함께 풀린 것이지, `enqueue` 만 넣었다면 membership 은 그대로 막혀 있었을 것이다.
+
+**증명의 모양이 바뀌었으므로 게이트도 바뀌었다.** 옛 게이트는 "우회 경로 2곳이 무엇을 실어 나를 수 있는가"를 계산했다. 이제 우회가 없으므로 게이트가 지키는 것은 **우회가 다시 생기지 않는 것**이다 — `transport.send` 호출 지점 집합, `StreamPublisher.sendMessage` 를 부르는 메서드 집합, `validateOnPublish: false` 의 부재, `publishRawEnvelope` 의 부재. 넷 다 AST 로 세며, 앞의 둘은 손으로 유지하는 목록과 대조한다. 실제로 무는 것은 확인했다(새 `sendMessage` 호출자를 심어 exit 1, `validateOnPublish: false` 를 심어 exit 1).
+
+**`DLQHandler.reprocessDLQ` 는 명시적으로 면제한다.** 이 관리자 수동 경로는 DLQ 메시지를 원본 토픽으로 되돌려 보내며 `StreamPublisher` 를 지나지 않는다. 면제 근거는 "그 토픽에 이미 있던 메시지만 다시 보낸다 — 새 모양을 만들지 않는다"이며, 이는 이 증명이 원래부터 덮지 못한다고 선언한 "토픽에 남아 있는 옛 메시지"와 같은 한계다. 면제를 목록에 적어 두었으므로 조용히 늘어날 수 없다.
+
+**계약의 구멍이 하나 드러났고 고쳤다 — `CategoryChanged.ancestors`.** payload 인터페이스에는 처음부터 있었는데 zod 스키마에만 빠져 있었다. 검증이 발행 경로에 없던 동안은 무증상이었지만, 적재 시점 검증이 켜지면 zod 가 미선언 키를 **조용히 떼어낸다**. channel-adapter 의 Medusa 카테고리 동기화가 `ancestors` 로 부모를 먼저 보장하므로(`pim-medusa-sync.service.ts:662`), 그 손실은 자식 카테고리를 최상위로 붙이는 버그가 됐을 것이다. 스키마에 optional 로 추가했다(additive — 옛 producer 를 깨지 않는다). **이것이 이 변경의 실질적 위험이 어디에 있는지 보여준다**: 검증 실패는 시끄럽지만 *strip* 은 조용하다. 그래서 회귀 네트는 "통과하는가"가 아니라 **"손실 없이 통과하는가"**(`parse(payload)` 가 `payload` 와 deep-equal)를 단언한다 — `projection-snapshot.assembler.spec.ts` 와 `categories.service.spec.ts` 에 실 조립 결과로 걸어 두었다.
+
 **이 분석은 일회성 결론이 아니라 상시 불변식이 된다.** `--gate` 는 *검증을 켜 둔 앱*에 UNVERIFIED 이벤트가 생기면 exit 1 한다. core 에 나중에 outbox 발행 이벤트의 핸들러를 추가하면 CI 가 막는다 — 이 워크스트림이 반복해서 만난 "판정이 조용히 낡는" 실패 모드를 그 자리에서 닫는 것이다. 게이트가 실제로 무는 것은 확인했다(search 를 일부러 `true` 로 바꿔 exit 1 재현). 게이트는 자기 자신의 가정도 감시한다 — `publishRawEnvelope` 호출 지점을 AST 로 세어 손으로 유지하는 우회 목록과 어긋나면 실패한다. (첫 실행에서 이 검사가 실제로 걸렸다: grep 판본이 근거 주석 속 함수명을 세 번째 "호출자"로 집계했다. 그래서 AST 로 바꿨다.)
 
 **켜는 비용은 낮다 — 스키마 위반은 재시도하지 않는다.** `EventRetryInterceptor` 가 `SchemaValidationError` 를 `nonRetryableErrors` 에 강제로 넣으므로(`event-retry.interceptor.ts:91`) 위반 메시지는 백오프 없이 즉시 DLQ 로 가고 offset 이 전진한다. 검증을 켜는 것이 파티션을 막는 재시도 폭풍을 부르지 않는다는 뜻이다. 이 사실과 위 2번의 멱등성은 `libs/events/src/transport/consume-validation.spec.ts` 가 실행으로 고정한다 — 재시도 억제는 **대조군**(스키마와 무관한 에러는 같은 `@RetryPolicy` 로 4회 실행됨)과 나란히 두어야 `maxRetries` 설정 탓이 아님이 드러나므로 둘을 함께 넣었다.
@@ -304,7 +331,9 @@ microservice.setIsInitHookCalled(true);
    **전반부(데코레이터 도입) 완료 (2026-08-09).** `@On` · `@InjectPublisher` · `PublisherFor` · `EnvelopeOf` 가 옛 표면과 **병행**으로 존재한다. `@On` 은 `@OnEvent` 과 **바이트 단위로 같은 메타데이터**를 남기고(스펙이 메타데이터 키 집합과 값을 전수 비교한다), `@InjectPublisher` 는 `EventsModule.getPublisherToken` 과 같은 토큰을 만든다 — 토큰 형식은 `publishers/publisher-token.ts` 한 곳으로 모았다. 따라서 한 앱 안에서 두 표면을 섞어 써도 되고, 앱 이주는 파일 단위로 쪼갤 수 있다. 앱 이주(후반부)는 아직 0개다. 위 §4 의 두 가지 이행 차이도 참조.
 6. 공용 outbox 에 `idempotencyKey`·`partitionKey`·enqueue 시점 검증 추가 후 앱 자체 판본 5벌 회수. **core 의 두 벌은 import 경로만 다른 동일 파일이므로 이 작업과 무관하게 지금 하나로 합칠 수 있다.**
 
-   ⚠️ **이 항목이 5-C 의 나머지 3개 앱을 막고 있다 (2026-08-09, 위 §8 의 C 스위치 절).** analytics·search·channel-adapter 를 켜지 못하는 원인은 관측성이 아니라 `saveEvent`→`publishRawEnvelope` 의 zod 우회이며, 여기서 enqueue 시점 검증을 넣는 순간 막고 있던 4개 이벤트(`MembershipStatusChanged` · `ProductMasterActiveVersionChanged` · `ProductMasterDeleted` · `CategoryChanged`)가 기계적으로 PROVEN 이 된다. 즉 **의존 방향이 플랜과 반대다** — 5-C 가 6번을 기다린다. 진행 후 `npm run audit:consume-validation` 이 그 세 앱을 `켜도 안전` 으로 바꾸는지 확인하면 되고, 그것이 이 항목의 완료 신호 중 하나다.
+   ~~⚠️ **이 항목이 5-C 의 나머지 3개 앱을 막고 있다.**~~ **enqueue 시점 검증 완료 (2026-08-09, Task 6-A).** `StreamPublisher.enqueue` + `publishStoredEnvelope` 두 문이 들어가 zod 우회가 0이 됐고, `npm run audit:consume-validation` 의 UNVERIFIED 가 **14 → 0** 이 됐다. 막고 있던 4개 이벤트만이 아니라 membership 의 5건까지 함께 풀렸다(원인이 달랐다 — 위 §8 참조). **7개 앱 전부 `켜도 안전`이다.**
+
+   남은 것은 이 항목의 다른 절반이다: `idempotencyKey`·`partitionKey` 추가와 5벌 회수(Task 6-C, 데이터 마이그레이션 성격) + `@InjectStreamPublisher` → `@InjectPublisher` 26곳(Task 6-B). 6-A 에서 `OutboxPublisher.saveEvent` 는 삭제했고 공용 outbox 의 유일한 진입점은 `OutboxWriter.write` 다 — 6-C 의 회수 대상은 그 port 뒤로 들어온다.
 7. 옛 표면(`forRoot`/`forConsumerModule`/`forConsumer`) 제거 — contract phase.
 8. ~~channel-adapter 가 `forConsumerModule` 을 호출하지 않는 현재 상태는 이 ADR 이 시행되기 전까지 남는 실재 구멍이다 — 소비 측 zod 검증이 없다. 4번 이전에 단독으로 메울지, 이주에 묶을지 결정한다.~~ **결정: 이주에 묶었다 (2026-08-09).** 다만 배선 이주 시점에 **검증을 켜지는 않았다.** `forConsumerModule` 미호출 → `EVENTS_CONSUMER_POLICY` 토큰 부재 → `optionalGet` 이 undefined → 기본값 `true` 라, 아무 조치 없이 `startConsumer` 로 옮기면 이 앱만 배선과 검증이 **선택이 아니라 누락으로** 동시에 켜진다. 외부 채널 유래 payload 라 그 조합이 가장 위험한 앱이기도 하다. 그래서 `adapter.module.ts` 의 providers 에 `EVENTS_CONSUMER_POLICY` 를 직접 등록하고 `validateOnConsume: false` 를 명시했다. `forConsumerModule` 을 새로 부르지 않은 이유는 그 표면이 `streams` 를 필수로 받기 때문이다 — 그 목록이야말로 §2·§3 이 지우는 중인 두 번째 진실이라, 정책 하나를 얻자고 그것을 되살릴 수 없다. Task 7 의 `forApp` 이 이 자리를 흡수한다. 검증을 실제로 켜는 것은 payload 샘플링 후(플랜 Task 5-C).
 9. **소비 경로 CLS 컨텍스트 부재** (2026-08-09 발견, 미수정).

--- a/docs/superpowers/plans/2026-08-09-events-module-registration.md
+++ b/docs/superpowers/plans/2026-08-09-events-module-registration.md
@@ -357,7 +357,7 @@ B 는 위험을 더하는 게 아니라 **없던 탈출구를 만드는 쪽에 �
 
 **🔴 순서를 뒤집었다 — 나머지 3개 앱의 게이트는 관측성이 아니라 Task 6 이다.** 세 앱을 막는 UNVERIFIED 는 전부 같은 원인의 **4개 이벤트**다: `MembershipStatusChanged` · `ProductMasterActiveVersionChanged` · `ProductMasterDeleted` · `CategoryChanged`. 넷 다 `OutboxPublisher.saveEvent` 로 적재돼 `publishRawEnvelope` 로 나간다. Task 6 의 "enqueue 시점 zod 검증"이 정확히 이 구멍이며, 들어가는 순간 넷 다 기계적으로 PROVEN 이 된다. 5-C 를 먼저 하면 payload 를 추측해야 하고, Task 6 을 먼저 하면 추측할 것이 남지 않는다. 게다가 Task 6 은 실패를 **발행자의 도메인 트랜잭션**에서 드러내므로 소비자 DLQ 에서 사후 발견하는 것보다 진단 위치가 낫다. **ADR-0029 §8 과 Follow-up 6 을 먼저 고쳤다.**
 
-**남은 5-C 대상은 3개가 아니라 4개다 (2026-08-09 게이트 리포트 실측).** `membership` 도 UNVERIFIED 5건으로 같은 처지인데 5-C 논의에서 빠져 있었다 — 6-A 후에 함께 판정한다. 반대로 **`notification`(UNVERIFIED 0 · PROVEN 21) 과 `wallet`(PROVEN 4) 은 이미 `켜도 안전`** 이다. 두 앱의 `validateOnConsume: false` 는 이 워크스트림 이전부터의 **의도**(notification 은 "HTTP 요청과 충돌 방지" 주석)이므로 그대로 두되, **Task 7 에서 정책을 `forApp` 으로 옮길 때 그 `false` 를 반드시 보존해야 한다** — 안 그러면 의도치 않게 켜진다.
+**남은 5-C 대상은 3개가 아니라 4개다 (2026-08-09 게이트 리포트 실측).** `membership` 도 UNVERIFIED 5건으로 같은 처지인데 5-C 논의에서 빠져 있었다 — 6-A 후에 함께 판정한다. **판정 완료: 원인이 달랐다** — 그 5건은 core 카탈로그의 `saveEvent` 가 아니라 wallet 이 자기 outbox 테이블에 직접 insert 하는 `invoice.*`/`mandate.rejected` 행이었다. 6-A 가 `enqueue` 와 `publishStoredEnvelope` 두 문을 다 달았기에 함께 풀렸다. 반대로 **`notification`(UNVERIFIED 0 · PROVEN 21) 과 `wallet`(PROVEN 4) 은 이미 `켜도 안전`** 이다. 두 앱의 `validateOnConsume: false` 는 이 워크스트림 이전부터의 **의도**(notification 은 "HTTP 요청과 충돌 방지" 주석)이므로 그대로 두되, **Task 7 에서 정책을 `forApp` 으로 옮길 때 그 `false` 를 반드시 보존해야 한다** — 안 그러면 의도치 않게 켜진다.
 
 - **core 를 켠 근거:** 4개 이벤트가 전부 `orders.events.v1` 이고 발행자 셋(channel-adapter order publisher 2벌 + 자체 outbox dispatcher)이 모두 `publishEvent` 를 지난다. `OrderRefundCreated` 는 발행자가 아예 없다. 우회 2곳 중 어느 것도 이 토픽에 닿지 않는다. core 는 **DLQ 가 관측되는 유일한 앱**이라(`dlq.metrics.ts:10`) 증명이 틀렸을 때 알아차릴 수 있는 유일한 앱이기도 하다.
 - **분석을 상시 불변식으로 바꿨다.** `--gate` 는 *검증을 켜 둔 앱*에 UNVERIFIED 가 생기면 exit 1 한다 — core 에 나중에 outbox 발행 이벤트 핸들러를 추가하면 CI 가 막는다. 게이트가 실제로 무는 것을 확인했다(search 를 일부러 `true` 로 바꿔 exit 1 재현 후 원복). 게이트는 자기 가정도 감시한다: `publishRawEnvelope` 호출 지점을 AST 로 세어 손으로 유지하는 우회 목록과 어긋나면 실패하며, **첫 실행에서 실제로 걸렸다** — grep 판본이 내가 방금 쓴 근거 주석 속 함수명을 세 번째 "호출자"로 집계했다. 그래서 AST 로 바꿨다.
@@ -373,8 +373,11 @@ B 는 위험을 더하는 게 아니라 **없던 탈출구를 만드는 쪽에 �
 5-B   7개 앱 배선 일괄                         ✅ 완료
 5-C   core                                     ✅ 완료 — 정적 증명 · 관측 가능한 유일 앱
 ──────────────────────────────────────────────────────────────
-Task 6  outbox enqueue 시점 zod 검증            ← 여기가 나머지를 여는 열쇠
-5-C   analytics · search · channel-adapter     Task 6 후. 4개 이벤트가 자동으로 PROVEN 이 된다
+6-A   outbox enqueue 시점 zod 검증            ✅ 완료 — UNVERIFIED 14 → 0
+5-C   analytics · search · channel-adapter     남은 것은 `validateOnConsume` 한 줄을 뒤집는 결정뿐
+      (+ membership — 원인이 달랐으나 6-A 가 함께 풀었다)
+6-B   @InjectStreamPublisher → @InjectPublisher (26곳)
+6-C   outbox 5벌 회수 (Task 0 선행)
 ```
 
 **완료 기준:** 7개 앱 전부 `startConsumer` 를 쓰고, `forConsumer` 호출이 0건이며, `@OnEvent` 호출이 0건이다. `start-consumer.spec.ts` 의 "옛 배선" describe 를 삭제한다 (그게 초록이라는 사실이 라이브 결함의 증거였다). ⚠️ **삭제 시점은 5-B 배포 후다** — 배포 전까지 라이브는 여전히 옛 배선이라 그 describe 의 주장은 아직 참이다.
@@ -392,13 +395,21 @@ Task 6  outbox enqueue 시점 zod 검증            ← 여기가 나머지를 �
 
 그리고 **5-C 를 막고 있는 것은 6-A 하나뿐**이다. 6-B·6-C 를 기다릴 이유가 없다.
 
-### Task 6-A: enqueue 시점 zod 검증 (5-C 를 푸는 최소 변경)
+### Task 6-A: enqueue 시점 zod 검증 (5-C 를 푸는 최소 변경) — ✅ 완료 (2026-08-09)
 
-- [ ] `PublisherFor<S>` 에 `enqueue(eventName, {...}, tx)` 를 둔다 — `publish` 와 같은 타입 도출, 같은 검증. 다른 건 배달 방식뿐
-- [ ] **`enqueue` 시점에 zod 검증** — 잘못된 payload 가 poison row 가 되는 대신 도메인 트랜잭션을 실패시킨다
-- [ ] `publishRawEnvelope` 의 zod 우회 제거. 호출자는 정확히 **2곳** (2026-08-09 실측): `libs/events/src/outbox/outbox-dispatcher.service.ts:121` · `apps/wallet/src/messaging/outbox-dispatcher.service.ts:171`
-- [ ] Task 2 하네스로 "잘못된 payload → enqueue 실패" 를 증명하는 스펙. **대조군 필수** — 검증을 끄는 변이로 실패하는지 확인하지 않으면 초록불이 무엇을 뜻하는지 알 수 없다
-- [ ] `npm run audit:consume-validation` 이 analytics·search·channel-adapter 를 `켜기 전 사람 확인 필요` → `켜도 안전` 으로 바꾸는지 확인. **안 바뀌면 6-A 가 목적을 달성하지 못한 것이다**
+- [x] `PublisherFor<S>` 에 `enqueue(…, tx)` 를 둔다 — `publishEvent` 와 같은 타입 도출, 같은 검증. **인자 모양도 `publishEvent` 와 같게 했다**(`enqueue({ eventType, aggregateId, payload }, tx)`) — 원안의 `enqueue('Name', {…}, tx)` 를 쓰면 "다른 건 배달 방식뿐"이 문서에서만 참이 된다. 적재 대상은 `OutboxWriter` port 로 받는다(publisher 가 drizzle 을 알면 §7 seam 이 무너진다)
+- [x] **`enqueue` 시점에 zod 검증** — 잘못된 payload 가 poison row 가 되는 대신 도메인 트랜잭션을 실패시킨다
+- [x] `publishRawEnvelope` 의 zod 우회 제거 — **이름째 없애고** `publishStoredEnvelope`(검증함)로 대체. 호출자 2곳 모두 이주
+- [x] **`publishCommand` 에도 검증 추가 (계획에 없던 것).** 5-C 의 "발행 경로 전수 폐쇄" 논증이 세지 않은 **네 번째 경로**였다. 호출자는 ugc-service 1곳뿐이라 실해는 없었지만, 그 논증이 wallet 을 `켜도 안전`으로 판정한 근거에는 구멍이 있었다
+- [x] `OutboxPublisher.saveEvent` 삭제 — 호출부 5곳(core 카탈로그 4 · membership 1)을 `enqueue` 로 이주. 검증 없는 적재 API 를 남기면 새 호출자가 우회를 조용히 되살린다
+- [x] Task 2 하네스 스펙 `libs/events/src/outbox/enqueue-validation.spec.ts` (7건) — **대조군 포함**: `validateOnPublish: false` publisher 로 같은 payload 가 적재되고, 같은 poison envelope 가 발행되는 것을 나란히 둔다
+- [x] `npm run audit:consume-validation` 판정 — **UNVERIFIED 14 → 0.** analytics·search·channel-adapter 가 `켜기 전 사람 확인 필요` → `켜도 안전` 으로 바뀌었다. **membership(5건)도 함께 풀렸다 — 원인이 달랐다**: 그 5건은 `saveEvent` 가 아니라 wallet 이 자기 outbox 테이블에 직접 insert 하는 행에서 왔고, `enqueue` 문이 아니라 `publishStoredEnvelope` 문이 닫았다
+- [x] 게이트 재설계 — 우회 목록 대신 **우회가 다시 생기지 않는 것**을 지킨다(`transport.send` 호출 지점 · `sendMessage` 호출 메서드 · `validateOnPublish: false` 부재 · `publishRawEnvelope` 부재, 전부 AST). 변이 2종으로 exit 1 재현 확인
+- [x] 계약 구멍 1건 수정 — `CategoryChanged.ancestors` 가 payload 인터페이스에만 있고 스키마에 없어, 검증이 켜지면 **조용히 strip** 됐다(channel-adapter 의 Medusa 부모 카테고리 보장이 그 배열을 읽는다). optional 로 추가(additive). 회귀 네트는 "통과"가 아니라 **"손실 없이 통과"** 를 단언한다
+
+**게이트 실측:** `type-check` 164 = 기준선 · `audit:event-handlers` exit 0 · `audit:consume-validation --gate` exit 0 · jest 실패 suite **18 = 기준선**(집합 동일, 신규 0) · 10개 앱 `nest build` 전부 OK.
+
+**⚠️ 배포 전 결정 1건 (사람):** wallet 아웃박스에 **이 배포 시점에 PENDING 으로 남아 있는 행**은 `enqueue` 를 지나지 않았으므로 `publishStoredEnvelope` 에서 처음 검증을 만난다. 위반하면 발행되지 않고 백오프 후 `DEAD_LETTER` 로 남는다(옛 동작: 그대로 발행). 정적으로는 안전하다 — wallet 의 `invoice.*`/`mandate.rejected` payload 는 전부 계약 타입으로 빌드되고(`invoice-event.builder.ts`), `payment.intent.*`/`gateway.*` 스키마는 `catchall` 이라 확장 필드를 보존한다. 그래도 배포 직후 `outbox_events` 의 `DEAD_LETTER`/`FAILED` 증가와 `lastErrorCode` 를 한 번 본다.
 
 ### Task 6-B: `@InjectStreamPublisher` → `@InjectPublisher` (26곳)
 
@@ -438,7 +449,7 @@ Task 6  outbox enqueue 시점 zod 검증            ← 여기가 나머지를 �
 - [x] `grep -rn "@OnEvent(" apps --include=*.ts | grep -v spec` 결과가 0건 — 5-A
 - [x] `EventKeysOf` / `EventPayloadOf` 사용처가 0건이 아니다 — 5-A (87 핸들러)
 - [x] 인메모리 어댑터로 발행→소비 왕복이 테스트된다 — Task 2
-- [ ] outbox enqueue 가 zod 검증을 탄다 — Task 6
+- [x] outbox enqueue 가 zod 검증을 탄다 — Task 6-A
 - [x] `libs/events/src` 스펙 파일 수가 5개보다 많다 — 현재 11
 - [x] 컨트롤러를 `controllers: []` 에 등록하지 않으면 부팅이 실패한다 — Task 3 에서 구현, 5-B 로 7개 앱 전부에 실효
 - [ ] `npm run type-check` 가 이 워크스트림으로 새 오류를 만들지 않았다 — 5-B 까지 164 유지. Task 6·7 후 최종 확인

--- a/libs/events/src/events.module.spec.ts
+++ b/libs/events/src/events.module.spec.ts
@@ -64,3 +64,64 @@ describe('EventsModule global retry interceptor registration', () => {
     expect(interceptors[0].useClass).toBe(EventRetryInterceptor);
   });
 });
+
+/**
+ * `enqueue` 는 publisher provider 가 `OutboxPublisher` 를 함께 주입받아야 동작한다
+ * (ADR-0029 §5). 그 배선은 앱 **부팅 경로**에 있고, 스펙이 publisher 를 손으로 조립하면
+ * 영영 검사되지 않는다 — 이 워크스트림이 반복해서 만난 실패 모드가 정확히 그것이다
+ * (선언과 실제가 갈라져도 아무 일이 안 일어남).
+ *
+ * `inject` 배열을 보는 이유는 컨테이너를 띄우려면 `DbService` 가 필요해서다. 여기서
+ * 확인하는 것은 "아웃박스를 켠 앱에서만 writer 가 따라 들어간다"는 배선 자체다.
+ */
+describe('EventsModule outbox writer 배선 (ADR-0029 §5)', () => {
+  const kafka = { clientId: 'test-service', brokers: ['localhost:9092'] };
+
+  /** `forRoot` 가 만드는 publisher provider 의 모양. DynamicModule 은 이보다 넓게 타이핑돼 있다. */
+  interface PublisherProvider {
+    provide: string;
+    inject: Array<string | symbol | { name?: string }>;
+    useFactory: (...args: unknown[]) => { enqueue: (params: unknown, tx: unknown) => Promise<void> };
+  }
+
+  function publisherProviderOf(moduleRef: DynamicModule): PublisherProvider {
+    const token = EventsModule.getPublisherToken(USER_STREAM.topic.topic);
+    const found = (moduleRef.providers ?? []).find((provider) => (provider as { provide?: unknown }).provide === token);
+    return found as unknown as PublisherProvider;
+  }
+
+  const injectedNames = (provider: PublisherProvider) =>
+    provider.inject.map((token) => (typeof token === 'function' ? (token as { name: string }).name : String(token)));
+
+  it('enableOutbox: true 면 publisher 가 OutboxPublisher 를 함께 주입받고 enqueue 가 그리로 쓴다', async () => {
+    const provider = publisherProviderOf(EventsModule.forRoot({ streams: [USER_STREAM], kafka, enableOutbox: true }));
+
+    expect(injectedNames(provider)).toContain('OutboxPublisher');
+
+    // 토큰만 보면 팩토리가 그 인자를 버려도 초록이다. 실제로 조립해 적재까지 확인한다.
+    const rows: unknown[] = [];
+    const publisher = provider.useFactory({ send: jest.fn() }, undefined, undefined, {
+      write: (record: unknown) => {
+        rows.push(record);
+        return Promise.resolve();
+      },
+    });
+
+    await publisher.enqueue(
+      {
+        eventType: 'UserEmailVerified',
+        aggregateId: 'user-1',
+        payload: { userId: 'user-1', email: 'user@example.com', name: '홍길동' },
+      },
+      {},
+    );
+
+    expect(rows).toHaveLength(1);
+  });
+
+  it('대조군 — 아웃박스를 켜지 않으면 주입하지 않는다 (그 앱에서 enqueue 는 던진다)', () => {
+    const provider = publisherProviderOf(EventsModule.forRoot({ streams: [USER_STREAM], kafka }));
+
+    expect(injectedNames(provider)).not.toContain('OutboxPublisher');
+  });
+});

--- a/libs/events/src/events.module.ts
+++ b/libs/events/src/events.module.ts
@@ -4,15 +4,7 @@
  * Stream 기반 이벤트 시스템을 위한 NestJS 모듈
  */
 
-import {
-  DynamicModule,
-  Global,
-  INestApplication,
-  Inject,
-  Module,
-  OnApplicationShutdown,
-  Logger,
-} from '@nestjs/common';
+import { DynamicModule, Global, INestApplication, Inject, Module, OnApplicationShutdown, Logger } from '@nestjs/common';
 import {
   ClientKafka,
   ClientsModule,
@@ -38,6 +30,7 @@ import { SchemaValidationOptions } from '@packages/event-contracts/types';
 import { OutboxConfig } from './outbox/outbox.types';
 import { OutboxPublisher } from './outbox/outbox-publisher.service';
 import { OutboxDispatcher } from './outbox/outbox-dispatcher.service';
+import { OutboxWriter } from './outbox/outbox-writer.port';
 import { bootstrapKafkaTopics } from './bootstrap/topic-bootstrap.service';
 import { outboxSchema } from './outbox/outbox.schema';
 import { trackingSchema } from './tracking/tracking.schema';
@@ -155,6 +148,10 @@ export class EventsModule {
     const serviceName = options.serviceName || process.env.SERVICE_NAME || 'unknown-service';
     const enableDLQ = options.enableDLQ ?? true;
 
+    // 아웃박스를 켠 앱에서만 `enqueue` 가 동작한다 — publisher 가 적재 대상을 알아야 하기
+    // 때문이다(ADR-0029 §5). 켜지 않은 앱에서 `enqueue` 를 부르면 던진다.
+    const enableOutbox = options.enableOutbox ?? false;
+
     // 각 stream별 StreamPublisher 제공자 생성
     const publisherProviders = options.streams.map((stream) => ({
       provide: this.getPublisherToken(stream.topic.topic),
@@ -162,6 +159,7 @@ export class EventsModule {
         transport: EventTransport,
         eventChainService: EventChainService,
         eventTrackingService: EventTrackingService,
+        outboxWriter?: OutboxWriter,
       ) => {
         return new StreamPublisher(
           transport,
@@ -170,9 +168,10 @@ export class EventsModule {
           options.validation, // 스키마 검증 옵션 전달
           eventChainService,
           eventTrackingService,
+          outboxWriter,
         );
       },
-      inject: [EVENT_TRANSPORT, EventChainService, EventTrackingService],
+      inject: [EVENT_TRANSPORT, EventChainService, EventTrackingService, ...(enableOutbox ? [OutboxPublisher] : [])],
     }));
 
     // DLQ Handler 제공자 (DLQ가 활성화된 경우에만)
@@ -207,7 +206,6 @@ export class EventsModule {
     };
 
     // Outbox 관련 providers
-    const enableOutbox = options.enableOutbox ?? false;
     const outboxProviders = enableOutbox
       ? [
           {

--- a/libs/events/src/index.ts
+++ b/libs/events/src/index.ts
@@ -59,6 +59,7 @@ export * from './bootstrap/topic-bootstrap.service';
 // Outbox Pattern
 export * from './outbox/outbox.schema';
 export * from './outbox/outbox.types';
+export * from './outbox/outbox-writer.port';
 export * from './outbox/outbox-publisher.service';
 export * from './outbox/outbox-dispatcher.service';
 

--- a/libs/events/src/outbox/enqueue-validation.spec.ts
+++ b/libs/events/src/outbox/enqueue-validation.spec.ts
@@ -1,0 +1,265 @@
+/**
+ * 아웃박스 적재(enqueue) 시점의 스키마 검증 (ADR-0029 §5, 플랜 Task 6-A)
+ *
+ * 이 워크스트림의 5-C 는 "발행 경로를 전수로 닫아" 소비 검증을 켜도 되는지 판정한다. 그 논증이
+ * 남긴 구멍이 정확히 하나였다 — `OutboxPublisher.saveEvent` 는 검증 없이 envelope 를 넣고,
+ * `publishRawEnvelope` 가 zod 를 우회해 그것을 그대로 Kafka 로 실어 보냈다. 그래서 아웃박스로
+ * 나가는 4개 이벤트가 UNVERIFIED 로 남아 analytics·search·channel-adapter 를 막고 있었다.
+ *
+ * 여기서 고정하는 것은 두 개의 문(門)이다:
+ *
+ * 1. **enqueue 문** — 잘못된 payload 는 아웃박스 행이 되지 못하고 호출자의 트랜잭션을 실패시킨다.
+ *    poison row 가 남아 소비자 DLQ 에서 사후 발견되는 대신, 발행자의 도메인 연산이 그 자리에서
+ *    터진다. 진단 위치가 원인에 붙어 있다는 것이 이 설계의 요지다 (ADR-0029 §5).
+ * 2. **dispatch 문** — 그럼에도 어떤 경로로든 아웃박스에 들어온 행(배포 이전에 적재된 행,
+ *    테이블에 직접 insert 하는 wallet 판본)은 Kafka 로 나가기 직전에 한 번 더 걸린다.
+ *
+ * 두 문이 함께 있어야 "Kafka 로 나간 payload 는 zod 파싱을 통과한 값"이 조건 없는 불변식이 된다.
+ * 그 불변식이 5-C 의 나머지를 여는 열쇠다.
+ *
+ * **대조군을 함께 둔다.** 검증을 끄는 변이(`validateOnPublish: false`)로 같은 테스트가 반대
+ * 결과를 내는지 확인하지 않으면, 초록불이 "검증이 막았다"인지 "애초에 그 payload 가 안 갔다"인지
+ * 구분할 수 없다. 이 워크스트림이 반복해서 밟은 함정이다.
+ *
+ * 계약이 아니라 하네스 스트림을 쓰는 것은 `consume-validation.spec.ts` 와 같은 이유다 — 여기서
+ * 고정하는 것은 메커니즘이고, 어느 앱의 어느 이벤트가 실제로 안전한가는
+ * `npm run audit:consume-validation -- --gate` 가 상시 판정한다.
+ */
+
+import { Controller, INestMicroservice, UseInterceptors } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { z } from 'zod';
+import { event, getDLQTopicName, stream, SchemaValidationError } from '@packages/event-contracts/types';
+import type { MessageEnvelope } from '@packages/event-contracts/types';
+import type { DLQMessage } from '../dlq/dlq.types';
+import { EventsModule } from '../events.module';
+import { EventPayload, OnEvent } from '../consumers/decorators';
+import { EventTypeGuard } from '../guards/event-type.guard';
+import { StreamPublisher } from '../publishers/stream-publisher.service';
+import { EVENT_TRANSPORT } from '../transport/transport.port';
+import { InMemoryBroker } from '../transport/in-memory.broker';
+import { InMemoryTransport } from '../transport/in-memory.transport';
+import { InMemoryServer } from '../transport/in-memory.server';
+import type { OutboxRecord, OutboxWriter } from './outbox-writer.port';
+import type { DbTx } from './outbox.types';
+
+const StockMovedSchema = z.object({
+  sku: z.string().min(1),
+  quantity: z.number().int().positive(),
+});
+
+const OUTBOX_STREAM = stream({
+  topic: 'outbox.events.v1',
+  partitions: 1,
+  aggregateType: 'OutboxHarness',
+  events: {
+    StockMoved: event('StockMoved', StockMovedSchema),
+  },
+});
+
+/** 아웃박스 테이블 대신 배열에 적재한다 — 이 스펙이 확인하는 것은 "적재되는가"이지 SQL 이 아니다. */
+class RecordingOutboxWriter implements OutboxWriter {
+  readonly rows: OutboxRecord[] = [];
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async write(record: OutboxRecord, tx: DbTx): Promise<void> {
+    void tx;
+    this.rows.push(record);
+  }
+}
+
+const received: unknown[] = [];
+
+@Controller()
+@UseInterceptors(EventTypeGuard)
+class OutboxHarnessConsumer {
+  @OnEvent('outbox.events.v1', 'StockMoved')
+  onMoved(@EventPayload() payload: { sku: string; quantity: number }): void {
+    received.push(payload);
+  }
+}
+
+/** 트랜잭션 핸들은 writer 에게만 의미가 있다 — publisher 는 그대로 넘기기만 한다. */
+const TX = {} as DbTx;
+
+describe('아웃박스 enqueue 시점 스키마 검증', () => {
+  let app: INestMicroservice;
+  let broker: InMemoryBroker;
+  let writer: RecordingOutboxWriter;
+  /** 검증 기본값(켜짐)으로 만든 publisher — 운영 배선과 같다. */
+  let publisher: StreamPublisher<typeof OUTBOX_STREAM.events>;
+  /** 대조군 — 검증만 끈 같은 publisher. */
+  let unvalidated: StreamPublisher<typeof OUTBOX_STREAM.events>;
+
+  beforeAll(async () => {
+    process.env.KAFKA_BOOTSTRAP_TOPICS = 'false';
+    broker = new InMemoryBroker();
+    const kafka = { clientId: 'outbox-harness', brokers: ['unused:9092'] };
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        EventsModule.forConsumerModule({
+          streams: [OUTBOX_STREAM],
+          groupId: 'outbox-harness-consumer',
+          kafka,
+          validation: { validateOnConsume: true },
+        }),
+      ],
+      controllers: [OutboxHarnessConsumer],
+    })
+      .overrideProvider(EVENT_TRANSPORT)
+      .useValue(new InMemoryTransport(broker))
+      .compile();
+
+    app = moduleRef.createNestMicroservice({ strategy: new InMemoryServer(broker), logger: false });
+    await app.listen();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  beforeEach(() => {
+    received.length = 0;
+    broker.reset();
+    writer = new RecordingOutboxWriter();
+    const transport = new InMemoryTransport(broker);
+    publisher = new StreamPublisher(
+      transport,
+      OUTBOX_STREAM,
+      'outbox-harness',
+      undefined,
+      undefined,
+      undefined,
+      writer,
+    );
+    unvalidated = new StreamPublisher(
+      transport,
+      OUTBOX_STREAM,
+      'outbox-harness',
+      { validateOnPublish: false },
+      undefined,
+      undefined,
+      writer,
+    );
+  });
+
+  const dlqOf = () => broker.envelopesOn<DLQMessage>(getDLQTopicName(OUTBOX_STREAM.topic.topic));
+
+  // ── 문 1: enqueue ────────────────────────────────────────────────────────
+
+  it('잘못된 payload 는 아웃박스 행이 되지 못하고 호출자에게 던진다', async () => {
+    await expect(
+      publisher.enqueue(
+        {
+          eventType: 'StockMoved',
+          aggregateId: 'sku-1',
+          payload: { sku: 'sku-1', quantity: -3 } as never, // positive() 위반
+        },
+        TX,
+      ),
+    ).rejects.toBeInstanceOf(SchemaValidationError);
+
+    // 도메인 트랜잭션이 롤백되든 말든, 아웃박스에 poison row 자체가 생기지 않았다.
+    expect(writer.rows).toHaveLength(0);
+  });
+
+  it('대조군 — 검증을 끄면 같은 payload 가 그대로 아웃박스에 적재된다', async () => {
+    await unvalidated.enqueue(
+      {
+        eventType: 'StockMoved',
+        aggregateId: 'sku-1',
+        payload: { sku: 'sku-1', quantity: -3 } as never,
+      },
+      TX,
+    );
+
+    // 위 테스트의 초록이 "검증이 막았다"임을 이 줄이 증명한다 — 경로 자체는 살아 있다.
+    expect(writer.rows).toHaveLength(1);
+    expect(writer.rows[0].envelope.payload).toEqual({ sku: 'sku-1', quantity: -3 });
+  });
+
+  it('enqueue 는 zod 파싱 결과를 싣는다 — 계약에 없는 키는 적재 시점에 떨어진다', async () => {
+    await publisher.enqueue(
+      {
+        eventType: 'StockMoved',
+        aggregateId: 'sku-2',
+        payload: { sku: 'sku-2', quantity: 5, legacyField: 'dropped' } as never,
+      },
+      TX,
+    );
+
+    expect(writer.rows).toHaveLength(1);
+    expect(writer.rows[0].envelope.payload).toEqual({ sku: 'sku-2', quantity: 5 });
+    expect(writer.rows[0]).toMatchObject({
+      topic: 'outbox.events.v1',
+      aggregateType: 'OutboxHarness',
+      aggregateId: 'sku-2',
+      eventType: 'StockMoved',
+    });
+  });
+
+  it('아웃박스 writer 가 없으면 enqueue 는 조용히 성공하지 않는다', async () => {
+    const noWriter = new StreamPublisher(new InMemoryTransport(broker), OUTBOX_STREAM, 'outbox-harness');
+
+    await expect(
+      noWriter.enqueue({ eventType: 'StockMoved', aggregateId: 'sku-3', payload: { sku: 'sku-3', quantity: 1 } }, TX),
+    ).rejects.toThrow(/outbox/i);
+  });
+
+  // ── 문 2: dispatch ───────────────────────────────────────────────────────
+
+  it('적재된 envelope 는 발행 → 소비 검증을 그대로 통과한다', async () => {
+    await publisher.enqueue(
+      { eventType: 'StockMoved', aggregateId: 'sku-4', payload: { sku: 'sku-4', quantity: 7 } },
+      TX,
+    );
+
+    // 디스패처가 하는 일 그대로 — 저장된 envelope 를 그대로 싣는다.
+    await publisher.publishStoredEnvelope(writer.rows[0].envelope, writer.rows[0].aggregateId);
+
+    expect(received).toEqual([{ sku: 'sku-4', quantity: 7 }]);
+    expect(dlqOf()).toHaveLength(0);
+  });
+
+  it('enqueue 를 우회해 들어온 poison 행은 발행 직전에 막힌다', async () => {
+    const poison: MessageEnvelope = {
+      messageId: 'msg-poison',
+      messageType: 'StockMoved',
+      messageVersion: 1,
+      messageKind: 'event',
+      correlationId: 'corr-poison',
+      timestamp: new Date().toISOString(),
+      occurredAt: new Date().toISOString(),
+      source: { service: 'legacy', aggregateType: 'OutboxHarness', aggregateId: 'sku-5' },
+      payload: { sku: '', quantity: 0 },
+    };
+
+    await expect(publisher.publishStoredEnvelope(poison, 'sku-5')).rejects.toBeInstanceOf(SchemaValidationError);
+
+    // 브로커에 아무것도 나가지 않았다 = 디스패처가 실패로 기록하고 행을 다시 잡는다.
+    expect(broker.envelopesOn(OUTBOX_STREAM.topic.topic)).toHaveLength(0);
+    expect(received).toHaveLength(0);
+  });
+
+  it('대조군 — 검증을 끈 publisher 는 같은 poison 행을 그대로 내보낸다', async () => {
+    const poison: MessageEnvelope = {
+      messageId: 'msg-poison-2',
+      messageType: 'StockMoved',
+      messageVersion: 1,
+      messageKind: 'event',
+      correlationId: 'corr-poison-2',
+      timestamp: new Date().toISOString(),
+      occurredAt: new Date().toISOString(),
+      source: { service: 'legacy', aggregateType: 'OutboxHarness', aggregateId: 'sku-6' },
+      payload: { sku: '', quantity: 0 },
+    };
+
+    await unvalidated.publishStoredEnvelope(poison, 'sku-6');
+
+    // 옛 `publishRawEnvelope` 의 동작이 이것이었다. 나간 뒤 소비 측 검증이 DLQ 로 보낸다.
+    expect(broker.envelopesOn(OUTBOX_STREAM.topic.topic)).toHaveLength(1);
+    expect(received).toHaveLength(0);
+    expect(dlqOf()).toHaveLength(1);
+  });
+});

--- a/libs/events/src/outbox/outbox-dispatcher.service.ts
+++ b/libs/events/src/outbox/outbox-dispatcher.service.ts
@@ -118,7 +118,10 @@ export class OutboxDispatcher {
         throw new Error(`No publisher found for topic: ${event.topic}`);
       }
 
-      await publisher.publishRawEnvelope(event.payload, event.aggregateId);
+      // 검증을 탄다 (ADR-0029 §5). `enqueue` 를 지나지 않은 행 — 이 변경 이전에 적재된 PENDING
+      // 행 — 이 스키마를 위반하면 여기서 실패로 기록되고 재시도 후 FAILED 로 남는다. 발행돼서
+      // 소비자 DLQ 에 쌓이는 것보다 발행 측에 남는 편이 진단에 가깝다.
+      await publisher.publishStoredEnvelope(event.payload, event.aggregateId);
 
       await this.db
         .update(outbox_events)

--- a/libs/events/src/outbox/outbox-publisher.service.ts
+++ b/libs/events/src/outbox/outbox-publisher.service.ts
@@ -1,11 +1,19 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { DbService } from '@app/db';
 import { outbox_events } from './outbox.schema';
-import { SaveEventParams, DbTx } from './outbox.types';
-import { generateMessageId } from '../utils/message-id.util';
+import { DbTx } from './outbox.types';
+import { OutboxRecord, OutboxWriter } from './outbox-writer.port';
 
+/**
+ * 공용 아웃박스 테이블(`outbox_events`) 적재기.
+ *
+ * **envelope 조립과 검증은 하지 않는다** — 그건 `StreamPublisher.enqueue` 의 일이다(ADR-0029 §5).
+ * 옛 `saveEvent` 는 topic·eventType 을 생문자열로 받아 envelope 를 직접 만들었고, 계약을 몰랐기
+ * 때문에 zod 를 탈 수 없었다. 그것이 이 레포에서 아웃박스가 "검증되지 않는 쪽 경로"였던 이유다.
+ * 이제 이 클래스는 이미 검증된 envelope 를 행으로 옮기기만 한다.
+ */
 @Injectable()
-export class OutboxPublisher {
+export class OutboxPublisher implements OutboxWriter {
   private readonly logger = new Logger(OutboxPublisher.name);
 
   constructor(private readonly dbService: DbService) {}
@@ -14,41 +22,19 @@ export class OutboxPublisher {
     return this.dbService.db;
   }
 
-  async saveEvent(params: SaveEventParams, tx: DbTx): Promise<void> {
-    const messageId = generateMessageId();
-    const now = new Date();
-
-    // MessageEnvelope 구조로 payload 구성
-    const envelope = {
-      messageId,
-      messageType: params.eventType,
-      messageVersion: 1,
-      messageKind: 'event' as const,
-      correlationId: params.correlationId || messageId,
-      causationId: params.causationId,
-      timestamp: now.toISOString(),
-      occurredAt: now.toISOString(),
-      source: {
-        service: 'unknown', // OutboxDispatcher에서 발행 시 설정됨
-        aggregateType: params.aggregateType,
-        aggregateId: params.aggregateId,
-      },
-      payload: params.payload,
-      metadata: params.metadata,
-    };
-
+  async write(record: OutboxRecord, tx: DbTx): Promise<void> {
     await tx.insert(outbox_events).values({
-      topic: params.topic,
-      aggregateType: params.aggregateType,
-      aggregateId: params.aggregateId,
-      eventType: params.eventType,
-      payload: envelope,
+      topic: record.topic,
+      aggregateType: record.aggregateType,
+      aggregateId: record.aggregateId,
+      eventType: record.eventType,
+      payload: record.envelope,
       status: 'PENDING',
     });
 
-    this.logger.debug(`Outbox event saved: ${params.eventType}`, {
-      topic: params.topic,
-      aggregateId: params.aggregateId,
+    this.logger.debug(`Outbox event saved: ${record.eventType}`, {
+      topic: record.topic,
+      aggregateId: record.aggregateId,
     });
   }
 }

--- a/libs/events/src/outbox/outbox-writer.port.ts
+++ b/libs/events/src/outbox/outbox-writer.port.ts
@@ -1,0 +1,30 @@
+/**
+ * Outbox Writer Port (ADR-0029 §5·§7)
+ *
+ * `StreamPublisher.enqueue` 가 검증을 끝낸 envelope 를 넘기는 자리. 발행 방향에 port 를 두는
+ * 이유는 §7 과 같다 — 적재 대상(테이블·ORM)이 아니라 **"검증된 envelope 를 트랜잭션에 싣는다"**
+ * 는 것만이 publisher 의 관심사다. 덕분에 `libs/events` 의 publisher 는 drizzle 을 몰라도 되고,
+ * 스펙은 DB 없이 적재를 관찰할 수 있다.
+ *
+ * 구현체는 현재 `OutboxPublisher`(공용 `outbox_events` 테이블) 하나다. 앱 자체 outbox 5벌을
+ * 회수하는 Task 6-C 가 이 port 뒤로 들어온다.
+ */
+
+import type { MessageEnvelope } from '@packages/event-contracts/types';
+import type { DbTx } from './outbox.types';
+
+/**
+ * 아웃박스 한 행. `envelope.payload` 는 **이미 zod 파싱을 통과한 값**이다 —
+ * 검증은 publisher 가 적재 전에 끝낸다(ADR-0029 §5).
+ */
+export interface OutboxRecord {
+  topic: string;
+  aggregateType: string;
+  aggregateId: string;
+  eventType: string;
+  envelope: MessageEnvelope;
+}
+
+export interface OutboxWriter {
+  write(record: OutboxRecord, tx: DbTx): Promise<void>;
+}

--- a/libs/events/src/outbox/outbox.types.ts
+++ b/libs/events/src/outbox/outbox.types.ts
@@ -15,14 +15,3 @@ export interface OutboxConfig {
   processingTimeoutMs?: number; // 기본값: 300000 (5분)
   cleanupDays?: number; // 기본값: 7
 }
-
-export interface SaveEventParams {
-  topic: string;
-  eventType: string;
-  aggregateType: string;
-  aggregateId: string;
-  payload: any;
-  correlationId?: string;
-  causationId?: string;
-  metadata?: Record<string, unknown>;
-}

--- a/libs/events/src/publishers/stream-publisher.service.ts
+++ b/libs/events/src/publishers/stream-publisher.service.ts
@@ -14,6 +14,8 @@ import { validateSchemaOrThrow, logValidationError, isZodSchema } from '../valid
 import { EventChainService } from '../tracking/event-chain.service';
 import { EventTrackingService } from '../tracking/event-tracking.service';
 import { EventTransport } from '../transport/transport.port';
+import type { OutboxWriter } from '../outbox/outbox-writer.port';
+import type { DbTx } from '../outbox/outbox.types';
 
 export interface CausedByResource {
   resourceType: string;
@@ -64,6 +66,11 @@ export class StreamPublisher<TEvents extends StreamEventTypes = StreamEventTypes
     validationOptions?: SchemaValidationOptions,
     private readonly eventChainService?: EventChainService,
     private readonly eventTrackingService?: EventTrackingService,
+    /**
+     * 아웃박스 적재 대상 (ADR-0029 §5). 없으면 `enqueue` 가 던진다 — 이 앱이 아웃박스를
+     * 켜지 않았다는 뜻이고, 조용히 이벤트를 버리는 것보다 부팅/호출 시점에 드러나는 편이 낫다.
+     */
+    private readonly outboxWriter?: OutboxWriter,
   ) {
     this.logger = new Logger(`StreamPublisher:${streamConfig.topic.topic}`);
     this.validationOptions = {
@@ -87,6 +94,79 @@ export class StreamPublisher<TEvents extends StreamEventTypes = StreamEventTypes
       causedBy?: CausedByResource;
     },
   ): Promise<void> {
+    const envelope = this.buildEventEnvelope(params);
+
+    const partitionKey = this.resolvePartitionKey(envelope.payload, params.aggregateId);
+    await this.sendMessage(envelope, partitionKey);
+
+    // causedBy가 있으면 CAUSE 링크 기록
+    if (params.causedBy && this.eventTrackingService) {
+      await this.eventTrackingService
+        .trackCause({
+          eventId: envelope.messageId,
+          chainId: envelope.chainId as string,
+          eventType: envelope.messageType,
+          ...params.causedBy,
+        })
+        .catch((err) => this.logger.warn('Failed to track cause', err?.message));
+    }
+  }
+
+  /**
+   * 트랜잭셔널 아웃박스 적재 (ADR-0029 §5)
+   *
+   * `publishEvent` 와 **같은 파라미터·같은 타입 도출·같은 검증**이고, 다른 것은 배달 방식뿐이다.
+   * 즉시 Kafka 로 보내는 대신 호출자의 트랜잭션에 행으로 남기고, 디스패처가 커밋 이후에 발행한다.
+   *
+   * 검증이 여기서 일어나는 것이 이 메서드의 요점이다. 잘못된 payload 는 아웃박스에 poison row 로
+   * 남아 나중에 소비자 DLQ 에서 발견되는 대신, **호출자의 도메인 트랜잭션을 그 자리에서 실패시킨다.**
+   * 진단 위치가 원인에 붙어 있다.
+   *
+   * @example
+   * await this.products.enqueue(
+   *   { eventType: 'ProductMasterDeleted', aggregateId: masterId, payload: { masterId, deletedAt } },
+   *   tx,
+   * );
+   */
+  async enqueue<K extends keyof TEvents & string>(
+    params: PublishEventParams<K, TEvents[K] extends EventType<any, infer TPayload> ? TPayload : never>,
+    tx: DbTx,
+  ): Promise<void> {
+    if (!this.outboxWriter) {
+      throw new Error(
+        `Stream ${this.streamConfig.topic.topic} has no outbox writer — ` +
+          'EventsModule.forRoot({ enableOutbox: true }) 가 필요하다.',
+      );
+    }
+
+    const envelope = this.buildEventEnvelope(params);
+
+    await this.outboxWriter.write(
+      {
+        topic: this.streamConfig.topic.topic,
+        aggregateType: this.streamConfig.aggregateType,
+        aggregateId: params.aggregateId,
+        eventType: String(params.eventType),
+        envelope,
+      },
+      tx,
+    );
+
+    this.logger.debug(`📥 event enqueued: ${envelope.messageType}`, {
+      messageId: envelope.messageId,
+      aggregateId: params.aggregateId,
+    });
+  }
+
+  /**
+   * Envelope 조립 + 검증 — `publishEvent` 와 `enqueue` 의 공통부.
+   *
+   * 싣는 것은 원본이 아니라 **zod 가 파싱한 결과**다. 파싱은 멱등이므로 이 envelope 는 같은
+   * 스키마의 소비 검증을 반드시 통과한다 (ADR-0029 §8 "검증 스위치(C)").
+   */
+  private buildEventEnvelope<K extends keyof TEvents & string>(
+    params: PublishEventParams<K, TEvents[K] extends EventType<any, infer TPayload> ? TPayload : never>,
+  ): DomainEvent<TEvents[K] extends EventType<any, infer TPayload> ? TPayload : never> {
     const messageId = generateMessageId();
     const now = new Date();
 
@@ -99,8 +179,7 @@ export class StreamPublisher<TEvents extends StreamEventTypes = StreamEventTypes
     // chainId: CLS에서 읽거나 새 UUID v7 생성
     const chainId = this.eventChainService?.getChainId() ?? v7();
 
-    // Envelope 생성
-    const envelope: DomainEvent<TEvents[K] extends EventType<any, infer TPayload> ? TPayload : never> = {
+    return {
       messageId,
       messageType: String(params.eventType),
       messageVersion: 1,
@@ -123,24 +202,14 @@ export class StreamPublisher<TEvents extends StreamEventTypes = StreamEventTypes
       payload: validatedPayload,
       metadata: params.metadata,
     };
+  }
 
-    const partitionKey = this.streamConfig.partitionKey?.(validatedPayload) ?? params.aggregateId;
+  private resolvePartitionKey(payload: unknown, aggregateId: string): string {
+    const partitionKey = this.streamConfig.partitionKey?.(payload as never) ?? aggregateId;
     if (typeof partitionKey !== 'string' || partitionKey.length === 0) {
       throw new Error(`Stream ${this.streamConfig.topic.topic} resolved an invalid partition key`);
     }
-    await this.sendMessage(envelope, partitionKey);
-
-    // causedBy가 있으면 CAUSE 링크 기록
-    if (params.causedBy && this.eventTrackingService) {
-      await this.eventTrackingService
-        .trackCause({
-          eventId: envelope.messageId,
-          chainId,
-          eventType: envelope.messageType,
-          ...params.causedBy,
-        })
-        .catch((err) => this.logger.warn('Failed to track cause', err?.message));
-    }
+    return partitionKey;
   }
 
   /**
@@ -175,6 +244,13 @@ export class StreamPublisher<TEvents extends StreamEventTypes = StreamEventTypes
     const messageId = generateMessageId();
     const now = new Date();
 
+    // 이벤트와 같은 검증을 탄다. 이 줄이 없던 동안 커맨드는 zod 를 우회하는 세 번째 경로였다
+    // (ADR-0029 §8 "검증 스위치(C)" 의 전수 폐쇄 논증이 놓쳤던 자리).
+    let validatedPayload = params.payload;
+    if (this.validationOptions.validateOnPublish) {
+      validatedPayload = this.validatePayload(String(params.commandType), params.payload);
+    }
+
     const envelope: DomainCommand<TEvents[K] extends EventType<any, infer TPayload> ? TPayload : never> = {
       messageId,
       messageType: String(params.commandType),
@@ -192,7 +268,7 @@ export class StreamPublisher<TEvents extends StreamEventTypes = StreamEventTypes
         aggregateId: params.aggregateId,
       },
 
-      payload: params.payload,
+      payload: validatedPayload,
       metadata: params.metadata,
 
       expiresAt: params.expiresIn ? new Date(Date.now() + params.expiresIn).toISOString() : undefined,
@@ -239,12 +315,26 @@ export class StreamPublisher<TEvents extends StreamEventTypes = StreamEventTypes
   }
 
   /**
-   * Raw MessageEnvelope 발행 (Outbox 패턴용)
+   * 아웃박스에 저장된 envelope 발행 (ADR-0029 §5)
    *
-   * Outbox에 저장된 envelope를 그대로 Kafka로 발행
+   * 옛 이름은 `publishRawEnvelope` 였고 zod 를 우회했다 — 그것이 이 레포에서 검증되지 않는
+   * 유일한 발행 경로였고, 소비 검증을 앱별로 켤 수 없게 만든 원인이었다(§8 "검증 스위치(C)").
+   *
+   * 이제 검증한다. `enqueue` 가 이미 적재 시점에 걸렀으므로 정상 경로에서는 두 번째 통과이고
+   * 비용은 파싱 한 번이다. 이 문이 실제로 무는 것은 **enqueue 를 지나지 않은 행**이다:
+   * 이 변경 이전에 적재돼 아직 PENDING 인 행, 그리고 테이블에 직접 insert 하는 앱 자체 판본
+   * (wallet). 그 행들이 남아 있는 한 "Kafka 로 나간 것은 검증을 통과한 값"이 조건부가 된다.
+   *
+   * 실패하면 던진다 — 디스패처가 그 행을 실패로 기록하고 재시도/DLQ 정책에 태운다. 조용히
+   * 넘기면 아웃박스가 검증을 무력화하는 우회로로 되돌아간다.
    */
-  async publishRawEnvelope(envelope: MessageEnvelope, partitionKey: string): Promise<void> {
-    await this.sendMessage(envelope, partitionKey);
+  async publishStoredEnvelope(envelope: MessageEnvelope, partitionKey: string): Promise<void> {
+    let payload = envelope.payload;
+    if (this.validationOptions.validateOnPublish) {
+      payload = this.validatePayload(envelope.messageType, envelope.payload);
+    }
+
+    await this.sendMessage({ ...envelope, payload }, partitionKey);
   }
 
   /**

--- a/packages/event-contracts/streams/product.stream.ts
+++ b/packages/event-contracts/streams/product.stream.ts
@@ -414,6 +414,15 @@ const CategoryChangedSchema = z.object({
   changeType: z.enum(['created', 'updated', 'deleted', 'moved']),
   timestamp: z.string().datetime(),
   category: CategorySnapshotSchema.nullable(),
+  /**
+   * `CategoryChangedPayload` 는 처음부터 이 필드를 선언했는데 스키마에만 빠져 있었다.
+   * 검증이 발행 경로에 없던 동안은 무증상이었지만, 적재 시점 검증(ADR-0029 §5)이 켜지면
+   * zod 가 미선언 키를 **조용히 떼어낸다** — channel-adapter 의 Medusa 카테고리 동기화가
+   * `ancestors` 로 부모를 먼저 보장하므로(`pim-medusa-sync.service.ts:662`), 그 조용한 손실이
+   * 자식 카테고리를 최상위로 붙이는 버그가 된다. 계약을 채우는 쪽이 옳다 (ADR-0029 §1).
+   * 추가는 additive 라 옛 producer 를 깨지 않는다.
+   */
+  ancestors: z.array(CategorySnapshotSchema).optional(),
 });
 
 // ===== Stream Config =====

--- a/scripts/events/consume-validation-readiness.ts
+++ b/scripts/events/consume-validation-readiness.ts
@@ -6,29 +6,29 @@
  *
  * 플랜 Task 5-C 는 "인바운드 payload 가 실제로 zod 스키마를 만족하는지 **먼저** 확인"하라고 하고
  * 그 방법으로 "스테이징 샘플링 또는 5-B 상태에서 로그 관찰"을 제시한다. **둘 다 지금 불가능하다** —
- * AWS `dev` stage 는 폐기됐고, 5-B(배선 이주)는 커밋됐을 뿐 배포되지 않아 라이브는 여전히 옛 배선이라
- * 검증 인터셉터가 붙지 않는다(§8). 관찰할 로그 자체가 생기지 않는다.
+ * AWS `dev` stage 는 폐기됐고, 배선 이주가 배포되기 전에는 검증 인터셉터가 붙지 않아 관찰할 로그
+ * 자체가 생기지 않는다. 대신 **발행 경로를 전수로 닫아** 같은 결론에 도달한다.
  *
- * 대신 **발행 경로를 전수로 닫아** 같은 결론에 도달한다. 논증은 세 걸음이다:
+ * ## 불변식 (Task 6-A 이후)
  *
- * 1. Kafka 로 나가는 모든 경로는 `StreamPublisher` 를 지난다 (ADR-0029 §7, Task 2 에서 확립).
- * 2. `StreamPublisher` 의 발행 진입점은 **둘뿐**이다:
- *    - `publishEvent`  → `validateOnPublish` 로 zod 검증. 게다가 envelope 에 싣는 것은 원본이 아니라
- *      **zod 가 파싱한 결과**(`payload: validatedPayload`, `stream-publisher.service.ts:123`)다.
- *      즉 나가는 payload 는 스키마의 출력 그 자체라, 같은 스키마로 다시 검증하면 반드시 통과한다.
- *    - `publishRawEnvelope` → zod 우회.
- * 3. 따라서 **`publishRawEnvelope` 가 실어 나를 수 있는 (토픽, 이벤트) 만이 위험하다.**
- *    그 호출자는 레포 전체에 **2곳**뿐이다 (아래 BYPASS_PATHS).
+ * **Kafka 로 나가는 모든 payload 는 zod 파싱을 통과한 값이다.** 근거는 세 걸음이고 전부 AST 로 센다:
  *
- * `validateOnPublish` 를 `false` 로 끄는 곳은 레포에 하나도 없다(실측). 발행·소비가 같은
- * `StreamConfig` 객체를 공유하는 것도 확인했다 — 모든 `forRoot({streams})` 가 계약 패키지의
- * 정규 export 를 그대로 넘긴다. 그래서 스키마가 양쪽에서 갈라질 수 없다.
+ * 1. 프로덕션 코드에서 `kafkajs` 를 직접 잡는 곳은 없다 → 모든 전송은 `EventTransport.send` 를 지난다.
+ * 2. `transport.send` 호출 지점은 아래 `SEND_PATHS` 가 전부다.
+ * 3. 그중 `StreamPublisher.sendMessage` 를 지나는 것은 검증된 진입점 셋뿐이다
+ *    (`publishEvent` · `publishCommand` · `publishStoredEnvelope`). 셋 다 envelope 에 싣는 것이
+ *    원본이 아니라 **zod 가 파싱한 결과**다. 파싱은 멱등이므로 같은 스키마의 소비 검증을 반드시
+ *    통과한다.
+ *
+ * Task 6-A 이전에는 `publishRawEnvelope` 가 3번의 예외였다 — 아웃박스가 zod 를 우회하는 유일한
+ * 경로였고, 그래서 아웃박스로 나가는 4개 이벤트가 UNVERIFIED 로 남아 세 앱을 막고 있었다.
+ * 이제 적재(`enqueue`)와 발행(`publishStoredEnvelope`) 양쪽에 문이 있고 우회는 없다.
  *
  * ## 판정
  *
  *   SAFE       스키마 없음, 또는 빈 객체까지 통과하는 관대한 스키마 → 켜도 동작이 안 바뀐다
- *   PROVEN     필수 필드가 있으나 우회 경로가 이 (토픽,이벤트) 에 닿지 않는다 → 발행 시 이미 검증됨
- *   UNVERIFIED 필수 필드 + 우회 경로가 닿는다 → 사람이 payload 를 봐야 한다
+ *   PROVEN     필수 필드가 있고, 우회 경로가 이 (토픽,이벤트) 에 닿지 않는다 → 발행 시 이미 검증됨
+ *   UNVERIFIED 필수 필드 + 검증되지 않는 발행 경로가 닿는다 → 사람이 payload 를 봐야 한다
  *
  * `UNVERIFIED` 가 0인 앱은 검증을 켜도 안전하다는 정적 증명을 가진 것이다.
  *
@@ -36,17 +36,23 @@
  *
  * - **토픽에 남아 있는 옛 메시지.** 발행 코드가 지금 옳아도 계약 이전에 쌓인 메시지는 모양이 다를 수
  *   있다. 이 논증은 "앞으로 발행될 것"만 덮는다. retention 을 넘긴 뒤에야 완결된다.
+ *   `DLQHandler.reprocessDLQ`(관리자 수동 재처리)가 이 한계와 같은 성질이라 아래에서 면제된다 —
+ *   그 토픽에 이미 있던 메시지를 되돌려 보낼 뿐 새 모양을 만들지 않는다.
  * - **레포 밖 발행자.** Medusa 등 다른 프로세스가 같은 토픽에 쓰면 이 논증 밖이다. 현재 확인된
  *   외부 발행자는 없다.
- * - `BYPASS_PATHS` 는 **손으로 유지하는 목록이다.** 그래서 `--gate` 가 `publishRawEnvelope` 호출
- *   지점을 실제로 세어 이 목록과 어긋나면 실패한다 — 목록이 조용히 낡는 것을 막는다.
+ * - `SEND_PATHS` 는 **손으로 유지하는 목록이다.** 그래서 `--gate` 가 실제 호출 지점을 세어 이
+ *   목록과 어긋나면 실패한다 — 목록이 조용히 낡는 것을 막는다.
  *
  * ## `--gate` 가 막는 것
  *
- * 1. **검증을 켜 둔 앱에 UNVERIFIED 이벤트가 생기는 것.** 5-C 로 켠 앱에 나중에 누가 outbox 발행
- *    이벤트의 핸들러를 추가하면, 이 판정이 조용히 뒤집히는 대신 CI 가 막는다. 5-C 의 분석을
- *    일회성 결론이 아니라 **상시 불변식**으로 바꾸는 것이 이 게이트의 목적이다.
- * 2. 위의 `BYPASS_PATHS` 낡음.
+ * 1. **검증을 켜 둔 앱에 UNVERIFIED 이벤트가 생기는 것.** 5-C 의 분석을 일회성 결론이 아니라
+ *    **상시 불변식**으로 바꾸는 것이 이 게이트의 목적이다.
+ * 2. **발행 경로가 늘어나는 것.** `transport.send` 호출 지점이 `SEND_PATHS` 와 다르거나,
+ *    `StreamPublisher.sendMessage` 를 부르는 메서드가 검증된 셋 밖으로 늘어나면 실패한다.
+ *    새 발행 경로는 반드시 사람이 검증 여부를 판단하고 이 목록에 적어야 한다.
+ * 3. **`validateOnPublish: false`.** 위 불변식은 이 스위치가 켜져 있다는 데 전적으로 기댄다.
+ *    끄는 순간 증명 전체가 무너지므로 레포 어디에도 있어선 안 된다.
+ * 4. **`publishRawEnvelope` 부활.** 6-A 가 지운 이름이다. 되살아나면 우회도 되살아난다.
  *
  * 사용법:
  *   npm run audit:consume-validation
@@ -65,33 +71,37 @@ import type { StreamConfig } from '../../packages/event-contracts/types/stream-c
 const REPO = path.resolve(__dirname, '..', '..');
 
 /**
- * zod 를 우회해 Kafka 에 도달할 수 있는 경로. `publishRawEnvelope` 의 호출자와 1:1 대응한다.
+ * `EventTransport.send` 호출 지점 전부. 손으로 유지하고 `--gate` 가 AST 로 대조한다.
  *
- * 각 항목은 "이 dispatcher 가 어느 토픽에 무엇을 실을 수 있는가" 를 적는다. 그 답은 dispatcher 가
- * 어떤 publisher 를 들고 있고 어떤 행을 읽는가로 정해진다.
+ * `validated: true` 인 항목은 그 경로로 나가는 payload 가 zod 파싱을 통과한 값임을 뜻한다.
+ * `validated: false` 인 항목이 하나라도 생기면 그 경로가 실어 나를 수 있는 (토픽, 이벤트) 가
+ * UNVERIFIED 가 되고, `resolve` 로 그 집합을 계산하는 코드를 여기에 붙여야 한다.
  */
-const BYPASS_PATHS = [
+const SEND_PATHS: Array<{ site: string; what: string; validated: boolean }> = [
   {
-    dispatcher: 'libs/events/src/outbox/outbox-dispatcher.service.ts:121',
-    /** publisherMap 이 행의 `topic` 컬럼으로 조회되므로, 실릴 수 있는 것은 `saveEvent` 가 쓴 (topic,eventType) 뿐이다. */
-    writers: 'OutboxPublisher.saveEvent',
-    resolve: 'saveEvent-call-sites' as const,
+    site: 'libs/events/src/publishers/stream-publisher.service.ts',
+    what: 'StreamPublisher.sendMessage — 검증된 진입점 셋만 부른다 (아래 VALIDATED_SEND_ENTRYPOINTS)',
+    validated: true,
   },
   {
-    dispatcher: 'apps/wallet/src/messaging/outbox-dispatcher.service.ts:171',
-    /**
-     * publisher 가 `PAYMENT_EVENTS_TOPIC` 하나로 고정 주입된다(:45) — 즉 실리는 토픽은
-     * `payments.events.v1` 하나다. 실릴 수 있는 **이벤트명**은 wallet 이 자기 `outbox_events` 에
-     * 넣는 것뿐이고, 그 이름은 전부 `*EventType` const 맵에서 온다 (`GatewayEventType` ·
-     * `InvoiceEventType`). 그 맵들의 값 전체를 우회 집합으로 잡는다 — 실제 insert 지점을 일일이
-     * 따라가면 헬퍼 함수를 거치는 갈래에서 놓칠 수 있고, 놓치면 위험한 쪽(PROVEN 오판)으로 틀린다.
-     * 과대추정은 안전한 방향이다.
-     */
-    writers: 'wallet outbox_events 직접 insert',
-    resolve: 'wallet-event-consts' as const,
-    topic: 'payments.events.v1',
+    site: 'libs/events/src/dlq/dlq-handler.service.ts',
+    what: 'DLQHandler.sendToDLQ — DLQ 토픽으로만 나간다. 계약 토픽이 아니므로 소비 검증 대상이 아니다',
+    validated: true,
+  },
+  {
+    site: 'libs/events/src/dlq/dlq-handler.service.ts',
+    what:
+      'DLQHandler.reprocessDLQ — 관리자 수동 재처리. 원본 토픽으로 되돌려 보내지만 ' +
+      '**그 토픽에 이미 있던 메시지**뿐이라 새 모양을 만들지 않는다 (위 "한계" 의 옛 메시지와 같은 성질)',
+    validated: true,
   },
 ];
+
+/**
+ * `StreamPublisher.sendMessage` 를 부르는 메서드 — 전부 zod 파싱 결과를 싣는다.
+ * 여기 없는 메서드가 `sendMessage` 를 부르면 게이트가 실패한다. 그것이 새 우회의 모양이다.
+ */
+const VALIDATED_SEND_ENTRYPOINTS = ['publishEvent', 'publishCommand', 'publishStoredEnvelope'].sort();
 
 /**
  * 앱의 `validateOnConsume` 선언을 **소스에서 도출한다.** 목록으로 들고 있지 않는 이유는
@@ -197,19 +207,12 @@ function propOf(obj: ts.ObjectLiteralExpression, name: string): ts.Expression | 
   return undefined;
 }
 
-interface SaveEventSite {
-  where: string;
-  topic?: string;
-  event?: string;
-}
-
-function scanFile(rel: string): { consumers: Consumer[]; saveEvents: SaveEventSite[] } {
+function scanFile(rel: string): { consumers: Consumer[] } {
   const abs = path.join(REPO, rel);
   const source = ts.createSourceFile(abs, fs.readFileSync(abs, 'utf8'), ts.ScriptTarget.Latest, true);
   const consts = collectStringConsts(source);
   const app = rel.split('/')[1];
   const consumers: Consumer[] = [];
-  const saveEvents: SaveEventSite[] = [];
   const lineOf = (n: ts.Node) => source.getLineAndCharacterOfPosition(n.getStart()).line + 1;
 
   const visit = (node: ts.Node) => {
@@ -232,23 +235,11 @@ function scanFile(rel: string): { consumers: Consumer[]; saveEvents: SaveEventSi
       }
     }
 
-    // 우회 경로 1의 writer: `outboxPublisher.saveEvent({ topic, eventType, … }, tx)`
-    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
-      const arg0 = node.arguments[0];
-      if (node.expression.name.getText() === 'saveEvent' && arg0 && ts.isObjectLiteralExpression(arg0)) {
-        saveEvents.push({
-          where: `${rel}:${lineOf(node)}`,
-          topic: resolveTopicExpression(propOf(arg0, 'topic'), consts),
-          event: resolveString(propOf(arg0, 'eventType'), consts),
-        });
-      }
-    }
-
     ts.forEachChild(node, visit);
   };
 
   visit(source);
-  return { consumers, saveEvents };
+  return { consumers };
 }
 
 // ─── 스키마 분류 ────────────────────────────────────────────────────────────
@@ -287,66 +278,70 @@ function grepFiles(pattern: string, scope: string): string[] {
   }
 }
 
-/**
- * wallet 이 자기 outbox 에 실을 수 있는 이벤트명 전부.
- *
- * `apps/wallet/src` 안의 `const *EventType = { … } as const` 값들과, `eventType:` 자리에 직접 쓰인
- * 문자열 리터럴을 모은다. 과대추정 방향으로만 틀리게 설계했다 — 빠뜨리면 PROVEN 오판이 되고,
- * 더 넣으면 UNVERIFIED 가 늘 뿐이다.
- */
-function walletOutboxEventTypes(): Set<string> {
-  const found = new Set<string>();
-  for (const rel of grepFiles('EventType|eventType:', 'apps/wallet/src')) {
-    const abs = path.join(REPO, rel);
-    const source = ts.createSourceFile(abs, fs.readFileSync(abs, 'utf8'), ts.ScriptTarget.Latest, true);
-    const consts = collectStringConsts(source);
-
-    const visit = (node: ts.Node) => {
-      // const XxxEventType = { KEY: 'value' } as const
-      if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && /EventType$/.test(node.name.text)) {
-        let init = node.initializer;
-        while (init && ts.isAsExpression(init)) init = init.expression;
-        if (init && ts.isObjectLiteralExpression(init)) {
-          for (const p of init.properties) {
-            if (ts.isPropertyAssignment(p) && ts.isStringLiteral(p.initializer)) found.add(p.initializer.text);
-          }
-        }
-      }
-      // eventType: 'literal'
-      if (ts.isPropertyAssignment(node) && node.name.getText() === 'eventType') {
-        const v = resolveString(node.initializer, consts);
-        if (v) found.add(v);
-      }
-      ts.forEachChild(node, visit);
-    };
-    visit(source);
-  }
-  return found;
+/** AST 로 파일을 훑는 공통 헬퍼. */
+function eachNode(rel: string, fn: (node: ts.Node, line: () => number) => void): void {
+  const abs = path.join(REPO, rel);
+  const source = ts.createSourceFile(abs, fs.readFileSync(abs, 'utf8'), ts.ScriptTarget.Latest, true);
+  const visit = (node: ts.Node) => {
+    fn(node, () => source.getLineAndCharacterOfPosition(node.getStart()).line + 1);
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
 }
 
-/**
- * `publishRawEnvelope` **호출** 지점 — BYPASS_PATHS 가 낡았는지 확인하는 근거.
- *
- * grep 이 아니라 AST 로 센다. 이 이름은 설명 주석에도 자주 등장하고(이 스크립트를 설명하는
- * 주석까지 포함해서), 실제로 grep 판본이 `sales-order.module.ts` 의 근거 주석을 세 번째
- * "호출자"로 집계해 거짓 경보를 냈다. 세는 대상이 호출이면 호출만 세야 한다.
- */
-function findRawEnvelopeCallers(): string[] {
+/** 이름으로 메서드 호출 지점을 센다. grep 이 아니라 AST — 이름은 주석에도 자주 등장한다. */
+function findMethodCalls(name: string, scope: string): string[] {
   const hits: string[] = [];
-  for (const rel of grepFiles('publishRawEnvelope', 'apps libs')) {
-    const abs = path.join(REPO, rel);
-    const source = ts.createSourceFile(abs, fs.readFileSync(abs, 'utf8'), ts.ScriptTarget.Latest, true);
-    const visit = (node: ts.Node) => {
+  for (const rel of grepFiles(name, scope)) {
+    eachNode(rel, (node, line) => {
       if (
         ts.isCallExpression(node) &&
         ts.isPropertyAccessExpression(node.expression) &&
-        node.expression.name.getText() === 'publishRawEnvelope'
+        node.expression.name.getText() === name
       ) {
-        hits.push(`${rel}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}`);
+        hits.push(`${rel}:${line()}`);
       }
-      ts.forEachChild(node, visit);
-    };
-    visit(source);
+    });
+  }
+  return hits.sort();
+}
+
+/**
+ * `StreamPublisher.sendMessage` 를 부르는 **메서드 이름** 집합.
+ *
+ * 새 발행 진입점이 생기면 여기 나타난다. 그 메서드가 검증을 하는지는 사람만 판단할 수 있으므로,
+ * 게이트는 판단을 요구할 뿐 대신 내리지 않는다.
+ */
+function findSendMessageCallers(): string[] {
+  const rel = 'libs/events/src/publishers/stream-publisher.service.ts';
+  const names = new Set<string>();
+  eachNode(rel, (node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.getText() === 'sendMessage'
+    ) {
+      let cur: ts.Node | undefined = node;
+      while (cur && !ts.isMethodDeclaration(cur)) cur = cur.parent;
+      if (cur && ts.isMethodDeclaration(cur)) names.add(cur.name.getText());
+    }
+  });
+  return [...names].sort();
+}
+
+/** `validateOnPublish: false` — 위 불변식 전체가 이 스위치에 기댄다. */
+function findValidateOnPublishOff(): string[] {
+  const hits: string[] = [];
+  for (const rel of grepFiles('validateOnPublish', 'apps libs packages')) {
+    eachNode(rel, (node, line) => {
+      if (
+        ts.isPropertyAssignment(node) &&
+        node.name.getText() === 'validateOnPublish' &&
+        node.initializer.kind === ts.SyntaxKind.FalseKeyword
+      ) {
+        hits.push(`${rel}:${line()}`);
+      }
+    });
   }
   return hits.sort();
 }
@@ -357,30 +352,16 @@ function main() {
   const gate = argv.includes('--gate');
   const only = argv.filter((a) => !a.startsWith('--'));
 
-  const files = [...new Set([...grepFiles('@On\\(', 'apps'), ...grepFiles('saveEvent\\(', 'apps')])];
+  const files = grepFiles('@On\\(', 'apps');
   const consumers: Consumer[] = [];
-  const saveEvents: SaveEventSite[] = [];
   for (const rel of files) {
-    const r = scanFile(rel);
-    consumers.push(...r.consumers);
-    saveEvents.push(...r.saveEvents);
+    consumers.push(...scanFile(rel).consumers);
   }
 
-  // 우회 가능한 (토픽, 이벤트) 집합을 만든다.
+  // 검증되지 않는 발행 경로가 실어 나를 수 있는 (토픽, 이벤트). Task 6-A 이후 그런 경로는 없다 —
+  // `SEND_PATHS` 에 `validated: false` 항목이 다시 생기면 여기에 그 집합을 계산하는 코드를 붙인다.
   const bypassPairs = new Map<string, string[]>(); // "topic|event" → 근거
-  for (const p of BYPASS_PATHS) {
-    const add = (topic: string, event: string, why: string) => {
-      const key = `${topic}|${event}`;
-      bypassPairs.set(key, [...(bypassPairs.get(key) ?? []), why]);
-    };
-    if (p.resolve === 'wallet-event-consts') {
-      for (const event of walletOutboxEventTypes()) add(p.topic, event, `${p.writers} → ${p.dispatcher}`);
-    } else {
-      for (const s of saveEvents) {
-        if (s.topic && s.event) add(s.topic, s.event, `${p.writers} ${s.where}`);
-      }
-    }
-  }
+  const unvalidatedSendPaths = SEND_PATHS.filter((p) => !p.validated);
 
   interface Row {
     app: string;
@@ -436,10 +417,10 @@ function main() {
       reason = '빈 객체까지 통과하는 관대한 스키마 → 켜도 동작 불변';
     } else if (bypass.length > 0) {
       verdict = 'UNVERIFIED';
-      reason = `필수 필드 + zod 우회 발행 경로 ${bypass.length}건이 이 이벤트에 닿는다`;
+      reason = `필수 필드 + 검증되지 않는 발행 경로 ${bypass.length}건이 이 이벤트에 닿는다`;
     } else {
       verdict = 'PROVEN';
-      reason = '필수 필드가 있으나 우회 경로가 닿지 않는다 → publishEvent 가 zod 파싱 결과를 실어 보낸다';
+      reason = '필수 필드가 있으나 검증되지 않는 발행 경로가 없다 → 나가는 payload 는 zod 파싱 결과다';
     }
 
     rows.push({
@@ -477,21 +458,49 @@ function main() {
     };
   });
 
-  // BYPASS_PATHS 가 실제 호출자와 어긋났는지 — 손으로 유지하는 목록이 조용히 낡는 것을 막는다.
-  const callers = findRawEnvelopeCallers();
-  const staleBypassList = callers.length !== BYPASS_PATHS.length;
+  // ── 발행 경로 무결성 ─────────────────────────────────────────────────────
+  // 손으로 유지하는 SEND_PATHS 가 실제 코드와 어긋나면 위 불변식의 근거가 사라진다.
+  const transportSends = findMethodCalls('send', 'libs/events/src').filter((h) => !h.includes('.spec.'));
+  const sendMessageCallers = findSendMessageCallers();
+  const validateOff = findValidateOnPublishOff();
+  const rawEnvelopeCallers = findMethodCalls('publishRawEnvelope', 'apps libs');
+
+  const integrity: string[] = [];
+  if (transportSends.length !== SEND_PATHS.length) {
+    integrity.push(
+      `transport.send 호출이 ${transportSends.length}곳인데 SEND_PATHS 는 ${SEND_PATHS.length}곳을 가정한다 — ` +
+        `목록이 낡았다: ${transportSends.join(', ')}`,
+    );
+  }
+  if (sendMessageCallers.join('|') !== VALIDATED_SEND_ENTRYPOINTS.join('|')) {
+    integrity.push(
+      `StreamPublisher.sendMessage 를 부르는 메서드가 [${sendMessageCallers.join(', ')}] 인데 ` +
+        `검증된 진입점은 [${VALIDATED_SEND_ENTRYPOINTS.join(', ')}] 이다 — 새 발행 경로의 검증 여부를 사람이 판단해야 한다`,
+    );
+  }
+  if (validateOff.length > 0) {
+    integrity.push(`validateOnPublish: false 가 있다 (${validateOff.join(', ')}) — 이 증명 전체가 무너진다`);
+  }
+  if (rawEnvelopeCallers.length > 0) {
+    integrity.push(`publishRawEnvelope 가 되살아났다 (${rawEnvelopeCallers.join(', ')}) — zod 우회가 함께 돌아온다`);
+  }
+  if (unvalidatedSendPaths.length > 0) {
+    integrity.push(
+      `SEND_PATHS 에 검증되지 않는 경로가 있다 (${unvalidatedSendPaths.map((p) => p.what).join('; ')}) — ` +
+        'bypassPairs 계산을 다시 붙여야 한다',
+    );
+  }
 
   if (asJson) {
-    console.log(JSON.stringify({ summary, rows, bypassPaths: BYPASS_PATHS, rawEnvelopeCallers: callers }, null, 2));
+    console.log(
+      JSON.stringify({ summary, rows, sendPaths: SEND_PATHS, transportSends, sendMessageCallers, integrity }, null, 2),
+    );
   } else {
-    console.log('소비 검증 준비도 (validateOnConsume 를 켜도 되는가) — ADR-0029 §8 / 플랜 Task 5-C\n');
-    console.log(`zod 우회 경로: publishRawEnvelope 호출자 ${callers.length}곳`);
-    for (const c of callers) console.log(`  ${c}`);
-    if (staleBypassList) {
-      console.log(
-        `\n⚠️  BYPASS_PATHS 는 ${BYPASS_PATHS.length}곳을 가정하는데 실제는 ${callers.length}곳이다 — 목록이 낡았다.`,
-      );
-    }
+    console.log('소비 검증 준비도 (validateOnConsume 를 켜도 되는가) — ADR-0029 §8 / 플랜 Task 5-C·6-A\n');
+    console.log(`발행 경로 (transport.send 호출 ${transportSends.length}곳):`);
+    for (const p of SEND_PATHS) console.log(`  ${p.validated ? '✅' : '⚠️ '} ${p.site} — ${p.what}`);
+    console.log(`검증된 발행 진입점: ${sendMessageCallers.join(', ')}`);
+    for (const problem of integrity) console.log(`\n⚠️  ${problem}`);
 
     console.log('\n앱                검증  이벤트  핸들러   SAFE  PROVEN  UNVERIFIED   판정');
     for (const s of summary) {
@@ -516,7 +525,7 @@ function main() {
       console.log(`\n${r.app}  ${r.topic}  ${r.event}  (핸들러 ${r.handlers})`);
       console.log(`  ${r.reason}`);
       if (r.required.length) console.log(`  필수: ${r.required.join(', ')}`);
-      for (const b of r.bypass) console.log(`  우회: ${b}`);
+      for (const b of r.bypass) console.log(`  경로: ${b}`);
     }
 
     const proven = rows.filter((r) => r.verdict === 'PROVEN');
@@ -535,13 +544,14 @@ function main() {
           .join(', ') || '없음'
       }`,
     );
-    if (violations.length === 0 && !staleBypassList) console.log('위반 없음.');
+    if (violations.length === 0 && integrity.length === 0) console.log('위반 없음.');
     for (const v of violations) {
       console.log(`🔴 ${v.app}: validateOnConsume=true (${v.policyAt}) 인데 UNVERIFIED ${v.UNVERIFIED}건`);
     }
+    for (const problem of integrity) console.log(`🔴 ${problem}`);
   }
 
-  process.exit(gate && (staleBypassList || violations.length > 0) ? 1 : 0);
+  process.exit(gate && (integrity.length > 0 || violations.length > 0) ? 1 : 0);
 }
 
 main();


### PR DESCRIPTION
ADR-0029 Task 6-A. 아웃박스가 zod 를 우회하던 마지막 경로를 닫는다.

**완료 판정 통과** — `npm run audit:consume-validation` 의 UNVERIFIED **14 → 0**.

| 앱 | 전 | 후 |
|---|---|---|
| analytics | ⚠️ 확인 필요 (UNVERIFIED 3) | ☑️ 켜도 안전 (PROVEN 10) |
| search | ⚠️ 확인 필요 (2) | ☑️ 켜도 안전 (3) |
| channel-adapter | ⚠️ 확인 필요 (4) | ☑️ 켜도 안전 (SAFE 11 / PROVEN 23) |
| membership | ⚠️ 확인 필요 (5) | ☑️ 켜도 안전 |
| core | ✅ 켜짐 (4) | ✅ 켜짐 (4) |

## 무엇을 왜

`StreamPublisher.enqueue(params, tx)` 를 `publishEvent` 와 **같은 파라미터·같은 타입 도출·같은 검증**으로 추가하고, 검증을 **적재 시점**에 수행한다. 잘못된 payload 가 poison row 로 남아 나중에 소비자 DLQ 에서 발견되는 대신 호출자의 도메인 트랜잭션을 그 자리에서 실패시킨다 — 진단 위치가 원인에 붙어 있다.

`publishRawEnvelope` 는 **이름째 삭제**하고 검증하는 `publishStoredEnvelope` 로 대체했다. 이름을 남기면 "raw = 검증 안 함" 모델이 이름 안에서 계속 산다. 이 문이 실제로 무는 것은 `enqueue` 를 지나지 않은 행이다 — 배포 이전에 적재된 PENDING 행, 그리고 테이블에 직접 insert 하는 wallet 판본.

`OutboxPublisher.saveEvent` 도 삭제하고 호출부 5곳(core 카탈로그 4 · membership 1)을 `enqueue` 로 이주했다. 검증 없는 적재 API 를 남기면 새 호출자가 우회를 조용히 되살린다. 적재 대상은 `OutboxWriter` port 로 받아 publisher 가 drizzle 을 모르게 뒀다(ADR-0029 §7 — publisher 가 ORM 을 알면 seam 이 무너지고 스펙이 DB 를 요구하게 된다).

## 플랜/ADR 과 다르게 판단한 것

- **`enqueue` 인자 모양을 `publishEvent` 와 같게 했다.** ADR 스케치는 `enqueue('OrderCreated', {…}, tx)` 인데 `publishEvent({eventType, …})` 와 배치가 다르다. "다른 건 배달 방식뿐"이라는 §5 의 주장은 두 메서드가 같은 파라미터 타입을 받을 때만 참이고, 다르게 두면 그 문장이 문서에서만 참이 된다. ADR §5 를 먼저 고치고 근거를 적었다.
- **5-C 의 마지막 한 줄은 이 PR 에 넣지 않았다.** analytics·search·channel-adapter 의 `validateOnConsume: false` 를 `true` 로 뒤집는 것은 별개의 배포 결정이고 플랜도 6-A 다음 줄에 따로 두고 있다. 세 앱 모듈의 주석은 "막는 이유가 사라졌다"로 갱신해 뒀다.

## 🔴 계획에 없던 발견 2건

**1. `publishCommand` 가 검증되지 않는 네 번째 발행 경로였다.**

5-C 의 "발행 경로 전수 폐쇄" 논증은 `publishEvent` 와 `publishRawEnvelope` 만 셌다. 호출자는 ugc-service 1곳(`EarnPointsRequested` → wallet 소비)뿐이라 실해는 없었지만, **그 논증이 wallet 을 "켜도 안전"으로 판정한 근거에는 구멍이 있었다.** 검증을 넣었다. 지금은 `sendMessage` 를 부르는 세 메서드가 전부 검증한다.

**2. `CategoryChanged.ancestors` 가 payload 인터페이스에만 있고 zod 스키마에 없었다.**

검증이 발행 경로에 없던 동안은 무증상이었지만, 적재 시점 검증이 켜지면 zod 가 미선언 키를 **조용히 떼어낸다.** channel-adapter 의 Medusa 카테고리 동기화가 `ancestors` 로 부모를 먼저 보장하므로(`pim-medusa-sync.service.ts:662`), 그 손실은 자식 카테고리를 최상위로 붙이는 버그가 됐을 것이다. 스키마에 optional 로 추가했다(additive — 옛 producer 를 깨지 않는다).

**이 변경의 실질 위험이 어디에 있는지 보여주는 사례다: 검증 실패는 시끄럽지만 strip 은 조용하다.** 그래서 회귀 네트를 "통과하는가"가 아니라 **"손실 없이 통과하는가"**(`parse(payload)` 가 `payload` 와 deep-equal)로 짰다 — `projection-snapshot.assembler.spec.ts`(실 조립 결과)와 `categories.service.spec.ts`(실 카테고리 스냅샷 + 조상). 스키마 필드를 지우는 변이로 실패하는 것도 확인했다.

## membership 은 원인이 달랐다

5-C 는 "같은 4개 이벤트가 세 앱을 막는다"로 정리했고 membership 은 논외였다. 실측하면 그 5건(`invoice.paid` · `invoice.voided` · `mandate.rejected` 등)은 `saveEvent` 가 아니라 **wallet 이 자기 `outbox_events` 에 직접 insert 하는 행**에서 왔다. 즉 `enqueue` 문이 아니라 **`publishStoredEnvelope` 문**이 닫는다. 두 문을 다 달았기에 함께 풀린 것이지, enqueue 검증만 넣었으면 membership 은 그대로였다.

## 게이트 재설계

옛 게이트는 "우회 경로 2곳이 무엇을 실어 나를 수 있는가"를 계산했다. 우회가 없어졌으므로 이제 **우회가 다시 생기지 않는 것**을 지킨다 — 전부 AST:

- `transport.send` 호출 지점 집합 = `SEND_PATHS`(3곳)
- `StreamPublisher.sendMessage` 를 부르는 메서드 = `publishEvent` · `publishCommand` · `publishStoredEnvelope`
- `validateOnPublish: false` 부재 (증명 전체가 이 스위치에 기댄다)
- `publishRawEnvelope` 부재

**무는 것 확인함** — 새 `sendMessage` 호출자를 심어 exit 1, `validateOnPublish: false` 를 심어 exit 1.

`DLQHandler.reprocessDLQ` 는 **명시적 면제**로 목록에 적었다. 관리자 수동 재처리가 원본 토픽으로 되돌려 보내지만 **그 토픽에 이미 있던 메시지**뿐이라 새 모양을 만들지 않는다 = 이 증명이 원래부터 못 덮는다고 선언한 "옛 메시지"와 같은 한계다. 목록에 있으므로 조용히 늘 수 없다.

## 라이브 DLQ 실측 (착수 전, `core.almondyoung.com/metrics`)

```
events_dlq_messages_total{topic="orders.events.v1",consumer="handleOrderCancelled",error="NotFoundException"} 1
events_dlq_messages_total{topic="orders.events.v1",consumer="handleOrderRefundCreated",error="NotFoundException"} 1
events_dlq_send_failures_total  (항목 없음)
```

`SchemaValidationError` 가 **0** 이므로 5-C 의 core 판정은 아직 반증되지 않았다. 부수로, 이 카운터가 0 이 아니라는 사실 자체가 **5-B 가 라이브에 붙어 있다는 독립 증거**다 — `dlqMessagesTotal.inc` 의 유일한 프로덕션 호출자가 `EventRetryInterceptor` 이고, 그 인터셉터는 `startConsumer` 배선에서만 붙는다. `NotFoundException` 2건은 옛 배선이었다면 로그 한 줄 없이 사라졌을 실패다 — 별건으로 원인을 볼 값어치가 있다.

## ⚠️ 배포 전 사람 결정 1건

**wallet 아웃박스에 배포 시점 PENDING 인 행**은 `enqueue` 를 지나지 않았으므로 `publishStoredEnvelope` 에서 처음 검증을 만난다. 위반하면 발행되지 않고 백오프 후 `DEAD_LETTER` 로 남는다(옛 동작: 그대로 발행).

정적으로는 안전하다 — `invoice.*`/`mandate.rejected` payload 는 전부 계약 타입으로 빌드되고(`invoice-event.builder.ts`), `payment.intent.*`/`gateway.*` 스키마는 `catchall` 이라 확장 필드를 보존한다. 창도 좁다(디스패처 5초 주기). 그래도 배포 직후 wallet `outbox_events` 의 `DEAD_LETTER`/`FAILED` 와 `last_error_code` 를 한 번 볼 것.

마이그레이션 0 / 시크릿 0 / env 0. 계약 변경 1건은 additive(`CategoryChanged.ancestors` optional 추가)라 소비자 선배포가 필요 없다.

## 게이트 실측 (전부 기준선 대조)

- `npm run type-check` → **164 = 기준선**. 신규 0 — 유일한 차이는 같은 파일의 기존 오류가 import 1줄만큼 밀린 것
- `npm run audit:event-handlers` → exit 0 (핸들러 87개 · `@OnEvent` 0)
- `npm run audit:consume-validation -- --gate` → exit 0
- 전체 jest 실패 suite **18 = 기준선, 집합 동일**(신규 0 · 소멸 0, 통과 +11)
- **10개 앱 `nest build` 전부 OK**
- 변경 파일 eslint 신규 0

## 리뷰 볼 곳

- `libs/events/src/publishers/stream-publisher.service.ts` — `enqueue` / `publishStoredEnvelope` / `buildEventEnvelope` 공통부 / `publishCommand` 검증 추가
- `libs/events/src/outbox/outbox-writer.port.ts` · `outbox-publisher.service.ts` — port 와 그 유일한 구현
- `scripts/events/consume-validation-readiness.ts` — 증명 모양이 바뀌었으므로 게이트도 바뀌었다
- `packages/event-contracts/streams/product.stream.ts` — `ancestors` 추가 (유일한 계약 변경)

https://claude.ai/code/session_01Phyx7rWAAe7uVLp3FCU6uZ
