### PR TITLE
fix(events): 진단 로그가 구조화 필드를 잃던 것 (ADR-0029 Task 5-C 관측 선행)

### DIFF
--- a/libs/events/src/dlq/dlq-handler.service.ts
+++ b/libs/events/src/dlq/dlq-handler.service.ts
@@ -104,7 +104,8 @@ export class DLQHandler {
         },
       });
 
-      this.logger.warn(`📤 Message sent to DLQ: ${params.originalMessage.messageType}`, {
+      this.logger.warn({
+        msg: `📤 Message sent to DLQ: ${params.originalMessage.messageType}`,
         dlqTopic,
         dlqMessageId,
         originalMessageId: params.originalMessage.messageId,
@@ -127,7 +128,8 @@ export class DLQHandler {
         consumer: params.context.consumer,
       });
 
-      this.logger.error(`❌ CRITICAL: Failed to send message to DLQ`, {
+      this.logger.error({
+        msg: `❌ CRITICAL: Failed to send message to DLQ`,
         originalTopic: params.originalTopic,
         dlqTopic,
         error: error instanceof Error ? error.message : String(error),
@@ -182,7 +184,8 @@ export class DLQHandler {
         },
       });
 
-      this.logger.log(`✅ DLQ message reprocessed: ${dlqMessage.dlqMessageId}`, {
+      this.logger.log({
+        msg: `✅ DLQ message reprocessed: ${dlqMessage.dlqMessageId}`,
         originalTopic: dlqMessage.originalTopic,
         messageType: dlqMessage.originalMessage.messageType,
         aggregateId: dlqMessage.originalMessage.source.aggregateId,
@@ -191,7 +194,8 @@ export class DLQHandler {
       // TODO: DB 상태 업데이트
       // await this.markAsReprocessed(dlqMessage.dlqMessageId);
     } catch (error) {
-      this.logger.error(`❌ Failed to reprocess DLQ message: ${dlqMessage.dlqMessageId}`, {
+      this.logger.error({
+        msg: `❌ Failed to reprocess DLQ message: ${dlqMessage.dlqMessageId}`,
         error: error instanceof Error ? error.message : String(error),
       });
 
@@ -300,9 +304,7 @@ export class DLQHandler {
    * });
    */
   async resolveDLQ(params: { dlqMessageId: string; reason: string }): Promise<void> {
-    this.logger.log(`DLQ message resolved: ${params.dlqMessageId}`, {
-      reason: params.reason,
-    });
+    this.logger.log({ msg: `DLQ message resolved: ${params.dlqMessageId}`, reason: params.reason });
 
     // TODO: DB 업데이트
     // await this.markAsResolved(params.dlqMessageId, params.reason);

--- a/libs/events/src/interceptors/event-retry.interceptor.spec.ts
+++ b/libs/events/src/interceptors/event-retry.interceptor.spec.ts
@@ -199,11 +199,16 @@ describe('EventRetryInterceptor', () => {
   it('backoff가 escalate 한다 (exponential: 2ms → 4ms)', async () => {
     const { ctx } = makeKafkaContext();
     const impl = jest.fn().mockRejectedValue(new TransientError('db down'));
-    const warnSpy = jest.spyOn((interceptor as unknown as { logger: { warn: (msg: string) => void } }).logger, 'warn');
+    const warnSpy = jest.spyOn(
+      (interceptor as unknown as { logger: { warn: (arg: { msg: string }) => void } }).logger,
+      'warn',
+    );
 
     await run(TestConsumer.prototype.handleExponential, nextFrom(impl), ctx);
 
-    const delays = warnSpy.mock.calls.map(([msg]) => /Retrying in (\d+)ms/.exec(String(msg))?.[1]).filter(Boolean);
+    // 진단 로그는 `{ msg, ...필드 }` 로 찍는다 — 문자열+객체 모양은 nestjs-pino 가 객체를
+    // 통째로 버린다 (`observability/log-shape.spec.ts` 참조).
+    const delays = warnSpy.mock.calls.map(([arg]) => /Retrying in (\d+)ms/.exec(String(arg?.msg))?.[1]).filter(Boolean);
     expect(delays).toEqual(['2', '4']);
   });
 

--- a/libs/events/src/interceptors/event-retry.interceptor.ts
+++ b/libs/events/src/interceptors/event-retry.interceptor.ts
@@ -125,7 +125,8 @@ export class EventRetryInterceptor implements NestInterceptor {
         const retriesSoFar = retryContext.attemptNumber - 1; // 초기 시도 제외한 재시도 횟수
 
         if (retryContext.attemptNumber === 1) {
-          this.logger.error(`Event handler failed: ${handlerName}`, {
+          this.logger.error({
+            msg: `Event handler failed: ${handlerName}`,
             error: failure.message,
             stack: failure.stack,
             errorType: failure.name,
@@ -147,7 +148,8 @@ export class EventRetryInterceptor implements NestInterceptor {
           retryPolicy.initialDelayMs,
           retryPolicy.maxDelayMs,
         );
-        this.logger.warn(`Retrying in ${delay}ms... (attempt ${nextRetryNumber}/${retryPolicy.maxRetries})`, {
+        this.logger.warn({
+          msg: `Retrying in ${delay}ms... (attempt ${nextRetryNumber}/${retryPolicy.maxRetries})`,
           handler: handlerName,
           topic: kafkaContext.getTopic(),
         });
@@ -168,17 +170,18 @@ export class EventRetryInterceptor implements NestInterceptor {
     const retries = retryContext.attemptNumber - 1;
 
     if (disableDLQ) {
-      this.logger.warn(`DLQ disabled for handler: ${handlerName}. Discarding message.`, { topic, offset });
+      this.logger.warn({ msg: `DLQ disabled for handler: ${handlerName}. Discarding message.`, topic, offset });
       return;
     }
     if (!this.dlqHandler) {
-      this.logger.error(`DLQHandler not available. Cannot send message to DLQ.`, { handler: handlerName, topic });
+      this.logger.error({ msg: `DLQHandler not available. Cannot send message to DLQ.`, handler: handlerName, topic });
       return;
     }
 
     await this.sendToDLQ(kafkaContext, error, handlerName, retryContext, this.dlqHandler);
 
-    this.logger.error(`❌ Handler failed after ${retries} retries: ${handlerName}`, {
+    this.logger.error({
+      msg: `❌ Handler failed after ${retries} retries: ${handlerName}`,
       error: error.message,
       topic,
       partition: kafkaContext.getPartition(),
@@ -215,13 +218,15 @@ export class EventRetryInterceptor implements NestInterceptor {
         },
       });
 
-      this.logger.log(`📤 Message sent to DLQ after ${retryContext.attemptHistory.length} failed attempts`, {
+      this.logger.log({
+        msg: `📤 Message sent to DLQ after ${retryContext.attemptHistory.length} failed attempts`,
         topic,
         messageType: envelope.messageType,
         aggregateId: envelope.source?.aggregateId,
       });
     } catch (dlqError) {
-      this.logger.error(`❌ CRITICAL: Failed to send message to DLQ`, {
+      this.logger.error({
+        msg: `❌ CRITICAL: Failed to send message to DLQ`,
         originalError: error.message,
         dlqError: dlqError instanceof Error ? dlqError.message : String(dlqError),
         topic,

--- a/libs/events/src/interceptors/schema-validation.interceptor.ts
+++ b/libs/events/src/interceptors/schema-validation.interceptor.ts
@@ -69,7 +69,7 @@ export class SchemaValidationInterceptor implements NestInterceptor {
       const eventConfig = streamConfig.events[eventType];
 
       if (!eventConfig) {
-        this.logger.warn(`Event type not found in stream config: ${eventType}`, { topic });
+        this.logger.warn({ msg: `Event type not found in stream config: ${eventType}`, topic });
         return next.handle();
       }
 
@@ -84,13 +84,15 @@ export class SchemaValidationInterceptor implements NestInterceptor {
       try {
         validateSchemaOrThrow(schema, envelope.payload, `${topic}.${eventType} (consumer)`);
 
-        this.logger.debug(`✅ Consumer schema validation passed: ${eventType}`, {
+        this.logger.debug({
+          msg: `✅ Consumer schema validation passed: ${eventType}`,
           topic,
           messageId: envelope.messageId,
         });
       } catch (error) {
         if (error instanceof SchemaValidationError) {
-          this.logger.error(`❌ Consumer schema validation failed: ${eventType}`, {
+          this.logger.error({
+            msg: `❌ Consumer schema validation failed: ${eventType}`,
             topic,
             messageId: envelope.messageId,
             errors: formatValidationErrors(error.errors),
@@ -112,7 +114,8 @@ export class SchemaValidationInterceptor implements NestInterceptor {
         throw error;
       }
 
-      this.logger.error(`Schema validation interceptor error`, {
+      this.logger.error({
+        msg: `Schema validation interceptor error`,
         error: error instanceof Error ? error.message : String(error),
         topic,
       });

--- a/libs/events/src/observability/log-shape.spec.ts
+++ b/libs/events/src/observability/log-shape.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * 진단 로그가 **구조화 필드를 잃지 않는지** 봉인한다 (플랜 Task 5-C 관측 결정).
+ *
+ * ## 왜 이 스펙인가
+ *
+ * 5-C 는 core 를 제외한 앱에서 검증을 켠다. 그 앱들은 Alloy 가 `/metrics` 를 긁지 않으므로
+ * (`dlq.metrics.ts:10`) 증명이 틀렸을 때 알아차릴 수단이 **로그뿐**이다. 그런데 이 라이브러리의
+ * 진단 로그는 오랫동안 `logger.error('메시지', { topic, messageId, errors })` 모양이었고,
+ * **그 두 번째 인자는 통째로 버려지고 있었다.**
+ *
+ * 이유는 nestjs-pino `Logger.call` 이다 — Nest 의 `Logger` 는 자기 context 를 마지막 인자로
+ * 덧붙이므로 optionalParams 는 `[{객체}, 'ClassName']` 이 되고, nestjs-pino 는 **마지막**을
+ * context 로 쓰고 나머지를 pino 의 보간 인자로 넘긴다. 메시지에 `%s` 가 없으면 pino 는 그것을
+ * 출력하지 않는다. 결과: stdout 에도 Loki 에도 topic·messageId·errors 가 없다.
+ *
+ * 아래 첫 describe 가 그 사실의 **대조군**이다 — 옛 모양과 새 모양을 나란히 실행해 무엇이
+ * 사라지고 무엇이 남는지 보인다. 두 번째 describe 는 옛 모양이 라이브러리에 다시 자라지 않게
+ * AST 로 막는다. 대조군 없이 AST 단언만 두면 "왜 이 모양이어야 하는가"가 사라진다.
+ */
+import 'reflect-metadata';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as ts from 'typescript';
+import { Logger as NestLogger, Module } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { LoggerModule, Logger as PinoNestLogger } from 'nestjs-pino';
+import { Writable } from 'stream';
+
+describe('진단 로그 모양 — nestjs-pino 를 지나며 무엇이 남는가', () => {
+  /**
+   * 앱들의 실제 배선을 그대로 세운다: `LoggerModule.forRoot` + `app.useLogger(app.get(Logger))`.
+   * 목적지만 파일 대신 메모리 스트림으로 돌려 출력 줄을 읽는다.
+   *
+   * 두 모양을 **한 번의 부팅에서** 찍는다 — nestjs-pino 의 루트 pino 인스턴스는 모듈 스코프
+   * 싱글턴이라 `forRoot` 를 두 번 부르면 두 번째 목적지가 무시되고 첫 번째 sink 로 흘러간다
+   * (실제로 그렇게 한 판본이 조용히 빈 배열을 받았다).
+   */
+  let records: Array<Record<string, unknown>>;
+
+  beforeAll(async () => {
+    const lines: string[] = [];
+    const sink = new Writable({
+      write(chunk: Buffer | string, _enc, cb) {
+        lines.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+        cb();
+      },
+    });
+
+    @Module({
+      imports: [LoggerModule.forRoot({ pinoHttp: [{ level: 'debug' }, sink] })],
+    })
+    class ProbeModule {}
+
+    const app = await NestFactory.createApplicationContext(ProbeModule, { logger: false });
+    app.useLogger(app.get(PinoNestLogger));
+    const log = new NestLogger('SchemaValidationInterceptor');
+
+    log.error('OLD_SHAPE OrderCreated', {
+      topic: 'orders.events.v1',
+      messageId: 'mid-1',
+      errors: '  - payload.sku: Required',
+    });
+    log.error({
+      msg: 'NEW_SHAPE OrderCreated',
+      topic: 'orders.events.v1',
+      messageId: 'mid-1',
+      errors: '  - payload.sku: Required',
+    });
+
+    await app.close();
+
+    records = lines
+      .join('')
+      .split('\n')
+      .filter((l) => l.trim().length > 0)
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+  });
+
+  const find = (marker: string) => records.find((r) => String(r.msg).includes(marker));
+
+  it('옛 모양 `error(문자열, {객체})` 는 객체를 통째로 잃는다 (대조군)', () => {
+    const record = find('OLD_SHAPE');
+    expect(record).toBeDefined();
+    // 메시지와 context 는 남는다 — 그래서 "로그가 아예 안 나온다"로 오해하기 쉽다.
+    expect(record!.context).toBe('SchemaValidationInterceptor');
+    // 그러나 진단에 필요한 것은 전부 사라진다.
+    expect(record).not.toHaveProperty('topic');
+    expect(record).not.toHaveProperty('messageId');
+    expect(record).not.toHaveProperty('errors');
+  });
+
+  it('새 모양 `error({ msg, ...필드 })` 는 필드를 구조화해 남긴다', () => {
+    const record = find('NEW_SHAPE');
+    expect(record).toBeDefined();
+    expect(record!.context).toBe('SchemaValidationInterceptor');
+    expect(record!.topic).toBe('orders.events.v1');
+    expect(record!.messageId).toBe('mid-1');
+    expect(record!.errors).toBe('  - payload.sku: Required');
+  });
+});
+
+describe('옛 모양이 libs/events 에 다시 자라지 않는다', () => {
+  const SRC = path.resolve(__dirname, '..');
+  const LEVELS = new Set(['log', 'warn', 'error', 'debug', 'verbose', 'fatal']);
+
+  function collectTsFiles(dir: string, acc: string[] = []): string[] {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) collectTsFiles(full, acc);
+      else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.spec.ts')) acc.push(full);
+    }
+    return acc;
+  }
+
+  /** `<무엇이든>logger.<level>(<문자열>, {객체})` 호출 지점을 전부 찾는다. */
+  function findDroppedFieldCalls(file: string): string[] {
+    const text = fs.readFileSync(file, 'utf8');
+    const src = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+    const hits: string[] = [];
+
+    const visit = (node: ts.Node): void => {
+      if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+        const method = node.expression.name.text;
+        const receiver = node.expression.expression.getText(src);
+        if (LEVELS.has(method) && /logger$/i.test(receiver) && node.arguments.length >= 2) {
+          const [first, second] = node.arguments;
+          const firstIsString =
+            ts.isStringLiteral(first) || ts.isTemplateExpression(first) || ts.isNoSubstitutionTemplateLiteral(first);
+          if (firstIsString && ts.isObjectLiteralExpression(second)) {
+            const line = src.getLineAndCharacterOfPosition(node.getStart(src)).line + 1;
+            hits.push(`${path.relative(SRC, file)}:${line}  ${receiver}.${method}(…, { … })`);
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(src);
+    return hits;
+  }
+
+  it('`logger.<level>(문자열, {객체})` 호출이 0곳이다', () => {
+    const files = collectTsFiles(SRC);
+    // 판정기 자신이 죽어 있으면 0곳도 초록이다. 파일을 실제로 훑었는지 먼저 고정한다.
+    expect(files.length).toBeGreaterThan(20);
+
+    const hits = files.flatMap(findDroppedFieldCalls);
+    expect(hits).toEqual([]);
+  });
+
+  it('판정기는 그 모양을 실제로 잡는다 (대조군 — 위 0곳이 무엇을 뜻하는지 고정)', () => {
+    const fixture = path.join(__dirname, '__log-shape-fixture__.ts');
+    fs.writeFileSync(
+      fixture,
+      [
+        'declare const logger: { error: (...a: unknown[]) => void };',
+        'export function f(topic: string) {',
+        '  logger.error(`boom: ${topic}`, { topic });',
+        '}',
+        '',
+      ].join('\n'),
+    );
+    try {
+      expect(findDroppedFieldCalls(fixture)).toHaveLength(1);
+    } finally {
+      fs.unlinkSync(fixture);
+    }
+  });
+});

--- a/libs/events/src/outbox/outbox-publisher.service.ts
+++ b/libs/events/src/outbox/outbox-publisher.service.ts
@@ -52,7 +52,8 @@ export class OutboxPublisher implements OutboxWriter {
       })
       .onConflictDoNothing();
 
-    this.logger.debug(`Outbox event saved: ${record.eventType}`, {
+    this.logger.debug({
+      msg: `Outbox event saved: ${record.eventType}`,
       topic: record.topic,
       aggregateId: record.aggregateId,
     });

--- a/libs/events/src/publishers/stream-publisher.service.ts
+++ b/libs/events/src/publishers/stream-publisher.service.ts
@@ -196,7 +196,8 @@ export class StreamPublisher<TEvents extends StreamEventTypes = StreamEventTypes
       tx,
     );
 
-    this.logger.debug(`📥 event enqueued: ${envelope.messageType}`, {
+    this.logger.debug({
+      msg: `📥 event enqueued: ${envelope.messageType}`,
       messageId: envelope.messageId,
       aggregateId: params.aggregateId,
     });
@@ -350,13 +351,15 @@ export class StreamPublisher<TEvents extends StreamEventTypes = StreamEventTypes
         },
       });
 
-      this.logger.debug(`📤 ${envelope.messageKind} published: ${envelope.messageType}`, {
+      this.logger.debug({
+        msg: `📤 ${envelope.messageKind} published: ${envelope.messageType}`,
         messageId: envelope.messageId,
         aggregateId: envelope.source.aggregateId,
         correlationId: envelope.correlationId,
       });
     } catch (error) {
-      this.logger.error(`❌ Failed to publish ${envelope.messageKind}: ${envelope.messageType}`, {
+      this.logger.error({
+        msg: `❌ Failed to publish ${envelope.messageKind}: ${envelope.messageType}`,
         error: error instanceof Error ? error.message : String(error),
         messageId: envelope.messageId,
         aggregateId: envelope.source.aggregateId,

--- a/libs/events/src/tracking/event-tracking.service.ts
+++ b/libs/events/src/tracking/event-tracking.service.ts
@@ -72,7 +72,8 @@ export class EventTrackingService {
     const eventId = this.eventChainService.getEventId();
 
     if (!chainId || !eventId) {
-      this.logger.warn('trackEffect called without CLS chain context - skipping', {
+      this.logger.warn({
+        msg: 'trackEffect called without CLS chain context - skipping',
         resourceType: params.resourceType,
         resourceId: params.resourceId,
       });

--- a/libs/events/src/validation/schema-validation.util.ts
+++ b/libs/events/src/validation/schema-validation.util.ts
@@ -33,7 +33,8 @@ export function validateSchema<T>(schema: ZodSchema<T>, data: unknown): Validati
       };
     }
   } catch (error) {
-    logger.error('Schema validation threw unexpected error', {
+    logger.error({
+      msg: 'Schema validation threw unexpected error',
       error: error instanceof Error ? error.message : String(error),
     });
 
@@ -84,10 +85,16 @@ export function formatValidationErrors(errors: z.ZodIssue[]): string {
 }
 
 /**
- * 스키마 검증 에러 로깅
+ * 스키마 검증 에러 로깅.
+ *
+ * ⚠️ **호출자가 0곳이다.** 그 상태를 유지할 것 — `payload` 를 통째로 싣기 때문이다. 로그 필드는
+ * 이제 Loki 까지 나가므로(아래 log-shape 스펙 참조) 이 함수를 배선하는 순간 이벤트 payload 전문이
+ * 로그 백엔드에 적재된다. 이 레포는 계약 payload 에 이메일·주소를 담는 이벤트가 있다.
+ * 진단이 필요하면 `formatValidationErrors`(경로+사유만) 를 쓴다.
  */
 export function logValidationError(context: string, errors: z.ZodIssue[], payload: unknown): void {
-  logger.error(`❌ ${context}`, {
+  logger.error({
+    msg: `❌ ${context}`,
     errors: formatValidationErrors(errors),
     payload: JSON.stringify(payload, null, 2),
   });


### PR DESCRIPTION
## 왜

플랜 Task 5-C 의 "core 밖 앱에서 검증을 켜기 전, **관측을 넓힐지 로그로 갈지 정하라**" 에 대한 답이 이 PR 이다.

**결론: 로그로 간다.** Prometheus 를 넓히는 쪽은 비용이 이 태스크의 범위를 넘는다 — 대상 4개 앱 중 3개는 `/metrics` 컨트롤러가 없고, 넷 다 `ServicesBundleA/B` 의 Fargate 태스크 2개에 supervisor 로 묶여 있어 앱별 스크레이프 타깃을 세우려면 Alloy 설정 + SST env + ALB 노출까지 인프라를 건드려야 한다.

로그 쪽은 **이미 배선이 살아 있다.** 4개 앱 전부 `startTelemetry` → OTLP 로그 익스포터 → Alloy → Grafana Loki 이고, `service_name` 라벨로 갈린다. 실행으로 확인했다(가짜 OTLP 수신기를 세워 `Logger.error` 한 줄이 `/v1/logs` 로 나가는 것과, 엔드포인트 없는 대조군이 아무것도 보내지 않는 것).

**그런데 그 로그가 진단에 쓸 수 없는 상태였다.**

```ts
this.logger.error(`❌ Consumer schema validation failed: ${eventType}`, {
  topic, messageId, errors: formatValidationErrors(error.errors),
});
```

두 번째 인자가 **통째로 버려진다.** Nest 의 `Logger` 가 자기 context 를 마지막 인자로 덧붙이므로 nestjs-pino `Logger.call` 은 `optionalParams` 의 **마지막**을 context 로 쓰고 나머지를 pino 의 보간 인자로 넘기는데, 메시지에 `%s` 가 없으면 pino 는 그것을 출력하지 않는다. stdout(CloudWatch)에도 Loki 에도 `topic`·`messageId`·`errors` 가 없다.

즉 5-C 를 이대로 켜면 "analytics 에서 OrderCreated 검증이 실패했다"까지는 보이고 **어느 필드가 왜 틀렸는지는 못 본다.** 그 상태의 "로그로 간다"는 결정이 아니라 말이다.

## 무엇을

libs/events 안의 그 모양 **23곳**을 `logger.<level>({ msg, ...필드 })` 로 옮겼다. AST 코드모드로 찾고 옮겼다 — 손으로 23곳을 고치면 하나가 조용히 빠진다. 동작 변경은 로그 줄의 모양뿐이다.

| 파일 | 곳 |
|---|---:|
| `interceptors/event-retry.interceptor.ts` | 7 |
| `dlq/dlq-handler.service.ts` | 5 |
| `interceptors/schema-validation.interceptor.ts` | 4 |
| `publishers/stream-publisher.service.ts` | 3 |
| `validation/schema-validation.util.ts` | 2 |
| `outbox/outbox-publisher.service.ts` · `tracking/event-tracking.service.ts` | 각 1 |

### 새 스펙 `observability/log-shape.spec.ts` (4건)

- **대조군이 먼저다.** 실제 nestjs-pino 배선(`LoggerModule.forRoot` + `app.useLogger`)을 세워 옛 모양과 새 모양을 나란히 찍고, 옛 모양에서 `topic`/`messageId`/`errors` 가 **사라지는 것**과 새 모양에서 남는 것을 둘 다 단언한다. 이게 없으면 "왜 이 모양이어야 하는가"가 코드에서 사라진다.
- **불변식**: libs/events 에 `logger.<level>(문자열, {객체})` 가 0곳임을 AST 로 단언한다. 판정기가 죽어도 0곳은 초록이므로 (a) 훑은 파일 수 하한과 (b) 픽스처로 판정기가 실제로 무는 것을 함께 고정했다.

### 곁가지

- `event-retry.interceptor.spec.ts` 의 backoff 단언이 `warn` 의 첫 인자를 문자열로 읽고 있었다 — 새 모양에 맞췄다. **이 PR 이 실제로 깬 유일한 기존 스펙**이고, 전체 jest 를 돌려서 발견했다.
- `logValidationError` 는 **호출자가 0곳인데 payload 전문을 싣는다.** 이제 로그 필드가 Loki 까지 나가므로, 배선하는 순간 이벤트 payload 가 로그 백엔드에 적재된다(이 레포 계약엔 이메일·주소를 담는 이벤트가 있다). 배선 금지를 주석으로 못박았다.
- 검증 실패 로그가 싣는 `errors` 는 `formatValidationErrors` 의 `경로: 사유` 뿐이라 payload 값을 노출하지 않는다.

## 배포 후 쓸 Loki 질의

```
{service_name="analytics"} | json | msg =~ ".*Consumer schema validation failed.*"
{service_name=~"analytics|search|membership|channel-adapter"} | json | msg =~ ".*Message sent to DLQ.*"
{service_name=~"analytics|search|membership|channel-adapter"} | json | msg =~ ".*CRITICAL: Failed to send message to DLQ.*"
```

셋째 줄이 가장 중요하다 — DLQ 전송 실패는 **offset 미커밋 → 무한 재전달**로 가는 유일한 치명 경로다.

## 게이트

- `npm run type-check` **162 = 기준선** (file:line:code 집합 완전 동일, 신규 0 · 소멸 0)
- 10개 앱 `nest build` 전부 OK
- `audit:event-handlers` · `audit:event-publishers` · `audit:consume-validation --gate` 전부 exit 0
- 전체 jest **실패 suite 18 = 기준선(집합 완전 동일)**, 통과 373 → 374
- 변경 파일 eslint **신규 메시지 0** (기존 24건 집합 동일, 신규 스펙 clean)
- AST 불변식이 무는 것을 **실파일 변이**로 확인 — `dlq-handler.service.ts` 를 옛 모양으로 되돌리자 정확한 file:line 을 지목하며 빨간불. `cp` 백업 + `sha1sum` 대조로 복구(`git checkout --` 는 미커밋 작업분을 날리므로 쓰지 않는다).

## 배포

마이그레이션 0 · 시크릿 0 · env 0 · 계약 변경 0. `libs/events` 를 물고 있는 앱 전부에 영향이 있으나 **로그 줄의 모양뿐**이고 순서 제약이 없다. 5-C 의 앱별 PR 4개보다 **먼저** 배포되는 편이 좋다(그래야 검증을 켤 때 진단이 보인다).

https://claude.ai/code/session_01Phyx7rWAAe7uVLp3FCU6uZ