### PR TITLE
feat(events): analytics 소비 스키마 검증 켜기 (ADR-0029 Task 5-C)

### DIFF
--- a/apps/analytics/src/analytics.module.ts
+++ b/apps/analytics/src/analytics.module.ts
@@ -41,18 +41,21 @@ import { MembershipEventsConsumer } from './datasets/memberships/ingest/membersh
       streams: [ORDER_STREAM, PRODUCT_STREAM, MEMBERSHIP_STREAM],
       groupId: process.env.KAFKA_GROUP_ID || 'analytics-consumer',
       enableAutoDLQ: true,
-      // ⚠️ 아직 끈다 — 그러나 **막는 이유는 사라졌다** (ADR-0029 §5, 플랜 Task 6-A).
+      // 소비 스키마 검증 ON (플랜 Task 5-C, 2026-08-10).
       //
       // 이 앱을 막던 3개 이벤트(`MembershipStatusChanged` ·
       // `ProductMasterActiveVersionChanged` · `ProductMasterDeleted`)는 아웃박스로 나가면서
       // zod 를 우회했다. 6-A 가 적재(`enqueue`)와 발행(`publishStoredEnvelope`) 양쪽에 문을
       // 달아 그 우회를 없앴고, 셋 다 PROVEN 이 됐다 — 10/10 이 검증된 발행 경로만 탄다.
       //
-      // 남은 것은 **이 한 줄을 뒤집는 결정**뿐이고 그건 5-C 의 마지막 조각이다. 이 앱은 DLQ 를
-      // 스크레이프하지 않으므로(`dlq.metrics.ts:10`) 켠 뒤 증명이 틀렸을 때 알아차릴 수단이
-      // core 뿐이라는 점을 감안해 결정한다.
+      // 이 앱은 DLQ 메트릭이 스크레이프되지 않는다(`dlq.metrics.ts:10` — Alloy 는 Core 만).
+      // 관측은 로그로 간다: 검증 실패는 `SchemaValidationInterceptor` 가 error 로,
+      // DLQ 전송은 `DLQHandler` 가 warn 으로 찍고, 둘 다 OTLP 로그로 Loki 까지 간다.
+      // 이 앱의 로그가 실제로 Loki 에 닿는지·구조화 필드가 남는지는 별도 PR 에서 확인·수정했다.
+      //
+      // 되돌리기는 이 한 줄을 `false` 로 바꾸는 것이다.
       // 현황: `npm run audit:consume-validation -- analytics`
-      validation: { validateOnConsume: false },
+      validation: { validateOnConsume: true },
     }),
     AuthorizationModule.forRoot({
       microserviceName: 'analytics',


### PR DESCRIPTION
## 무엇을

`apps/analytics/src/analytics.module.ts` 의 `validateOnConsume` 을 `false` → `true`. **한 줄이다.**

5-C 의 마지막 조각을 앱별로 뒤집는 4개 PR 중 하나(핸들러 10 · 토픽 3).

## 왜 지금 안전한가

이 앱을 막던 3개 이벤트(`MembershipStatusChanged` · `ProductMasterActiveVersionChanged` · `ProductMasterDeleted`)는 아웃박스로 나가며 zod 를 우회했다. 6-A 가 적재(`enqueue`)와 발행(`publishStoredEnvelope`) 양쪽에 문을 달아 그 우회를 없앴고, 10/10 전부 PROVEN 이 됐다.

```
앱                검증  이벤트  핸들러   SAFE  PROVEN  UNVERIFIED   판정
analytics        ON       10      10      0      10           0   ✅ 켜짐 · 전부 검증됨
```

**SAFE 가 0이라는 점을 짚어 둔다** — 이 앱이 소비하는 10개는 전부 필수 필드가 있는 스키마다. 즉 검증이 실제로 무언가를 검사하는 앱이고, 증명이 틀렸다면 여기서 드러난다. (반대로 channel-adapter 는 11개가 SAFE 라 그만큼은 no-op 이다.)

이 한 줄을 뒤집는 것은 **`audit:consume-validation --gate` 를 이 앱에 대해 켜는 것**이기도 하다 — 앞으로 검증 안 된 발행 경로가 닿는 핸들러가 추가되면 CI 가 막는다.

## 관측 — 로그로 간다

이 앱은 Alloy 가 `/metrics` 를 긁지 않는다(`dlq.metrics.ts:10`). 관측 방침 결정과 그 결정을 실제로 성립시키는 수정은 **#604** 에 있다. #604 를 먼저 배포하는 편이 좋다.

```
{service_name="analytics"} | json | msg =~ ".*Consumer schema validation failed.*"
{service_name="analytics"} | json | msg =~ ".*CRITICAL: Failed to send message to DLQ.*"
```

## 되돌리기

이 한 줄을 `false` 로 되돌리고 배포. 마이그레이션·시크릿·env·계약 변경 0.

## 게이트

- `audit:consume-validation --gate` exit 0 · `audit:event-handlers` exit 0 · `audit:event-publishers` exit 0
- `npm run type-check` **162 = 기준선**
- `nest build analytics` OK
- `apps/analytics` jest **13 suite / 106 tests 전부 통과**
- eslint 신규 메시지 0

4개 앱을 **모두 적용한 합집합**에 대해서도 전체 배터리를 한 번 돌렸다: type-check 162 · 10개 앱 `nest build` OK · 전체 jest **실패 suite 18 = 기준선(집합 완전 동일)** · 감사 3종 exit 0.

https://claude.ai/code/session_01Phyx7rWAAe7uVLp3FCU6uZ