### PR TITLE
feat(events): membership 소비 스키마 검증 켜기 (ADR-0029 Task 5-C)

### DIFF
--- a/apps/membership/src/app.module.ts
+++ b/apps/membership/src/app.module.ts
@@ -106,7 +106,21 @@ import { InternalApiKeyGuard } from './shared/guards/internal-api-key.guard';
       streams: [PAYMENT_STREAM],
       groupId: process.env.KAFKA_GROUP_ID || 'membership-consumer',
       enableAutoDLQ: true,
-      validation: { validateOnConsume: false },
+      // 소비 스키마 검증 ON (플랜 Task 5-C, 2026-08-10).
+      //
+      // 여기 `false` 는 이 앱의 의도가 아니라 #501 이 `forConsumerModule` 을 처음 붙이며 같이
+      // 들어온 값이었다(근거 주석 없음 — notification 의 "HTTP 요청과 충돌 방지" 같은 판단이
+      // 아니다). 5-C 논의에서 한동안 빠져 있었던 것도 그래서다.
+      //
+      // 이 앱을 막던 UNVERIFIED 5건은 원인이 달랐다 — core 카탈로그의 `saveEvent` 가 아니라
+      // wallet 이 자기 아웃박스에 직접 insert 하던 `invoice.*`/`mandate.rejected` 행이었고,
+      // 6-A 의 `publishStoredEnvelope` 문이 닫았다. 지금 10/10 (SAFE 5 · PROVEN 5).
+      //
+      // DLQ 메트릭은 스크레이프되지 않는다(`dlq.metrics.ts:10`) — 관측은 로그다.
+      //
+      // 되돌리기는 이 한 줄을 `false` 로 바꾸는 것이다.
+      // 현황: `npm run audit:consume-validation -- membership`
+      validation: { validateOnConsume: true },
     }),
     EventTraceApiModule,
   ],


### PR DESCRIPTION
## 무엇을

`apps/membership/src/app.module.ts` 의 `validateOnConsume` 을 `false` → `true`. **한 줄이다.**

5-C 의 마지막 조각을 앱별로 뒤집는 4개 PR 중 하나(핸들러 10 · 토픽 1).

## 이 앱의 `false` 는 의도가 아니었다

notification 의 `false` 에는 근거 주석이 있다(`// HTTP 요청과 충돌 방지를 위해 비활성화`). **membership 에는 없다.** `git log -L 109,109:apps/membership/src/app.module.ts` 로 보면 #501(ADR-0027 인보이스 모델)이 `forConsumerModule` 을 처음 붙이며 같이 들어온 값이고, 판단의 흔적이 없다. 5-C 논의에서 이 앱이 한동안 빠져 있었던 것도 그래서다 — "명시 `false` 니까 의도" 로 묶여 있었다.

**notification · wallet 은 이 PR 계열에서 건드리지 않는다.** 그 둘의 `false` 는 이 워크스트림 이전부터의 의도다.

## 왜 지금 안전한가

이 앱을 막던 UNVERIFIED 5건은 다른 세 앱과 **원인이 달랐다.** core 카탈로그의 `saveEvent` 가 아니라, wallet 이 자기 아웃박스 테이블에 직접 insert 하던 `invoice.*`/`mandate.rejected` 행이었다. 그래서 6-A 의 `enqueue` 문이 아니라 `publishStoredEnvelope` 문이 닫았다.

```
앱                검증  이벤트  핸들러   SAFE  PROVEN  UNVERIFIED   판정
membership       ON       10      10      5       5           0   ✅ 켜짐 · 전부 검증됨
```

이 한 줄을 뒤집는 것은 **`audit:consume-validation --gate` 를 이 앱에 대해 켜는 것**이기도 하다 — 앞으로 검증 안 된 발행 경로가 닿는 핸들러가 추가되면 CI 가 막는다.

## 관측 — 로그로 간다

이 앱은 Alloy 가 `/metrics` 를 긁지 않는다(`dlq.metrics.ts:10`). 관측 방침 결정과 그 결정을 실제로 성립시키는 수정은 **#604** 에 있다. #604 를 먼저 배포하는 편이 좋다.

```
{service_name="membership"} | json | msg =~ ".*Consumer schema validation failed.*"
{service_name="membership"} | json | msg =~ ".*CRITICAL: Failed to send message to DLQ.*"
```

## 되돌리기

이 한 줄을 `false` 로 되돌리고 배포. 마이그레이션·시크릿·env·계약 변경 0.

## 게이트

- `audit:consume-validation --gate` exit 0 · `audit:event-handlers` exit 0 · `audit:event-publishers` exit 0
- `npm run type-check` **162 = 기준선**
- `nest build membership` OK
- `apps/membership` jest 24 suite 통과 / 1 실패 — `membership-api.itdoc.spec.ts` 는 **기준선 18개 실패 집합에 이미 있는 것**
- eslint 신규 메시지 0

4개 앱을 **모두 적용한 합집합**에 대해서도 전체 배터리를 한 번 돌렸다: type-check 162 · 10개 앱 `nest build` OK · 전체 jest **실패 suite 18 = 기준선(집합 완전 동일)** · 감사 3종 exit 0.

https://claude.ai/code/session_01Phyx7rWAAe7uVLp3FCU6uZ