### PR TITLE
feat(events): search 소비 스키마 검증 켜기 (ADR-0029 Task 5-C)

### DIFF
--- a/apps/search/src/search.module.ts
+++ b/apps/search/src/search.module.ts
@@ -35,14 +35,18 @@ import { SearchKeywordService } from './search-keyword.service';
             groupId: process.env.KAFKA_GROUP_ID || 'search-indexer',
             kafka: createKafkaConfigFromEnv()!,
             enableAutoDLQ: true,
-            // ⚠️ 아직 끈다 — 그러나 **막는 이유는 사라졌다** (ADR-0029 §5, 플랜 Task 6-A).
+            // 소비 스키마 검증 ON (플랜 Task 5-C, 2026-08-10).
             //
             // 이 앱을 막던 2개 이벤트(`ProductMasterActiveVersionChanged` ·
             // `ProductMasterDeleted`)는 core 카탈로그가 아웃박스로 내보내며 zod 를 우회했다.
             // 6-A 가 적재·발행 양쪽에 문을 달아 그 우회를 없앴고 둘 다 PROVEN 이 됐다.
-            // 남은 것은 이 한 줄을 뒤집는 결정뿐이며 그건 5-C 의 마지막 조각이다.
+            //
+            // DLQ 메트릭은 스크레이프되지 않는다(`dlq.metrics.ts:10`) — 관측은 로그다.
+            // 검증 실패는 `SchemaValidationInterceptor` 가 error 로 찍고 OTLP 로 Loki 에 간다.
+            //
+            // 되돌리기는 이 한 줄을 `false` 로 바꾸는 것이다.
             // 현황: `npm run audit:consume-validation -- search`
-            validation: { validateOnConsume: false },
+            validation: { validateOnConsume: true },
           }),
         ]
       : []),


### PR DESCRIPTION
## 무엇을

`apps/search/src/search.module.ts` 의 `validateOnConsume` 을 `false` → `true`. **한 줄이다.**

5-C 의 마지막 조각을 앱별로 뒤집는 4개 PR 중 하나이고, 넷 중 가장 작다(핸들러 3 · 토픽 2). 먼저 머지·배포하기 좋은 순서다.

## 왜 지금 안전한가

이 앱을 막던 2개 이벤트(`ProductMasterActiveVersionChanged` · `ProductMasterDeleted`)는 core 카탈로그가 아웃박스로 내보내며 zod 를 우회했다. 6-A 가 적재(`enqueue`)와 발행(`publishStoredEnvelope`) 양쪽에 문을 달아 그 우회를 없앴고, 3/3 전부 PROVEN 이 됐다.

```
앱                검증  이벤트  핸들러   SAFE  PROVEN  UNVERIFIED   판정
search           ON        3       3      0       3           0   ✅ 켜짐 · 전부 검증됨
```

이 한 줄을 뒤집는 것은 **`audit:consume-validation --gate` 를 이 앱에 대해 켜는 것**이기도 하다. 게이트 규칙 1이 "검증 ON 인 앱에 UNVERIFIED 가 생기면 exit 1" 이므로, 앞으로 이 앱에 검증 안 된 발행 경로가 닿는 핸들러가 추가되면 CI 가 막는다.

## 관측 — 로그로 간다

이 앱은 Alloy 가 `/metrics` 를 긁지 않는다(`dlq.metrics.ts:10`). 관측 방침 결정과 그 결정을 실제로 성립시키는 수정은 **#604** 에 있다(진단 로그가 구조화 필드를 잃고 있었다). #604 를 먼저 배포하는 편이 좋다.

배포 후 볼 것:

```
{service_name="search"} | json | msg =~ ".*Consumer schema validation failed.*"
{service_name="search"} | json | msg =~ ".*CRITICAL: Failed to send message to DLQ.*"
```

## 되돌리기

이 한 줄을 `false` 로 되돌리고 배포. 마이그레이션·시크릿·env·계약 변경 0.

## 게이트

- `audit:consume-validation --gate` exit 0 · `audit:event-handlers` exit 0 · `audit:event-publishers` exit 0
- `npm run type-check` **162 = 기준선**
- `nest build search` OK
- `apps/search` jest **5 suite / 35 tests 전부 통과**
- eslint 신규 메시지 0

4개 앱을 **모두 적용한 합집합**에 대해서도 전체 배터리를 한 번 돌렸다: type-check 162 · 10개 앱 `nest build` OK · 전체 jest **실패 suite 18 = 기준선(집합 완전 동일)** · 감사 3종 exit 0.

https://claude.ai/code/session_01Phyx7rWAAe7uVLp3FCU6uZ