### PR TITLE
fix(events): 표지 백필이 drizzle-kit 전용 URL 로 postgres.js 에 붙던 것 (ADR-0029 Task 6-C-4)

### DIFF
--- a/scripts/events/outbox-marker-backfill.ts
+++ b/scripts/events/outbox-marker-backfill.ts
@@ -298,20 +298,23 @@ async function main(): Promise<void> {
 
   // 명시 URL(로컬·스크래치)이 있으면 그대로 쓰고 sst 재진입을 건너뛴다. 없으면 `db:migrate`
   // 와 같은 경로로 간다 — `sst shell` 안에서 Resource 자격증명 + 앱별 논리 DB 이름.
+  //
+  // ⚠️ SST 경로에서 `buildDatabaseUrl` 을 쓰면 안 된다 — 그건 **drizzle-kit 전용** URL 이고
+  // `uselibpqcompat` 이 붙어 있어 postgres.js 로 붙으면 서버가 startup 파라미터로 받아
+  // 거부한다. `createServiceConnection` 이 같은 자격증명에서 postgres.js 모양으로 만든다.
   const explicitUrl = typeof args.get('url') === 'string' ? (args.get('url') as string) : process.env.DATABASE_URL;
 
-  let databaseUrl: string;
+  let sql: Sql;
   if (explicitUrl) {
-    databaseUrl = explicitUrl;
+    sql = postgres(explicitUrl, { max: 1, prepare: false });
   } else {
     const stage = typeof args.get('stage') === 'string' ? (args.get('stage') as string) : undefined;
     const deployment = typeof args.get('deployment') === 'string' ? (args.get('deployment') as string) : undefined;
     await ensureInsideSstShell({ stage, deployment });
-    const { buildDatabaseUrl } = await import('../seeding/lib/db-connection');
-    databaseUrl = buildDatabaseUrl(APP_DATABASE[app]);
+    const { createServiceConnection } = await import('../seeding/lib/db-connection');
+    sql = createServiceConnection(APP_DATABASE[app], { max: 1, prepare: false });
   }
 
-  const sql = postgres(databaseUrl, { max: 1, prepare: false });
   try {
     if (!(await legacyTableExists(sql))) {
       console.log(

--- a/scripts/seeding/lib/db-connection.ts
+++ b/scripts/seeding/lib/db-connection.ts
@@ -34,9 +34,27 @@ function getDbCredentials() {
   };
 }
 
+/**
+ * **drizzle-kit 전용 URL 이다.** `uselibpqcompat` 은 libpq 쪽 파라미터라 `postgres.js` 에
+ * 그대로 물리면 서버가 startup 파라미터로 받아 `unrecognized configuration parameter
+ * "uselibpqcompat"` 으로 거부한다. postgres.js 로 붙을 거면 `createServiceConnection()` 을
+ * 써라 — 같은 자격증명에서 클라이언트에 맞는 모양으로 만든다.
+ */
 export function buildDatabaseUrl(dbName: string): string {
   const { username, password, host, port } = getDbCredentials();
   return `postgresql://${username}:${password}@${host}:${port}/${dbName}?sslmode=require&uselibpqcompat=true`;
+}
+
+/**
+ * 특정 논리 DB 에 `postgres.js` 로 붙는다.
+ *
+ * `buildDatabaseUrl` 의 postgres.js 짝. URL 을 문자열로 만들어 파라미터를 도로 떼어내는
+ * 대신(그 우회가 이미 두 곳에 생길 뻔했다) 자격증명에서 바로 옵션 객체를 만든다 —
+ * `createAdminConnection` 과 같은 모양이고 DB 이름만 다르다.
+ */
+export function createServiceConnection(dbName: string, options: Record<string, unknown> = {}): Sql {
+  const { host, port, username, password } = getDbCredentials();
+  return postgres({ host, port, user: username, password, database: dbName, ssl: 'require', ...options });
 }
 
 /** Connect to the default `postgres` database for admin operations (CREATE DATABASE, etc.) */


### PR DESCRIPTION
라이브 실행이 `unrecognized configuration parameter "uselibpqcompat"` 로 죽었다.

## 원인

`buildDatabaseUrl` 은 **drizzle-kit 전용** URL 이다 — `uselibpqcompat` 은 libpq 쪽 파라미터라 `postgres.js` 에 물리면 서버 startup 파라미터로 나가고 Postgres 가 거부한다. #602 가 접속 경로를 `db:migrate` 와 맞추면서 그 URL 을 그대로 postgres.js 에 넘겼다.

`scripts/fix-lolliking-membership-flag.ts:45` 가 이미 같은 문제를 `.replace('&uselibpqcompat=true','')` 로 우회하고 있었다 — 주석까지 원인을 정확히 적어 두고서.

## 고친 방식

우회를 한 벌 더 만드는 대신 `createServiceConnection(dbName, options)` 을 `db-connection.ts` 에 넣었다. 자격증명에서 바로 postgres.js 옵션 객체를 만든다 — `createAdminConnection` 과 같은 모양이고 DB 이름만 다르다. `buildDatabaseUrl` 에는 "이건 drizzle-kit 전용, postgres.js 면 저쪽을 써라" 경고를 달았다.

## 대조군 (실 Postgres)

옛 방식이 **정확히 같은 메시지로 거부**되는 것을 로컬에서 재현하고, 새 방식이 접속되는 것을 나란히 확인했다:

```
ok   옛 방식 거부됨: unrecognized configuration parameter "uselibpqcompat"
ok   새 방식 접속 성공: core
```

## ⚠️ 남는 미검증

`ssl: 'require'` 는 로컬 PG 에 TLS 가 없어 확인하지 못했다. 다만 이는 `buildDatabaseUrl` 의 `sslmode=require` 를 그대로 옮긴 것이고, **실패한 실행이 startup 파라미터 단계까지 갔다는 것은 그 handshake 가 이미 성공했다는 뜻**이다.

## 게이트

`type-check` 신규 0 · 변경 2파일 eslint **신규 0**(잔여 8건은 `getDbCredentials` 의 기존 `Resource as any` 부채) · `npm run events:marker-backfill:verify` **20 단언 전부 통과**.

https://claude.ai/code/session_01Phyx7rWAAe7uVLp3FCU6uZ