### PR TITLE
feat(events): 옛 아웃박스의 존재 표지를 공용으로 백필 (ADR-0029 Task 6-C-4 선행)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,8 @@
     "audit:event-handlers": "node scripts/events/event-handler-contract-audit.js",
     "audit:event-publishers": "node scripts/events/publisher-contract-audit.js",
     "audit:consume-validation": "tsx scripts/events/consume-validation-readiness.ts",
+    "events:marker-backfill": "tsx scripts/events/outbox-marker-backfill.ts",
+    "events:marker-backfill:verify": "bash scripts/events/outbox-marker-backfill.verify.sh",
     "membership:backfill:last-payment-intent": "./scripts/with-ipv4.sh node apps/membership/scripts/backfill-last-payment-intent.js",
     "migrate:auth": "./scripts/with-ipv4.sh ts-node -r tsconfig-paths/register libs/authorization/scripts/migrate-auth-schema.ts",
     "migrate:backfill": "./scripts/with-ipv4.sh dotenv -e apps/channel-adapter/.env.migration -- ts-node -r tsconfig-paths/register apps/channel-adapter/scripts/backfill-v2.ts",

--- a/scripts/events/outbox-marker-backfill.ts
+++ b/scripts/events/outbox-marker-backfill.ts
@@ -1,0 +1,326 @@
+/**
+ * 옛 아웃박스의 **존재 표지(marker)** 를 공용 `event.outbox_events` 로 옮긴다.
+ * ADR-0029 §5-1, Task 6-C-4 의 선행 단계.
+ *
+ * ## 왜 필요한가
+ *
+ * 6-C-2·3 은 옛 아웃박스를 *읽는* 코드 3곳을 **두 테이블 다 읽기**로 처리하고 옛 갈래 제거를
+ * 6-C-4 로 미뤘다. 그런데 그 3곳은 이벤트 큐를 읽는 게 아니라 **"이 사실이 이미 기록됐는가"를
+ * 행의 존재로 판정**한다. 즉 옛 테이블을 DROP 하면 큐가 아니라 **판정 근거**가 사라진다.
+ *
+ * 드레인(미발행 행이 다 빠지는 것)과는 **시계가 다르다.** 드레인은 몇 분이면 끝나지만, 이
+ * 표지들은 `published` 로 굳은 뒤에도 계속 읽힌다:
+ *
+ * | 표지 | 읽는 곳 | 잃으면 |
+ * |---|---|---|
+ * | `FulfillmentShipped` / `<foId>:fully-shipped` | `ShipmentDeliveryTrackingService.hasFullyShippedProjection` | 배포 이전에 출고된 FO 의 **배송완료 이벤트가 안 나간다**. 출고→배송 리드타임(며칠)만큼 노출 |
+ * | `payment.intent.failed` / `aggregate_id` | `BillingChargeConsumer` FAILED 분기 | 커맨드 재전달 시 같은 실패가 **두 번** 발행된다 |
+ * | `mandate.rejected` / `payload->>'idempotencyKey'` | `InvoiceCommandConsumer` | 같은 mandate.rejected 가 **두 번** 발행된다 |
+ *
+ * 그래서 순서가 이렇게 된다 — **이 스크립트 → 6-C-4 배포 → DROP**. 이 스크립트가 먼저 돌지
+ * 않으면 6-C-4 가 배포되는 순간부터 DROP 전이라도 이미 옛 갈래를 안 읽으므로 구멍이 열린다.
+ *
+ * ## 무엇을 넣는가
+ *
+ * 표지일 뿐이므로 `status='PUBLISHED'` 로 넣는다 — 공용 디스패처의 acquire 술어
+ * (`status='PENDING'`)에 걸리지 않아 **재발행되지 않는다**. `published_at` 은 옛 행의 값을
+ * 그대로 옮기고, 없으면 `created_at` 으로 채운다.
+ *
+ * `unique(topic, event_type, idempotency_key)` 덕에 `ON CONFLICT DO NOTHING` 이 재실행을
+ * 흡수한다 — 여러 번 돌려도 안전하다. 단 `idempotency_key` 가 NULL 인 갈래(wallet 의
+ * `payment.intent.failed`)는 Postgres 가 NULL 을 서로 다르게 보므로 제약이 막지 못한다.
+ * 그 갈래는 `NOT EXISTS` 로 직접 거른다.
+ *
+ * ## 사용법
+ *
+ *   npx tsx scripts/events/outbox-marker-backfill.ts --app core            # dry-run
+ *   npx tsx scripts/events/outbox-marker-backfill.ts --app core --execute
+ *   npx tsx scripts/events/outbox-marker-backfill.ts --app wallet --execute
+ *
+ * `DATABASE_URL` 은 **그 앱의 논리 DB** 를 가리켜야 한다. core 와 wallet 은 서로 다른 DB 다.
+ * channel-adapter 는 대상이 아니다 — 옛 아웃박스를 읽는 코드가 0곳이었다(6-C-3 실측).
+ */
+
+import postgres, { type Sql } from 'postgres';
+
+const FULFILLMENT_TOPIC = 'fulfillments.events.v1';
+const FULFILLMENT_SHIPPED = 'FulfillmentShipped';
+const PAYMENT_TOPIC = 'payments.events.v1';
+const INTENT_FAILED = 'payment.intent.failed';
+const MANDATE_REJECTED = 'mandate.rejected';
+
+type AppName = 'core' | 'wallet';
+
+interface MarkerReport {
+  marker: string;
+  legacyRows: number;
+  alreadyPresent: number;
+  missing: number;
+  inserted: number | null;
+}
+
+function parseArgs(argv: string[]): Map<string, string | true> {
+  const parsed = new Map<string, string | true>();
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith('--')) throw new Error(`Unexpected argument: ${token}`);
+    const equals = token.indexOf('=');
+    if (equals >= 0) {
+      parsed.set(token.slice(2, equals), token.slice(equals + 1));
+      continue;
+    }
+    const key = token.slice(2);
+    const next = argv[index + 1];
+    if (next && !next.startsWith('--')) {
+      parsed.set(key, next);
+      index += 1;
+    } else {
+      parsed.set(key, true);
+    }
+  }
+  return parsed;
+}
+
+async function legacyTableExists(sql: Sql): Promise<boolean> {
+  const [row] = await sql<{ exists: boolean }[]>`
+    SELECT to_regclass('public.outbox_events') IS NOT NULL AS exists
+  `;
+  return row.exists;
+}
+
+/**
+ * core: `<foId>:fully-shipped` 표지.
+ *
+ * 읽는 쪽이 `topic + event_type + idempotency_key` 삼자로 찾으므로 그 셋을 그대로 옮긴다.
+ * 옛 테이블의 `idempotency_key` 는 NOT NULL 이라 `ON CONFLICT` 가 전부 흡수한다.
+ */
+async function backfillCore(sql: Sql, execute: boolean): Promise<MarkerReport[]> {
+  const [counts] = await sql<{ legacy: string; present: string }[]>`
+    SELECT
+      (SELECT count(*) FROM public.outbox_events
+        WHERE topic = ${FULFILLMENT_TOPIC}
+          AND event_type = ${FULFILLMENT_SHIPPED}
+          AND idempotency_key LIKE '%:fully-shipped') AS legacy,
+      (SELECT count(*) FROM public.outbox_events legacy
+        WHERE legacy.topic = ${FULFILLMENT_TOPIC}
+          AND legacy.event_type = ${FULFILLMENT_SHIPPED}
+          AND legacy.idempotency_key LIKE '%:fully-shipped'
+          AND EXISTS (
+            SELECT 1 FROM event.outbox_events shared
+            WHERE shared.topic = legacy.topic
+              AND shared.event_type = legacy.event_type
+              AND shared.idempotency_key = legacy.idempotency_key
+          )) AS present
+  `;
+  const legacyRows = Number(counts.legacy);
+  const alreadyPresent = Number(counts.present);
+
+  let inserted: number | null = null;
+  if (execute) {
+    const rows = await sql`
+      INSERT INTO event.outbox_events
+        (topic, aggregate_type, aggregate_id, event_type, idempotency_key, partition_key,
+         payload, status, created_at, published_at, next_attempt_at, retry_count)
+      SELECT
+        legacy.topic,
+        legacy.aggregate_type,
+        legacy.aggregate_id::text,
+        legacy.event_type,
+        legacy.idempotency_key,
+        legacy.partition_key,
+        legacy.payload::jsonb,
+        'PUBLISHED',
+        legacy.created_at,
+        COALESCE(legacy.published_at, legacy.created_at),
+        COALESCE(legacy.published_at, legacy.created_at),
+        0
+      FROM public.outbox_events legacy
+      WHERE legacy.topic = ${FULFILLMENT_TOPIC}
+        AND legacy.event_type = ${FULFILLMENT_SHIPPED}
+        AND legacy.idempotency_key LIKE '%:fully-shipped'
+      ON CONFLICT (topic, event_type, idempotency_key) DO NOTHING
+      RETURNING id
+    `;
+    inserted = rows.length;
+  }
+
+  return [
+    {
+      marker: `${FULFILLMENT_TOPIC}/${FULFILLMENT_SHIPPED}/*:fully-shipped`,
+      legacyRows,
+      alreadyPresent,
+      missing: legacyRows - alreadyPresent,
+      inserted,
+    },
+  ];
+}
+
+/**
+ * wallet: 두 갈래.
+ *
+ * 1. `payment.intent.failed` — 읽는 쪽이 `aggregate_id + event_type` 으로 찾는다.
+ *    옛 테이블에 `topic`·`idempotency_key` 컬럼이 **없다** (wallet 로컬 판본이다). 그래서
+ *    `topic` 은 계약값을 채우고 `idempotency_key` 는 NULL 로 둔다 — NULL 이면 unique 가
+ *    막지 못하므로 `NOT EXISTS` 로 직접 중복을 거른다.
+ * 2. `mandate.rejected` — 읽는 쪽이 옛 테이블에서는 `payload->>'idempotencyKey'` 로,
+ *    새 테이블에서는 `idempotency_key` **컬럼**으로 찾는다. 옛 payload 는 도메인 payload 라
+ *    그 JSON 경로에 값이 있다. 그 값을 컬럼으로 끌어올려 옮긴다.
+ */
+async function backfillWallet(sql: Sql, execute: boolean): Promise<MarkerReport[]> {
+  const reports: MarkerReport[] = [];
+
+  // ── 1. payment.intent.failed (aggregate_id 로 판정, 멱등키 없음)
+  const [failedCounts] = await sql<{ legacy: string; present: string }[]>`
+    SELECT
+      (SELECT count(DISTINCT aggregate_id) FROM public.outbox_events
+        WHERE event_type = ${INTENT_FAILED}) AS legacy,
+      (SELECT count(DISTINCT legacy.aggregate_id) FROM public.outbox_events legacy
+        WHERE legacy.event_type = ${INTENT_FAILED}
+          AND EXISTS (
+            SELECT 1 FROM event.outbox_events shared
+            WHERE shared.aggregate_id = legacy.aggregate_id::text
+              AND shared.event_type = legacy.event_type
+          )) AS present
+  `;
+  let failedInserted: number | null = null;
+  if (execute) {
+    const rows = await sql`
+      INSERT INTO event.outbox_events
+        (topic, aggregate_type, aggregate_id, event_type, idempotency_key, partition_key,
+         payload, status, created_at, published_at, next_attempt_at, retry_count)
+      SELECT DISTINCT ON (legacy.aggregate_id)
+        ${PAYMENT_TOPIC},
+        legacy.aggregate_type,
+        legacy.aggregate_id::text,
+        legacy.event_type,
+        NULL,
+        legacy.partition_key,
+        legacy.payload,
+        'PUBLISHED',
+        legacy.created_at,
+        COALESCE(legacy.published_at, legacy.created_at),
+        COALESCE(legacy.published_at, legacy.created_at),
+        0
+      FROM public.outbox_events legacy
+      WHERE legacy.event_type = ${INTENT_FAILED}
+        AND NOT EXISTS (
+          SELECT 1 FROM event.outbox_events shared
+          WHERE shared.aggregate_id = legacy.aggregate_id::text
+            AND shared.event_type = legacy.event_type
+        )
+      ORDER BY legacy.aggregate_id, legacy.created_at ASC
+      RETURNING id
+    `;
+    failedInserted = rows.length;
+  }
+  reports.push({
+    marker: `${PAYMENT_TOPIC}/${INTENT_FAILED} (by aggregate_id)`,
+    legacyRows: Number(failedCounts.legacy),
+    alreadyPresent: Number(failedCounts.present),
+    missing: Number(failedCounts.legacy) - Number(failedCounts.present),
+    inserted: failedInserted,
+  });
+
+  // ── 2. mandate.rejected (옛 payload JSON → 새 idempotency_key 컬럼)
+  const [mandateCounts] = await sql<{ legacy: string; present: string }[]>`
+    SELECT
+      (SELECT count(*) FROM public.outbox_events
+        WHERE event_type = ${MANDATE_REJECTED}
+          AND payload ->> 'idempotencyKey' IS NOT NULL) AS legacy,
+      (SELECT count(*) FROM public.outbox_events legacy
+        WHERE legacy.event_type = ${MANDATE_REJECTED}
+          AND legacy.payload ->> 'idempotencyKey' IS NOT NULL
+          AND EXISTS (
+            SELECT 1 FROM event.outbox_events shared
+            WHERE shared.event_type = legacy.event_type
+              AND shared.idempotency_key = legacy.payload ->> 'idempotencyKey'
+          )) AS present
+  `;
+  let mandateInserted: number | null = null;
+  if (execute) {
+    const rows = await sql`
+      INSERT INTO event.outbox_events
+        (topic, aggregate_type, aggregate_id, event_type, idempotency_key, partition_key,
+         payload, status, created_at, published_at, next_attempt_at, retry_count)
+      SELECT DISTINCT ON (legacy.payload ->> 'idempotencyKey')
+        ${PAYMENT_TOPIC},
+        legacy.aggregate_type,
+        legacy.aggregate_id::text,
+        legacy.event_type,
+        legacy.payload ->> 'idempotencyKey',
+        legacy.partition_key,
+        legacy.payload,
+        'PUBLISHED',
+        legacy.created_at,
+        COALESCE(legacy.published_at, legacy.created_at),
+        COALESCE(legacy.published_at, legacy.created_at),
+        0
+      FROM public.outbox_events legacy
+      WHERE legacy.event_type = ${MANDATE_REJECTED}
+        AND legacy.payload ->> 'idempotencyKey' IS NOT NULL
+      ORDER BY legacy.payload ->> 'idempotencyKey', legacy.created_at ASC
+      ON CONFLICT (topic, event_type, idempotency_key) DO NOTHING
+      RETURNING id
+    `;
+    mandateInserted = rows.length;
+  }
+  reports.push({
+    marker: `${PAYMENT_TOPIC}/${MANDATE_REJECTED} (by payload idempotencyKey)`,
+    legacyRows: Number(mandateCounts.legacy),
+    alreadyPresent: Number(mandateCounts.present),
+    missing: Number(mandateCounts.legacy) - Number(mandateCounts.present),
+    inserted: mandateInserted,
+  });
+
+  return reports;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const app = args.get('app');
+  if (app !== 'core' && app !== 'wallet') {
+    throw new Error('--app must be "core" or "wallet" (channel-adapter has no marker reads).');
+  }
+  const execute = args.get('execute') === true;
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) throw new Error(`DATABASE_URL is required (the ${app} logical database).`);
+
+  const sql = postgres(databaseUrl, { max: 1, prepare: false });
+  try {
+    if (!(await legacyTableExists(sql))) {
+      console.log(
+        JSON.stringify(
+          { app, status: 'skipped', reason: 'public.outbox_events does not exist — already dropped.' },
+          null,
+          2,
+        ),
+      );
+      return;
+    }
+
+    const markers = await ((app as AppName) === 'core' ? backfillCore(sql, execute) : backfillWallet(sql, execute));
+
+    console.log(
+      JSON.stringify(
+        {
+          app,
+          mode: execute ? 'execute' : 'dry-run',
+          markers,
+          message: execute
+            ? 'Markers backfilled. 6-C-4 배포는 이제 안전하다 — DROP 은 배포 뒤에.'
+            : 'Dry-run. `missing` 이 이번에 옮겨질 행 수다. --execute 를 붙여 실행한다.',
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/events/outbox-marker-backfill.verify.sh
+++ b/scripts/events/outbox-marker-backfill.verify.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# `outbox-marker-backfill.ts` 의 실 Postgres 검증 (ADR-0029 Task 6-C-4 선행).
+#
+# **왜 bash + 실 DB 인가.** 이 스크립트가 하는 일은 전부 SQL 술어다 — `LIKE '%:fully-shipped'`,
+# `DISTINCT ON`, `ON CONFLICT`, NULL 이 unique 를 통과하는 것. 목 DB 로는 그 술어가 무엇을
+# 거르는지 보이지 않는다(6-C-2·3 이 같은 이유로 실 PG 통합을 게이트에 넣었다).
+#
+# 로컬 compose postgres(5432) 에 **스크래치 DB 2개**를 만들고, 두 테이블 DDL 을 실 DB 에서
+# `pg_dump` 로 복사해 온다. 손으로 다시 적으면 운영과 다른 것을 테스트하게 된다.
+#
+# 사용법:  bash scripts/events/outbox-marker-backfill.verify.sh
+#          LOCAL_PG=postgresql://... bash scripts/events/outbox-marker-backfill.verify.sh
+#
+set -uo pipefail
+cd "$(dirname "$0")/../.."
+
+PG_URL="${LOCAL_PG:-postgresql://postgres:postgres@localhost:5432}"
+PGHOST=$(node -e "console.log(new URL(process.argv[1]).hostname)" "$PG_URL")
+PGPORT=$(node -e "console.log(new URL(process.argv[1]).port||5432)" "$PG_URL")
+PGUSER=$(node -e "console.log(new URL(process.argv[1]).username||'postgres')" "$PG_URL")
+export PGPASSWORD=$(node -e "console.log(decodeURIComponent(new URL(process.argv[1]).password||'postgres'))" "$PG_URL")
+export PGHOST PGPORT PGUSER
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+FAIL=0
+assert() { # name expected actual
+  if [ "$2" = "$3" ]; then echo "  ok   $1 = $3"; else echo "  FAIL $1: expected $2, got $3"; FAIL=1; fi
+}
+
+# 실 DB 에서 테이블 DDL 을 그대로 떠 온다. 공용 `event.outbox_events` 는 libs/events 한 파일이
+# 6개 앱에 동일 생성하므로 core 의 적용본이 그 판본이다.
+seed_scratch() { # $1=scratch db  $2=legacy source db  $3=legacy enum name
+  local scr="$1" src="$2" enum="$3"
+  psql -d postgres -Atqc "DROP DATABASE IF EXISTS $scr" >/dev/null 2>&1
+  psql -d postgres -Atqc "CREATE DATABASE $scr" >/dev/null
+  psql -d "$scr" -qc "CREATE SCHEMA IF NOT EXISTS event;" >/dev/null
+
+  psql -d "$src" -Atqc "SELECT 'CREATE TYPE public.$enum AS ENUM (' || string_agg(quote_literal(enumlabel), ',' ORDER BY enumsortorder) || ');' FROM pg_enum e JOIN pg_type t ON t.oid=e.enumtypid WHERE t.typname='$enum';" > "$TMP/enum.sql"
+  psql -d "$scr" -qf "$TMP/enum.sql" >/dev/null 2>&1
+
+  pg_dump -d "$src" --schema-only -t 'public.outbox_events' 2>/dev/null | grep -v '^--' > "$TMP/legacy.sql"
+  psql -d "$scr" -qf "$TMP/legacy.sql" >/dev/null 2>&1
+  pg_dump -d core --schema-only -t 'event.outbox_events' 2>/dev/null | grep -v '^--' > "$TMP/shared.sql"
+  psql -d "$scr" -qf "$TMP/shared.sql" >/dev/null 2>&1
+
+  local ok
+  ok=$(psql -d "$scr" -Atqc "SELECT (to_regclass('public.outbox_events') IS NOT NULL AND to_regclass('event.outbox_events') IS NOT NULL)")
+  if [ "$ok" != "t" ]; then echo "  FAIL 스크래치 DB 준비 실패: $scr"; FAIL=1; return 1; fi
+}
+
+run() { # $1=scratch  $2=app  $3..=flags
+  local scr="$1" app="$2"; shift 2
+  DATABASE_URL="${PG_URL}/${scr}" npx tsx scripts/events/outbox-marker-backfill.ts --app "$app" "$@"
+}
+
+# ══════════════════════ core ══════════════════════
+echo "══ core"
+SCR_CORE=obmb_verify_core
+seed_scratch "$SCR_CORE" core outbox_status || exit 1
+QC() { psql -d "$SCR_CORE" -Atqc "$1"; }
+
+QC "TRUNCATE public.outbox_events; TRUNCATE event.outbox_events;" >/dev/null
+# 옮겨야 하는 표지 2건 (하나는 published_at 이 2일 전 — 보존되는지 본다)
+QC "INSERT INTO public.outbox_events (topic, idempotency_key, event_type, aggregate_type, aggregate_id, partition_key, payload, status, published_at) VALUES
+ ('fulfillments.events.v1','11111111-1111-1111-1111-111111111111:fully-shipped','FulfillmentShipped','fulfillment','11111111-1111-1111-1111-111111111111','pk1','{\"a\":1}','published', now() - interval '2 days'),
+ ('fulfillments.events.v1','22222222-2222-2222-2222-222222222222:fully-shipped','FulfillmentShipped','fulfillment','22222222-2222-2222-2222-222222222222','pk2','{\"a\":2}','published', now() - interval '1 day');" >/dev/null
+# 대조군 A: 같은 topic/event_type 이지만 fully-shipped 표지가 아니다
+QC "INSERT INTO public.outbox_events (topic, idempotency_key, event_type, aggregate_type, aggregate_id, partition_key, payload, status) VALUES
+ ('fulfillments.events.v1','33333333-3333-3333-3333-333333333333:line-shipped','FulfillmentShipped','fulfillment','33333333-3333-3333-3333-333333333333','pk3','{\"a\":3}','published');" >/dev/null
+# 대조군 B: 다른 토픽
+QC "INSERT INTO public.outbox_events (topic, idempotency_key, event_type, aggregate_type, aggregate_id, partition_key, payload, status) VALUES
+ ('core.orders.events.v1','44444444-4444-4444-4444-444444444444:fully-shipped','SalesOrderCancelled','sales_order','44444444-4444-4444-4444-444444444444','pk4','{\"a\":4}','published');" >/dev/null
+# 이미 공용에 있는 표지 — 덮어쓰지 않아야 한다
+QC "INSERT INTO public.outbox_events (topic, idempotency_key, event_type, aggregate_type, aggregate_id, partition_key, payload, status) VALUES
+ ('fulfillments.events.v1','55555555-5555-5555-5555-555555555555:fully-shipped','FulfillmentShipped','fulfillment','55555555-5555-5555-5555-555555555555','pk5','{\"a\":5}','published');" >/dev/null
+QC "INSERT INTO event.outbox_events (topic, aggregate_type, aggregate_id, event_type, idempotency_key, partition_key, payload, status) VALUES
+ ('fulfillments.events.v1','Fulfillment','55555555-5555-5555-5555-555555555555','FulfillmentShipped','55555555-5555-5555-5555-555555555555:fully-shipped','pk5','{\"b\":5}','PUBLISHED');" >/dev/null
+
+DRY=$(run "$SCR_CORE" core | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).markers[0].missing))")
+assert "dry-run 이 옮길 행 수를 맞게 센다" 2 "$DRY"
+INS=$(run "$SCR_CORE" core --execute | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).markers[0].inserted))")
+assert "1회차 삽입" 2 "$INS"
+INS2=$(run "$SCR_CORE" core --execute | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).markers[0].inserted))")
+assert "2회차 삽입 0 (멱등)" 0 "$INS2"
+
+assert "공용 총 행수(기존1+옮긴2)" 3 "$(QC "SELECT count(*) FROM event.outbox_events")"
+assert "전부 PUBLISHED — 재발행되지 않는다" 0 "$(QC "SELECT count(*) FROM event.outbox_events WHERE status <> 'PUBLISHED'")"
+assert "대조군A(line-shipped) 미이동" 0 "$(QC "SELECT count(*) FROM event.outbox_events WHERE idempotency_key LIKE '%:line-shipped'")"
+assert "대조군B(다른 토픽) 미이동" 0 "$(QC "SELECT count(*) FROM event.outbox_events WHERE topic='core.orders.events.v1'")"
+assert "기존 행 payload 안 덮어씀" 1 "$(QC "SELECT count(*) FROM event.outbox_events WHERE idempotency_key LIKE '55555555%' AND payload::text='{\"b\": 5}'")"
+assert "published_at 보존" 1 "$(QC "SELECT count(*) FROM event.outbox_events WHERE idempotency_key LIKE '11111111%' AND published_at < now() - interval '1 day'")"
+# 읽는 쪽(hasFullyShippedProjection)의 술어를 그대로 재현
+assert "표지 3건 전부 공용 술어로 조회됨" 3 "$(QC "SELECT count(*) FROM event.outbox_events WHERE topic='fulfillments.events.v1' AND event_type='FulfillmentShipped' AND idempotency_key IN ('11111111-1111-1111-1111-111111111111:fully-shipped','22222222-2222-2222-2222-222222222222:fully-shipped','55555555-5555-5555-5555-555555555555:fully-shipped')")"
+
+# ══════════════════════ wallet ══════════════════════
+echo "══ wallet"
+SCR_W=obmb_verify_wallet
+seed_scratch "$SCR_W" wallet wallet_outbox_status || exit 1
+QW() { psql -d "$SCR_W" -Atqc "$1"; }
+
+QW "TRUNCATE public.outbox_events; TRUNCATE event.outbox_events;" >/dev/null
+# 같은 인텐트에 2행 → 공용엔 1행만
+QW "INSERT INTO public.outbox_events (message_id, event_type, aggregate_type, aggregate_id, partition_key, payload, status, published_at) VALUES
+ ('m1','payment.intent.failed','PaymentGateway','aaaaaaaa-0000-0000-0000-000000000001','pk-a','{\"x\":1}','PUBLISHED', now() - interval '3 days'),
+ ('m2','payment.intent.failed','PaymentGateway','aaaaaaaa-0000-0000-0000-000000000001','pk-a','{\"x\":2}','PUBLISHED', now() - interval '2 days'),
+ ('m3','payment.intent.failed','PaymentGateway','aaaaaaaa-0000-0000-0000-000000000002','pk-b','{\"x\":3}','PUBLISHED', now() - interval '1 day');" >/dev/null
+# 대조군 A: 다른 event_type
+QW "INSERT INTO public.outbox_events (message_id, event_type, aggregate_type, aggregate_id, partition_key, payload, status) VALUES
+ ('m4','payment.intent.succeeded','PaymentGateway','aaaaaaaa-0000-0000-0000-000000000003','pk-c','{\"x\":4}','PUBLISHED');" >/dev/null
+# 같은 멱등키 2행 → 공용엔 1행
+QW "INSERT INTO public.outbox_events (message_id, event_type, aggregate_type, aggregate_id, partition_key, payload, status) VALUES
+ ('m5','mandate.rejected','PaymentGateway','bbbbbbbb-0000-0000-0000-000000000001','pk-d','{\"idempotencyKey\":\"idem-1\"}','PUBLISHED'),
+ ('m6','mandate.rejected','PaymentGateway','bbbbbbbb-0000-0000-0000-000000000002','pk-e','{\"idempotencyKey\":\"idem-1\"}','PUBLISHED'),
+ ('m7','mandate.rejected','PaymentGateway','bbbbbbbb-0000-0000-0000-000000000003','pk-f','{\"idempotencyKey\":\"idem-2\"}','PUBLISHED');" >/dev/null
+# 대조군 B: 멱등키 없는 mandate.rejected — 옮길 근거가 없다
+QW "INSERT INTO public.outbox_events (message_id, event_type, aggregate_type, aggregate_id, partition_key, payload, status) VALUES
+ ('m8','mandate.rejected','PaymentGateway','bbbbbbbb-0000-0000-0000-000000000004','pk-g','{\"invoiceId\":null}','PUBLISHED');" >/dev/null
+
+run "$SCR_W" wallet >/dev/null
+run "$SCR_W" wallet --execute >/dev/null
+SECOND=$(run "$SCR_W" wallet --execute | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const m=JSON.parse(s).markers;console.log(m[0].inserted+m[1].inserted)})")
+assert "2회차 삽입 0 (멱등)" 0 "$SECOND"
+
+assert "intent.failed 인텐트당 1행" 2 "$(QW "SELECT count(*) FROM event.outbox_events WHERE event_type='payment.intent.failed'")"
+assert "mandate 멱등키당 1행" 2 "$(QW "SELECT count(*) FROM event.outbox_events WHERE event_type='mandate.rejected'")"
+assert "공용 총 행수" 4 "$(QW "SELECT count(*) FROM event.outbox_events")"
+assert "전부 PUBLISHED — 재발행되지 않는다" 0 "$(QW "SELECT count(*) FROM event.outbox_events WHERE status <> 'PUBLISHED'")"
+assert "대조군A(succeeded) 미이동" 0 "$(QW "SELECT count(*) FROM event.outbox_events WHERE event_type='payment.intent.succeeded'")"
+assert "대조군B(멱등키 없는 mandate) 미이동" 0 "$(QW "SELECT count(*) FROM event.outbox_events WHERE event_type='mandate.rejected' AND idempotency_key IS NULL")"
+assert "topic 이 계약값으로 채워짐" 4 "$(QW "SELECT count(*) FROM event.outbox_events WHERE topic='payments.events.v1'")"
+# 읽는 쪽 두 술어를 그대로 재현
+assert "BillingCharge dedupe 재현(인텐트1)" 1 "$(QW "SELECT count(*) FROM event.outbox_events WHERE aggregate_id='aaaaaaaa-0000-0000-0000-000000000001' AND event_type='payment.intent.failed'")"
+assert "Invoice dedupe 재현(idem-1)" 1 "$(QW "SELECT count(*) FROM event.outbox_events WHERE event_type='mandate.rejected' AND idempotency_key='idem-1'")"
+
+psql -d postgres -Atqc "DROP DATABASE IF EXISTS $SCR_CORE" >/dev/null 2>&1
+psql -d postgres -Atqc "DROP DATABASE IF EXISTS $SCR_W" >/dev/null 2>&1
+
+echo
+if [ "$FAIL" = 0 ]; then echo "전부 통과"; else echo "실패 있음"; fi
+exit $FAIL


### PR DESCRIPTION
6-C-4 가 옛 테이블을 DROP 하기 전에 **반드시 먼저 돌아야 하는** 선행 단계다. 코드 변경 0, 마이그레이션 0 — 스크립트 하나와 그 검증 하네스뿐이라 머지 자체는 무해하다.

## 왜 필요한가 — 드레인은 "큐"만 보호한다

6-C-2·3 은 옛 아웃박스를 *읽는* 코드 3곳을 "두 테이블 다 읽기"로 처리하고 옛 갈래 제거를 6-C-4 로 미뤘다. 그런데 그 3곳은 큐를 읽는 게 아니라 **"이 사실이 이미 기록됐는가"를 행의 존재로 판정**한다. 즉 DROP 은 큐가 아니라 **판정 근거**를 지운다.

드레인과 시계가 다르다 — 미발행 행이 다 빠진 뒤에도 이 표지들은 `published` 로 굳은 채 계속 읽힌다:

| 표지 | 읽는 곳 | 잃으면 |
|---|---|---|
| `FulfillmentShipped` / `<foId>:fully-shipped` | `ShipmentDeliveryTrackingService.hasFullyShippedProjection` | 배포 이전에 출고된 FO 의 **배송완료 이벤트가 안 나간다.** 노출 창 = 출고→배송 리드타임(며칠) |
| `payment.intent.failed` / `aggregate_id` | `BillingChargeConsumer` FAILED 분기 | 커맨드 재전달 시 같은 실패가 **두 번** 발행된다 |
| `mandate.rejected` / `payload->>'idempotencyKey'` | `InvoiceCommandConsumer` | 같은 mandate.rejected 가 **두 번** 발행된다 |

## 설계 선택

- **drizzle 마이그레이션이 아니라 일회성 ops 스크립트다.** 데이터 전용 마이그레이션은 저널·스냅샷을 손으로 엮어야 하는데, 그게 정확히 #593 에서 wallet 체인을 부순 종류의 취약함이다. 레포에도 데이터 백필은 `scripts/` 로 두는 선례가 있다(`migrate:backfill` 등).
- 표지는 **`status='PUBLISHED'`** 로 넣는다 — 공용 디스패처의 acquire 술어(`status='PENDING'`)에 안 걸려 **재발행되지 않는다**.
- 재실행 멱등: 멱등키 있는 갈래는 `ON CONFLICT DO NOTHING`, wallet `intent.failed` 은 멱등키가 NULL 이라 unique 가 못 막으므로 `NOT EXISTS` 로 직접 거른다.
- channel-adapter 는 대상이 아니다 — 옛 아웃박스를 읽는 코드가 0곳이었다(6-C-3 실측).

## 검증 — 실 Postgres

이 스크립트는 전부 SQL 술어(`LIKE`, `DISTINCT ON`, `ON CONFLICT`, NULL 이 unique 를 통과하는 것)라 목 DB 로는 무엇을 거르는지 보이지 않는다.

`npm run events:marker-backfill:verify` 가 스크래치 DB 2개를 **실 DDL(`pg_dump`)** 로 세우고 **20 단언** 전부 통과. 대조군 4종이 옮겨지지 *않는* 것을 단언한다 — 다른 멱등키 모양(`:line-shipped`) · 다른 토픽 · 다른 event_type · 멱등키 없는 행. 멱등성(2회차 삽입 0)과 기존 행 미덮어씀, `published_at` 보존도 포함.

**변이로 빨간불 재현:** 표지 필터(`LIKE '%:fully-shipped'`)를 제거하니 대조군 단언이 정확히 빨간불이 됐고, `cp` 백업 + `sha1sum -c` 로 원복했다(`git checkout --` 는 쓰지 않았다).

## 사용법

```bash
# 각 앱의 DATABASE_URL 로. dry-run 이 기본 — `missing` 이 이번에 옮겨질 행 수다.
npm run events:marker-backfill -- --app core
npm run events:marker-backfill -- --app core --execute
npm run events:marker-backfill -- --app wallet --execute
```

## 게이트

`type-check` **163 = 기준선**(집합 완전 동일) · 신규 파일 eslint 0.

https://claude.ai/code/session_01Phyx7rWAAe7uVLp3FCU6uZ