### PR TITLE
feat(events): channel-adapter 소비 스키마 검증 켜기 (ADR-0029 Task 5-C)

### DIFF
--- a/apps/channel-adapter/src/adapter.module.ts
+++ b/apps/channel-adapter/src/adapter.module.ts
@@ -287,19 +287,24 @@ const NO_KAFKA_PUBLISHER_STREAMS: StreamConfig[] = [
     // 그 목록이야말로 이 워크스트림이 없애는 중인 두 번째 진실이다. 필요한 것은
     // 정책 하나뿐이므로 정책만 등록한다. Task 7 의 `forApp` 이 이 자리를 흡수한다.
     //
-    // 5-C 현황: 아직 끄지만 **막는 이유는 사라졌다** (플랜 Task 6-A). 이 앱을 막던 4개
+    // 소비 스키마 검증 ON (플랜 Task 5-C, 2026-08-10). 이 앱을 막던 4개
     // 이벤트(`MembershipStatusChanged` · `ProductMasterActiveVersionChanged` ·
     // `ProductMasterDeleted` · `CategoryChanged`)는 아웃박스로 나가며 zod 를 우회했는데,
     // 6-A 가 적재·발행 양쪽에 문을 달아 그 우회를 없앴다. 34개가 전부 SAFE(11) 또는
-    // PROVEN(23) 이다. 남은 것은 이 한 줄을 뒤집는 결정뿐이며 그건 5-C 의 마지막 조각이다.
+    // PROVEN(23) 이다.
     //
     // 이 앱은 외부 채널 유래 payload 라 가장 위험한 앱이라고 적어왔는데, 실측은 조금 다르다 —
     // 외부 payload 는 HTTP 로 들어와 이 앱이 *발행측*에서 정규화하므로, 소비하는 34개는
-    // 전부 내부 발행이다. 남은 위험은 외부성이 아니라 위 outbox 우회다.
+    // 전부 내부 발행이다. 남은 위험은 외부성이 아니라 위 outbox 우회였고 그건 닫혔다.
+    //
+    // 4개 앱 중 blast radius 가 가장 크다 — 핸들러 34개 · 도출 토픽 9개. DLQ 메트릭은
+    // 스크레이프되지 않으므로(`dlq.metrics.ts:10`) 관측은 로그다.
+    //
+    // 되돌리기는 이 한 줄을 `false` 로 바꾸는 것이다.
     // 현황: `npm run audit:consume-validation -- channel-adapter`
     {
       provide: EVENTS_CONSUMER_POLICY,
-      useValue: { validation: { validateOnConsume: false } } satisfies EventsConsumerPolicy,
+      useValue: { validation: { validateOnConsume: true } } satisfies EventsConsumerPolicy,
     },
 
     // Kafka 환경변수 없을 때(로컬): publisher DI 를 채운다.

--- a/libs/events/src/consumers/consumer-policy-wiring.spec.ts
+++ b/libs/events/src/consumers/consumer-policy-wiring.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * `EVENTS_CONSUMER_POLICY` 를 **평범한 provider 로 선언한 모양**이 실제로 읽히는가 (플랜 Task 5-C).
+ *
+ * ## 왜 이것만 따로 고정하는가
+ *
+ * 정책을 선언하는 자리가 두 가지다:
+ *
+ * - `EventsModule.forConsumerModule({ validation })` — analytics · search · membership · core
+ * - 모듈 providers 에 `EVENTS_CONSUMER_POLICY` 를 직접 등록 — **channel-adapter 뿐**
+ *
+ * 앞의 모양은 `transport/consume-validation.spec.ts` 가 실행으로 덮는다. 뒤의 모양은 5-B 가
+ * 도입한 뒤로 **어느 스펙도 덮지 않았다.** channel-adapter 가 `forConsumerModule` 을 부르지
+ * 않는 이유는 그 표면이 `streams` 를 필수로 받기 때문인데(그 목록이 이 워크스트림이 지우는 중인
+ * 두 번째 진실이다), 그래서 이 앱만 다른 자리에 선언한다.
+ *
+ * 이 차이가 조용한 이유가 고약하다 — 토큰을 못 찾으면 `optionalGet` 이 `undefined` 를 반환하고
+ * 기본값 `validateOnConsume: true` 가 먹는다. 즉 **배선이 끊겨도 5-C 이후에는 원하던 값과
+ * 같아져서** 증상이 없다. 배선이 산 것과 죽은 것을 구별하려면 `false` 를 넣어 보는 수밖에 없고,
+ * 그것이 아래 두 번째 케이스(대조군)다.
+ */
+import 'reflect-metadata';
+import { CallHandler } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { ExecutionContextHost } from '@nestjs/core/helpers/execution-context-host';
+import { KafkaContext } from '@nestjs/microservices';
+import type { Consumer, KafkaMessage, Producer } from '@nestjs/microservices/external/kafka.interface';
+import { of } from 'rxjs';
+import { z } from 'zod';
+import { event, stream, SchemaValidationError } from '@packages/event-contracts/types';
+import { SchemaValidationInterceptor } from '../interceptors/schema-validation.interceptor';
+import { buildConsumerInterceptors, EVENTS_CONSUMER_POLICY, type EventsConsumerPolicy } from './consumer-interceptors';
+
+const POLICY_STREAM = stream({
+  topic: 'policy-wiring.events.v1',
+  partitions: 1,
+  aggregateType: 'PolicyWiring',
+  events: {
+    Placed: event('Placed', z.object({ orderId: z.string().min(1) })),
+  },
+});
+
+/** 계약이 `orderId: string` 을 요구하는데 숫자를 싣는다 — 검증이 켜져 있으면 반드시 걸린다. */
+const VIOLATING_ENVELOPE = {
+  messageType: 'Placed',
+  messageId: 'mid-1',
+  source: { aggregateId: 'agg-1' },
+  payload: { orderId: 12345 },
+};
+
+function rpcContextWithViolatingMessage(): ExecutionContextHost {
+  const message = {
+    value: Buffer.from(JSON.stringify(VIOLATING_ENVELOPE)),
+    offset: '1',
+    headers: {},
+  } as unknown as KafkaMessage;
+
+  const kafkaCtx = new KafkaContext([
+    message,
+    0,
+    POLICY_STREAM.topic.topic,
+    {} as unknown as Consumer,
+    jest.fn(),
+    {} as unknown as Producer,
+  ]);
+
+  // RpcContextCreator 가 만드는 형태 그대로: args = [data, context]
+  const host = new ExecutionContextHost([{}, kafkaCtx], class Consumer {}, function handler() {});
+  host.setType('rpc');
+  return host;
+}
+
+/**
+ * 앱 모듈이 정책을 어떻게 선언하든, `startConsumer` 는 결국 이 함수로 인터셉터를 만든다.
+ * 그래서 여기서 컨테이너를 세우고 이 함수를 부르는 것이 실제 경로다.
+ */
+async function schemaInterceptorFor(policyProvider?: EventsConsumerPolicy): Promise<SchemaValidationInterceptor> {
+  const moduleRef = await Test.createTestingModule({
+    providers: policyProvider ? [{ provide: EVENTS_CONSUMER_POLICY, useValue: policyProvider }] : [],
+  }).compile();
+
+  const interceptors = buildConsumerInterceptors(moduleRef, [POLICY_STREAM]);
+  const schema = interceptors.find((i): i is SchemaValidationInterceptor => i instanceof SchemaValidationInterceptor);
+  if (!schema) throw new Error('SchemaValidationInterceptor 가 배선되지 않았다');
+  return schema;
+}
+
+const nextThatSucceeds: CallHandler = { handle: () => of('handled') };
+
+describe('EVENTS_CONSUMER_POLICY 를 평범한 provider 로 선언하는 모양 (channel-adapter)', () => {
+  it('`validateOnConsume: true` 를 그 자리에서 읽는다 — 위반 메시지가 거부된다', async () => {
+    const interceptor = await schemaInterceptorFor({ validation: { validateOnConsume: true } });
+
+    expect(() => interceptor.intercept(rpcContextWithViolatingMessage(), nextThatSucceeds)).toThrow(
+      SchemaValidationError,
+    );
+  });
+
+  it('대조군 — `false` 를 넣으면 같은 메시지가 통과한다 (배선이 실제로 살아 있다는 증거)', async () => {
+    const interceptor = await schemaInterceptorFor({ validation: { validateOnConsume: false } });
+
+    // 이 케이스가 없으면 위 테스트는 "기본값이 true 라서" 초록일 수도 있다 — 그러면
+    // provider 를 읽었는지 아닌지를 아무것도 증명하지 못한다.
+    expect(() => interceptor.intercept(rpcContextWithViolatingMessage(), nextThatSucceeds)).not.toThrow();
+  });
+
+  it('토큰이 아예 없으면 기본값 `true` 로 떨어진다 — 5-B 가 경고한 "누락으로 켜짐"', async () => {
+    const interceptor = await schemaInterceptorFor(undefined);
+
+    expect(() => interceptor.intercept(rpcContextWithViolatingMessage(), nextThatSucceeds)).toThrow(
+      SchemaValidationError,
+    );
+  });
+});


### PR DESCRIPTION
## 무엇을

`apps/channel-adapter/src/adapter.module.ts` 의 `validateOnConsume` 을 `false` → `true` + **새 스펙 1개(3건)**.

5-C 의 4개 PR 중 **마지막에 두는 것**이다. blast radius 가 가장 크다 — 핸들러 34개 · 도출 토픽 9개.

## 왜 지금 안전한가

이 앱을 막던 4개 이벤트(`MembershipStatusChanged` · `ProductMasterActiveVersionChanged` · `ProductMasterDeleted` · `CategoryChanged`)는 아웃박스로 나가며 zod 를 우회했다. 6-A 가 적재·발행 양쪽에 문을 달아 그 우회를 없앴다.

```
앱                검증  이벤트  핸들러   SAFE  PROVEN  UNVERIFIED   판정
channel-adapter  ON       34      34     11      23           0   ✅ 켜짐 · 전부 검증됨
```

**"외부 채널 유래 payload 라 가장 위험한 앱" 이라는 서술은 소비 측에 맞지 않는다.** 외부 payload 는 HTTP 로 들어와 이 앱이 *발행측*에서 정규화하므로, 소비하는 34개는 전부 내부 발행이다(프로덕션 `kafkajs` 직접 사용 0곳으로 확인). 남은 위험은 외부성이 아니라 outbox 우회였고 그건 6-A 가 닫았다.

## 새 스펙 — 이 앱만 쓰는 정책 선언 모양에 커버리지가 없었다

정책을 선언하는 자리가 두 가지다:

| 자리 | 앱 | 스펙 |
|---|---|---|
| `forConsumerModule({ validation })` | analytics · search · membership · core | `transport/consume-validation.spec.ts` |
| 모듈 providers 의 `EVENTS_CONSUMER_POLICY` | **channel-adapter 뿐** | **없었다** |

이 앱이 `forConsumerModule` 을 부르지 않는 이유는 그 표면이 `streams` 를 필수로 받기 때문이다(그 목록이 이 워크스트림이 지우는 중인 두 번째 진실이다). 그래서 5-B 가 정책만 provider 로 등록했는데, **그 모양은 그 뒤로 어느 스펙도 덮지 않았다.**

이 공백이 고약한 이유: 배선이 끊겨 토큰을 못 찾으면 `optionalGet` 이 `undefined` 를 반환하고 기본값 `validateOnConsume: true` 가 먹는다. 즉 **5-C 이후에는 배선이 죽어도 원하던 값과 같아져서 증상이 없다.** 산 것과 죽은 것을 구별하려면 `false` 를 넣어 보는 수밖에 없고, 그것이 새 스펙의 **대조군**이다.

`consumers/consumer-policy-wiring.spec.ts` — 실제 경로(`buildConsumerInterceptors`)로 인터셉터를 만들고 위반 envelope 를 넣는다:

1. bare provider `true` → `SchemaValidationError` 로 거부
2. bare provider `false` → **같은 메시지가 통과**(대조군 — provider 를 실제로 읽었다는 증거)
3. 토큰 부재 → 기본값 `true` 로 거부 (5-B 가 경고한 "선택이 아니라 누락으로 켜짐")

## 관측 — 로그로 간다

이 앱은 Alloy 가 `/metrics` 를 긁지 않는다(`dlq.metrics.ts:10`). 관측 방침 결정과 그 결정을 실제로 성립시키는 수정은 **#604** 에 있다. **넷 중 이 앱이 #604 선배포의 값어치가 가장 크다** — 34개 핸들러 · 9개 토픽이라 실패가 나면 "어느 토픽의 어느 필드인지"가 곧 진단이다.

```
{service_name="channel-adapter"} | json | msg =~ ".*Consumer schema validation failed.*"
{service_name="channel-adapter"} | json | msg =~ ".*CRITICAL: Failed to send message to DLQ.*"
```

## 되돌리기

한 줄을 `false` 로 되돌리고 배포. 마이그레이션·시크릿·env·계약 변경 0.

## 게이트

- `audit:consume-validation --gate` exit 0 · `audit:event-handlers` exit 0 · `audit:event-publishers` exit 0
- `npm run type-check` **162 = 기준선**
- `nest build channel-adapter` · `core` OK
- `apps/channel-adapter` + `libs/events` jest 35 suite 통과 / 3 실패 — 셋 다 **기준선 18개 실패 집합에 이미 있는 것**(`coupang-integration` · `pim-snapshot-builder` · `medusa.client`)
- eslint 신규 메시지 0 (`adapter.module.ts` 의 기존 1건 `'schema' is defined but never used` 는 develop 에도 있다)

4개 앱을 **모두 적용한 합집합**에 대해서도 전체 배터리를 한 번 돌렸다: type-check 162 · 10개 앱 `nest build` OK · 전체 jest **실패 suite 18 = 기준선(집합 완전 동일)** · 감사 3종 exit 0.

https://claude.ai/code/session_01Phyx7rWAAe7uVLp3FCU6uZ