### PR TITLE
refactor(events)!: 옛 등록 표면 제거 — forApp + startConsumer 둘만 남긴다 (ADR-0029 Task 7)

### DIFF
--- a/apps/analytics/src/analytics.module.ts
+++ b/apps/analytics/src/analytics.module.ts
@@ -5,7 +5,6 @@ import { ConfigModule } from '@nestjs/config';
 import { DbModule } from '@app/db';
 import { EventsModule } from '@app/events';
 import { AuthorizationModule } from '@app/authorization';
-import { ORDER_STREAM, PRODUCT_STREAM, MEMBERSHIP_STREAM } from '@packages/event-contracts';
 import { AnalyticsController } from './features/analytics-api/analytics.controller';
 import { AnalyticsService } from './features/analytics-api/analytics.service';
 import { OrderEventsConsumer } from './datasets/orders/ingest/order-events.consumer';
@@ -37,10 +36,8 @@ import { MembershipEventsConsumer } from './datasets/memberships/ingest/membersh
       },
       schema: analyticsSchema,
     }),
-    EventsModule.forConsumerModule({
-      streams: [ORDER_STREAM, PRODUCT_STREAM, MEMBERSHIP_STREAM],
-      groupId: process.env.KAFKA_GROUP_ID || 'analytics-consumer',
-      enableAutoDLQ: true,
+    // 소비만 하는 앱이다 — `publishes` 가 없다. 구독 토픽은 `@On` 에서 도출된다.
+    EventsModule.forApp({
       // 소비 스키마 검증 ON (플랜 Task 5-C, 2026-08-10).
       //
       // 이 앱을 막던 3개 이벤트(`MembershipStatusChanged` ·
@@ -55,7 +52,7 @@ import { MembershipEventsConsumer } from './datasets/memberships/ingest/membersh
       //
       // 되돌리기는 이 한 줄을 `false` 로 바꾸는 것이다.
       // 현황: `npm run audit:consume-validation -- analytics`
-      validation: { validateOnConsume: true },
+      policy: { validateOnConsume: true },
     }),
     AuthorizationModule.forRoot({
       microserviceName: 'analytics',

--- a/apps/channel-adapter/src/adapter.module.ts
+++ b/apps/channel-adapter/src/adapter.module.ts
@@ -13,11 +13,9 @@ import {
   EventTraceApiModule,
   createKafkaConfigFromEnv,
   getPublisherToken,
-  EVENTS_CONSUMER_POLICY,
   OutboxPublisher,
   StreamPublisher,
   type EventTransport,
-  type EventsConsumerPolicy,
   type StreamConfig,
 } from '@app/events';
 import { NaverSmartstoreAdapter } from './adapters/naver/naver-smartstore.adapter';
@@ -113,7 +111,7 @@ const DISCARDING_TRANSPORT: EventTransport = { send: () => Promise.resolve() };
  *
  * `StreamConfig[]` 로 **명시 표기**한다. 이종 스트림 배열을 그냥 `.map` 하면 원소 타입이
  * 유니온으로 넓어져 `new StreamPublisher(...)` 의 제네릭 추론이 첫 원소에 고정되고 나머지가
- * 거부된다. `EventsModule.forRoot({ streams })` 도 같은 표기를 받는다.
+ * 거부된다. `EventsModule.forApp({ publishes })` 도 같은 표기를 받는다.
  */
 const NO_KAFKA_PUBLISHER_STREAMS: StreamConfig[] = [
   CHANNEL_ADAPTER_STREAM,
@@ -150,8 +148,8 @@ const NO_KAFKA_PUBLISHER_STREAMS: StreamConfig[] = [
     // Kafka 환경변수가 있으면 실제 EventsModule 활성화 (로컬 개발 환경 제외)
     ...(process.env.KAFKA_BROKERS
       ? [
-          EventsModule.forRoot({
-            streams: [
+          EventsModule.forApp({
+            publishes: [
               CHANNEL_ADAPTER_STREAM,
               ORDER_STREAM,
               CORE_ORDER_STREAM,
@@ -176,6 +174,28 @@ const NO_KAFKA_PUBLISHER_STREAMS: StreamConfig[] = [
               validateOnPublish: true,
               throwOnValidationError: true,
             },
+            // 소비 정책 (ADR-0029 §1 — 정책은 도출 불가한 사실이라 선언이 맞다).
+            //
+            // Task 7 이전에는 이 앱만 선언 자리가 없어(`forConsumerModule` 미호출) providers
+            // 배열에 `EVENTS_CONSUMER_POLICY` 를 손으로 등록하고 있었다. 그 자리를 `forApp`
+            // 이 흡수했다 — `forConsumerModule` 을 피한 이유였던 필수 `streams` 인자가
+            // 사라졌기 때문이다.
+            //
+            // 소비 스키마 검증 ON (플랜 Task 5-C, 2026-08-10). 이 앱을 막던 4개
+            // 이벤트(`MembershipStatusChanged` · `ProductMasterActiveVersionChanged` ·
+            // `ProductMasterDeleted` · `CategoryChanged`)는 아웃박스로 나가며 zod 를 우회했는데,
+            // 6-A 가 적재·발행 양쪽에 문을 달아 그 우회를 없앴다. 34개가 전부 SAFE(11) 또는
+            // PROVEN(23) 이다.
+            //
+            // 소비하는 34개는 전부 내부 발행이다 — 외부 payload 는 HTTP 로 들어와 이 앱이
+            // *발행측*에서 정규화한다. 남은 위험은 외부성이 아니라 outbox 우회였고 닫혔다.
+            //
+            // 앱 중 blast radius 가 가장 크다 — 핸들러 34개 · 도출 토픽 9개. DLQ 메트릭은
+            // 스크레이프되지 않으므로(`dlq.metrics.ts:10`) 관측은 로그다.
+            //
+            // 되돌리기는 이 한 줄을 `false` 로 바꾸는 것이다.
+            // 현황: `npm run audit:consume-validation -- channel-adapter`
+            policy: { validateOnConsume: true },
           }),
         ]
       : []),
@@ -274,39 +294,6 @@ const NO_KAFKA_PUBLISHER_STREAMS: StreamConfig[] = [
     EventChainService,
     EventTrackingService,
 
-    // 소비 정책 (ADR-0029 §1 — 정책은 도출 불가한 사실이라 선언이 맞다).
-    //
-    // 이 앱만 `forConsumerModule` 을 부르지 않아 정책 선언 자리가 없었고, 그래서
-    // `EVENTS_CONSUMER_POLICY` 토큰이 컨테이너에 없었다. 그 상태로 startConsumer 로
-    // 이주하면 `buildConsumerInterceptors` 의 optionalGet 이 undefined 를 받아
-    // 기본값 `validateOnConsume: true` 가 먹는다 — **선택이 아니라 누락으로** 배선
-    // 이주와 검증 활성화가 한 배포에 같이 켜지는 것이다. 외부 채널에서 들어오는
-    // payload 라 그 조합이 가장 위험한 앱이기도 하다. 그래서 명시한다.
-    //
-    // `forConsumerModule` 을 부르지 않는 이유: 그 표면은 `streams` 를 필수로 받는데,
-    // 그 목록이야말로 이 워크스트림이 없애는 중인 두 번째 진실이다. 필요한 것은
-    // 정책 하나뿐이므로 정책만 등록한다. Task 7 의 `forApp` 이 이 자리를 흡수한다.
-    //
-    // 소비 스키마 검증 ON (플랜 Task 5-C, 2026-08-10). 이 앱을 막던 4개
-    // 이벤트(`MembershipStatusChanged` · `ProductMasterActiveVersionChanged` ·
-    // `ProductMasterDeleted` · `CategoryChanged`)는 아웃박스로 나가며 zod 를 우회했는데,
-    // 6-A 가 적재·발행 양쪽에 문을 달아 그 우회를 없앴다. 34개가 전부 SAFE(11) 또는
-    // PROVEN(23) 이다.
-    //
-    // 이 앱은 외부 채널 유래 payload 라 가장 위험한 앱이라고 적어왔는데, 실측은 조금 다르다 —
-    // 외부 payload 는 HTTP 로 들어와 이 앱이 *발행측*에서 정규화하므로, 소비하는 34개는
-    // 전부 내부 발행이다. 남은 위험은 외부성이 아니라 위 outbox 우회였고 그건 닫혔다.
-    //
-    // 4개 앱 중 blast radius 가 가장 크다 — 핸들러 34개 · 도출 토픽 9개. DLQ 메트릭은
-    // 스크레이프되지 않으므로(`dlq.metrics.ts:10`) 관측은 로그다.
-    //
-    // 되돌리기는 이 한 줄을 `false` 로 바꾸는 것이다.
-    // 현황: `npm run audit:consume-validation -- channel-adapter`
-    {
-      provide: EVENTS_CONSUMER_POLICY,
-      useValue: { validation: { validateOnConsume: true } } satisfies EventsConsumerPolicy,
-    },
-
     // Kafka 환경변수 없을 때(로컬): publisher DI 를 채운다.
     //
     // **`NullEventPublisher` 를 여기서 없앴다 (Task 6-C-3).** 그 클래스는 `publishEvent` /
@@ -329,7 +316,7 @@ const NO_KAFKA_PUBLISHER_STREAMS: StreamConfig[] = [
           { provide: OutboxPublisher, useClass: OutboxPublisher },
           // 토큰 문자열을 손으로 적지 않는다 — 형식의 소유자는 `publisher-token.ts` 한 곳이며
           // (ADR-0029 §4), 손으로 적은 사본은 형식이 바뀌어도 조용히 어긋난다. 계약 상수에서
-          // 도출하면 `forRoot({streams})` 목록과 이 목록이 같은 출처를 갖는다.
+          // 도출하면 `forApp({publishes})` 목록과 이 목록이 같은 출처를 갖는다.
           ...NO_KAFKA_PUBLISHER_STREAMS.map((stream) => ({
             provide: getPublisherToken(stream.topic.topic),
             useFactory: (outboxWriter: OutboxPublisher) =>

--- a/apps/channel-adapter/src/adapter.module.ts
+++ b/apps/channel-adapter/src/adapter.module.ts
@@ -312,7 +312,7 @@ const NO_KAFKA_PUBLISHER_STREAMS: StreamConfig[] = [
     // 처리하던 것보다 정직하다.
     ...(!process.env.KAFKA_BROKERS
       ? [
-          // 적재기. `EventsModule.forRoot` 가 없는 분기라 여기서 직접 등록한다.
+          // 적재기. `EventsModule.forApp` 이 없는 분기라 여기서 직접 등록한다.
           { provide: OutboxPublisher, useClass: OutboxPublisher },
           // 토큰 문자열을 손으로 적지 않는다 — 형식의 소유자는 `publisher-token.ts` 한 곳이며
           // (ADR-0029 §4), 손으로 적은 사본은 형식이 바뀌어도 조용히 어긋난다. 계약 상수에서

--- a/apps/core/src/app.module.ts
+++ b/apps/core/src/app.module.ts
@@ -39,7 +39,7 @@ import { CustomerServiceModule } from './modules/customer-service/customer-servi
       scopes: ALL_SCOPES,
       roleMappings: ALL_ROLE_MAPPINGS,
     }),
-    // EventsModule.forRoot은 각 BC 모듈 내부에서 등록 (Catalog: PRODUCT_STREAM)
+    // EventsModule.forApp 은 각 BC 모듈 내부에서 등록 (Catalog: PRODUCT_STREAM)
 
     CatalogModule,
     InventoryModule,

--- a/apps/core/src/modules/catalog/catalog.module.ts
+++ b/apps/core/src/modules/catalog/catalog.module.ts
@@ -24,8 +24,8 @@ import { DashboardModule } from './analytics/dashboard/dashboard.module';
 
 @Module({
   imports: [
-    EventsModule.forRoot({
-      streams: [PRODUCT_STREAM],
+    EventsModule.forApp({
+      publishes: [PRODUCT_STREAM],
       serviceName: 'almondyoung',
       enableDLQ: true,
       enableOutbox: true,

--- a/apps/core/src/modules/catalog/operations/bulk-session/bulk-session.module.spec.ts
+++ b/apps/core/src/modules/catalog/operations/bulk-session/bulk-session.module.spec.ts
@@ -20,7 +20,7 @@ jest.mock(
 // 일어난다.
 //
 // 필요한 건 DB 뿐이고 Kafka 브로커는 필요 없다: CatalogModule 이 정적으로 문
-// EventsModule.forRoot({enableOutbox:true}) 는 `providers` 배열에 "토픽을 만드는" async
+// EventsModule.forApp({enableOutbox:true}) 는 `providers` 배열에 "토픽을 만드는" async
 // useFactory 를 등록해두지만(일반 provider 라 constructor DI 범주 안 — `.compile()` 이
 // resolve 함), bootstrapKafkaTopics()(libs/events/src/bootstrap/topic-bootstrap.service.ts)
 // 는 KAFKA_BOOTSTRAP_TOPICS=false 면 admin.connect() 조차 시도하지 않고 곧장 리턴한다.
@@ -37,7 +37,7 @@ describeIfDb('BulkSessionModule DI', () => {
 
   it('CatalogModule 안에서 FormExportService/FormExportSnapshotReader 를 해석한다', async () => {
     process.env.AUTH_SECRET = process.env.AUTH_SECRET ?? 'bulk-session-module-spec-test-secret';
-    // CatalogModule 이 EventsModule.forRoot({enableOutbox:true}) 를 정적으로 물고 있어
+    // CatalogModule 이 EventsModule.forApp({enableOutbox:true}) 를 정적으로 물고 있어
     // 없으면 kafkajs 설정 생성 자체가 던진다 — 실제 브로커에 붙지는 않으므로 값 자체는
     // 아무 host:port 나 상관없다.
     process.env.KAFKA_BROKERS = process.env.KAFKA_BROKERS ?? 'localhost:9092';

--- a/apps/core/src/modules/catalog/operations/bulk-session/services/bulk-session-draft.integration.spec.ts
+++ b/apps/core/src/modules/catalog/operations/bulk-session/services/bulk-session-draft.integration.spec.ts
@@ -140,7 +140,7 @@ describeIfDb('일괄 세션 drafting 레인 (실 Postgres + 실 Nest DI)', () =>
   const createdSessionIds = new Set<string>();
 
   beforeAll(async () => {
-    // CatalogModule 이 EventsModule.forRoot({enableOutbox:true}) 를 정적으로 물고 있어 없으면
+    // CatalogModule 이 EventsModule.forApp({enableOutbox:true}) 를 정적으로 물고 있어 없으면
     // kafkajs 설정 생성 자체가 던진다 — 실제 브로커에 붙지는 않으므로 값은 아무 host:port 나
     // 상관없다(bulk-session.module.spec.ts:39-49 와 같은 이유·같은 값).
     process.env.AUTH_SECRET = process.env.AUTH_SECRET ?? 'bulk-session-draft-spec-test-secret';

--- a/apps/core/src/modules/catalog/operations/bulk-session/services/bulk-session-publish.integration.spec.ts
+++ b/apps/core/src/modules/catalog/operations/bulk-session/services/bulk-session-publish.integration.spec.ts
@@ -132,7 +132,7 @@ describeIfDb('일괄 세션 발행·제외·정리 레인 (실 Postgres + 실 Ne
   const createdSessionIds = new Set<string>();
 
   beforeAll(async () => {
-    // CatalogModule 이 EventsModule.forRoot({enableOutbox:true}) 를 정적으로 물고 있어 없으면
+    // CatalogModule 이 EventsModule.forApp({enableOutbox:true}) 를 정적으로 물고 있어 없으면
     // kafkajs 설정 생성 자체가 던진다 — 실제 브로커에 붙지는 않으므로 값은 아무 host:port 나
     // 상관없다(bulk-session.module.spec.ts 와 같은 이유·같은 값).
     process.env.AUTH_SECRET = process.env.AUTH_SECRET ?? 'bulk-session-publish-spec-test-secret';

--- a/apps/core/src/modules/fulfillment/controllers/simple-outbound.route-order.spec.ts
+++ b/apps/core/src/modules/fulfillment/controllers/simple-outbound.route-order.spec.ts
@@ -26,7 +26,7 @@ import { ShipmentPlanningService } from '../services/shipment-planning.service';
  *
  * Deriving the order requires reading `fulfillment.module.ts` WITHOUT importing/executing it: importing
  * it (statically or dynamically, `require` or `import()` — evaluation happens either way) pulls in
- * `SalesOrderModule`, which calls `EventsModule.forConsumerModule(...)` at class-decoration time; that
+ * `SalesOrderModule`, which calls `EventsModule.forApp(...)` at class-decoration time; that
  * throws synchronously (`Cannot read properties of null (reading 'clientId')`) in any process without
  * `KAFKA_BROKERS` set, and is the same hazard `waybill.module.spec.ts` already documents and works
  * around for `WaybillModule`. So instead of `Reflect.getMetadata('controllers', FulfillmentModule)` on

--- a/apps/core/src/modules/fulfillment/fulfillment.module.ts
+++ b/apps/core/src/modules/fulfillment/fulfillment.module.ts
@@ -67,8 +67,8 @@ import { ShipmentRecallController, ShipmentRecallOperationController } from './c
   imports: [
     // FULFILLMENT_STREAM Kafka producer (공용 OutboxDispatcher 가 발행 — ADR-0029 §5-1)
     // INVENTORY_STREAM publisher는 InventoryModule이 전역으로 등록
-    EventsModule.forRoot({
-      streams: [FULFILLMENT_STREAM, CORE_ORDER_STREAM, SHIPMENT_STREAM, FULFILLMENT_V2_STREAM],
+    EventsModule.forApp({
+      publishes: [FULFILLMENT_STREAM, CORE_ORDER_STREAM, SHIPMENT_STREAM, FULFILLMENT_V2_STREAM],
       serviceName: 'almondyoung',
       enableDLQ: true,
     }),

--- a/apps/core/src/modules/fulfillment/outbox/fulfillment-dispatch-gate.module.ts
+++ b/apps/core/src/modules/fulfillment/outbox/fulfillment-dispatch-gate.module.ts
@@ -39,7 +39,7 @@ export class FulfillmentOutboxDispatchGate implements OutboxDispatchGate {
 }
 
 /**
- * `@Global()` 인 이유: 공용 디스패처는 아웃박스를 켠 `EventsModule.forRoot` 안에서 만들어지는데
+ * `@Global()` 인 이유: 공용 디스패처는 아웃박스를 켠 `EventsModule.forApp` 안에서 만들어지는데
  * (core 에서는 catalog), 이 게이트는 fulfillment 의 정책이다. 두 모듈은 서로를 import 하지
  * 않으므로 토큰이 전역이어야 optional 주입이 닿는다. `FulfillmentWorkflowGate` 를 여기서도
  * 제공하는 것은 env 파생 무상태 객체라 인스턴스가 둘이어도 같은 답을 내기 때문이다.

--- a/apps/core/src/modules/fulfillment/waybill/README.md
+++ b/apps/core/src/modules/fulfillment/waybill/README.md
@@ -124,7 +124,7 @@ CI 아님 — 사람이 dev key 를 손에 쥐고 직접 실행하는 스크립�
    검증되지 않았다. 원인은 두 가지 모두 `WaybillModule` 자체와 무관한 선행 이슈: (a) `FulfillmentModule` →
    `SalesOrderModule` 이 `@packages/event-contracts` 를 bare specifier 로 import 하는데 루트 jest
    `moduleNameMapper` 는 subpath 폼(`^@packages/event-contracts/(.*)$`)만 매핑해 bare import 가 Jest 아래서
-   해석되지 않는다. (b) 그 매핑을 임시로 고쳐도 `SalesOrderModule` 의 `EventsModule.forConsumerModule(...)`
+   해석되지 않는다. (b) 그 매핑을 임시로 고쳐도 `SalesOrderModule` 의 `EventsModule.forApp(...)`
    정적 Kafka 부트스트랩이 `KAFKA_BROKERS` 없이는 크래시하고, 더미 브로커를 주면 연결을 무한 재시도하며
    행(hang)한다. 대신 `nest build core` 전체 그래프 컴파일 성공 + 수동 의존성 감사(Task 12 리포트 참고)로
    간접 검증했다. `WaybillModule` 배선 자체를 의심할 근거는 없지만, 실제 `moduleRef.get()` 해석을 목격한 적은

--- a/apps/core/src/modules/fulfillment/waybill/waybill.module.spec.ts
+++ b/apps/core/src/modules/fulfillment/waybill/waybill.module.spec.ts
@@ -1,7 +1,7 @@
 import { CarrierGatewayRegistry } from './carrier/carrier-gateway.registry';
 import { buildCarrierGatewayRegistry, buildHanjinConfig } from './carrier/hanjin/carrier-gateway.factory';
 
-// FulfillmentModule 은 EventsModule.forConsumerModule(SalesOrderModule 경유)을 정적으로 물고 있어, import 만
+// FulfillmentModule 은 EventsModule.forApp(SalesOrderModule 경유)을 정적으로 물고 있어, import 만
 // 해도 KAFKA_BROKERS 연결을 시도한다(실측: 로컬에 브로커가 없으면 재시도를 반복하며 멈추지 않는다 — Task 12
 // 조사 결과, hang 재현 확인). 그래서 WaybillModule/WaybillService 는 정적 import 로 파일 최상단에 두지 않고
 // it() 안에서 동적 import 로만 불러온다 — DATABASE_URL 이 없어 describeIfDb 가 skip 되는 기본 테스트런에서는

--- a/apps/core/src/modules/inventory/inventory.module.ts
+++ b/apps/core/src/modules/inventory/inventory.module.ts
@@ -15,8 +15,8 @@ import { ProductSellableQuantityModule } from './product-sellable-quantity/produ
 
 @Module({
   imports: [
-    EventsModule.forRoot({
-      streams: [INVENTORY_STREAM],
+    EventsModule.forApp({
+      publishes: [INVENTORY_STREAM],
       serviceName: 'almondyoung',
       enableDLQ: true,
     }),

--- a/apps/core/src/modules/sales-order/sales-order.module.ts
+++ b/apps/core/src/modules/sales-order/sales-order.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { EventsModule } from '@app/events';
-import { ORDER_STREAM } from '@packages/event-contracts';
 
 import { CoreInventoryModule } from '../inventory/core/inventory.module';
 import { SharedModule } from '../inventory/shared/shared.module';
@@ -25,12 +24,14 @@ import { WalletRefundClient } from './services/wallet-refund.client';
 
 @Module({
   imports: [
-    // ORDER_STREAM Kafka consumer (group: almondyoung-order-consumer)
-    // WMS는 wms-consumer 그룹을 유지하므로 동일 이벤트를 독립적으로 소비
-    EventsModule.forConsumerModule({
-      streams: [ORDER_STREAM],
-      groupId: 'almondyoung-order-consumer',
-      enableAutoDLQ: true,
+    // core 의 **소비 정책** 선언 자리 (ADR-0029 §1·§3). 이 앱의 컨슈머는 전부 이 BC 에
+    // 있다 — `OrderEventsConsumer` 하나. 구독 토픽·groupId 는 여기 없다: 토픽은 `@On` 에서
+    // 도출되고(`startConsumer`), groupId 는 `main.ts` 가 준다. 옛 `forConsumerModule` 은
+    // 둘 다 받았지만 **어느 쪽도 쓰지 않았다** — 도출 불가한 사실만 남긴 결과가 이 한 줄이다.
+    //
+    // 정책은 앱 전체에 하나다. core 는 `forApp` 을 4번 부르는데(inventory · fulfillment ·
+    // catalog · 여기) `policy` 를 선언하는 곳은 여기뿐이며, 둘 이상이면 부팅이 거부된다.
+    EventsModule.forApp({
       // 소비 스키마 검증 ON (ADR-0029 §8, 플랜 Task 5-C — 이 앱이 첫 번째다).
       //
       // 근거는 샘플링이 아니라 **발행 경로를 전수로 닫은 정적 증명**이다. 이 앱이 구독하는
@@ -44,7 +45,7 @@ import { WalletRefundClient } from './services/wallet-refund.client';
       // 이 논증은 `npm run audit:consume-validation -- --gate` 가 상시 재검증한다 — 검증을
       // 켜 둔 앱에 우회 경로가 닿는 이벤트가 새로 생기면 게이트가 exit 1 로 막는다.
       // 남은 노출은 계약 이전에 토픽에 쌓인 옛 메시지뿐이며, 그건 정적으로 알 수 없다.
-      validation: { validateOnConsume: true },
+      policy: { validateOnConsume: true },
     }),
 
     // OutboxService (Sales Order 이벤트 발행용)
@@ -64,8 +65,23 @@ import { WalletRefundClient } from './services/wallet-refund.client';
 
     ProductSellableQuantityModule,
   ],
-  controllers: [SalesOrdersController, SalesOrderAmendmentsController, StoreSalesOrdersController, StoreSalesOrderReturnExchangeController, AdminReturnExchangeController, OrderEventsConsumer],
-  providers: [SalesOrdersService, SalesOrderAmendmentsService, SalesOrderQueryService, PoliciesService, StoreSalesOrdersService, StoreReturnExchangeService, WalletRefundClient],
+  controllers: [
+    SalesOrdersController,
+    SalesOrderAmendmentsController,
+    StoreSalesOrdersController,
+    StoreSalesOrderReturnExchangeController,
+    AdminReturnExchangeController,
+    OrderEventsConsumer,
+  ],
+  providers: [
+    SalesOrdersService,
+    SalesOrderAmendmentsService,
+    SalesOrderQueryService,
+    PoliciesService,
+    StoreSalesOrdersService,
+    StoreReturnExchangeService,
+    WalletRefundClient,
+  ],
   exports: [
     SalesOrdersService, // Fulfillment BC (cancel, merge 시 SO 상태 변경)
     SalesOrderAmendmentsService,

--- a/apps/membership/src/app.module.ts
+++ b/apps/membership/src/app.module.ts
@@ -93,19 +93,16 @@ import { InternalApiKeyGuard } from './shared/guards/internal-api-key.guard';
       },
       schema: membershipSchema,
     }),
-    EventsModule.forRoot({
-      streams: [MEMBERSHIP_STREAM, WALLET_COMMAND_STREAM, PAYMENT_STREAM],
+    // 발행 능력 + 소비 정책을 한 자리에서 선언한다. 옛 `forRoot`+`forConsumerModule`
+    // 두 벌에서 합쳤다 — 소비 스트림 목록(`[PAYMENT_STREAM]`)과 groupId 는 쓰이지 않던
+    // 선언이라 함께 사라졌다 (ADR-0029 §1·§3).
+    EventsModule.forApp({
+      publishes: [MEMBERSHIP_STREAM, WALLET_COMMAND_STREAM, PAYMENT_STREAM],
       serviceName: 'membership',
       enableDLQ: true,
       // 트랜잭셔널 아웃박스: 신규 구독 생성 시 MembershipStatusChanged 를 엔타이틀먼트와
       // 같은 트랜잭션에 기록하고, 디스패처가 재시도하며 Kafka 로 발행 — 실시간 발행 유실 방지.
       enableOutbox: true,
-    }),
-    // 컨슈머 인프라(DLQ) — poison message 가 파티션을 재전달 루프로 정체시키지 않게 한다.
-    EventsModule.forConsumerModule({
-      streams: [PAYMENT_STREAM],
-      groupId: process.env.KAFKA_GROUP_ID || 'membership-consumer',
-      enableAutoDLQ: true,
       // 소비 스키마 검증 ON (플랜 Task 5-C, 2026-08-10).
       //
       // 여기 `false` 는 이 앱의 의도가 아니라 #501 이 `forConsumerModule` 을 처음 붙이며 같이
@@ -120,7 +117,7 @@ import { InternalApiKeyGuard } from './shared/guards/internal-api-key.guard';
       //
       // 되돌리기는 이 한 줄을 `false` 로 바꾸는 것이다.
       // 현황: `npm run audit:consume-validation -- membership`
-      validation: { validateOnConsume: true },
+      policy: { validateOnConsume: true },
     }),
     EventTraceApiModule,
   ],

--- a/apps/notification/docs/EVENT_FLOW_ANALYSIS.md
+++ b/apps/notification/docs/EVENT_FLOW_ANALYSIS.md
@@ -13,7 +13,7 @@
          ▼                                 ▼
 ┌────────────────────┐        ┌──────────────────────┐
 │  Event Consumer    │        │  EventController    │
-│  (@OnEvent)        │        │  (HTTP /trigger)     │
+│  (@On)             │        │  (HTTP /trigger)     │
 └────────┬───────────┘        └──────────┬───────────┘
          │                               │
          │                               │
@@ -75,8 +75,8 @@
 
 ### 플로우:
 1. **이벤트 수신**: `UserEventConsumer`, `OrderEventConsumer`, `WalletEventConsumer`
-   - `@OnEvent('stream', 'eventType')` 데코레이터로 이벤트 수신
-   - 예: `@OnEvent('users.events.v1', 'UserVerification')`
+   - `@On(STREAM, 'EventName')` 데코레이터로 이벤트 수신
+   - 예: `@On(USER_STREAM, 'UserVerification')`
 
 2. **이벤트 매핑 조회**: `EventMappingService.getEventMapping(eventKey)`
    - `notification_events` 테이블에서 매핑 정보 조회

--- a/apps/notification/src/dispatcher/dispatcher.module.ts
+++ b/apps/notification/src/dispatcher/dispatcher.module.ts
@@ -3,7 +3,6 @@ import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bull';
 import { DbModule } from '@app/db';
 import { EventsModule } from '@app/events';
-import { USER_STREAM, ORDER_STREAM, PAYMENT_STREAM } from '@packages/event-contracts';
 import { SharedModule } from '../shared/shared.module';
 
 import { ProviderModule } from '../provider/provider.module';
@@ -22,11 +21,11 @@ import { WalletEventConsumer } from './handlers/wallet-event.consumer';
     DbModule,
     ProviderModule,
     SharedModule,
-    EventsModule.forConsumerModule({
-      streams: [USER_STREAM, ORDER_STREAM, PAYMENT_STREAM],
-      groupId: process.env.KAFKA_GROUP_ID || 'notification-consumer',
-      enableAutoDLQ: true,
-      validation: {
+    // 소비만 하는 앱이다 — `publishes` 가 없다. 구독 토픽은 `@On` 에서 도출되고
+    // (`startConsumer`), groupId 는 `main.ts` 가 준다. 옛 `forConsumerModule` 은 그 둘을
+    // 여기서도 받았지만 어느 쪽도 쓰지 않았다 (ADR-0029 §1).
+    EventsModule.forApp({
+      policy: {
         validateOnConsume: false, // HTTP 요청과 충돌 방지를 위해 비활성화
       },
     }),

--- a/apps/search/src/search.module.spec.ts
+++ b/apps/search/src/search.module.spec.ts
@@ -1,5 +1,5 @@
 /**
- * #510 회귀 가드: SearchModule 이 EventsModule.forConsumerModule 을 통해
+ * #510 회귀 가드: SearchModule 이 EventsModule.forApp 을 통해
  * 전역 EventRetryInterceptor(재시도/DLQ/offset commit)를 실제로 등록하는지 봉인한다.
  *
  * SearchModule 의 imports 는 process.env.KAFKA_BROKERS 조건부(channel-adapter 판례)이므로

--- a/apps/search/src/search.module.ts
+++ b/apps/search/src/search.module.ts
@@ -3,7 +3,6 @@ import { LoggerModule } from 'nestjs-pino';
 import { loggerConfig } from '@app/shared/observability/logger.config';
 import { ConfigModule } from '@nestjs/config';
 import { EventsModule, createKafkaConfigFromEnv } from '@app/events';
-import { PRODUCT_STREAM, UGC_EVENT_STREAM } from '@packages/event-contracts/streams';
 import { SearchController } from './search.controller';
 import { ProductEventsConsumer } from './product-events.consumer';
 import { ReviewEventsConsumer } from './review-events.consumer';
@@ -23,18 +22,15 @@ import { SearchKeywordService } from './search-keyword.service';
       envFilePath: ['.env', 'apps/search/.env'],
     }),
     // #510: Kafka 브로커가 있으면 DLQ 핸들러·추적 서비스·소비 정책을 등록한다.
-    // forConsumerModule 은 provider 만 등록하고 connectMicroservice 를 부르지 않으므로
+    // forApp 은 provider 만 등록하고 connectMicroservice 를 부르지 않으므로
     // 두 번째 컨슈머를 만들지 않는다 — 소비 전송 배선은 main.ts 의 startConsumer 가 한다.
     // 조건부인 이유: createKafkaConfigFromEnv() 는 KAFKA_BROKERS 미설정 시 null 이라
     // 무조건 넣으면 브로커 없는 로컬에서 부팅 실패 (channel-adapter adapter.module.ts:112 판례).
     // main.ts 도 같은 조건으로 startConsumer 를 건너뛰므로 두 조건은 짝이다.
     ...(process.env.KAFKA_BROKERS
       ? [
-          EventsModule.forConsumerModule({
-            streams: [PRODUCT_STREAM, UGC_EVENT_STREAM],
-            groupId: process.env.KAFKA_GROUP_ID || 'search-indexer',
+          EventsModule.forApp({
             kafka: createKafkaConfigFromEnv()!,
-            enableAutoDLQ: true,
             // 소비 스키마 검증 ON (플랜 Task 5-C, 2026-08-10).
             //
             // 이 앱을 막던 2개 이벤트(`ProductMasterActiveVersionChanged` ·
@@ -46,7 +42,7 @@ import { SearchKeywordService } from './search-keyword.service';
             //
             // 되돌리기는 이 한 줄을 `false` 로 바꾸는 것이다.
             // 현황: `npm run audit:consume-validation -- search`
-            validation: { validateOnConsume: true },
+            policy: { validateOnConsume: true },
           }),
         ]
       : []),

--- a/apps/ugc-service/src/reviews/reviews.module.ts
+++ b/apps/ugc-service/src/reviews/reviews.module.ts
@@ -12,12 +12,18 @@ import { ReviewStatsPublisher } from './services/review-stats-publisher.service'
 
 @Module({
   imports: [
-    EventsModule.forRoot({
-      streams: [UGC_COMMAND_STREAM, UGC_EVENT_STREAM],
+    EventsModule.forApp({
+      publishes: [UGC_COMMAND_STREAM, UGC_EVENT_STREAM],
       serviceName: 'ugc-service',
     }),
   ],
   controllers: [ReviewEligibilityController, ReviewsController, RewardPolicyController],
-  providers: [ReviewEligibilityService, ReviewsService, ReviewRewardPolicyService, ReviewRewardPublisher, ReviewStatsPublisher],
+  providers: [
+    ReviewEligibilityService,
+    ReviewsService,
+    ReviewRewardPolicyService,
+    ReviewRewardPublisher,
+    ReviewStatsPublisher,
+  ],
 })
 export class ReviewsModule {}

--- a/apps/user-service/src/app.module.ts
+++ b/apps/user-service/src/app.module.ts
@@ -83,8 +83,8 @@ const staticRoot = existsSync(join(__dirname, 'static')) ? join(__dirname, 'stat
       },
       schema: userServiceSchema,
     }),
-    EventsModule.forRoot({
-      streams: [USER_STREAM],
+    EventsModule.forApp({
+      publishes: [USER_STREAM],
       serviceName: 'user-service',
       kafka: createKafkaConfigFromEnv()!,
       validation: {

--- a/apps/wallet/src/wallet.module.ts
+++ b/apps/wallet/src/wallet.module.ts
@@ -15,7 +15,7 @@ import { DbModule } from '@app/db';
 import { LoggerModule } from 'nestjs-pino';
 import { loggerConfig } from '@app/shared/observability/logger.config';
 import { EventsModule, EventTraceApiModule } from '@app/events';
-import { UGC_COMMAND_STREAM, WALLET_COMMAND_STREAM, PAYMENT_STREAM } from '@packages/event-contracts/streams';
+import { PAYMENT_STREAM } from '@packages/event-contracts/streams';
 import { WALLET_OUTBOX_CONFIG } from './messaging/wallet-outbox.config';
 import { Observable, firstValueFrom, isObservable } from 'rxjs';
 import { validateWalletEnv } from './config/env';
@@ -379,19 +379,17 @@ async function resolveCanActivate(result: boolean | Promise<boolean> | unknown):
       schema: walletSchema,
     }),
     ScheduleModule.forRoot(),
-    EventsModule.forRoot({
-      streams: [PAYMENT_STREAM],
+    // 발행 능력 + 소비 정책을 한 자리에서. 옛 `forRoot`+`forConsumerModule` 두 벌에서
+    // 합쳤다 — 소비 스트림 목록과 groupId 는 쓰이지 않던 선언이라 사라졌다 (ADR-0029 §1).
+    EventsModule.forApp({
+      publishes: [PAYMENT_STREAM],
       // 공용 아웃박스를 켠다 (ADR-0029 §5-1, Task 6-C-3). `OutboxPublisher`(적재기)와
       // `OutboxDispatcher`(발행기)가 등록되고, `PAYMENT_STREAM` 이 위 목록에 있으므로
       // 디스패처의 publisherMap 이 회수 대상 토픽을 처음부터 안다.
       enableOutbox: true,
       outbox: WALLET_OUTBOX_CONFIG,
-    }),
-    EventsModule.forConsumerModule({
-      streams: [UGC_COMMAND_STREAM, WALLET_COMMAND_STREAM],
-      groupId: process.env.KAFKA_GROUP_ID || 'wallet-consumer',
-      enableAutoDLQ: true,
-      validation: { validateOnConsume: false },
+      // 이 `false` 는 이 워크스트림 이전부터의 상태다 — 5-C 대상이 아니었다.
+      policy: { validateOnConsume: false },
     }),
     EventTraceApiModule,
   ],

--- a/docs/adr/0029-events-module-registration-surfaces.md
+++ b/docs/adr/0029-events-module-registration-surfaces.md
@@ -61,7 +61,7 @@ async bindEvents(consumer) {
 ```ts
 // app.module.ts — 이 앱이 가진 "능력"만 선언
 EventsModule.forApp({
-  service: 'channel-adapter',
+  serviceName: 'channel-adapter',
   kafka: kafkaFromEnv(),
   publishes: [ORDER_STREAM, CHANNEL_ADAPTER_STREAM],
   policy: { validateOnConsume: true },
@@ -74,6 +74,12 @@ await EventsModule.startConsumer(app, { groupId });
 `startConsumer` 는 컨테이너를 갖고 있으므로 `DiscoveryService` 로 `@On` 메타데이터를 훑어 `(topic, eventType)` 집합을 얻고, 거기서 **구독 토픽 · 검증 스키마 맵 · 토픽 부트스트랩 목록을 전부 파생**한다. 계약 레지스트리에 없는 토픽을 구독하려 하면 부팅을 거부한다.
 
 이를 위해 `packages/event-contracts` 에 `topic → StreamConfig` 레지스트리를 추가한다. `streams/index.ts` 가 이미 전 스트림을 export 하므로 순수 추가이며 위험이 없다.
+
+**이행 시 위 스케치에서 세 가지가 달라졌다 (2026-08-10, Follow-up 7).**
+
+- **`service` 가 아니라 `serviceName` 이다.** 옛 `forRoot` 의 이름을 그대로 뒀다 — 이 필드는 뜻이 모호했던 적이 없고(`streams` 와 달리), 바꾸면 순수 churn 이다. 이름을 고친 것은 **뜻이 세 갈래였던 `streams` 하나**다.
+- **정책이 한 필드가 아니라 두 필드다** — `validation`(발행)과 `policy`(소비). 옛 두 표면이 `validation: SchemaValidationOptions` 라는 **같은 이름·같은 타입으로 다른 뜻**을 받던 것이 §1 이 지적한 문제의 절반이었다. 각각 `Pick<…>` 으로 좁혀 반대쪽 플래그를 쓰면 컴파일 에러가 되게 했다.
+- **`policy` 는 앱 전체에 하나이고, 둘 이상 선언하면 부팅을 거부한다.** `forApp` 은 BC 별로 여러 번 불릴 수 있어(core 4번) 실제로 일어날 수 있는 실수인데, `optionalGet` 은 경고 없이 하나만 돌려주고 어느 것이 이기는지는 모듈 등록 순서에 달렸다 — §3 의 다른 두 부팅 거부와 같은 종류의 무증상 결함이다. `assertSinglePolicyDeclaration` 이 막는다.
 
 ### 4. 계약을 타입 seam 으로 끌어올린다
 
@@ -464,13 +470,23 @@ Task 6-C 의 "outbox 5벌 회수" 가 두 가지로 읽혀서 코드가 갈렸�
    **`@InjectStreamPublisher` → `@InjectPublisher` 완료 (2026-08-09, Task 6-B)** — 사용처 0건, 주입 지점 22곳 전부 도출. 상세는 위 5번의 "발행 쪽 이주 완료" 참조.
 
    남은 것은 이 항목의 다른 절반이다: `idempotencyKey`·`partitionKey` 추가와 5벌 회수(Task 6-C, 데이터 마이그레이션 성격). 6-A 에서 `OutboxPublisher.saveEvent` 는 삭제했고 공용 outbox 의 유일한 진입점은 `OutboxWriter.write` 다 — 6-C 의 회수 대상은 그 port 뒤로 들어온다.
-7. 옛 표면(`forRoot`/`forConsumerModule`/`forConsumer`) 제거 — contract phase.
-8. ~~channel-adapter 가 `forConsumerModule` 을 호출하지 않는 현재 상태는 이 ADR 이 시행되기 전까지 남는 실재 구멍이다 — 소비 측 zod 검증이 없다. 4번 이전에 단독으로 메울지, 이주에 묶을지 결정한다.~~ **결정: 이주에 묶었다 (2026-08-09).** 다만 배선 이주 시점에 **검증을 켜지는 않았다.** `forConsumerModule` 미호출 → `EVENTS_CONSUMER_POLICY` 토큰 부재 → `optionalGet` 이 undefined → 기본값 `true` 라, 아무 조치 없이 `startConsumer` 로 옮기면 이 앱만 배선과 검증이 **선택이 아니라 누락으로** 동시에 켜진다. 외부 채널 유래 payload 라 그 조합이 가장 위험한 앱이기도 하다. 그래서 `adapter.module.ts` 의 providers 에 `EVENTS_CONSUMER_POLICY` 를 직접 등록하고 `validateOnConsume: false` 를 명시했다. `forConsumerModule` 을 새로 부르지 않은 이유는 그 표면이 `streams` 를 필수로 받기 때문이다 — 그 목록이야말로 §2·§3 이 지우는 중인 두 번째 진실이라, 정책 하나를 얻자고 그것을 되살릴 수 없다. Task 7 의 `forApp` 이 이 자리를 흡수한다. 검증을 실제로 켜는 것은 payload 샘플링 후(플랜 Task 5-C).
+7. ~~옛 표면(`forRoot`/`forConsumerModule`/`forConsumer`) 제거 — contract phase.~~ **완료 (2026-08-10, Task 7).** 등록 표면이 `forApp` + `startConsumer` 둘뿐이다.
+
+   - **삭제:** `forConsumer`(전송 설정을 `startConsumer` 안으로 인라인) · `forConsumerModule` · `@OnEvent` · `@InjectStreamPublisher`(+ 단축 export). 앱 사용처는 5-A·6-B 로 이미 0건이었고, 남아 있던 `libs/events` 스펙 7개를 `@On` 으로 이주했다.
+   - **`forRoot` → `forApp` 개명 + `streams` → `publishes`.** 표면이 하나로 줄었으니 이름이 뜻을 말해야 한다 — 세 표면이 같은 이름으로 각각 다른 뜻을 받던 것이 Context 의 첫 관측이다. 위 §3 의 "이행 시 세 가지가 달라졌다" 참조.
+   - **정책 이전이 선행이다.** `forConsumerModule` 을 먼저 걷어내면 `EVENTS_CONSUMER_POLICY` 가 사라지고 notification·membership·wallet 의 `validateOnConsume: false` 가 기본값 `true` 로 **조용히 뒤집힌다.** 6개 앱의 `forConsumerModule({validation})` 과 channel-adapter 의 수기 provider 를 먼저 `forApp({policy})` 로 옮긴 뒤 삭제했다. 7개 앱의 값은 전부 보존됐다(감사가 재확인: 검증 ON 5앱 = analytics·channel-adapter·core·membership·search).
+   - **`forConsumerModule` 의 `APP_INTERCEPTOR` 등록(SchemaValidation·ChainContext)은 되살리지 않았다.** 하이브리드 앱에서 그 등록은 소비 경로에 닿은 적이 없고(§8), 셋 다 `context.getType() === 'http'` 에서 즉시 통과하므로 HTTP 동작도 바뀌지 않는다. 되살릴 수도 없다 — `SchemaValidationInterceptor` 는 소비 스트림 목록을 요구하는데 그건 §3 이 지운 두 번째 진실이다.
+   - **부수 실측: `forConsumerModule` 의 `groupId`·`sessionTimeout`·`heartbeatInterval`·`maxPollInterval`·`autoCommit` 은 한 번도 읽히지 않았다.** 6개 앱이 `groupId` 를 모듈과 `main.ts` 에 두 번 적고 있었고 효력이 있는 것은 `main.ts` 쪽뿐이었다 — §1 이 말하는 "두 벌" 의 또 다른 실례이며, 표면과 함께 사라졌다.
+   - **`start-consumer.spec.ts` 의 "옛 앱 배선" describe 를 삭제했다.** 5-B 가 라이브에 배포돼 그 주장("라이브는 여전히 옛 배선")이 더는 참이 아니다 — 아래 10번이 이것으로 닫힌다.
+   - **하네스 스펙 3개가 옛 `APP_INTERCEPTOR` 등록에 기대고 있었음이 드러났다.** `round-trip` · `consume-validation` · `enqueue-validation` 은 `createNestMicroservice` 로 도는데, 그 경로에서는 `APP_INTERCEPTOR` 가 **적용된다** — 즉 이 하네스들은 운영(하이브리드 `connectMicroservice`)과 다른 배선을 검증하고 있었다. 이제 셋 다 운영과 같은 팩토리(`buildConsumerInterceptors`)를 명시적으로 얹는다. `startConsumer` 를 부르지 않는 이유는 하나뿐이다 — 그것은 레지스트리 밖 토픽을 거부하는데 이 하네스들은 일부러 레지스트리 밖의 전용 계약을 쓴다.
+8. ~~channel-adapter 가 `forConsumerModule` 을 호출하지 않는 현재 상태는 이 ADR 이 시행되기 전까지 남는 실재 구멍이다 — 소비 측 zod 검증이 없다. 4번 이전에 단독으로 메울지, 이주에 묶을지 결정한다.~~ **결정: 이주에 묶었다 (2026-08-09).** 다만 배선 이주 시점에 **검증을 켜지는 않았다.** `forConsumerModule` 미호출 → `EVENTS_CONSUMER_POLICY` 토큰 부재 → `optionalGet` 이 undefined → 기본값 `true` 라, 아무 조치 없이 `startConsumer` 로 옮기면 이 앱만 배선과 검증이 **선택이 아니라 누락으로** 동시에 켜진다. 외부 채널 유래 payload 라 그 조합이 가장 위험한 앱이기도 하다. 그래서 `adapter.module.ts` 의 providers 에 `EVENTS_CONSUMER_POLICY` 를 직접 등록하고 `validateOnConsume: false` 를 명시했다. `forConsumerModule` 을 새로 부르지 않은 이유는 그 표면이 `streams` 를 필수로 받기 때문이다 — 그 목록이야말로 §2·§3 이 지우는 중인 두 번째 진실이라, 정책 하나를 얻자고 그것을 되살릴 수 없다. Task 7 의 `forApp` 이 이 자리를 흡수한다 — **완료 (2026-08-10)**: 이제 이 앱도 `forApp({ policy })` 로 선언한다. 검증을 실제로 켜는 것은 payload 샘플링 후(플랜 Task 5-C).
 9. **소비 경로 CLS 컨텍스트 부재** (2026-08-09 발견, 미수정).
  `ClsModule.forRoot({ middleware: { mount: false } })` 이고 RPC 경로에 ClsGuard/ClsInterceptor 가 없어 `EventChainService.setChainId` 가 "No CLS context available" 로 던지고, `ChainContextInterceptor` 의 `catch {}` 가 그것을 삼킨다. 결과적으로 **소비 측 `chainId`/`eventId` 전파가 전 앱에서 죽어 있다.** 3번의 파싱 버그와 원인이 다르므로 별도 수정이 필요하다 — 이 워크스트림에 묶을지 독립 처리할지 결정한다. 회귀 감지는 `round-trip.spec.ts` 의 `it.failing` 이 맡는다. (그 인터셉터 자체가 하이브리드 앱에서 붙지 않는다는 §8 이 겹친다 — 두 원인이 독립적으로 존재한다.)
 10. 🔴 **라이브 구멍: 7개 소비 앱 전부에서 스키마 검증·재시도·DLQ·chain 인터셉터가 적용되지 않고 있다** (2026-08-09 발견, §8). `startConsumer` 는 이 구멍이 없는 새 배선을 제공하지만, **앱들이 이주하기 전까지 라이브 상태는 그대로다.** 옛 표면(`forConsumer`)에 같은 배선을 소급 적용하는 것은 의도적으로 하지 않았다 — 7개 앱에서 검증·DLQ 가 한 배포에 동시에 켜지며, 지금까지 검증 없이 통과하던 인바운드 payload 가 있다면 그 배포가 DLQ 폭탄이 된다. 대신 앱별 이주(5번)에서 하나씩, 관찰 가능한 단위로 켠다.
 
-    **코드상으로는 닫혔다 (2026-08-09) — 라이브에서는 아직이다.** 7개 앱이 모두 `startConsumer` 로 이주했으나 이 레포는 autodeploy 가 없어([[0005-drizzle-migration-and-autodeploy]] §4) 누군가 `sst deploy` 를 부르기 전까지 라이브는 옛 배선이다. **이 항목이 닫히는 시점은 마지막 앱이 배포된 때다.** 그때 `start-consumer.spec.ts` 의 "옛 앱 배선" describe 도 함께 지운다 — 그 전까지는 아직 살아 있는 결함의 유일한 실행 가능한 기록이다. 배포는 앱 간 순서가 없다(각 앱 이주가 그 앱에만 영향을 준다). 배포 후 켜지는 것은 **재시도·DLQ·chain 뿐이고 스키마 검증은 아니다** — 8번·5번 참조.
+    **닫혔다 (2026-08-10).** 7개 앱 전부 배포 완료. `start-consumer.spec.ts` 의 "옛 앱 배선" describe 는 Task 7 에서 삭제했다.
+
+    이하 착수 당시 기록(보존): **코드상으로는 닫혔다 (2026-08-09) — 라이브에서는 아직이다.** 7개 앱이 모두 `startConsumer` 로 이주했으나 이 레포는 autodeploy 가 없어([[0005-drizzle-migration-and-autodeploy]] §4) 누군가 `sst deploy` 를 부르기 전까지 라이브는 옛 배선이다. **이 항목이 닫히는 시점은 마지막 앱이 배포된 때다.** 그때 `start-consumer.spec.ts` 의 "옛 앱 배선" describe 도 함께 지운다 — 그 전까지는 아직 살아 있는 결함의 유일한 실행 가능한 기록이다. 배포는 앱 간 순서가 없다(각 앱 이주가 그 앱에만 영향을 준다). 배포 후 켜지는 것은 **재시도·DLQ·chain 뿐이고 스키마 검증은 아니다** — 8번·5번 참조.
 11. ⚠️ **notification 의 소비 핸들러는 재실행에 안전하지 않다** (2026-08-09 발견, 미수정). 배선 이주로 재시도가 처음 실재하게 되면서 87개 핸들러의 멱등성을 전수 확인했고, 6개 앱은 안전했다(core = `messageId` 마커 / channel-adapter = `inbox_events` 단일 insert / membership = unique 마커 + 상태 가드 / wallet = idempotency key / analytics = `onConflictDoNothing(messageId)` + upsert / search = 고정 ID upsert). **notification 만 멱등 키가 없다.** `NotificationDispatcherService.send` 는 `dto.channels` 를 루프 돌며 채널마다 행을 insert 하고 큐에 넣으므로, 채널 1 성공 후 채널 2 에서 throw 하면 재시도가 루프를 처음부터 다시 돌아 **채널 1 이 다시 발송된다.** 노출은 좁다 — 프로바이더 전송 실패는 `sendNotificationDirectly` 의 `catch` 가 삼켜 핸들러까지 올라오지 않고, 실제로 throw 하는 건 DB·템플릿 조회 실패 정도다. 그 경우 옛 배선에서는 메시지가 통째로 소실됐고 새 배선에서는 앞 채널이 최대 4회 중복될 수 있다. **결정 (2026-08-09, 5-B PR 에 포함): (b) `@RetryPolicy({ maxRetries: 0 })`.**
 
 "소실 ↔ 중복" 교환으로 제시했으나 **교환이 아니었다.** `maxRetries: 0` 은 시도 횟수를 옛 배선과 동일한 1회로 유지하므로 중복 위험이 0 이고, 동시에 실패가 조용한 소실이 아니라 **DLQ 로 관측된다.** 두 축 모두에서 옛 배선보다 나쁘지 않고 한 축에서 낫다 — 저울에 올릴 사안이 아니었다. (a) dedup 키는 재시도의 이점을 실제로 얻고 싶어질 때 별건으로 다룬다.

--- a/docs/superpowers/plans/2026-08-09-events-module-registration.md
+++ b/docs/superpowers/plans/2026-08-09-events-module-registration.md
@@ -669,16 +669,52 @@ PR 별로도 type-check 162 · 해당 앱 build · 감사 3종 · 해당 앱 jes
 
 ---
 
-## Task 7: 옛 표면 제거 (contract phase)
+## Task 7: 옛 표면 제거 (contract phase) — ✅ 완료 (2026-08-10)
 
-**Task 5 가 전부 끝나고 배포가 완료된 뒤에만 착수한다.**
+**Task 5 가 전부 끝나고 배포가 완료된 뒤에만 착수한다.** 선행조건 충족 확인 후 착수했다.
 
-- [ ] `forConsumer` 삭제
-- [ ] `forConsumerModule` 을 `forApp` 으로 흡수하거나 삭제
-- [ ] `@OnEvent` / `@InjectStreamPublisher` 삭제
-- [ ] `npm run type-check` 초록 · 전 앱 `nest build` 초록 · 커밋 · 푸시
+- [x] `forConsumer` 삭제 — 전송 설정을 `startConsumer` 안으로 인라인
+- [x] `forConsumerModule` 을 `forApp` 으로 흡수
+- [x] `@OnEvent` / `@InjectStreamPublisher` 삭제
+- [x] `npm run type-check` 초록 · 전 앱 `nest build` 초록 · 커밋 · 푸시
 
 **완료 기준:** 등록 표면이 `forApp` + `startConsumer` 둘뿐이다.
+
+**완료 (2026-08-10).** 브랜치 `feat/events-drop-legacy-surfaces`.
+
+**`forRoot` 는 삭제가 아니라 개명이다 — `forApp`.** 태스크 지시의 삭제 목록에 `forRoot` 가 없는데 완료 기준은 "표면이 `forApp` + `startConsumer` 둘뿐"이다. 둘을 동시에 만족하는 읽기는 개명 하나뿐이고, ADR §3 의 스케치도 그 형태다. `streams` → `publishes` 로 인자도 바꿨다 — 세 표면이 같은 이름으로 각각 다른 뜻(발행 능력 · 검증 맵 · 무의미한 subscribe 목록)을 받던 것이 ADR Context 의 첫 관측이므로, 표면이 하나로 줄면 이름이 뜻을 말해야 한다.
+
+**정책을 먼저 옮겼다 (지시대로).** 6개 앱의 `forConsumerModule({validation})` 과 channel-adapter 의 수기 `EVENTS_CONSUMER_POLICY` provider 를 `forApp({policy})` 로 이전한 뒤 표면을 지웠다. 순서를 뒤집으면 notification·membership·wallet 의 `validateOnConsume: false` 가 기본값 `true` 로 조용히 뒤집힌다. 감사가 사후 확인했다 — 검증 ON 5앱(analytics·channel-adapter·core·membership·search)으로 기준선과 동일.
+
+**정책 필드는 발행/소비로 갈랐다.** `validation`(발행, `Pick<…,'validateOnPublish'|'throwOnValidationError'>`) · `policy`(소비, `Pick<…,'validateOnConsume'|'throwOnValidationError'>`). 옛 두 표면이 `validation: SchemaValidationOptions` 라는 **같은 이름·같은 타입으로 다른 뜻**을 받던 것이 ADR §1 이 지적한 문제의 절반이고, 한 표면으로 합치면서 그 모호함을 물려받을 이유가 없다. 이제 반대쪽 플래그를 쓰면 컴파일 에러다.
+
+**새 부팅 거부 1건 — 정책 중복 선언.** `forApp` 은 BC 별로 여러 번 불릴 수 있고(core 4번: inventory·fulfillment·catalog·sales-order) 그중 둘이 `policy` 를 선언하면 `optionalGet` 이 경고 없이 하나만 돌려준다. 어느 것이 이기는지는 모듈 등록 순서에 달렸고 두 선언이 갈리면 검증이 조용히 켜지거나 꺼진다 — §3 의 기존 두 거부(레지스트리 밖 토픽 · 핸들러 0개)와 같은 종류다. `assertSinglePolicyDeclaration` 이 `ModulesContainer` 를 훑어 센다.
+
+**🔴 하네스 스펙 3개가 운영과 다른 배선을 검증하고 있었다 (이 태스크가 드러냄).**
+
+`round-trip` · `consume-validation` · `enqueue-validation` 은 `createNestMicroservice` 로 도는데, **그 경로에서는 `APP_INTERCEPTOR` 가 적용된다.** 운영 7개 앱은 하이브리드 `connectMicroservice` 라 적용되지 않는다(§8). 즉 이 셋은 `forConsumerModule` 이 달아 주던 `APP_INTERCEPTOR` 로 검증·DLQ 를 얻고 있었고, **라이브에는 없던 배선을 초록으로 증명하고 있었다** — ADR §8 이 고발한 그 모양 그대로다. `forConsumerModule` 삭제로 5개 테스트가 빨간불이 되면서 드러났다. 셋 다 운영과 같은 팩토리 `buildConsumerInterceptors(app, streams)` 를 명시적으로 얹도록 고쳤다. `startConsumer` 를 쓰지 않는 이유는 하나뿐이다 — 그것은 레지스트리 밖 토픽을 거부하는데 이 하네스들은 일부러 레지스트리 밖 전용 계약을 쓴다(`start-consumer.spec.ts` 만 실제 `CART_STREAM` 을 쓴다).
+
+**부수 실측 — `forConsumerModule` 의 인자 5개가 한 번도 읽히지 않았다.** `groupId`·`sessionTimeout`·`heartbeatInterval`·`maxPollInterval`·`autoCommit`. 6개 앱이 `groupId` 를 모듈과 `main.ts` 에 두 번 적고 있었고 효력이 있는 것은 `main.ts` 쪽뿐이었다(값은 다행히 전부 일치). ADR §1 의 "두 벌" 의 또 다른 실례이며 표면과 함께 사라졌다.
+
+**`APP_INTERCEPTOR` 의 SchemaValidation·ChainContext 는 되살리지 않았다.** 되살릴 수도 없다 — `SchemaValidationInterceptor` 생성자가 소비 스트림 목록을 요구하는데 그건 이 워크스트림이 지운 두 번째 진실이다. 운영 영향 0(하이브리드에서 닿지 않았고, 셋 다 `context.getType() === 'http'` 에서 즉시 통과한다). `EventRetryInterceptor` 의 `APP_INTERCEPTOR` 등록은 옛 `forRoot` 그대로 남겼다.
+
+**문서를 함께 고쳤다.** `libs/events/README.md` + `docs/*.md` 7개 + `MIGRATION_GUIDE.md` + `apps/notification/docs/EVENT_FLOW_ANALYSIS.md`. 삭제된 API 를 가르치는 문서를 남기는 것은 ADR Context 가 고발한 "틀린 모델이 체크인돼 있다" 의 더 나쁜 판본이다. **`docs/first-look.md` 만 본문을 두고 경고 헤더를 달았다** — 특정 시점의 평가 기록이라 고치면 기록이 아니라 거짓이 된다.
+
+**대조군 (변이 5종, 전부 빨간불 재현 후 `cp` 백업 + `sha1sum -c` 로 원복 — `git checkout --` 는 쓰지 않았다):**
+
+| 변이 | 빨간불 |
+|---|---|
+| 가드 임계값 `> 1` → `> 2` | 중복 선언 2건이 통과 → 2 tests |
+| `buildConsumerInterceptors` 의 가드 호출 삭제(배선만 끊음) | 1 test |
+| `forApp` 이 `policy` 없이도 provider 등록 | 대조군 1 test |
+| `forApp` 이 인터셉터를 `APP_INTERCEPTOR` 로 추가 등록 | 1 test |
+| `@On` 이 `EVENT_TYPE_FILTER` 를 안 남김 | 3 tests |
+
+두 번째 변이가 특히 필요했다 — 가드 함수를 직접 부르는 테스트 3개만으로는 **그것이 부팅 경로에 꽂혀 있다는 것**을 증명하지 못한다. 호출 한 줄을 지워도 셋 다 초록이었다.
+
+**게이트 실측:** `npm run type-check` **162 = 기준선**(file+code 집합 완전 동일, 신규 0) · `audit:event-handlers` exit 0 (87 핸들러 / `@OnEvent` 0) · `audit:event-publishers` exit 0 (37 주입 / 옛 표면 0) · `audit:consume-validation --gate` exit 0 (검증 ON 5앱 = 기준선) · 10개 앱 `nest build` OK · 전체 jest **실패 suite 18 = 기준선(집합 완전 동일)**, 통과 3079 → 3083(+4 = 신규 5 − 삭제 1) · 변경 파일 eslint **신규 0**(60 → 52).
+
+**배포:** 마이그레이션 0 · 시크릿 0 · env 0 · 계약 변경 0. 앱 간 순서 없음 — 동작 중립이라 한 배포에 묶어도 된다.
 
 ---
 
@@ -691,7 +727,8 @@ PR 별로도 type-check 162 · 해당 앱 build · 감사 3종 · 해당 앱 jes
 - [x] outbox enqueue 가 zod 검증을 탄다 — Task 6-A
 - [x] `libs/events/src` 스펙 파일 수가 5개보다 많다 — 현재 11
 - [x] 컨트롤러를 `controllers: []` 에 등록하지 않으면 부팅이 실패한다 — Task 3 에서 구현, 5-B 로 7개 앱 전부에 실효
-- [x] `npm run type-check` 가 이 워크스트림으로 새 오류를 만들지 않았다 — 5-B 까지 164, 6-C-2 가 163, 6-C-4 가 162. **신규 오류 0 유지.** Task 7 후 최종 재확인
+- [x] `npm run type-check` 가 이 워크스트림으로 새 오류를 만들지 않았다 — 5-B 까지 164, 6-C-2 가 163, 6-C-4 가 162. **신규 오류 0 유지.** Task 7 후 최종 재확인 완료 (162)
+- [x] 등록 표면이 `forApp` + `startConsumer` 둘뿐이다 — Task 7
 - [x] ADR-0029 의 Status 가 Accepted 로 갱신됐다
 
 ---

--- a/libs/events/MIGRATION_GUIDE.md
+++ b/libs/events/MIGRATION_GUIDE.md
@@ -100,8 +100,8 @@ const combinedSchema = {
       },
       schema: combinedSchema,  // 병합된 스키마 사용
     }),
-    EventsModule.forRoot({
-      streams: [ORDER_STREAM],
+    EventsModule.forApp({
+      publishes: [ORDER_STREAM],
       serviceName: 'wms',
       enableOutbox: true,  // Outbox 활성화
     }),
@@ -139,7 +139,7 @@ npm run db:push:wms
 
 - [ ] `drizzle.config.ts`에 outbox 스키마 경로 추가
 - [ ] `AppModule`에서 `EventsModule.outboxSchema` 병합
-- [ ] `EventsModule.forRoot({ enableOutbox: true })` 설정
+- [ ] `EventsModule.forApp({ enableOutbox: true })` 설정
 - [ ] `npm run db:generate:<app>` 실행
 - [ ] `npm run db:push:<app>` 실행 (또는 마이그레이션 적용)
 - [ ] DB에 `event.outbox_events` 테이블 생성 확인

--- a/libs/events/README.md
+++ b/libs/events/README.md
@@ -109,12 +109,12 @@ import { ORDER_STREAM } from '@app/shared/streams/orders.stream';
 
 @Module({
   imports: [
-    EventsModule.forRoot({
+    EventsModule.forApp({
       kafka: createKafkaConfigFromEnv({
         KAFKA_CLIENT_ID: 'wms-order-publisher',
         KAFKA_BROKERS: process.env.KAFKA_BROKERS!,
       }),
-      streams: [ORDER_STREAM],
+      publishes: [ORDER_STREAM],
       serviceName: 'wms-order',
     }),
   ],
@@ -127,14 +127,14 @@ export class OrderModule {}
 ```typescript
 // apps/wms/src/order/services/order.service.ts
 import { Injectable } from '@nestjs/common';
-import { InjectStreamPublisher, StreamPublisher } from '@app/events';
-import { ORDER_STREAM, OrderEvents } from '@app/shared/streams/orders.stream';
+import { InjectPublisher, PublisherFor } from '@app/events';
+import { ORDER_STREAM } from '@app/shared/streams/orders.stream';
 
 @Injectable()
 export class OrderService {
   constructor(
-    @InjectStreamPublisher('orders.events.v1')
-    private readonly orderPublisher: StreamPublisher<OrderEvents>,
+    @InjectPublisher(ORDER_STREAM)
+    private readonly orderPublisher: PublisherFor<typeof ORDER_STREAM>,
   ) {}
 
   async createOrder(dto: CreateOrderDto) {
@@ -183,19 +183,16 @@ import { ORDER_STREAM } from '@app/shared/streams/orders.stream';
 async function bootstrap() {
   const app = await NestFactory.create(AdapterModule);
 
-  // Kafka Consumer 연결
-  const consumerOptions = EventsModule.forConsumer({
+  // Kafka Consumer 연결 — **구독 목록 인자가 없다.**
+  // 소비 집합은 컨트롤러의 `@On` 에서 도출된다 (ADR-0029 §3).
+  await EventsModule.startConsumer(app, {
     kafka: createKafkaConfigFromEnv({
       KAFKA_CLIENT_ID: 'channel-adapter-consumer',
       KAFKA_BROKERS: process.env.KAFKA_BROKERS!,
     }),
-    streams: [ORDER_STREAM],
     groupId: 'channel-adapter-consumers',
   });
 
-  app.connectMicroservice(consumerOptions);
-
-  await app.startAllMicroservices();
   await app.listen(3003);
 }
 bootstrap();
@@ -209,7 +206,7 @@ bootstrap();
 // apps/channel-adapter/src/consumers/order-events.consumer.ts
 import { Controller, Logger, UseInterceptors } from '@nestjs/common';
 import { 
-  OnEvent, 
+  On, 
   EventPayload, 
   EventMetadata,
   EventTypeGuard,  // ← 이벤트 타입 필터링 (필수!)
@@ -222,7 +219,7 @@ import { OrderCreatedPayload, OrderCancelledPayload } from '@app/shared/streams/
 export class OrderEventsConsumer {
   private readonly logger = new Logger(OrderEventsConsumer.name);
 
-  @OnEvent('orders.events.v1', 'OrderCreated')
+  @On(ORDER_STREAM, 'OrderCreated')
   @RetryPolicy({ maxAttempts: 3, backoff: 'exponential' })  // ← 재시도 정책
   async handleOrderCreated(
     @EventPayload() payload: OrderCreatedPayload,
@@ -236,7 +233,7 @@ export class OrderEventsConsumer {
     await this.syncOrderToChannels(payload);
   }
 
-  @OnEvent('orders.events.v1', 'OrderCancelled')
+  @On(ORDER_STREAM, 'OrderCancelled')
   async handleOrderCancelled(
     @EventPayload() payload: OrderCancelledPayload,
   ) {
@@ -305,13 +302,11 @@ await this.orderPublisher.publishCommand({
 ### 자동 DLQ 처리 (권장) ⭐
 
 ```typescript
-// 1. Consumer Module에서 자동 DLQ 활성화
+// 1. 앱 모듈에서 DLQ 활성화 (기본값이라 생략해도 된다)
 @Module({
   imports: [
-    EventsModule.forConsumerModule({
-      streams: [ORDER_STREAM],
-      groupId: 'order-consumer',
-      enableAutoDLQ: true,  // 자동 DLQ 처리 (기본값: true)
+    EventsModule.forApp({
+      enableDLQ: true,  // 자동 DLQ 처리 (기본값: true)
     }),
   ],
 })
@@ -320,7 +315,7 @@ export class AppModule {}
 // 2. 핸들러에서 try-catch 불필요!
 @Controller()
 export class OrderEventsConsumer {
-  @OnEvent('orders.events.v1', 'OrderCreated')
+  @On(ORDER_STREAM, 'OrderCreated')
   async handleOrderCreated(@EventPayload() payload: OrderCreatedPayload) {
     // 에러 발생 시:
     // 1. 자동으로 3번 재시도 (exponential backoff)
@@ -328,7 +323,7 @@ export class OrderEventsConsumer {
     await this.processOrder(payload);
   }
 
-  @OnEvent('orders.events.v1', 'OrderUpdated')
+  @On(ORDER_STREAM, 'OrderUpdated')
   @RetryPolicy({ maxRetries: 5, backoff: 'exponential' })
   async handleOrderUpdated(@EventPayload() payload: OrderUpdatedPayload) {
     // 핸들러별 재시도 정책 커스터마이즈
@@ -364,8 +359,8 @@ export const ORDER_STREAM: StreamConfig<OrderEvents> = {
 };
 
 // 2. Publisher (발행 시 자동 검증)
-EventsModule.forRoot({
-  streams: [ORDER_STREAM],
+EventsModule.forApp({
+  publishes: [ORDER_STREAM],
   validation: { validateOnPublish: true },  // 기본값: true
 });
 
@@ -375,13 +370,15 @@ await publisher.publishEvent({
   payload: { orderId: 'invalid-uuid', ... },  // ❌ 검증 실패 → SchemaValidationError
 });
 
-// 3. Consumer (수신 시 자동 검증)
-EventsModule.forConsumerModule({
-  streams: [ORDER_STREAM],
-  validation: { validateOnConsume: true },  // 기본값: true
+// 3. Consumer (수신 시 자동 검증) — 같은 forApp 호출에 얹는다.
+//    `validation` 은 발행측, `policy` 는 소비측이고 타입이 갈려 있다.
+//    소비 정책은 앱 전체에 하나다 — 둘 이상 선언하면 부팅이 거부된다.
+EventsModule.forApp({
+  publishes: [ORDER_STREAM],
+  policy: { validateOnConsume: true },  // 기본값: true
 });
 
-@OnEvent('orders.events.v1', 'OrderCreated')
+@On(ORDER_STREAM, 'OrderCreated')
 async handleOrderCreated(@EventPayload() payload: OrderCreatedPayload) {
   // ✅ 이 시점에 payload는 이미 스키마 검증 완료!
   // ✅ 타입 안전성 + 런타임 검증 보장
@@ -401,8 +398,8 @@ app.enableShutdownHooks();  // ✅ 필수!
 await app.listen(3000);
 
 // 2. EventsModule 사용 시 자동으로 활성화됨!
-EventsModule.forRoot({
-  streams: [ORDER_STREAM],
+EventsModule.forApp({
+  publishes: [ORDER_STREAM],
 });
 
 // 애플리케이션 종료 시:
@@ -430,7 +427,7 @@ import { DLQHandler, DisableDLQ } from '@app/events';
 export class MyConsumer {
   constructor(private readonly dlqHandler: DLQHandler) {}
 
-  @OnEvent('orders.events.v1', 'OrderCreated')
+  @On(ORDER_STREAM, 'OrderCreated')
   @DisableDLQ()  // 자동 DLQ 비활성화
   async handleOrderCreated(@EventEnvelope() envelope: DomainEvent) {
     try {
@@ -461,11 +458,11 @@ export class MyConsumer {
 libs/events/src/
 ├── envelope.types.ts              # MessageEnvelope, DomainEvent, DomainCommand
 ├── stream-config.types.ts         # StreamConfig, KafkaConfig (Zod schema 지원)
-├── events.module.ts               # EventsModule (forRoot, forConsumer, forConsumerModule)
+├── events.module.ts               # EventsModule (forApp, startConsumer)
 ├── publishers/
 │   └── stream-publisher.service.ts# 스키마 검증 포함
 ├── consumers/
-│   └── decorators.ts              # @OnEvent, @EventPayload, etc.
+│   └── decorators.ts              # @On, @EventPayload, etc.
 ├── dlq/
 │   ├── dlq.types.ts
 │   └── dlq-handler.service.ts
@@ -560,7 +557,7 @@ users.events.v1
 ## 🎯 Best Practices
 
 1. **Shutdown Hooks 활성화**: `app.enableShutdownHooks()` 필수 호출 (main.ts)
-2. **자동 DLQ 활성화**: `forConsumerModule()`로 자동 DLQ 처리 활성화 (권장)
+2. **자동 DLQ 활성화**: `forApp()` 이 기본으로 켠다 (`enableDLQ`, 기본 true)
 3. **스키마 검증 적용**: 중요한 이벤트에 Zod 스키마 추가 (런타임 검증)
 4. **Aggregate ID 기반 파티셔닝**: 같은 Order의 이벤트는 같은 파티션으로 → 순서 보장
 5. **Idempotency**: `messageId`로 중복 처리 방지 (핸들러는 멱등해야 함)
@@ -576,7 +573,7 @@ users.events.v1
 ### Consumer가 메시지를 받지 못할 때
 ```typescript
 // main.ts에서 connectMicroservice() 확인
-app.connectMicroservice(EventsModule.forConsumer({...}));
+await EventsModule.startConsumer(app, { groupId });
 await app.startAllMicroservices();  // 이거 필수!
 ```
 

--- a/libs/events/docs/auto-dlq-guide.md
+++ b/libs/events/docs/auto-dlq-guide.md
@@ -25,10 +25,10 @@ import { ORDER_STREAM } from '@app/shared/streams/orders.stream';
 
 @Module({
   imports: [
-    EventsModule.forConsumerModule({
-      streams: [ORDER_STREAM],
-      groupId: 'your-service-consumers',
-      enableAutoDLQ: true,  // 자동 DLQ 처리 활성화 (기본값: true)
+    EventsModule.forApp({
+      enableDLQ: true,  // 자동 DLQ 처리 활성화 (기본값: true)
+      // 구독 스트림·groupId 는 여기 없다 — 토픽은 `@On` 에서 도출되고
+      // groupId 는 main.ts 의 `startConsumer` 가 준다 (ADR-0029 §3).
     }),
   ],
 })
@@ -47,14 +47,8 @@ import { ORDER_STREAM } from '@app/shared/streams/orders.stream';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  // Kafka Consumer 연결
-  const consumerOptions = EventsModule.forConsumer({
-    streams: [ORDER_STREAM],
-    groupId: 'your-service-consumers',
-  });
-
-  app.connectMicroservice(consumerOptions);
-  await app.startAllMicroservices();
+  // Kafka Consumer 연결 — 구독 목록 인자 없음
+  await EventsModule.startConsumer(app, { groupId: 'your-service-consumers' });
 
   await app.listen(3000);
 }
@@ -65,14 +59,14 @@ bootstrap();
 
 ```typescript
 import { Controller, Logger } from '@nestjs/common';
-import { OnEvent, EventPayload } from '@app/events';
+import { On, EventPayload } from '@app/events';
 import { OrderCreatedPayload } from '@app/shared/streams/orders.stream';
 
 @Controller()
 export class OrderEventsConsumer {
   private readonly logger = new Logger(OrderEventsConsumer.name);
 
-  @OnEvent('orders.events.v1', 'OrderCreated')
+  @On(ORDER_STREAM, 'OrderCreated')
   async handleOrderCreated(@EventPayload() payload: OrderCreatedPayload) {
     // 에러가 발생하면:
     // 1. 자동으로 3번 재시도 (exponential backoff)
@@ -96,11 +90,11 @@ export class OrderEventsConsumer {
 
 ```typescript
 import { Controller } from '@nestjs/common';
-import { OnEvent, EventPayload, RetryPolicy } from '@app/events';
+import { On, EventPayload, RetryPolicy } from '@app/events';
 
 @Controller()
 export class OrderEventsConsumer {
-  @OnEvent('orders.events.v1', 'OrderCreated')
+  @On(ORDER_STREAM, 'OrderCreated')
   @RetryPolicy({
     maxRetries: 5,              // 5번 재시도
     backoff: 'exponential',     // 지수 백오프 (1s, 2s, 4s, 8s, 16s)
@@ -111,7 +105,7 @@ export class OrderEventsConsumer {
     await this.processOrder(payload);
   }
 
-  @OnEvent('orders.events.v1', 'OrderCancelled')
+  @On(ORDER_STREAM, 'OrderCancelled')
   @RetryPolicy({
     maxRetries: 3,
     backoff: 'linear',          // 선형 백오프 (1s, 2s, 3s)
@@ -152,7 +146,7 @@ class FatalError extends Error {}
 @Controller()
 export class OrderEventsConsumer {
   // 특정 에러만 재시도
-  @OnEvent('orders.events.v1', 'OrderCreated')
+  @On(ORDER_STREAM, 'OrderCreated')
   @RetryPolicy({
     maxRetries: 5,
     retryableErrors: [NetworkError, TimeoutError],  // 이 에러들만 재시도
@@ -163,7 +157,7 @@ export class OrderEventsConsumer {
   }
 
   // 특정 에러는 재시도 안 함
-  @OnEvent('orders.events.v1', 'OrderUpdated')
+  @On(ORDER_STREAM, 'OrderUpdated')
   @RetryPolicy({
     maxRetries: 3,
     nonRetryableErrors: [ValidationError, FatalError],  // 이 에러들은 재시도 안함
@@ -178,11 +172,11 @@ export class OrderEventsConsumer {
 ### 7. DLQ 비활성화 (중요하지 않은 이벤트)
 
 ```typescript
-import { OnEvent, EventPayload, DisableDLQ } from '@app/events';
+import { On, EventPayload, DisableDLQ } from '@app/events';
 
 @Controller()
 export class AnalyticsEventsConsumer {
-  @OnEvent('analytics.events.v1', 'PageView')
+  @On(ANALYTICS_STREAM, 'PageView')
   @DisableDLQ()  // 실패해도 DLQ에 보내지 않음 (버림)
   async handlePageView(@EventPayload() payload: PageViewPayload) {
     // 중요하지 않은 이벤트는 실패해도 괜찮음
@@ -195,13 +189,13 @@ export class AnalyticsEventsConsumer {
 
 ```typescript
 import { Controller, Logger } from '@nestjs/common';
-import { OnEvent, EventEnvelope, DisableDLQ, DLQHandler } from '@app/events';
+import { On, EventEnvelope, DisableDLQ, DLQHandler } from '@app/events';
 
 @Controller()
 export class CustomDLQConsumer {
   constructor(private readonly dlqHandler: DLQHandler) {}
 
-  @OnEvent('orders.events.v1', 'OrderCreated')
+  @On(ORDER_STREAM, 'OrderCreated')
   @DisableDLQ()  // 자동 DLQ 비활성화
   async handleOrderCreated(@EventEnvelope() envelope: DomainEvent) {
     try {
@@ -290,7 +284,7 @@ export class CustomDLQConsumer {
 
 ### Before (수동 DLQ 처리)
 ```typescript
-@OnEvent('orders.events.v1', 'OrderCreated')
+@On(ORDER_STREAM, 'OrderCreated')
 async handleOrderCreated(@EventEnvelope() envelope: DomainEvent) {
   try {
     await this.processOrder(envelope.payload);
@@ -308,7 +302,7 @@ async handleOrderCreated(@EventEnvelope() envelope: DomainEvent) {
 
 ### After (자동 DLQ 처리)
 ```typescript
-@OnEvent('orders.events.v1', 'OrderCreated')
+@On(ORDER_STREAM, 'OrderCreated')
 async handleOrderCreated(@EventPayload() payload: OrderCreatedPayload) {
   // try-catch 불필요!
   await this.processOrder(payload);

--- a/libs/events/docs/chain-tracking-guide.md
+++ b/libs/events/docs/chain-tracking-guide.md
@@ -35,7 +35,7 @@ npm run migrate:event
 
 ### AppModule 설정
 
-CLS가 동작하려면 앱 최상위 모듈에 `ClsModule.forRoot()`를 등록해야 합니다. `EventsModule.forRoot()`나 `EventsModule.forConsumerModule()`을 사용하면 **자동으로 포함**되므로 별도 등록은 필요 없습니다.
+CLS가 동작하려면 앱 최상위 모듈에 `ClsModule.forRoot()`를 등록해야 합니다. `EventsModule.forApp()`을 사용하면 **자동으로 포함**되므로 별도 등록은 필요 없습니다.
 
 직접 등록이 필요한 경우:
 

--- a/libs/events/docs/first-look.md
+++ b/libs/events/docs/first-look.md
@@ -1,3 +1,10 @@
+> ⚠️ **이 문서는 특정 시점의 평가 기록이다 — 현재 API 설명이 아니다.**
+> 여기 나오는 `@OnEvent` · `InjectStreamPublisher` · `forConsumer` 는 ADR-0029
+> Task 7(2026-08-10)에서 삭제됐고 각각 `@On` · `@InjectPublisher` ·
+> `startConsumer` 로 대체됐다. 본문은 당시의 관찰을 남기기 위해 그대로 둔다.
+> 현재 표면은 [`../README.md`](../README.md) 와
+> [`docs/adr/0029-events-module-registration-surfaces.md`](../../../docs/adr/0029-events-module-registration-surfaces.md) 를 보라.
+
 ● 현재 공용 이벤트 모듈 평가
 
   ✅ 강점

--- a/libs/events/docs/graceful-shutdown-guide.md
+++ b/libs/events/docs/graceful-shutdown-guide.md
@@ -42,8 +42,8 @@ import { ORDER_STREAM } from '@app/shared/streams/orders.stream';
 
 @Module({
   imports: [
-    EventsModule.forRoot({
-      streams: [ORDER_STREAM],
+    EventsModule.forApp({
+      publishes: [ORDER_STREAM],
       serviceName: 'wms-order',
     }),
     // ✅ GracefulShutdownService가 자동으로 등록됨!
@@ -58,15 +58,12 @@ export class OrderModule {}
 // apps/channel-adapter/src/app.module.ts
 import { Module } from '@nestjs/common';
 import { EventsModule } from '@app/events';
-import { ORDER_STREAM } from '@app/shared/streams/orders.stream';
 
 @Module({
   imports: [
-    EventsModule.forConsumerModule({
-      streams: [ORDER_STREAM],
-      groupId: 'channel-adapter-consumers',
-    }),
+    EventsModule.forApp(),
     // ✅ GracefulShutdownService가 자동으로 등록됨!
+    // (groupId 는 main.ts 의 `startConsumer` 가 준다)
   ],
 })
 export class AppModule {}

--- a/libs/events/docs/quick-start-guide.md
+++ b/libs/events/docs/quick-start-guide.md
@@ -106,8 +106,8 @@ import { ORDER_STREAM } from '@app/shared/streams';
 
 @Module({
   imports: [
-    EventsModule.forRoot({
-      streams: [ORDER_STREAM],
+    EventsModule.forApp({
+      publishes: [ORDER_STREAM],
       serviceName: process.env.SERVICE_NAME || 'my-service',
       // kafka 옵션은 생략 가능 (환경변수에서 자동 생성)
       validation: {
@@ -126,14 +126,14 @@ export class AppModule {}
 ```typescript
 // apps/my-service/src/orders/order.service.ts
 import { Injectable } from '@nestjs/common';
-import { InjectStreamPublisher, StreamPublisher } from '@app/events';
-import { ORDER_STREAM, OrderEvents } from '@app/shared/streams';
+import { InjectPublisher, PublisherFor } from '@app/events';
+import { ORDER_STREAM } from '@app/shared/streams';
 
 @Injectable()
 export class OrderService {
   constructor(
-    @InjectStreamPublisher('orders.events.v1')
-    private readonly orderPublisher: StreamPublisher<OrderEvents>,
+    @InjectPublisher(ORDER_STREAM)
+    private readonly orderPublisher: PublisherFor<typeof ORDER_STREAM>,
   ) {}
 
   async createOrder(dto: CreateOrderDto) {
@@ -165,24 +165,23 @@ export class OrderService {
 
 ## 3. Consumer 설정 (이벤트 수신)
 
-### 방법 A: forConsumerModule() - 자동 DLQ 처리 (권장)
+**구독 목록을 어디에도 적지 않는다.** 소비 집합은 컨트롤러의 `@On` 데코레이터에서
+도출된다 (ADR-0029 §3). 선언이 필요한 것은 코드에서 도출할 수 없는 것 — 정책과
+전송 설정뿐이다.
 
-**Module 설정:**
+**1) 모듈에 정책 선언** (기본값으로 충분하면 생략 가능)
 
 ```typescript
 // apps/my-service/src/app.module.ts
 import { Module } from '@nestjs/common';
 import { EventsModule } from '@app/events';
-import { ORDER_STREAM } from '@app/shared/streams';
 
 @Module({
   imports: [
-    EventsModule.forConsumerModule({
-      streams: [ORDER_STREAM],
-      groupId: 'my-service-orders-consumer',
-      enableAutoDLQ: true,  // 자동 DLQ 처리
-      validation: {
-        validateOnConsume: true,  // 수신 시 스키마 검증
+    EventsModule.forApp({
+      enableDLQ: true, // 자동 DLQ 처리 (기본값: true)
+      policy: {
+        validateOnConsume: true, // 수신 시 스키마 검증 (기본값: true)
       },
     }),
   ],
@@ -191,29 +190,23 @@ import { ORDER_STREAM } from '@app/shared/streams';
 export class AppModule {}
 ```
 
-### 방법 B: forConsumer() - main.ts에서 수동 연결
+`policy` 는 **앱 전체에 하나**다. `forApp` 을 BC 별로 여러 번 부르더라도 정책을
+선언하는 호출은 하나여야 하며, 둘 이상이면 부팅이 거부된다 — 어느 선언이 이기는지는
+모듈 등록 순서에 달려 있어 조용히 갈리기 때문이다.
 
-**main.ts:**
+**2) main.ts 에서 소비 시작**
 
 ```typescript
 // apps/my-service/src/main.ts
 import { NestFactory } from '@nestjs/core';
-import { MicroserviceOptions } from '@nestjs/microservices';
 import { AppModule } from './app.module';
 import { EventsModule } from '@app/events';
-import { ORDER_STREAM } from '@app/shared/streams';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  // Kafka Microservice 연결
-  const kafkaConfig = EventsModule.forConsumer({
-    streams: [ORDER_STREAM],
-    groupId: 'my-service-orders-consumer',
-  });
-
-  app.connectMicroservice<MicroserviceOptions>(kafkaConfig);
-  await app.startAllMicroservices();
+  // 구독 목록 인자가 없다. 도출된 토픽은 startConsumer 가 로그로 찍는다.
+  await EventsModule.startConsumer(app, { groupId: 'my-service-orders-consumer' });
 
   await app.listen(3000);
 }
@@ -221,13 +214,17 @@ async function bootstrap() {
 bootstrap();
 ```
 
+`startConsumer` 는 세 가지를 부팅에서 거부한다 — 전부 지금까지 무증상이던 실수다:
+계약 레지스트리에 없는 토픽 구독 · `@On` 핸들러 0개(컨슈머 컨트롤러를
+`controllers: []` 에 등록하지 않은 경우) · 정책 중복 선언.
+
 ### Consumer 구현
 
 ```typescript
 // apps/my-service/src/orders/order.consumer.ts
 import { Controller, UseInterceptors } from '@nestjs/common';
 import {
-  OnEvent,
+  On,
   EventPayload,
   EventEnvelope,
   EventMetadata,
@@ -245,7 +242,7 @@ export class OrderConsumer {
   /**
    * OrderCreated 이벤트 처리
    */
-  @OnEvent('orders.events.v1', 'OrderCreated')
+  @On(ORDER_STREAM, 'OrderCreated')
   @RetryPolicy({ maxAttempts: 3, backoff: 'exponential' })  // 재시도 정책
   async handleOrderCreated(
     @EventPayload() payload: OrderCreatedPayload,
@@ -263,7 +260,7 @@ export class OrderConsumer {
   /**
    * OrderCancelled 이벤트 처리
    */
-  @OnEvent('orders.events.v1', 'OrderCancelled')
+  @On(ORDER_STREAM, 'OrderCancelled')
   @RetryPolicy({ maxAttempts: 3 })
   async handleOrderCancelled(
     @EventPayload() payload: OrderCancelledPayload,
@@ -282,7 +279,7 @@ export class OrderConsumer {
 ## 4. 이벤트 타입 필터링
 
 `@UseInterceptors(EventTypeGuard)`를 사용하면:
-- `@OnEvent`에 지정한 이벤트 타입만 처리
+- `@On`에 지정한 이벤트 타입만 처리
 - 다른 이벤트는 조용히 무시 (에러 없이)
 - Offset commit 정상 처리
 
@@ -371,10 +368,10 @@ curl -X POST http://localhost:3100/test/create \
 - [ ] 토픽 생성 (main + dlq)
 - [ ] Stream 정의 (payload 타입 + 스키마)
 - [ ] 환경 변수 설정 (.env 파일)
-- [ ] Publisher 설정 (EventsModule.forRoot)
-- [ ] Consumer 설정 (forConsumerModule 또는 forConsumer)
+- [ ] Publisher 설정 (`EventsModule.forApp({ publishes })`)
+- [ ] Consumer 설정 (`main.ts` 의 `startConsumer`)
 - [ ] Consumer에 `@UseInterceptors(EventTypeGuard)` 추가
-- [ ] 이벤트 핸들러에 `@OnEvent` 데코레이터
+- [ ] 이벤트 핸들러에 `@On` 데코레이터
 - [ ] 재시도 정책 설정 (`@RetryPolicy`)
 
 ---

--- a/libs/events/docs/schema-validation-guide.md
+++ b/libs/events/docs/schema-validation-guide.md
@@ -73,8 +73,8 @@ import { ORDER_STREAM } from '@app/shared/streams/orders.stream';
 
 @Module({
   imports: [
-    EventsModule.forRoot({
-      streams: [ORDER_STREAM],
+    EventsModule.forApp({
+      publishes: [ORDER_STREAM],
       serviceName: 'wms-order',
       validation: {
         validateOnPublish: true,     // 발행 시 검증 (기본값: true)
@@ -91,13 +91,13 @@ export class OrderModule {}
 ```typescript
 // apps/wms/src/order/services/order.service.ts
 import { Injectable } from '@nestjs/common';
-import { InjectStreamPublisher, StreamPublisher } from '@app/events';
+import { InjectPublisher, PublisherFor } from '@app/events';
 import { ORDER_STREAM, OrderEvents, OrderCreatedPayload } from '@app/shared/streams/orders.stream';
 
 @Injectable()
 export class OrderService {
   constructor(
-    @InjectStreamPublisher('orders.events.v1')
+    @InjectPublisher(ORDER_STREAM)
     private readonly orderPublisher: StreamPublisher<OrderEvents>,
   ) {}
 
@@ -148,15 +148,13 @@ export class OrderService {
 // apps/channel-adapter/src/app.module.ts
 import { Module } from '@nestjs/common';
 import { EventsModule } from '@app/events';
-import { ORDER_STREAM } from '@app/shared/streams/orders.stream';
 
 @Module({
   imports: [
-    EventsModule.forConsumerModule({
-      streams: [ORDER_STREAM],
-      groupId: 'channel-adapter-consumers',
-      enableAutoDLQ: true,  // 자동 DLQ 처리
-      validation: {
+    EventsModule.forApp({
+      enableDLQ: true, // 자동 DLQ 처리
+      // 검증 맵은 구독 스트림에서 도출된다 — 스트림 목록을 여기 적지 않는다.
+      policy: {
         validateOnConsume: true,      // 수신 시 검증 (기본값: true)
         throwOnValidationError: true, // 검증 실패 시 에러 (기본값: true)
       },
@@ -171,14 +169,14 @@ export class AppModule {}
 ```typescript
 // apps/channel-adapter/src/consumers/order-events.consumer.ts
 import { Controller, Logger } from '@nestjs/common';
-import { OnEvent, EventPayload } from '@app/events';
+import { On, EventPayload } from '@app/events';
 import { OrderCreatedPayload } from '@app/shared/streams/orders.stream';
 
 @Controller()
 export class OrderEventsConsumer {
   private readonly logger = new Logger(OrderEventsConsumer.name);
 
-  @OnEvent('orders.events.v1', 'OrderCreated')
+  @On(ORDER_STREAM, 'OrderCreated')
   async handleOrderCreated(@EventPayload() payload: OrderCreatedPayload) {
     // ✅ 이 시점에 payload는 이미 스키마 검증 완료!
     // ✅ 타입 안전성 보장됨
@@ -218,10 +216,8 @@ export class OrderEventsConsumer {
 ### 검증 옵션 커스터마이즈
 
 ```typescript
-EventsModule.forConsumerModule({
-  streams: [ORDER_STREAM],
-  groupId: 'my-consumer',
-  validation: {
+EventsModule.forApp({
+  policy: {
     validateOnConsume: true,      // 수신 시 검증 활성화
     throwOnValidationError: false, // 검증 실패해도 에러 안던짐 (경고만)
   },

--- a/libs/events/docs/troubleshooting.md
+++ b/libs/events/docs/troubleshooting.md
@@ -41,7 +41,7 @@
 ```typescript
 @Controller()
 export class MyConsumer {  // ❌ EventTypeGuard 없음
-  @OnEvent('orders.events.v1', 'OrderCreated')
+  @On(ORDER_STREAM, 'OrderCreated')
   async handleOrderCreated(...) {}
 }
 ```
@@ -51,7 +51,7 @@ export class MyConsumer {  // ❌ EventTypeGuard 없음
 @Controller()
 @UseInterceptors(EventTypeGuard)  // ✅ 추가!
 export class MyConsumer {
-  @OnEvent('orders.events.v1', 'OrderCreated')
+  @On(ORDER_STREAM, 'OrderCreated')
   async handleOrderCreated(...) {}
 }
 ```
@@ -119,7 +119,7 @@ import { NestFactory } from '@nestjs/core';
 
 **문제:**
 ```typescript
-@OnEvent('orders.events.v1', 'OrderCreated')
+@On(ORDER_STREAM, 'OrderCreated')
 async handleOrderCreated(@EventPayload() payload: OrderCreatedPayload) {
   // 에러 발생 → Offset commit 실패 → 무한 재처리
   await this.processOrder(payload);  // 여기서 에러!
@@ -128,7 +128,7 @@ async handleOrderCreated(@EventPayload() payload: OrderCreatedPayload) {
 
 **해결:**
 ```typescript
-@OnEvent('orders.events.v1', 'OrderCreated')
+@On(ORDER_STREAM, 'OrderCreated')
 @RetryPolicy({ maxAttempts: 3, backoff: 'exponential' })  // ✅ 재시도 정책 추가
 async handleOrderCreated(@EventPayload() payload: OrderCreatedPayload) {
   try {
@@ -143,10 +143,8 @@ async handleOrderCreated(@EventPayload() payload: OrderCreatedPayload) {
 
 그리고 Module에서:
 ```typescript
-EventsModule.forConsumerModule({
-  streams: [ORDER_STREAM],
-  groupId: 'my-consumer',
-  enableAutoDLQ: true,  // ✅ 자동 DLQ 활성화
+EventsModule.forApp({
+  enableDLQ: true,  // ✅ 자동 DLQ 활성화 (기본값: true)
 })
 ```
 

--- a/libs/events/src/consumers/consumer-discovery.spec.ts
+++ b/libs/events/src/consumers/consumer-discovery.spec.ts
@@ -7,17 +7,29 @@
 
 import { Controller, Injectable } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
+import { event, stream } from '@packages/event-contracts/types';
 import { CART_STREAM } from '@packages/event-contracts/streams/cart.stream';
 import { ORDER_STREAM } from '@packages/event-contracts/streams/orders.stream';
-import { OnEvent } from './decorators';
+import { On } from './decorators';
 import { deriveConsumerConfig, discoverEventHandlers, type DiscoveredEventHandler } from './consumer-discovery';
+
+/**
+ * 레지스트리에 **없는** 스트림. `streams/index.ts` 가 export 하지 않으므로
+ * `STREAM_REGISTRY` 에 들어가지 않고, 그래서 도출이 이것을 거부해야 한다.
+ */
+const GHOST_STREAM = stream({
+  topic: 'nobody.declared.this.v1',
+  partitions: 1,
+  aggregateType: 'Ghost',
+  events: { Whatever: event<'Whatever', Record<string, never>>('Whatever') },
+});
 
 @Controller()
 class CartConsumer {
-  @OnEvent('carts.events.v1', 'CartCreated')
+  @On(CART_STREAM, 'CartCreated')
   onCreated(): void {}
 
-  @OnEvent('carts.events.v1', 'CartUpdated')
+  @On(CART_STREAM, 'CartUpdated')
   onUpdated(): void {}
 
   /** 이벤트 핸들러가 아닌 메서드는 도출에 잡히면 안 된다 */
@@ -26,13 +38,13 @@ class CartConsumer {
 
 @Controller()
 class OrderConsumer {
-  @OnEvent('orders.events.v1', 'OrderCreated')
+  @On(ORDER_STREAM, 'OrderCreated')
   onOrderCreated(): void {}
 }
 
 /** 상속받은 핸들러도 구독된다 — Nest 의 MetadataScanner 가 프로토타입 체인을 탄다 */
 class BaseConsumer {
-  @OnEvent('orders.events.v1', 'OrderCancelled')
+  @On(ORDER_STREAM, 'OrderCancelled')
   onInherited(): void {}
 }
 
@@ -41,24 +53,24 @@ class DerivedConsumer extends BaseConsumer {}
 
 @Controller()
 class UnregisteredTopicConsumer {
-  @OnEvent('nobody.declared.this.v1', 'Whatever')
+  @On(GHOST_STREAM, 'Whatever')
   onGhost(): void {}
 }
 
 /**
- * provider 에 붙인 `@OnEvent` 는 지금도 아무 일도 하지 않는다 —
+ * provider 에 붙인 `@On` 은 지금도 아무 일도 하지 않는다 —
  * Nest 의 `setupListeners` 가 `module.controllers` 만 순회하기 때문이다.
  * 도출도 같은 규칙을 따라야 한다. 안 그러면 "구독한다고 도출됐는데 실제로는
  * 안 오는" 토픽이 생겨, 이 ADR 이 없애려는 어긋남을 우리 손으로 다시 만든다.
  */
 @Injectable()
 class NotAController {
-  @OnEvent('carts.events.v1', 'CartCreated')
+  @On(CART_STREAM, 'CartCreated')
   onCreated(): void {}
 }
 
 describe('discoverEventHandlers', () => {
-  it('컨트롤러의 @OnEvent 에서 (topic, eventType) 집합을 도출한다', async () => {
+  it('컨트롤러의 @On 에서 (topic, eventType) 집합을 도출한다', async () => {
     const moduleRef = await Test.createTestingModule({
       controllers: [CartConsumer, OrderConsumer],
     }).compile();
@@ -93,7 +105,7 @@ describe('discoverEventHandlers', () => {
     ]);
   });
 
-  it('provider 의 @OnEvent 는 도출하지 않는다 — Nest 도 바인딩하지 않는다', async () => {
+  it('provider 의 @On 은 도출하지 않는다 — Nest 도 바인딩하지 않는다', async () => {
     const moduleRef = await Test.createTestingModule({ providers: [NotAController] }).compile();
 
     expect(discoverEventHandlers(moduleRef)).toEqual([]);

--- a/libs/events/src/consumers/consumer-discovery.ts
+++ b/libs/events/src/consumers/consumer-discovery.ts
@@ -1,7 +1,7 @@
 /**
  * 소비 집합 도출 (ADR-0029 §1·§3)
  *
- * 이 프로세스가 무엇을 소비하는지는 **선언하지 않는다** — `@OnEvent` 데코레이터가
+ * 이 프로세스가 무엇을 소비하는지는 **선언하지 않는다** — `@On` 데코레이터가
  * 이미 authoritative 하기 때문이다. Nest 의 `ServerKafka.bindEvents()` 는
  * `subscribe.topics` 를 `[...this.messageHandlers.keys()]` 로 덮어쓰므로
  * (`server-kafka.js:92`), 실제 구독 집합은 컨테이너 안의 데코레이터가 결정한다.
@@ -23,9 +23,9 @@ import { EVENT_TYPE_FILTER } from './decorators';
 
 /** 컨테이너에서 발견된 이벤트 핸들러 하나. */
 export interface DiscoveredEventHandler {
-  /** `@OnEvent` 의 첫 인자 = Kafka 토픽 = Nest 의 등록 패턴 */
+  /** `@On` 이 계약에서 읽은 토픽 = Nest 의 등록 패턴 */
   topic: string;
-  /** `@OnEvent` 의 두 번째 인자. 토픽 전체를 받는 핸들러면 undefined */
+  /** `@On` 의 두 번째 인자. 토픽 전체를 받는 핸들러면 undefined */
   eventType?: string;
   controller: string;
   methodName: string;
@@ -59,7 +59,7 @@ function controllerPrototype(wrapper: InstanceWrapper): object | undefined {
  * 컨테이너의 모든 컨트롤러에서 이벤트 핸들러를 훑는다.
  *
  * 컨트롤러만 본다 — Nest 도 그렇다 (`microservices-module.js` 의 `setupListeners` 는
- * `module.controllers` 만 순회한다). provider 에 `@OnEvent` 를 달면 지금도 아무 일이
+ * `module.controllers` 만 순회한다). provider 에 `@On` 을 달면 지금도 아무 일이
  * 일어나지 않으며, 여기서도 발견되지 않는다.
  */
 export function discoverEventHandlers(app: INestApplicationContext): DiscoveredEventHandler[] {
@@ -85,7 +85,7 @@ export function discoverEventHandlers(app: INestApplicationContext): DiscoveredE
         if (typeof pattern !== 'string' || pattern.length === 0) {
           throw new Error(
             `startConsumer(): ${controller}.${definition.methodKey} 의 이벤트 패턴이 토픽 문자열이 아니다 ` +
-              `(${JSON.stringify(pattern)}). @OnEvent 는 첫 인자로 토픽 문자열을 받는다.`,
+              `(${JSON.stringify(pattern)}). @On 은 계약에서 토픽 문자열을 읽는다.`,
           );
         }
 
@@ -112,7 +112,7 @@ export function discoverEventHandlers(app: INestApplicationContext): DiscoveredE
 export function deriveConsumerConfig(handlers: DiscoveredEventHandler[]): DerivedConsumerConfig {
   if (handlers.length === 0) {
     throw new Error(
-      'startConsumer(): @OnEvent 핸들러가 하나도 발견되지 않았다. ' +
+      'startConsumer(): @On 핸들러가 하나도 발견되지 않았다. ' +
         '컨슈머 컨트롤러를 모듈의 `controllers: []` 에 등록했는지 확인하라 — ' +
         '등록 누락은 이 시스템에서 가장 조용한 실수였다 (ADR-0029).',
     );

--- a/libs/events/src/consumers/consumer-interceptors.ts
+++ b/libs/events/src/consumers/consumer-interceptors.ts
@@ -1,7 +1,7 @@
 /**
  * 소비 경로 인터셉터 배선 (ADR-0029 §8)
  *
- * 이 인터셉터들은 `forRoot`/`forConsumerModule` 에서 `APP_INTERCEPTOR` 로도 등록되지만,
+ * `EventRetryInterceptor` 는 `forApp` 에서 `APP_INTERCEPTOR` 로도 등록되지만,
  * **하이브리드 앱에서는 그 등록이 소비 경로에 닿지 않는다.** `app.connectMicroservice(opts)`
  * 를 두 번째 인자 없이 부르면 Nest 가 마이크로서비스에 **새 `ApplicationConfig`** 를
  * 만들어 주기 때문이다 (`nest-application.js:128`). 그래서 `startConsumer` 는 마이크로서비스
@@ -13,7 +13,7 @@
  */
 
 import type { INestApplicationContext, NestInterceptor, Type } from '@nestjs/common';
-import { Reflector } from '@nestjs/core';
+import { ModulesContainer, Reflector } from '@nestjs/core';
 import type { SchemaValidationOptions, StreamConfig } from '@packages/event-contracts/types';
 import { DLQHandler } from '../dlq/dlq-handler.service';
 import { ChainContextInterceptor } from '../interceptors/chain-context.interceptor';
@@ -46,16 +46,46 @@ function optionalGet<T>(app: INestApplicationContext, token: Type<T> | string): 
 }
 
 /**
+ * 소비 정책이 두 곳 이상에서 선언됐으면 부팅을 거부한다.
+ *
+ * `forApp` 은 BC 별로 여러 번 불릴 수 있고(core 는 4번), 그중 둘이 `policy` 를 선언하면
+ * `optionalGet` 은 **아무 경고 없이 하나만** 돌려준다. 어느 것이 이기는지는 모듈 등록
+ * 순서에 달렸고, 두 선언이 `validateOnConsume` 에서 갈리면 그 순간 검증이 켜지거나
+ * 꺼진다 — 증상 없는 결함이다. 그래서 세어서 거부한다.
+ *
+ * 0개는 정상이다(기본값 `validateOnConsume: true` 로 떨어진다).
+ */
+export function assertSinglePolicyDeclaration(app: INestApplicationContext): void {
+  const container = app.get(ModulesContainer, { strict: false });
+  const declarations: unknown[] = [];
+
+  for (const module of container.values()) {
+    const wrapper = module.providers.get(EVENTS_CONSUMER_POLICY);
+    if (wrapper) declarations.push(wrapper.instance ?? wrapper.metatype);
+  }
+
+  if (declarations.length > 1) {
+    throw new Error(
+      `startConsumer(): 소비 정책(EVENTS_CONSUMER_POLICY)이 ${declarations.length}곳에서 선언됐다 — ` +
+        '`forApp({ policy })` 는 앱 전체에 하나여야 한다. 어느 선언이 이기는지는 모듈 등록 ' +
+        '순서에 달려 있어 조용히 갈린다.\n' +
+        declarations.map((declaration) => `  - ${JSON.stringify(declaration)}`).join('\n'),
+    );
+  }
+}
+
+/**
  * 마이크로서비스 스코프 전역 인터셉터를 만든다.
  *
  * **배열 순서 = 래핑 순서.** 재시도·분류·DLQ 가 최외곽이어야 안쪽에서 나온
  * `SchemaValidationError` 도 분류망에 걸린다 (`events.module.ts` 의 APP_INTERCEPTOR
  * 등록 순서와 같은 이유·같은 순서).
  *
- * @param streams `@OnEvent` 에서 **도출된** 스트림 목록 — 검증 스키마 맵이 된다
+ * @param streams `@On` 에서 **도출된** 스트림 목록 — 검증 스키마 맵이 된다
  */
 export function buildConsumerInterceptors(app: INestApplicationContext, streams: StreamConfig[]): NestInterceptor[] {
   const reflector = app.get(Reflector, { strict: false });
+  assertSinglePolicyDeclaration(app);
   const policy = optionalGet<EventsConsumerPolicy>(app, EVENTS_CONSUMER_POLICY);
 
   const interceptors: NestInterceptor[] = [

--- a/libs/events/src/consumers/consumer-policy-wiring.spec.ts
+++ b/libs/events/src/consumers/consumer-policy-wiring.spec.ts
@@ -1,25 +1,25 @@
 /**
- * `EVENTS_CONSUMER_POLICY` 를 **평범한 provider 로 선언한 모양**이 실제로 읽히는가 (플랜 Task 5-C).
+ * `EVENTS_CONSUMER_POLICY` 배선 — 선언한 값이 실제로 읽히는가, 그리고 두 번 선언하면
+ * 부팅이 거부되는가 (플랜 Task 5-C · Task 7).
  *
- * ## 왜 이것만 따로 고정하는가
+ * ## 왜 따로 고정하는가
  *
- * 정책을 선언하는 자리가 두 가지다:
+ * 정책 선언은 이제 자리가 하나다 — `EventsModule.forApp({ policy })`. Task 7 이전에는
+ * 둘이었다(`forConsumerModule({ validation })` 6개 앱 / 모듈 providers 직접 등록 1개 앱).
+ * `forApp` 은 그 자리를 흡수하면서 **평범한 provider 하나**를 등록하므로, 이 스펙이 덮는
+ * 모양이 곧 모든 앱의 모양이다.
  *
- * - `EventsModule.forConsumerModule({ validation })` — analytics · search · membership · core
- * - 모듈 providers 에 `EVENTS_CONSUMER_POLICY` 를 직접 등록 — **channel-adapter 뿐**
- *
- * 앞의 모양은 `transport/consume-validation.spec.ts` 가 실행으로 덮는다. 뒤의 모양은 5-B 가
- * 도입한 뒤로 **어느 스펙도 덮지 않았다.** channel-adapter 가 `forConsumerModule` 을 부르지
- * 않는 이유는 그 표면이 `streams` 를 필수로 받기 때문인데(그 목록이 이 워크스트림이 지우는 중인
- * 두 번째 진실이다), 그래서 이 앱만 다른 자리에 선언한다.
- *
- * 이 차이가 조용한 이유가 고약하다 — 토큰을 못 찾으면 `optionalGet` 이 `undefined` 를 반환하고
+ * 이 배선이 끊길 때가 고약하다 — 토큰을 못 찾으면 `optionalGet` 이 `undefined` 를 반환하고
  * 기본값 `validateOnConsume: true` 가 먹는다. 즉 **배선이 끊겨도 5-C 이후에는 원하던 값과
  * 같아져서** 증상이 없다. 배선이 산 것과 죽은 것을 구별하려면 `false` 를 넣어 보는 수밖에 없고,
  * 그것이 아래 두 번째 케이스(대조군)다.
+ *
+ * 두 번 선언하는 경우도 같은 종류로 조용하다 — `optionalGet` 은 경고 없이 하나만 돌려주고
+ * 어느 것이 이기는지는 모듈 등록 순서에 달렸다. `forApp` 은 BC 별로 여러 번 불릴 수 있어
+ * (core 는 4번) 실제로 일어날 수 있는 실수이며, 그래서 세어서 거부한다.
  */
 import 'reflect-metadata';
-import { CallHandler } from '@nestjs/common';
+import { CallHandler, Module } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { ExecutionContextHost } from '@nestjs/core/helpers/execution-context-host';
 import { KafkaContext } from '@nestjs/microservices';
@@ -27,8 +27,14 @@ import type { Consumer, KafkaMessage, Producer } from '@nestjs/microservices/ext
 import { of } from 'rxjs';
 import { z } from 'zod';
 import { event, stream, SchemaValidationError } from '@packages/event-contracts/types';
+import { EventsModule } from '../events.module';
 import { SchemaValidationInterceptor } from '../interceptors/schema-validation.interceptor';
-import { buildConsumerInterceptors, EVENTS_CONSUMER_POLICY, type EventsConsumerPolicy } from './consumer-interceptors';
+import {
+  assertSinglePolicyDeclaration,
+  buildConsumerInterceptors,
+  EVENTS_CONSUMER_POLICY,
+  type EventsConsumerPolicy,
+} from './consumer-interceptors';
 
 const POLICY_STREAM = stream({
   topic: 'policy-wiring.events.v1',
@@ -86,7 +92,7 @@ async function schemaInterceptorFor(policyProvider?: EventsConsumerPolicy): Prom
 
 const nextThatSucceeds: CallHandler = { handle: () => of('handled') };
 
-describe('EVENTS_CONSUMER_POLICY 를 평범한 provider 로 선언하는 모양 (channel-adapter)', () => {
+describe('EVENTS_CONSUMER_POLICY 를 provider 로 선언한 값이 실제로 읽힌다', () => {
   it('`validateOnConsume: true` 를 그 자리에서 읽는다 — 위반 메시지가 거부된다', async () => {
     const interceptor = await schemaInterceptorFor({ validation: { validateOnConsume: true } });
 
@@ -109,5 +115,79 @@ describe('EVENTS_CONSUMER_POLICY 를 평범한 provider 로 선언하는 모양 
     expect(() => interceptor.intercept(rpcContextWithViolatingMessage(), nextThatSucceeds)).toThrow(
       SchemaValidationError,
     );
+  });
+});
+
+describe('forApp({ policy }) 가 그 provider 를 등록한다', () => {
+  const kafka = { clientId: 'policy-wiring-spec', brokers: ['unused:9092'] };
+
+  /** DynamicModule 의 providers 는 넓게 타이핑돼 있어 좁혀서 찾는다. */
+  const policyProviderOf = (moduleRef: { providers?: unknown[] }) =>
+    (moduleRef.providers ?? []).find(
+      (provider) => (provider as { provide?: unknown }).provide === EVENTS_CONSUMER_POLICY,
+    ) as { useValue?: EventsConsumerPolicy } | undefined;
+
+  it('선언한 정책이 그대로 provider 값이 된다', () => {
+    const moduleRef = EventsModule.forApp({ kafka, policy: { validateOnConsume: false } });
+
+    expect(policyProviderOf(moduleRef)?.useValue).toEqual({ validation: { validateOnConsume: false } });
+  });
+
+  it('대조군 — 선언하지 않으면 provider 자체가 없다 (기본값으로 떨어진다)', () => {
+    const moduleRef = EventsModule.forApp({ kafka });
+
+    expect(policyProviderOf(moduleRef)).toBeUndefined();
+  });
+});
+
+describe('정책이 두 곳에서 선언되면 부팅을 거부한다', () => {
+  const declaring = (validateOnConsume: boolean) => {
+    @Module({
+      providers: [
+        {
+          provide: EVENTS_CONSUMER_POLICY,
+          useValue: { validation: { validateOnConsume } } satisfies EventsConsumerPolicy,
+        },
+      ],
+      exports: [EVENTS_CONSUMER_POLICY],
+    })
+    class PolicyModule {}
+    return PolicyModule;
+  };
+
+  it('두 모듈이 선언하면 어느 쪽이 이기는지 알 수 없으므로 던진다', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [declaring(true), declaring(false)],
+    }).compile();
+
+    expect(() => assertSinglePolicyDeclaration(moduleRef)).toThrow(/2곳에서 선언됐다/);
+    // 값이 에러에 실려야 어느 선언이 문제인지 볼 수 있다
+    expect(() => assertSinglePolicyDeclaration(moduleRef)).toThrow(/validateOnConsume/);
+  });
+
+  it('대조군 — 하나면 통과한다', async () => {
+    const moduleRef = await Test.createTestingModule({ imports: [declaring(true)] }).compile();
+
+    expect(() => assertSinglePolicyDeclaration(moduleRef)).not.toThrow();
+  });
+
+  it('대조군 — 0개도 통과한다 (기본값으로 떨어지는 정상 상태)', async () => {
+    const moduleRef = await Test.createTestingModule({}).compile();
+
+    expect(() => assertSinglePolicyDeclaration(moduleRef)).not.toThrow();
+  });
+
+  /**
+   * 위 세 케이스는 함수를 직접 부른다 — 함수가 옳다는 것만 증명하고, 그것이 **부팅
+   * 경로에 꽂혀 있다**는 것은 증명하지 않는다. `startConsumer` 가 인터셉터를 만드는
+   * 유일한 지점이 `buildConsumerInterceptors` 이므로, 거기서 터지는지를 따로 건다.
+   * 이 단언이 없으면 호출 한 줄을 지워도 위 셋은 그대로 초록이다.
+   */
+  it('부팅 경로(buildConsumerInterceptors)가 그 검사를 실제로 부른다', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [declaring(true), declaring(false)],
+    }).compile();
+
+    expect(() => buildConsumerInterceptors(moduleRef, [POLICY_STREAM])).toThrow(/2곳에서 선언됐다/);
   });
 });

--- a/libs/events/src/consumers/decorators.ts
+++ b/libs/events/src/consumers/decorators.ts
@@ -50,46 +50,16 @@ export function StreamEventHandler(
 }
 
 /**
- * 특정 이벤트 타입만 처리하는 핸들러 (권장)
- *
- * 내부적으로 messageType 필터링을 자동으로 처리
- *
- * @example
- * @Controller()
- * export class OrderEventsConsumer {
- *   @OnEvent('orders.events.v1', 'OrderCreated')
- *   async onOrderCreated(
- *     @EventEnvelope() envelope: DomainEvent<OrderCreatedPayload>,
- *     @EventPayload() payload: OrderCreatedPayload,
- *     @EventContext() ctx: KafkaContext,
- *   ) {
- *     console.log('Order created:', payload.orderId);
- *   }
- *
- *   @OnEvent('orders.events.v1', 'OrderCancelled')
- *   async onOrderCancelled(
- *     @EventPayload() payload: OrderCancelledPayload
- *   ) {
- *     console.log('Order cancelled:', payload.orderId);
- *   }
- * }
- */
-export function OnEvent(topic: string, eventType: string) {
-  return applyDecorators(EventPattern(topic), SetMetadata(EVENT_TYPE_FILTER, eventType));
-}
-
-/**
  * 계약에서 토픽·이벤트명을 도출하는 핸들러 데코레이터 (ADR-0029 §4)
  *
- * `@OnEvent('products.events.v1', 'ProductMasterDeleted')` 는 **두 개의 생문자열**이다.
- * 토픽은 계약이 이미 알고 있고(`STREAM.topic.topic`), 이벤트명은 계약이 가진 키 집합에
- * 속해야 한다. `@On` 은 토픽을 계약에서 읽고 이벤트명을 `EventKeysOf` 로 좁혀,
- * 오타가 **컴파일 에러**가 되게 한다.
+ * 옛 표면 `@OnEvent('products.events.v1', 'ProductMasterDeleted')` 는 **두 개의 생문자열**
+ * 이었다. 토픽은 계약이 이미 알고 있고(`STREAM.topic.topic`), 이벤트명은 계약이 가진 키
+ * 집합에 속해야 한다. `@On` 은 토픽을 계약에서 읽고 이벤트명을 `EventKeysOf` 로 좁혀,
+ * 오타가 **컴파일 에러**가 되게 한다. (`@OnEvent` 는 Task 7 에서 삭제됐다.)
  *
- * 런타임 동작은 `@OnEvent` 과 **완전히 같다** — `EventPattern(topic)` +
+ * 남기는 런타임 메타데이터는 Nest 네이티브 그대로다 — `EventPattern(topic)` +
  * `SetMetadata(EVENT_TYPE_FILTER, eventName)`. 따라서 `EventTypeGuard` · 소비 집합
- * 도출(`consumer-discovery.ts`) · Nest 의 바인딩이 전부 그대로 동작하며, 두 데코레이터를
- * 한 앱에서 섞어 써도 된다 (앱별 이주 중에는 실제로 섞인다).
+ * 도출(`consumer-discovery.ts`) · Nest 의 바인딩이 전부 그대로 동작한다.
  *
  * @example
  * @Controller()
@@ -124,7 +94,7 @@ export function On<S extends StreamConfig<StreamEventTypes>, K extends EventKeys
     );
   }
 
-  return OnEvent(topic, eventName);
+  return applyDecorators(EventPattern(topic), SetMetadata(EVENT_TYPE_FILTER, eventName));
 }
 
 /**

--- a/libs/events/src/consumers/typed-decorators.spec.ts
+++ b/libs/events/src/consumers/typed-decorators.spec.ts
@@ -3,22 +3,26 @@
  *
  * 증명해야 할 것이 둘이다:
  *
- * 1. **런타임이 옛 표면과 같다.** `@On` 은 `@OnEvent` 과 동일한 메타데이터를 남기고,
- *    `@InjectPublisher` 는 `@InjectStreamPublisher` 와 동일한 토큰을 만든다. 그래야
- *    앱별 이주(Task 5) 중 한 앱 안에서 두 표면이 섞여도 안전하다. 이건 Task 2 하네스로
- *    실제 발행→소비 왕복을 돌려서 확인한다 — 메타데이터만 비교하면 "같아 보인다"에서 끝난다.
+ * 1. **런타임이 Nest 네이티브 등록과 같다.** `@On` 은 `EventPattern` + `SetMetadata` 가
+ *    남기는 것과 똑같은 메타데이터를 남기고, `@InjectPublisher` 는 `getPublisherToken`
+ *    한 곳에서 나온 토큰을 만든다. 이건 Task 2 하네스로 실제 발행→소비 왕복을 돌려서
+ *    확인한다 — 메타데이터만 비교하면 "같아 보인다"에서 끝난다.
+ *    (옛 표면 `@OnEvent`/`@InjectStreamPublisher` 는 Task 7 에서 삭제됐다. 대조군은
+ *    그 자리에 Nest 네이티브 데코레이터를 직접 세운다 — 우리 헬퍼를 거치지 않으므로
+ *    옛 표면과 비교하던 것보다 오히려 강한 대조군이다.)
  * 2. **타입이 계약에서 도출된다.** 잘못된 이벤트명·payload 는 컴파일 에러다.
  *    타입 단계 단언은 `@ts-expect-error` 로 하며, 그 검사는 `npm run type-check` 가 강제한다
  *    (불필요한 `@ts-expect-error` 는 그 자체가 에러라 단언이 썩으면 바로 드러난다).
  */
 
-import { Controller, INestMicroservice, Injectable, UseInterceptors } from '@nestjs/common';
+import { Controller, INestMicroservice, Injectable, SetMetadata, UseInterceptors } from '@nestjs/common';
+import { EventPattern } from '@nestjs/microservices';
 import { Test } from '@nestjs/testing';
 import { z } from 'zod';
 import { event, stream } from '@packages/event-contracts/types';
 import type { EnvelopeOf, EventPayloadOf } from '@packages/event-contracts/types';
 import { EventsModule } from '../events.module';
-import { EventEnvelope, EventPayload, On, OnEvent } from './decorators';
+import { EVENT_TYPE_FILTER, EventEnvelope, EventPayload, On } from './decorators';
 import { EventTypeGuard } from '../guards/event-type.guard';
 import { InjectPublisher, PublisherFor } from '../publishers/inject-publisher';
 import { getPublisherToken } from '../publishers/publisher-token';
@@ -124,10 +128,7 @@ describe('@On / @InjectPublisher — 계약에서 도출하는 등록 표면', (
     const kafka = { clientId: 'typed-harness', brokers: ['unused:9092'] };
 
     const moduleRef = await Test.createTestingModule({
-      imports: [
-        EventsModule.forRoot({ streams: [TYPED_STREAM], serviceName: 'typed-harness', kafka }),
-        EventsModule.forConsumerModule({ streams: [TYPED_STREAM], groupId: 'typed-harness-consumer', kafka }),
-      ],
+      imports: [EventsModule.forApp({ publishes: [TYPED_STREAM], serviceName: 'typed-harness', kafka })],
       controllers: [TypedConsumer],
       providers: [TypedOrderService],
     })
@@ -180,14 +181,17 @@ describe('@On / @InjectPublisher — 계약에서 도출하는 등록 표면', (
       expect(calls[0].payload).toEqual({ orderId: 'order-2', reason: 'out-of-stock' });
     });
 
-    it('@On 이 남기는 메타데이터가 @OnEvent 과 완전히 같다', () => {
+    it('@On 이 남기는 메타데이터가 Nest 네이티브 등록과 완전히 같다', () => {
       class ViaOn {
         @On(TYPED_STREAM, 'OrderCreated')
         handle(): void {}
       }
 
-      class ViaOnEvent {
-        @OnEvent('harness.typed.v1', 'OrderCreated')
+      // 대조군은 우리 헬퍼가 아니라 Nest 자신의 데코레이터다. Nest 가 바인딩할 때 보는
+      // 것은 이 메타데이터이므로, 여기가 갈라지면 구독이 조용히 사라진다.
+      class ViaNative {
+        @EventPattern('harness.typed.v1')
+        @SetMetadata(EVENT_TYPE_FILTER, 'OrderCreated')
         handle(): void {}
       }
 
@@ -196,21 +200,21 @@ describe('@On / @InjectPublisher — 계약에서 도출하는 등록 표면', (
       const handlerOf = (proto: object): object => Reflect.get(proto, 'handle') as object;
 
       const onHandler = handlerOf(ViaOn.prototype);
-      const onEventHandler = handlerOf(ViaOnEvent.prototype);
+      const nativeHandler = handlerOf(ViaNative.prototype);
 
       const onKeys = Reflect.getMetadataKeys(onHandler).sort();
-      const onEventKeys = Reflect.getMetadataKeys(onEventHandler).sort();
+      const nativeKeys = Reflect.getMetadataKeys(nativeHandler).sort();
 
       // 키 집합이 같아야 한다 — 하나라도 빠지면 Nest 의 바인딩이나 EventTypeGuard 가 갈라진다
-      expect(onKeys).toEqual(onEventKeys);
+      expect(onKeys).toEqual(nativeKeys);
       expect(onKeys.length).toBeGreaterThan(0);
 
       for (const key of onKeys) {
-        expect(Reflect.getMetadata(key, onHandler)).toEqual(Reflect.getMetadata(key, onEventHandler));
+        expect(Reflect.getMetadata(key, onHandler)).toEqual(Reflect.getMetadata(key, nativeHandler));
       }
     });
 
-    it('@InjectPublisher 의 토큰이 @InjectStreamPublisher 와 같다', () => {
+    it('토큰 생성이 한 곳이다 — @InjectPublisher 와 EventsModule.getPublisherToken 이 같은 문자열', () => {
       expect(getPublisherToken(TYPED_STREAM.topic.topic)).toBe(
         EventsModule.getPublisherToken(TYPED_STREAM.topic.topic),
       );

--- a/libs/events/src/events.module.spec.ts
+++ b/libs/events/src/events.module.spec.ts
@@ -17,20 +17,18 @@ describe('EventsModule Kafka client configuration', () => {
   const kafka = { clientId: 'test-service', brokers: ['localhost:9092'] };
 
   it('uses producer-only ClientKafka for publishers', () => {
-    const moduleRef = EventsModule.forRoot({
-      streams: [USER_STREAM],
+    const moduleRef = EventsModule.forApp({
+      publishes: [USER_STREAM],
       kafka,
     });
 
     expect(getKafkaClientOptions(moduleRef)?.producerOnlyMode).toBe(true);
   });
 
-  it('uses producer-only ClientKafka for consumer-side DLQ publishing', () => {
-    const moduleRef = EventsModule.forConsumerModule({
-      streams: [USER_STREAM],
-      groupId: 'test-consumer',
-      kafka,
-    });
+  it('소비만 하는 앱(publishes 없음)도 DLQ 발행용 producer-only 클라이언트를 얻는다', () => {
+    // 옛 `forConsumerModule` 이 하던 일이다. 소비 앱도 DLQ 로 **발행**하므로
+    // KAFKA_CLIENT 가 필요하고, 소비 자체는 `startConsumer` 의 ServerKafka 가 따로 한다.
+    const moduleRef = EventsModule.forApp({ kafka });
 
     expect(getKafkaClientOptions(moduleRef)?.producerOnlyMode).toBe(true);
   });
@@ -48,19 +46,25 @@ describe('EventsModule global retry interceptor registration', () => {
     );
   }
 
-  it('forRoot: EventRetryInterceptor가 최외곽(첫 번째) 전역 인터셉터다', () => {
-    const moduleRef = EventsModule.forRoot({ streams: [USER_STREAM], kafka });
+  it('forApp: EventRetryInterceptor가 최외곽(첫 번째) 전역 인터셉터다', () => {
+    const moduleRef = EventsModule.forApp({ publishes: [USER_STREAM], kafka });
     const interceptors = appInterceptorsOf(moduleRef);
-    // forRoot는 producer 전용이라 SchemaValidation/ChainContext 인터셉터가 등록되지 않는다
-    // (그건 forConsumerModule 소관) — 여기서는 retry가 유일한 첫 항목이면 충분하다.
     expect(interceptors.length).toBeGreaterThanOrEqual(1);
     expect(interceptors[0].useClass).toBe(EventRetryInterceptor);
   });
 
-  it('forConsumerModule: EventRetryInterceptor가 최외곽(첫 번째) 전역 인터셉터다', () => {
-    const moduleRef = EventsModule.forConsumerModule({ streams: [USER_STREAM], groupId: 'test-consumer', kafka });
+  /**
+   * 소비 경로의 인터셉터는 `APP_INTERCEPTOR` 가 아니라 **마이크로서비스 스코프**로
+   * 붙는다 (`startConsumer` → `buildConsumerInterceptors`, ADR-0029 §8). 옛
+   * `forConsumerModule` 은 SchemaValidation·ChainContext 를 `APP_INTERCEPTOR` 로도
+   * 등록했지만 하이브리드 앱에서 그 등록은 소비 경로에 닿은 적이 없다. Task 7 에서
+   * 걷어냈고, 이 단언이 다시 자라지 않게 막는다.
+   */
+  it('forApp 은 소비 인터셉터를 APP_INTERCEPTOR 로 등록하지 않는다', () => {
+    const moduleRef = EventsModule.forApp({ publishes: [USER_STREAM], kafka, policy: { validateOnConsume: true } });
     const interceptors = appInterceptorsOf(moduleRef);
-    expect(interceptors.length).toBeGreaterThanOrEqual(2);
+
+    expect(interceptors).toHaveLength(1);
     expect(interceptors[0].useClass).toBe(EventRetryInterceptor);
   });
 });
@@ -71,8 +75,8 @@ describe('EventsModule global retry interceptor registration', () => {
  * 영영 검사되지 않는다 — 이 워크스트림이 반복해서 만난 실패 모드가 정확히 그것이다
  * (선언과 실제가 갈라져도 아무 일이 안 일어남).
  *
- * **Task 6-C-2 로 주입 조건이 바뀌었다.** 그 전에는 *같은* `forRoot` 호출이 `enableOutbox`
- * 여야 주입 목록에 들어갔는데, 아웃박스는 앱 하나에 테이블 하나이고 BC 별 `forRoot` 는 여럿이라
+ * **Task 6-C-2 로 주입 조건이 바뀌었다.** 그 전에는 *같은* `forApp` 호출이 `enableOutbox`
+ * 여야 주입 목록에 들어갔는데, 아웃박스는 앱 하나에 테이블 하나이고 BC 별 `forApp` 은 여럿이라
  * 그 결합이 어긋났다(core: catalog 만 켰지만 적재는 6개 토픽이 한다). 이제 **항상 optional 로**
  * 주입하고, 아무도 켜지 않은 앱에서는 `undefined` 가 들어와 `enqueue` 가 던진다. 그래서 대조군의
  * 주장도 "주입 목록에 없다" 가 아니라 **"writer 가 없으면 던진다"** 로 옮겼다 — 후자가 실제로
@@ -81,7 +85,7 @@ describe('EventsModule global retry interceptor registration', () => {
 describe('EventsModule outbox writer 배선 (ADR-0029 §5)', () => {
   const kafka = { clientId: 'test-service', brokers: ['localhost:9092'] };
 
-  /** `forRoot` 가 만드는 publisher provider 의 모양. DynamicModule 은 이보다 넓게 타이핑돼 있다. */
+  /** `forApp` 이 만드는 publisher provider 의 모양. DynamicModule 은 이보다 넓게 타이핑돼 있다. */
   interface PublisherProvider {
     provide: string;
     inject: Array<string | symbol | { name?: string }>;
@@ -103,7 +107,7 @@ describe('EventsModule outbox writer 배선 (ADR-0029 §5)', () => {
     });
 
   it('publisher 가 OutboxPublisher 를 주입받고 enqueue 가 그리로 쓴다', async () => {
-    const provider = publisherProviderOf(EventsModule.forRoot({ streams: [USER_STREAM], kafka, enableOutbox: true }));
+    const provider = publisherProviderOf(EventsModule.forApp({ publishes: [USER_STREAM], kafka, enableOutbox: true }));
 
     expect(injectedNames(provider)).toContain('OutboxPublisher');
 
@@ -129,7 +133,7 @@ describe('EventsModule outbox writer 배선 (ADR-0029 §5)', () => {
   });
 
   it('대조군 — writer 가 없으면 enqueue 가 던진다 (아웃박스를 아무도 켜지 않은 앱)', async () => {
-    const provider = publisherProviderOf(EventsModule.forRoot({ streams: [USER_STREAM], kafka }));
+    const provider = publisherProviderOf(EventsModule.forApp({ publishes: [USER_STREAM], kafka }));
 
     // 토큰은 optional 이라 목록에 남아 있다. 지켜야 할 성질은 목록의 모양이 아니라,
     // writer 가 실제로 없을 때 **조용히 버리지 않고 던지는 것**이다.
@@ -148,7 +152,7 @@ describe('EventsModule outbox writer 배선 (ADR-0029 §5)', () => {
   });
 
   it('OutboxPublisher 토큰이 optional 로 주입된다 — 켠 곳이 어디든 앱 전체 publisher 가 쓴다', () => {
-    const provider = publisherProviderOf(EventsModule.forRoot({ streams: [USER_STREAM], kafka }));
+    const provider = publisherProviderOf(EventsModule.forApp({ publishes: [USER_STREAM], kafka }));
     const entry = provider.inject.find(
       (e) => (e as { token?: { name?: string } }).token?.name === 'OutboxPublisher',
     ) as { optional?: boolean } | undefined;

--- a/libs/events/src/events.module.ts
+++ b/libs/events/src/events.module.ts
@@ -4,7 +4,7 @@
  * Stream 기반 이벤트 시스템을 위한 NestJS 모듈
  */
 
-import { DynamicModule, Global, INestApplication, Inject, Module, OnApplicationShutdown, Logger } from '@nestjs/common';
+import { DynamicModule, Global, INestApplication, Module, OnApplicationShutdown, Logger } from '@nestjs/common';
 import {
   ClientKafka,
   ClientsModule,
@@ -17,8 +17,6 @@ import { ClsModule } from 'nestjs-cls';
 import { StreamPublisher } from './publishers/stream-publisher.service';
 import { getPublisherToken } from './publishers/publisher-token';
 import { DLQHandler } from './dlq/dlq-handler.service';
-import { SchemaValidationInterceptor } from './interceptors/schema-validation.interceptor';
-import { ChainContextInterceptor } from './interceptors/chain-context.interceptor';
 import { EventRetryInterceptor } from './interceptors/event-retry.interceptor';
 import { GracefulShutdownService } from './shutdown/graceful-shutdown.service';
 import { EventChainService } from './tracking/event-chain.service';
@@ -53,58 +51,49 @@ const eventTransportProvider = {
 };
 
 /**
- * EventsModule 설정 옵션 (Publisher용)
+ * `forApp()` 설정 옵션 — 이 앱이 가진 **능력**만 선언한다 (ADR-0029 §3)
+ *
+ * **소비 스트림은 여기 없다.** 그건 `@On` 데코레이터에서 도출된다 (`startConsumer`).
+ * 선언은 코드에서 도출할 수 없는 사실에만 둔다는 §1 원칙의 결과다.
  */
-export interface EventsModuleOptions {
-  streams: StreamConfig[]; // 여러 stream 지원
+export interface EventsAppOptions {
+  /**
+   * 이 프로세스가 **발행**하는 스트림. 스트림당 `StreamPublisher` provider 가 하나
+   * 등록되고 토픽이 부트스트랩된다. 소비만 하는 앱은 생략한다.
+   *
+   * 옛 이름은 `streams` 였다. 세 표면이 같은 이름으로 각각 다른 뜻(발행 능력 · 검증
+   * 맵 · 무의미한 subscribe 목록)을 받던 것이 ADR-0029 Context 의 첫 번째 관측이다.
+   */
+  publishes?: StreamConfig[];
   kafka?: KafkaConfig; // 선택: 없으면 환경변수에서 생성
   serviceName?: string; // 선택: 기본값은 환경변수 SERVICE_NAME
   enableDLQ?: boolean; // DLQ 활성화 (기본: true)
-  validation?: SchemaValidationOptions; // 스키마 검증 옵션
+
+  /**
+   * **발행** 검증 정책 — 이 호출이 등록하는 publisher 에만 적용된다.
+   *
+   * 소비 정책과 타입이 갈려 있다. 옛 `forRoot`/`forConsumerModule` 은 둘 다
+   * `validation: SchemaValidationOptions` 를 받아 이름이 같고 뜻이 달랐다.
+   */
+  validation?: Pick<SchemaValidationOptions, 'validateOnPublish' | 'throwOnValidationError'>;
+
+  /**
+   * **소비** 검증 정책 — 앱 전체에 하나.
+   *
+   * `startConsumer` 가 마이크로서비스 스코프 인터셉터를 만들 때 읽는다 (ADR-0029 §8).
+   * 여러 `forApp` 호출이 선언하면 어느 것이 이기는지 알 수 없으므로 **부팅을 거부**한다
+   * (`assertSinglePolicyDeclaration`).
+   */
+  policy?: Pick<SchemaValidationOptions, 'validateOnConsume' | 'throwOnValidationError'>;
+
   enableOutbox?: boolean; // Outbox 패턴 활성화 (기본: false)
   outbox?: OutboxConfig; // Outbox 설정
 }
 
 /**
- * Consumer 설정 옵션
- */
-export interface ConsumerModuleOptions {
-  streams: StreamConfig[]; // 여러 stream 구독 지원
-  groupId: string;
-  kafka?: KafkaConfig; // 선택: 없으면 환경변수에서 생성
-
-  // Consumer 세부 설정
-  sessionTimeout?: number; // ms (기본: 30000)
-  heartbeatInterval?: number; // ms (기본: 3000)
-  maxPollInterval?: number; // ms (기본: 300000)
-  autoCommit?: boolean; // 기본: false
-
-  // DLQ 및 재시도 설정
-  enableAutoDLQ?: boolean; // 자동 DLQ 처리 활성화 (기본: true)
-
-  // 스키마 검증 설정
-  validation?: SchemaValidationOptions; // 스키마 검증 옵션
-}
-
-/**
- * `forConsumer()` 전송 설정 (deprecated 경로)
- *
- * `streams` 만 빠져 있다 — Nest 가 `subscribe.topics` 를 덮어쓰므로 무의미했다.
- * 아래 `forConsumer` 의 JSDoc 참조.
- */
-export interface ConsumerTransportOptions extends Omit<ConsumerModuleOptions, 'streams'> {
-  /**
-   * @deprecated 무시된다. Nest 의 `ServerKafka.bindEvents()` 가 `subscribe.topics` 를
-   * 등록된 `@OnEvent` 패턴으로 덮어쓰기 때문에 이 목록은 한 번도 효과를 낸 적이 없다
-   * (ADR-0029 Context). 필드는 기존 호출부 호환을 위해 남겨두었다.
-   */
-  streams?: StreamConfig[];
-}
-
-/**
  * `startConsumer()` 옵션 (ADR-0029 §3)
  *
- * **구독 목록이 없다.** 소비 집합은 `@OnEvent` 데코레이터에서 도출된다.
+ * **구독 목록이 없다.** 소비 집합은 `@On` 데코레이터에서 도출된다.
  * 여기 남는 것은 코드에서 도출할 수 없는 사실 — 전송 설정뿐이다.
  */
 export interface StartConsumerOptions {
@@ -133,28 +122,35 @@ export interface StartConsumerOptions {
 @Module({})
 export class EventsModule {
   /**
-   * Publisher 모듈 설정 (모든 서비스)
+   * 앱 등록 — 발행 능력 · 정책 · 인프라 (ADR-0029 §3)
    *
-   * - Kafka ClientsModule 등록
-   * - 각 Stream별 StreamPublisher 제공
+   * 등록 표면은 이것과 `startConsumer` 둘뿐이다. 옛 `forRoot`(발행) ·
+   * `forConsumerModule`(소비 인프라) · `forConsumer`(전송) 세 벌은 Task 7 에서
+   * 사라졌다 — 셋이 같은 이름·같은 타입의 `streams` 를 받고 각각 다른 뜻이었다.
+   *
+   * BC 별로 여러 번 불러도 된다(core 가 그렇게 쓴다). 다만 `policy` 는 앱 전체에
+   * 하나이므로 **한 호출에서만** 선언한다 — 둘 이상이면 `startConsumer` 가 거부한다.
    *
    * @example
-   * EventsModule.forRoot({
-   *   streams: [ORDER_STREAM, INVENTORY_STREAM],
+   * EventsModule.forApp({
+   *   publishes: [ORDER_STREAM, INVENTORY_STREAM],
+   *   serviceName: 'core',
+   *   policy: { validateOnConsume: true },
    * })
    */
-  static forRoot(options: EventsModuleOptions): DynamicModule {
+  static forApp(options: EventsAppOptions = {}): DynamicModule {
     // Kafka 설정 (환경변수 또는 명시적)
     const kafka = options.kafka || this.createKafkaConfigFromEnv();
     const serviceName = options.serviceName || process.env.SERVICE_NAME || 'unknown-service';
     const enableDLQ = options.enableDLQ ?? true;
+    const publishes = options.publishes ?? [];
 
     // 아웃박스를 켠 앱에서만 `enqueue` 가 동작한다 — publisher 가 적재 대상을 알아야 하기
     // 때문이다(ADR-0029 §5). 켜지 않은 앱에서 `enqueue` 를 부르면 던진다.
     const enableOutbox = options.enableOutbox ?? false;
 
     // 각 stream별 StreamPublisher 제공자 생성
-    const publisherProviders = options.streams.map((stream) => ({
+    const publisherProviders = publishes.map((stream) => ({
       provide: this.getPublisherToken(stream.topic.topic),
       useFactory: (
         transport: EventTransport,
@@ -198,7 +194,7 @@ export class EventsModule {
     const topicBootstrapProvider = {
       provide: bootstrapToken,
       useFactory: async () => {
-        await bootstrapKafkaTopics({ kafka, streams: options.streams, includeDLQ: enableDLQ });
+        await bootstrapKafkaTopics({ kafka, streams: publishes, includeDLQ: enableDLQ });
         return true;
       },
     };
@@ -231,7 +227,7 @@ export class EventsModule {
             ) => {
               // topic -> StreamPublisher 매핑 생성
               const publisherMap = new Map<string, StreamPublisher>();
-              options.streams.forEach((stream) => {
+              publishes.forEach((stream) => {
                 const publisher = new StreamPublisher(
                   transport,
                   stream,
@@ -282,6 +278,15 @@ export class EventsModule {
       useClass: EventRetryInterceptor,
     };
 
+    // 앱이 선언한 소비 검증 정책. `startConsumer` 가 읽어 마이크로서비스 스코프
+    // 인터셉터를 만들 때 쓴다 (ADR-0029 §8) — 정책은 도출 불가한 사실이라 선언이 맞고,
+    // 스트림 목록만 도출로 대체된다. 선언하지 않으면 provider 자체가 없고
+    // `buildConsumerInterceptors` 의 `optionalGet` 이 기본값(`validateOnConsume: true`)
+    // 으로 떨어진다.
+    const consumerPolicyProviders = options.policy
+      ? [{ provide: EVENTS_CONSUMER_POLICY, useValue: { validation: options.policy } }]
+      : [];
+
     const providers = [
       retryInterceptorProvider, // 최외곽 — 등록 순서가 래핑 순서
       eventTransportProvider, // Kafka 로 나가는 유일한 통로
@@ -289,6 +294,7 @@ export class EventsModule {
       ...(dlqProvider ? [dlqProvider] : []),
       ...outboxProviders,
       ...trackingProviders,
+      ...consumerPolicyProviders, // startConsumer 가 읽는 소비 정책
       shutdownProvider, // Graceful shutdown 항상 등록
       topicBootstrapProvider, // MSK Serverless 등 auto-create 불가 환경 대응
     ];
@@ -328,192 +334,16 @@ export class EventsModule {
   }
 
   /**
-   * Consumer 모듈 등록 (자동 DLQ 처리 포함)
-   *
-   * main.ts가 아닌 AppModule에서 사용
-   *
-   * @example
-   * @Module({
-   *   imports: [
-   *     EventsModule.forConsumer({
-   *       streams: [ORDER_STREAM],
-   *       groupId: 'order-consumer',
-   *       enableAutoDLQ: true,
-   *     }),
-   *   ],
-   * })
-   * export class AppModule {}
-   */
-  static forConsumerModule(options: ConsumerModuleOptions): DynamicModule {
-    const kafka = options.kafka || this.createKafkaConfigFromEnv();
-    const enableAutoDLQ = options.enableAutoDLQ ?? true;
-
-    // DLQ Handler 제공자
-    const dlqProvider = enableAutoDLQ
-      ? {
-          provide: DLQHandler,
-          useFactory: (transport: EventTransport) => {
-            return new DLQHandler(transport);
-          },
-          inject: [EVENT_TRANSPORT],
-        }
-      : null;
-
-    // 재시도/분류/DLQ/offset commit — 반드시 최외곽(다른 인터셉터보다 먼저 등록)이어야
-    // SchemaValidationError 등 안쪽 인터셉터의 에러도 분류망에 잡힌다.
-    const retryInterceptorProvider = {
-      provide: APP_INTERCEPTOR,
-      useClass: EventRetryInterceptor,
-    };
-
-    // Schema Validation Interceptor 제공자
-    const interceptorProvider = {
-      provide: APP_INTERCEPTOR,
-      useFactory: (reflector: any) => {
-        return new SchemaValidationInterceptor(reflector, options.streams, options.validation);
-      },
-      inject: ['Reflector'],
-    };
-
-    const bootstrapToken = Symbol('TOPIC_BOOTSTRAP_CONSUMER');
-    const topicBootstrapProvider = {
-      provide: bootstrapToken,
-      useFactory: async () => {
-        await bootstrapKafkaTopics({ kafka, streams: options.streams, includeDLQ: enableAutoDLQ });
-        return true;
-      },
-    };
-
-    // Graceful Shutdown — bootstrap 의존으로 강제 resolve.
-    const shutdownProvider = {
-      provide: GracefulShutdownService,
-      useFactory: (kafkaClient: any, _bootstrap: unknown) => {
-        return new GracefulShutdownService(kafkaClient);
-      },
-      inject: ['KAFKA_CLIENT', bootstrapToken],
-    };
-
-    const chainInterceptorProvider = {
-      provide: APP_INTERCEPTOR,
-      useClass: ChainContextInterceptor,
-    };
-
-    // 앱이 선언한 검증 정책. `startConsumer` 가 읽어 마이크로서비스 스코프 인터셉터를
-    // 만들 때 쓴다 (ADR-0029 §8) — 정책은 도출 불가한 사실이라 선언이 맞고, 스트림
-    // 목록만 도출로 대체된다.
-    const consumerPolicyProvider = {
-      provide: EVENTS_CONSUMER_POLICY,
-      useValue: { validation: options.validation },
-    };
-
-    const providers = [
-      eventTransportProvider, // Kafka 로 나가는 유일한 통로
-      ...(dlqProvider ? [dlqProvider] : []),
-      retryInterceptorProvider, // 최외곽 — 등록 순서가 래핑 순서
-      interceptorProvider, // 스키마 검증 Interceptor는 항상 등록
-      chainInterceptorProvider, // chain context 전파 인터셉터
-      consumerPolicyProvider, // startConsumer 가 읽는 소비 정책
-      shutdownProvider, // Graceful shutdown 항상 등록
-      topicBootstrapProvider, // MSK Serverless 등 auto-create 불가 환경 대응
-      { provide: EventChainService, useClass: EventChainService },
-      { provide: EventTrackingService, useClass: EventTrackingService },
-      { provide: EventTraceReader, useClass: EventTraceReader },
-    ];
-
-    return {
-      module: EventsModule,
-      global: true,
-      imports: [
-        ClsModule.forRoot({ global: true, middleware: { mount: false } }),
-        ClientsModule.register([
-          {
-            name: 'KAFKA_CLIENT',
-            transport: Transport.KAFKA,
-            options: {
-              producerOnlyMode: true,
-              client: {
-                clientId: kafka.clientId,
-                brokers: kafka.brokers,
-                ssl: kafka.ssl,
-                sasl: kafka.sasl,
-                retry: kafka.retry,
-              },
-            },
-          },
-        ]),
-      ],
-      providers,
-      exports: providers.filter((p) => p.provide !== APP_INTERCEPTOR).map((p) => p.provide),
-    };
-  }
-
-  /**
-   * Consumer 전송 설정 반환 (main.ts에서 connectMicroservice()에 사용)
-   *
-   * @deprecated `startConsumer(app, { groupId })` 를 쓴다. 두 가지 이유다 (ADR-0029):
-   *
-   * 1. **`streams` 인자가 무효다.** Nest 의 `ServerKafka.bindEvents()` 가
-   *    `subscribe.topics` 를 등록된 `@OnEvent` 패턴으로 덮어쓴다. 이 목록은 한 번도
-   *    구독에 영향을 준 적이 없으며, 그럼에도 "여기 없으면 메시지가 안 온다"는 틀린
-   *    모델이 주석으로 자라 2026-08-08 아키텍처 리뷰의 오판을 낳았다.
-   * 2. **이 경로로 붙인 마이크로서비스에는 소비 인터셉터가 적용되지 않는다.**
-   *    호출부가 `app.connectMicroservice(opts)` 를 두 번째 인자 없이 부르면 Nest 가
-   *    빈 `ApplicationConfig` 를 만들어, `APP_INTERCEPTOR` 로 등록한 스키마 검증·재시도·
-   *    DLQ 인터셉터가 전부 무력화된다 (ADR-0029 §8). `startConsumer` 는 그 배선을 한다.
-   *
-   * @example
-   * const consumerOptions = EventsModule.forConsumer({ groupId: 'events-test-consumer' });
-   * app.connectMicroservice(consumerOptions);
-   * await app.startAllMicroservices();
-   */
-  static forConsumer(options: ConsumerTransportOptions): {
-    transport: Transport.KAFKA;
-    options: any;
-  } {
-    // Kafka 설정 (환경변수 또는 명시적)
-    const kafka = options.kafka || this.createKafkaConfigFromEnv();
-
-    // subscribe.topics 를 만들지 않는다 — Nest 가 어차피 덮어쓴다. 만들어 두면
-    // "이 목록이 구독을 결정한다"는 틀린 모델이 다시 자란다.
-    return {
-      transport: Transport.KAFKA,
-      options: {
-        client: {
-          clientId: kafka.clientId,
-          brokers: kafka.brokers,
-          ssl: kafka.ssl,
-          sasl: kafka.sasl,
-          retry: kafka.retry,
-        },
-        consumer: {
-          groupId: options.groupId,
-          sessionTimeout: options.sessionTimeout || 30000,
-          heartbeatInterval: options.heartbeatInterval || 3000,
-          maxPollInterval: options.maxPollInterval || 300000,
-          allowAutoTopicCreation: false,
-        },
-        subscribe: {
-          fromBeginning: false,
-        },
-        run: {
-          autoCommit: options.autoCommit ?? false,
-          autoCommitInterval: 5000,
-          autoCommitThreshold: 100,
-        },
-      },
-    };
-  }
-
-  /**
    * 소비를 시작한다 — 구독 목록 인자 없음 (ADR-0029 §3)
    *
-   * 컨테이너를 훑어 `@OnEvent` 핸들러를 찾고, 거기서 **구독 토픽 · 검증 스키마 맵 ·
+   * 컨테이너를 훑어 `@On` 핸들러를 찾고, 거기서 **구독 토픽 · 검증 스키마 맵 ·
    * 토픽 부트스트랩 목록을 전부 파생**한다. 선언과 실제가 어긋날 자리가 없다.
    *
-   * 두 가지를 부팅에서 거부한다 — 둘 다 지금까지 완전 무증상이던 실수다:
+   * 세 가지를 부팅에서 거부한다 — 전부 지금까지 완전 무증상이던 실수다:
    * - 계약 레지스트리에 없는 토픽 구독
-   * - `@OnEvent` 핸들러 0개 (컨트롤러를 `controllers: []` 에 등록하지 않은 경우.
+   * - `@On` 핸들러 0개 (컨트롤러를 `controllers: []` 에 등록하지 않은 경우.
    *   Nest 는 이때 `subscribe` 자체를 건너뛰므로 로그조차 남지 않는다)
+   * - `forApp({ policy })` 를 두 곳 이상에서 선언 (어느 것이 이기는지 알 수 없다)
    *
    * 그리고 소비 인터셉터(재시도·DLQ·스키마 검증·chain)를 **마이크로서비스 스코프**로
    * 붙인다. 하이브리드 앱에서 `APP_INTERCEPTOR` 가 소비 경로에 닿지 않기 때문이며,
@@ -537,16 +367,38 @@ export class EventsModule {
       await bootstrapKafkaTopics({ kafka, streams: derived.streams, includeDLQ: enableAutoDLQ });
     }
 
-    const microserviceOptions = options.strategy
+    // subscribe.topics 를 만들지 않는다 — Nest 의 `ServerKafka.bindEvents()` 가
+    // 등록된 `@On` 패턴으로 어차피 덮어쓴다(`server-kafka.js:92`). 만들어 두면
+    // "이 목록이 구독을 결정한다"는 틀린 모델이 다시 자란다 (ADR-0029 §2).
+    const microserviceOptions:
+      | { strategy: CustomTransportStrategy }
+      | { transport: Transport.KAFKA; options: unknown } = options.strategy
       ? { strategy: options.strategy }
-      : this.forConsumer({
-          groupId: options.groupId,
-          kafka,
-          sessionTimeout: options.sessionTimeout,
-          heartbeatInterval: options.heartbeatInterval,
-          maxPollInterval: options.maxPollInterval,
-          autoCommit: options.autoCommit,
-        });
+      : {
+          transport: Transport.KAFKA,
+          options: {
+            client: {
+              clientId: kafka.clientId,
+              brokers: kafka.brokers,
+              ssl: kafka.ssl,
+              sasl: kafka.sasl,
+              retry: kafka.retry,
+            },
+            consumer: {
+              groupId: options.groupId,
+              sessionTimeout: options.sessionTimeout || 30000,
+              heartbeatInterval: options.heartbeatInterval || 3000,
+              maxPollInterval: options.maxPollInterval || 300000,
+              allowAutoTopicCreation: false,
+            },
+            subscribe: { fromBeginning: false },
+            run: {
+              autoCommit: options.autoCommit ?? false,
+              autoCommitInterval: 5000,
+              autoCommitThreshold: 100,
+            },
+          },
+        };
 
     // deferInitialization 없이 부르면 Nest 가 즉시 리스너를 바인딩해버려
     // useGlobalInterceptors 가 늦는다. 미룬 뒤 인터셉터를 얹고, 비-defer 경로가
@@ -602,24 +454,6 @@ export class EventsModule {
   }
 
   /**
-   * Publisher 주입 데코레이터
-   *
-   * @deprecated 토픽 문자열과 이벤트 타입 제네릭 두 사실을 따로 적게 한다. 계약에서
-   * 도출하는 `@InjectPublisher(STREAM)` + `PublisherFor<typeof STREAM>` 을 쓰라 —
-   * 같은 토큰을 만들므로 동작은 같다 (ADR-0029 §4). 앱 사용처는 Task 6-B 로 전부
-   * 이주해 0건이며, 이 표면 자체는 Task 7(contract phase)에서 삭제한다.
-   *
-   * @example
-   * constructor(
-   *   @InjectPublisher(ORDER_STREAM)
-   *   private readonly orderPublisher: PublisherFor<typeof ORDER_STREAM>
-   * ) {}
-   */
-  static InjectStreamPublisher(topicName: string) {
-    return Inject(this.getPublisherToken(topicName));
-  }
-
-  /**
    * Outbox 스키마 export (앱에서 병합할 수 있도록)
    *
    * @example
@@ -639,10 +473,3 @@ export class EventsModule {
     return trackingSchema;
   }
 }
-
-/**
- * Publisher 주입 데코레이터 (단축)
- *
- * @deprecated `@InjectPublisher(STREAM)` 을 쓰라 — 위 `EventsModule.InjectStreamPublisher` 참조.
- */
-export const InjectStreamPublisher = EventsModule.InjectStreamPublisher.bind(EventsModule);

--- a/libs/events/src/guards/event-type.guard.ts
+++ b/libs/events/src/guards/event-type.guard.ts
@@ -1,7 +1,7 @@
 /**
  * Event Type Filter Interceptor
  *
- * @OnEvent 데코레이터의 eventType 필터링을 처리
+ * @On 데코레이터의 eventType 필터링을 처리
  * Guard 대신 Interceptor를 사용하여 조용히 필터링 (에러 없이)
  */
 
@@ -17,7 +17,7 @@ export class EventTypeGuard implements NestInterceptor {
   constructor(private reflector: Reflector) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
-    // @OnEvent에서 설정한 eventType 메타데이터 가져오기
+    // @On에서 설정한 eventType 메타데이터 가져오기
     const expectedEventType = this.reflector.get<string>(EVENT_TYPE_FILTER, context.getHandler());
 
     // eventType이 설정되지 않았으면 필터링 없이 통과

--- a/libs/events/src/index.ts
+++ b/libs/events/src/index.ts
@@ -23,8 +23,8 @@ export * from './transport/in-memory.server';
 
 // Publisher
 export * from './publishers/stream-publisher.service';
-// 계약에서 도출하는 주입 표면 (ADR-0029 §4). 앱 사용처는 Task 6-B 로 전부 이주했고
-// 옛 @InjectStreamPublisher 는 Task 7 에서 삭제한다. 회귀 방지: npm run audit:event-publishers
+// 계약에서 도출하는 유일한 주입 표면 (ADR-0029 §4). 옛 `@InjectStreamPublisher` 는
+// Task 7 에서 삭제됐다. 회귀 방지: npm run audit:event-publishers
 export * from './publishers/publisher-token';
 export * from './publishers/inject-publisher';
 
@@ -48,7 +48,7 @@ export * from './retry/retry-policy.decorator';
 export * from './validation/schema-validation.util';
 export * from './interceptors/schema-validation.interceptor';
 
-// Retry Interceptor (전역 APP_INTERCEPTOR — EventsModule forRoot/forConsumerModule 자동 등록)
+// Retry Interceptor (EventsModule.forApp 이 APP_INTERCEPTOR 로, startConsumer 가 마이크로서비스 스코프로 등록)
 export * from './interceptors/event-retry.interceptor';
 
 // Graceful Shutdown

--- a/libs/events/src/interceptors/event-retry.wiring.spec.ts
+++ b/libs/events/src/interceptors/event-retry.wiring.spec.ts
@@ -12,10 +12,27 @@ import { KafkaContext, Server, CustomTransportStrategy } from '@nestjs/microserv
 import type { Consumer, KafkaMessage, Producer } from '@nestjs/microservices/external/kafka.interface';
 import { Test } from '@nestjs/testing';
 import { isObservable, lastValueFrom } from 'rxjs';
-import { OnEvent, EventPayload } from '../consumers/decorators';
+import { event, stream } from '@packages/event-contracts/types';
+import { On, EventPayload } from '../consumers/decorators';
 import { RetryPolicy } from '../retry/retry-policy.decorator';
 import { DLQHandler } from '../dlq/dlq-handler.service';
 import { EventRetryInterceptor } from './event-retry.interceptor';
+
+// 스펙 전용 계약. `@On` 은 토픽·이벤트명을 계약에서 읽으므로 생문자열을 쓸 수 없다.
+// `streams/index.ts` 밖이라 STREAM_REGISTRY 에도 들어가지 않는다.
+const WIRING_TEST_STREAM = stream({
+  topic: 'wiring.test.v1',
+  partitions: 1,
+  aggregateType: 'Wiring',
+  events: { WiringTested: event<'WiringTested', { poison: boolean }>('WiringTested') },
+});
+
+const WIRING_RETRY_STREAM = stream({
+  topic: 'wiring.retry.v1',
+  partitions: 1,
+  aggregateType: 'Wiring',
+  events: { WiringRetried: event<'WiringRetried', { poison: boolean }>('WiringRetried') },
+});
 
 /** 핸들러 바인딩만 캡처하는 transport — 브로커 불필요 */
 class CapturingServer extends Server implements CustomTransportStrategy {
@@ -34,7 +51,7 @@ const retryHandlerCalls: unknown[] = [];
 
 @Controller()
 class WiringTestConsumer {
-  @OnEvent('wiring.test.v1', 'WiringTested')
+  @On(WIRING_TEST_STREAM, 'WiringTested')
   @RetryPolicy({
     maxRetries: 1,
     backoff: 'fixed',
@@ -47,7 +64,7 @@ class WiringTestConsumer {
     return Promise.reject(new NotFoundException('so not found'));
   }
 
-  @OnEvent('wiring.retry.v1', 'WiringRetried')
+  @On(WIRING_RETRY_STREAM, 'WiringRetried')
   @RetryPolicy({ maxRetries: 1, backoff: 'fixed', initialDelayMs: 1, maxDelayMs: 1 })
   handleWiringRetried(@EventPayload() payload: { poison: boolean }): Promise<void> {
     retryHandlerCalls.push(payload);

--- a/libs/events/src/outbox/enqueue-validation.spec.ts
+++ b/libs/events/src/outbox/enqueue-validation.spec.ts
@@ -33,7 +33,8 @@ import { event, getDLQTopicName, stream, SchemaValidationError } from '@packages
 import type { MessageEnvelope } from '@packages/event-contracts/types';
 import type { DLQMessage } from '../dlq/dlq.types';
 import { EventsModule } from '../events.module';
-import { EventPayload, OnEvent } from '../consumers/decorators';
+import { EventPayload, On } from '../consumers/decorators';
+import { buildConsumerInterceptors } from '../consumers/consumer-interceptors';
 import { EventTypeGuard } from '../guards/event-type.guard';
 import { StreamPublisher } from '../publishers/stream-publisher.service';
 import { EVENT_TRANSPORT } from '../transport/transport.port';
@@ -73,7 +74,7 @@ const received: unknown[] = [];
 @Controller()
 @UseInterceptors(EventTypeGuard)
 class OutboxHarnessConsumer {
-  @OnEvent('outbox.events.v1', 'StockMoved')
+  @On(OUTBOX_STREAM, 'StockMoved')
   onMoved(@EventPayload() payload: { sku: string; quantity: number }): void {
     received.push(payload);
   }
@@ -98,11 +99,9 @@ describe('아웃박스 enqueue 시점 스키마 검증', () => {
 
     const moduleRef = await Test.createTestingModule({
       imports: [
-        EventsModule.forConsumerModule({
-          streams: [OUTBOX_STREAM],
-          groupId: 'outbox-harness-consumer',
+        EventsModule.forApp({
           kafka,
-          validation: { validateOnConsume: true },
+          policy: { validateOnConsume: true },
         }),
       ],
       controllers: [OutboxHarnessConsumer],
@@ -112,6 +111,14 @@ describe('아웃박스 enqueue 시점 스키마 검증', () => {
       .compile();
 
     app = moduleRef.createNestMicroservice({ strategy: new InMemoryServer(broker), logger: false });
+    // 소비 인터셉터는 운영과 **같은 팩토리**로 만들어 얹는다 (ADR-0029 §8).
+    // `startConsumer` 를 부르지 않는 이유는 하나뿐이다 — 그것은 계약 레지스트리에 없는
+    // 토픽의 구독을 거부하는데, 이 하네스는 일부러 레지스트리 밖의 전용 계약을 쓴다.
+    // 그래서 도출 대신 스트림을 손으로 주되, 인터셉터 구성 자체는 `buildConsumerInterceptors`
+    // 한 곳에서 가져온다. 옛 `forConsumerModule` 의 `APP_INTERCEPTOR` 등록에 기대던 코드였는데,
+    // 그 등록은 **운영 하이브리드 앱에서는 소비 경로에 닿은 적이 없다** — 즉 이 하네스는
+    // 여태 운영과 다른 배선을 검증하고 있었다.
+    app.useGlobalInterceptors(...buildConsumerInterceptors(app, [OUTBOX_STREAM]));
     await app.listen();
   });
 

--- a/libs/events/src/publishers/inject-publisher.ts
+++ b/libs/events/src/publishers/inject-publisher.ts
@@ -1,16 +1,12 @@
 /**
  * 계약에서 도출하는 Publisher 주입 (ADR-0029 §4)
  *
- * 옛 표면은 같은 사실을 두 번 적게 만든다:
- *
- * ```ts
- * @InjectStreamPublisher('orders.events.v1') p: StreamPublisher<OrderEvents>
- * //                      ^^^^^^^^^^^^^^^^^ 토큰(문자열)     ^^^^^^^^^^^ 이벤트 타입(제네릭)
- * ```
- *
- * 둘 다 `ORDER_STREAM` 하나에서 나온다. 어긋나면 컴파일은 통과하고 런타임에
- * 잘못된 publisher 가 주입되거나 DI 가 실패한다. `@InjectPublisher(ORDER_STREAM)` +
- * `PublisherFor<typeof ORDER_STREAM>` 은 두 사실을 하나로 줄인다.
+ * 옛 표면(`@InjectStreamPublisher`, Task 7 에서 삭제)은 같은 사실을 두 번 적게 만들었다 —
+ * 토큰을 생문자열로, 이벤트 타입을 제네릭으로. 둘 다 `ORDER_STREAM` 하나에서 나오는데,
+ * 어긋나면 컴파일은 통과하고 런타임에 잘못된 publisher 가 주입되거나 DI 가 실패한다.
+ * `@InjectPublisher(ORDER_STREAM)` + `PublisherFor<typeof ORDER_STREAM>` 은 두 사실을
+ * 하나로 줄인다. 데코레이터 스트림 ≡ 타입 파라미터 스트림 은 타입으로 막을 수 없어
+ * `npm run audit:event-publishers` 가 AST 로 단언한다.
  */
 
 import { Inject } from '@nestjs/common';
@@ -32,9 +28,8 @@ export type PublisherFor<S extends StreamConfig<any>> =
 /**
  * 스트림 계약으로 publisher 를 주입한다. 토큰은 계약의 토픽에서 도출된다.
  *
- * 런타임 동작은 `@InjectStreamPublisher(topic)` 과 같다 — 같은 토큰을 만든다.
- * 따라서 한 앱 안에서 두 표면을 섞어 써도 되고, `forRoot({streams})` 에 그 스트림이
- * 들어 있기만 하면 provider 는 이미 존재한다.
+ * `forApp({ publishes })` 에 그 스트림이 들어 있으면 provider 는 이미 존재한다 —
+ * 토큰 형식의 소유자는 `publisher-token.ts` 한 곳이다.
  */
 export function InjectPublisher<TEvents extends StreamEventTypes>(stream: StreamConfig<TEvents>) {
   const topic = stream?.topic?.topic;

--- a/libs/events/src/publishers/publisher-token.ts
+++ b/libs/events/src/publishers/publisher-token.ts
@@ -1,7 +1,7 @@
 /**
  * Publisher DI 토큰
  *
- * `EventsModule.forRoot({streams})` 가 스트림당 하나씩 등록하는 `StreamPublisher`
+ * `EventsModule.forApp({publishes})` 가 스트림당 하나씩 등록하는 `StreamPublisher`
  * provider 의 토큰 형식. `EventsModule.getPublisherToken` 과 `@InjectPublisher` 가
  * 같은 문자열을 만들어야 하므로 형식은 여기 한 곳에만 둔다 — 두 벌이 되는 순간
  * 어긋남이 무증상 DI 실패로 나타난다.

--- a/libs/events/src/publishers/stream-publisher.service.ts
+++ b/libs/events/src/publishers/stream-publisher.service.ts
@@ -172,7 +172,7 @@ export class StreamPublisher<TEvents extends StreamEventTypes = StreamEventTypes
     if (!this.outboxWriter) {
       throw new Error(
         `Stream ${this.streamConfig.topic.topic} has no outbox writer — ` +
-          'EventsModule.forRoot({ enableOutbox: true }) 가 필요하다.',
+          'EventsModule.forApp({ enableOutbox: true }) 가 필요하다.',
       );
     }
 

--- a/libs/events/src/retry/retry-policy.decorator.ts
+++ b/libs/events/src/retry/retry-policy.decorator.ts
@@ -11,7 +11,7 @@ import { RETRY_POLICY_METADATA, DISABLE_DLQ_METADATA, RetryPolicyConfig } from '
  * 이벤트 핸들러의 재시도 정책 지정
  *
  * @example
- * @OnEvent('orders.events.v1', 'OrderCreated')
+ * @On(ORDER_STREAM, 'OrderCreated')
  * @RetryPolicy({ maxRetries: 5, backoff: 'exponential' })
  * async handleOrderCreated(@EventPayload() payload: OrderCreatedPayload) {
  *   // 에러 발생 시 5번까지 재시도
@@ -27,7 +27,7 @@ export const RetryPolicy = (config: RetryPolicyConfig = {}) => SetMetadata(RETRY
  * (중요하지 않은 이벤트에 사용)
  *
  * @example
- * @OnEvent('analytics.events.v1', 'PageView')
+ * @On(ANALYTICS_STREAM, 'PageView')
  * @DisableDLQ()
  * async handlePageView(@EventPayload() payload: PageViewPayload) {
  *   // 실패해도 DLQ에 보내지 않음

--- a/libs/events/src/transport/consume-validation.spec.ts
+++ b/libs/events/src/transport/consume-validation.spec.ts
@@ -27,7 +27,8 @@ import { z } from 'zod';
 import { event, getDLQTopicName, stream } from '@packages/event-contracts/types';
 import type { DLQMessage } from '../dlq/dlq.types';
 import { EventsModule } from '../events.module';
-import { EventPayload, OnEvent } from '../consumers/decorators';
+import { EventPayload, On } from '../consumers/decorators';
+import { buildConsumerInterceptors } from '../consumers/consumer-interceptors';
 import { EventTypeGuard } from '../guards/event-type.guard';
 import { RetryPolicy } from '../retry/retry-policy.decorator';
 import { StreamPublisher } from '../publishers/stream-publisher.service';
@@ -64,7 +65,7 @@ class ValidatedConsumer {
    * `maxRetries` 가 아니라 `SchemaValidationError` 의 non-retryable 분류에서 온 것이다.
    * 대기 시간이 실제로 들어가지 않는지도 이 설정이 드러낸다 — 재시도가 돌면 백오프로 느려진다.
    */
-  @OnEvent('validated.events.v1', 'OrderPlaced')
+  @On(VALIDATED_STREAM, 'OrderPlaced')
   @RetryPolicy({ maxRetries: 3, initialDelayMs: 1 })
   onPlaced(@EventPayload() payload: { orderId: string; amount: number }): void {
     attempts.push(payload);
@@ -86,13 +87,12 @@ describe('소비 스키마 검증 ON (validateOnConsume: true)', () => {
 
     const moduleRef = await Test.createTestingModule({
       imports: [
-        EventsModule.forRoot({ streams: [VALIDATED_STREAM], serviceName: 'validation-harness', kafka }),
-        EventsModule.forConsumerModule({
-          streams: [VALIDATED_STREAM],
-          groupId: 'validation-harness-consumer',
+        EventsModule.forApp({
+          publishes: [VALIDATED_STREAM],
+          serviceName: 'validation-harness',
           kafka,
           // 이 스펙의 전제 — 5-C 가 앱에서 뒤집는 바로 그 한 줄이다
-          validation: { validateOnConsume: true },
+          policy: { validateOnConsume: true },
         }),
       ],
       controllers: [ValidatedConsumer],
@@ -102,6 +102,14 @@ describe('소비 스키마 검증 ON (validateOnConsume: true)', () => {
       .compile();
 
     app = moduleRef.createNestMicroservice({ strategy: new InMemoryServer(broker), logger: false });
+    // 소비 인터셉터는 운영과 **같은 팩토리**로 만들어 얹는다 (ADR-0029 §8).
+    // `startConsumer` 를 부르지 않는 이유는 하나뿐이다 — 그것은 계약 레지스트리에 없는
+    // 토픽의 구독을 거부하는데, 이 하네스는 일부러 레지스트리 밖의 전용 계약을 쓴다.
+    // 그래서 도출 대신 스트림을 손으로 주되, 인터셉터 구성 자체는 `buildConsumerInterceptors`
+    // 한 곳에서 가져온다. 옛 `forConsumerModule` 의 `APP_INTERCEPTOR` 등록에 기대던 코드였는데,
+    // 그 등록은 **운영 하이브리드 앱에서는 소비 경로에 닿은 적이 없다** — 즉 이 하네스는
+    // 여태 운영과 다른 배선을 검증하고 있었다.
+    app.useGlobalInterceptors(...buildConsumerInterceptors(app, [VALIDATED_STREAM]));
     await app.listen();
     publisher = app.get(EventsModule.getPublisherToken(VALIDATED_STREAM.topic.topic));
   });

--- a/libs/events/src/transport/handler-failure.spec.ts
+++ b/libs/events/src/transport/handler-failure.spec.ts
@@ -85,10 +85,7 @@ async function buildModule(broker: InMemoryBroker): Promise<TestingModule> {
   process.env.KAFKA_BOOTSTRAP_TOPICS = 'false';
 
   return Test.createTestingModule({
-    imports: [
-      EventsModule.forRoot({ streams: [CART_STREAM], serviceName: 'handler-failure-spec', kafka }),
-      EventsModule.forConsumerModule({ streams: [], groupId: 'spec-consumer', kafka }),
-    ],
+    imports: [EventsModule.forApp({ publishes: [CART_STREAM], serviceName: 'handler-failure-spec', kafka })],
     controllers: [ExplodingConsumer],
   })
     .overrideProvider(EVENT_TRANSPORT)

--- a/libs/events/src/transport/round-trip.spec.ts
+++ b/libs/events/src/transport/round-trip.spec.ts
@@ -1,12 +1,12 @@
 /**
  * 발행 → 소비 왕복 하네스 (ADR-0029 §7, 플랜 Task 2)
  *
- * 브로커 없이 한 프로세스 안에서 `StreamPublisher.publishEvent` 부터 `@OnEvent`
+ * 브로커 없이 한 프로세스 안에서 `StreamPublisher.publishEvent` 부터 `@On`
  * 핸들러 호출까지를 검증한다. **Nest 파이프라인은 실물이다** — `EventsModule` 을
  * 실제로 import 하고, 인터셉터·가드·파라미터 데코레이터·DI 가 모두 살아 있으며,
  * 바뀐 것은 `EVENT_TRANSPORT` 바인딩과 소비 전략뿐이다.
  *
- * 이 하네스가 없던 동안 `forConsumer({streams})` 가 무효라는 사실이 아무 테스트에도
+ * 이 하네스가 없던 동안 옛 `forConsumer({streams})` 가 무효라는 사실이 아무 테스트에도
  * 걸리지 않았고, 그래서 2026-08-08 아키텍처 리뷰가 오판했다.
  */
 
@@ -16,7 +16,8 @@ import { z } from 'zod';
 import { event, getDLQTopicName, stream } from '@packages/event-contracts/types';
 import type { DLQMessage } from '../dlq/dlq.types';
 import { EventsModule } from '../events.module';
-import { EventPayload, OnEvent } from '../consumers/decorators';
+import { EventPayload, On } from '../consumers/decorators';
+import { buildConsumerInterceptors } from '../consumers/consumer-interceptors';
 import { EventTypeGuard } from '../guards/event-type.guard';
 import { StreamPublisher } from '../publishers/stream-publisher.service';
 import { EventChainService } from '../tracking/event-chain.service';
@@ -73,17 +74,17 @@ class HarnessConsumer {
   // 생성자 주입이 하네스에서도 살아 있어야 한다 — 클로저 기반 핸들러였다면 잃었을 것
   constructor(private readonly chain: EventChainService) {}
 
-  @OnEvent('harness.events.v1', 'OrderCreated')
+  @On(HARNESS_STREAM, 'OrderCreated')
   onCreated(@EventPayload() payload: OrderCreatedPayload): void {
     calls.push({ handler: 'onCreated', payload, chainId: this.chain.getChainId() });
   }
 
-  @OnEvent('harness.events.v1', 'OrderCancelled')
+  @On(HARNESS_STREAM, 'OrderCancelled')
   onCancelled(@EventPayload() payload: unknown): void {
     calls.push({ handler: 'onCancelled', payload });
   }
 
-  @OnEvent('harness.events.v1', 'OrderShipped')
+  @On(HARNESS_STREAM, 'OrderShipped')
   onShipped(@EventPayload() payload: unknown): void {
     calls.push({ handler: 'onShipped', payload });
   }
@@ -92,7 +93,7 @@ class HarnessConsumer {
 @Controller()
 @UseInterceptors(EventTypeGuard)
 class StrictConsumer {
-  @OnEvent('harness.strict.v1', 'StrictEvent')
+  @On(STRICT_STREAM, 'StrictEvent')
   onStrict(@EventPayload() payload: unknown): void {
     calls.push({ handler: 'onStrict', payload });
   }
@@ -112,14 +113,7 @@ describe('발행 → 소비 왕복 (인메모리 transport)', () => {
     const kafka = { clientId: 'harness', brokers: ['unused:9092'] };
 
     const moduleRef = await Test.createTestingModule({
-      imports: [
-        EventsModule.forRoot({ streams: [HARNESS_STREAM, STRICT_STREAM], serviceName: 'harness', kafka }),
-        EventsModule.forConsumerModule({
-          streams: [HARNESS_STREAM, STRICT_STREAM],
-          groupId: 'harness-consumer',
-          kafka,
-        }),
-      ],
+      imports: [EventsModule.forApp({ publishes: [HARNESS_STREAM, STRICT_STREAM], serviceName: 'harness', kafka })],
       controllers: [HarnessConsumer, StrictConsumer],
     })
       // 유일한 교체 지점 — 나머지 배선은 운영과 같다
@@ -131,6 +125,14 @@ describe('발행 → 소비 왕복 (인메모리 transport)', () => {
       strategy: new InMemoryServer(broker),
       logger: false,
     });
+    // 소비 인터셉터는 운영과 **같은 팩토리**로 만들어 얹는다 (ADR-0029 §8).
+    // `startConsumer` 를 부르지 않는 이유는 하나뿐이다 — 그것은 계약 레지스트리에 없는
+    // 토픽의 구독을 거부하는데, 이 하네스는 일부러 레지스트리 밖의 전용 계약을 쓴다.
+    // 그래서 도출 대신 스트림을 손으로 주되, 인터셉터 구성 자체는 `buildConsumerInterceptors`
+    // 한 곳에서 가져온다. 옛 `forConsumerModule` 의 `APP_INTERCEPTOR` 등록에 기대던 코드였는데,
+    // 그 등록은 **운영 하이브리드 앱에서는 소비 경로에 닿은 적이 없다** — 즉 이 하네스는
+    // 여태 운영과 다른 배선을 검증하고 있었다.
+    app.useGlobalInterceptors(...buildConsumerInterceptors(app, [HARNESS_STREAM, STRICT_STREAM]));
     await app.listen();
 
     publisher = app.get(EventsModule.getPublisherToken(HARNESS_STREAM.topic.topic));
@@ -145,7 +147,7 @@ describe('발행 → 소비 왕복 (인메모리 transport)', () => {
     broker.reset();
   });
 
-  it('publishEvent 가 @OnEvent 핸들러까지 도달하고 payload 가 보존된다', async () => {
+  it('publishEvent 가 @On 핸들러까지 도달하고 payload 가 보존된다', async () => {
     await publisher.publishEvent({
       eventType: 'OrderCreated',
       aggregateId: 'order-1',

--- a/libs/events/src/transport/start-consumer.spec.ts
+++ b/libs/events/src/transport/start-consumer.spec.ts
@@ -13,11 +13,11 @@
 
 import { Controller, Injectable, INestApplication, OnModuleInit, UseInterceptors } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { getDLQTopicName } from '@packages/event-contracts/types';
+import { event, getDLQTopicName, stream } from '@packages/event-contracts/types';
 import { CART_STREAM } from '@packages/event-contracts/streams/cart.stream';
 import type { DLQMessage } from '../dlq/dlq.types';
 import { EventsModule } from '../events.module';
-import { EventPayload, OnEvent } from '../consumers/decorators';
+import { EventPayload, On } from '../consumers/decorators';
 import { EventTypeGuard } from '../guards/event-type.guard';
 import { StreamPublisher } from '../publishers/stream-publisher.service';
 import { EVENT_TRANSPORT } from './transport.port';
@@ -26,6 +26,14 @@ import { InMemoryTransport } from './in-memory.transport';
 import { InMemoryServer } from './in-memory.server';
 
 const TOPIC = CART_STREAM.topic.topic;
+
+/** 레지스트리에 없는 스트림 — 부팅 거부를 재현하는 데만 쓴다 */
+const GHOST_STREAM = stream({
+  topic: 'nobody.declared.this.v1',
+  partitions: 1,
+  aggregateType: 'Ghost',
+  events: { Whatever: event<'Whatever', Record<string, never>>('Whatever') },
+});
 
 interface HandlerCall {
   handler: string;
@@ -45,12 +53,12 @@ class InitCounter implements OnModuleInit {
 @Controller()
 @UseInterceptors(EventTypeGuard)
 class CartConsumer {
-  @OnEvent('carts.events.v1', 'CartCreated')
+  @On(CART_STREAM, 'CartCreated')
   onCreated(@EventPayload() payload: unknown): void {
     calls.push({ handler: 'onCreated', payload });
   }
 
-  @OnEvent('carts.events.v1', 'CartUpdated')
+  @On(CART_STREAM, 'CartUpdated')
   onUpdated(@EventPayload() payload: unknown): void {
     calls.push({ handler: 'onUpdated', payload });
   }
@@ -58,7 +66,7 @@ class CartConsumer {
 
 @Controller()
 class GhostConsumer {
-  @OnEvent('nobody.declared.this.v1', 'Whatever')
+  @On(GHOST_STREAM, 'Whatever')
   onGhost(): void {}
 }
 
@@ -78,10 +86,9 @@ async function buildModule(controllers: unknown[], broker: InMemoryBroker): Prom
 
   return Test.createTestingModule({
     imports: [
-      EventsModule.forRoot({ streams: [CART_STREAM], serviceName: 'start-consumer-spec', kafka }),
-      // ⚠️ streams 를 넘기지만 startConsumer 는 이것을 쓰지 않는다 — 검증 맵은 도출된다.
-      // 여기서 살아남는 것은 정책(validation)과 DLQ 설정뿐이다.
-      EventsModule.forConsumerModule({ streams: [], groupId: 'spec-consumer', kafka }),
+      // 발행 능력만 선언한다. 소비 스트림·groupId 를 넘길 자리가 애초에 없다 —
+      // 토픽은 `@On` 에서 도출되고 groupId 는 `startConsumer` 가 받는다 (ADR-0029 §3).
+      EventsModule.forApp({ publishes: [CART_STREAM], serviceName: 'start-consumer-spec', kafka }),
     ],
     // as 정당화: Nest 의 `controllers` 는 `Type<any>[]` 를 받고, 이 헬퍼는 테스트마다
     // 다른 컨트롤러 묶음을 받기 위해 unknown[] 로 선언돼 있다.
@@ -159,8 +166,11 @@ describe('startConsumer — 소비 집합 도출', () => {
    *
    * 앱들이 쓰던 `app.connectMicroservice(opts)` 는 마이크로서비스에 **빈
    * ApplicationConfig** 를 주므로 `APP_INTERCEPTOR` 로 등록한 스키마 검증·재시도·DLQ
-   * 인터셉터가 소비 경로에 하나도 붙지 않는다. 아래 `현재 앱 배선` describe 가 그
-   * 상태를 실행 가능한 형태로 박아둔다. `startConsumer` 는 그것을 고친다.
+   * 인터셉터가 소비 경로에 하나도 붙지 않았다. `startConsumer` 는 그것을 고친다.
+   *
+   * 옛 배선을 실행 가능한 형태로 박아뒀던 `옛 앱 배선` describe 는 Task 7 에서 지웠다 —
+   * 5-B 가 라이브에 배포돼 그 주장(“라이브는 여전히 옛 배선”)이 더는 참이 아니고,
+   * `forConsumer` 자체도 사라졌다.
    */
   it('스키마를 위반한 인바운드 메시지는 핸들러에 닿지 않고 DLQ 로 분류된다', async () => {
     await broker.inject(TOPIC, {
@@ -200,7 +210,7 @@ describe('startConsumer — 부팅 거부', () => {
     moduleInitCount = 0;
   });
 
-  it('@OnEvent 핸들러가 하나도 없으면 부팅을 거부한다', async () => {
+  it('@On 핸들러가 하나도 없으면 부팅을 거부한다', async () => {
     const broker = new InMemoryBroker();
     const moduleRef = await buildModule([], broker);
     const app = moduleRef.createNestApplication({ logger: false });
@@ -220,50 +230,6 @@ describe('startConsumer — 부팅 거부', () => {
     await expect(
       EventsModule.startConsumer(app, { groupId: 'spec-consumer', kafka, strategy: new InMemoryServer(broker) }),
     ).rejects.toThrow(/nobody\.declared\.this\.v1.*GhostConsumer\.onGhost/s);
-
-    await app.close();
-  });
-});
-
-/**
- * 옛 배선의 상태를 실행 가능한 형태로 남긴다 (ADR-0029 §8).
- *
- * 이 describe 가 **초록이라는 사실 자체가 라이브 결함의 증거**다 — 스키마를 위반한
- * 메시지가 검증을 통과해 핸들러까지 간다.
- *
- * **삭제 시점: Task 5-B 가 배포된 뒤.** 코드상으로는 7개 앱이 모두 `startConsumer` 로
- * 이주했지만(`forConsumer` 호출 0건), 이 레포는 autodeploy 가 없어(ADR-0005 §4) 누군가
- * `sst deploy` 를 부르기 전까지 **라이브는 여전히 이 배선**이다. 즉 위 문장은 지금도
- * 참이다. 배포가 끝나 라이브에서 옛 배선이 사라지면 이 describe 는 그때 지운다 —
- * 그 전에 지우면 아직 살아 있는 결함의 유일한 실행 가능한 기록이 없어진다.
- * (`forConsumer` 자체의 제거는 Task 7.)
- */
-describe('옛 앱 배선 (forConsumer + connectMicroservice) — 소비 인터셉터가 붙지 않는다', () => {
-  it('스키마 위반 메시지가 검증 없이 핸들러까지 도달한다', async () => {
-    const broker = new InMemoryBroker();
-    const moduleRef = await buildModule([CartConsumer], broker);
-    const app = moduleRef.createNestApplication({ logger: false });
-
-    // 앱들이 실제로 하는 그대로 — 두 번째 인자 없음
-    app.connectMicroservice({ strategy: new InMemoryServer(broker) });
-    await app.startAllMicroservices();
-    await app.init();
-
-    calls.length = 0;
-    await broker.inject(TOPIC, {
-      messageId: 'msg-bad-legacy',
-      messageType: 'CartCreated',
-      messageVersion: 1,
-      messageKind: 'event',
-      correlationId: 'corr-bad-legacy',
-      timestamp: new Date().toISOString(),
-      occurredAt: new Date().toISOString(),
-      source: { service: 'other-service', aggregateType: 'Cart', aggregateId: 'cart-9' },
-      payload: { id: 'cart-9' },
-    });
-
-    expect(calls).toHaveLength(1); // ← 검증되지 않은 채 도착했다
-    expect(broker.envelopesOn(getDLQTopicName(TOPIC))).toHaveLength(0);
 
     await app.close();
   });

--- a/packages/event-contracts/streams/inventory-with-schema.example.ts
+++ b/packages/event-contracts/streams/inventory-with-schema.example.ts
@@ -139,7 +139,7 @@ await stockPublisher.publishEvent({
 // Consumer (수신 시 자동 검증)
 @Controller()
 export class InventoryEventsConsumer {
-  @OnEvent('inventory.events.v1', 'StockReceived')
+  @On(INVENTORY_STREAM_WITH_SCHEMA, 'StockReceived')
   async handleStockReceived(@EventPayload() payload: StockReceivedPayload) {
     // 이 시점에 payload는 이미 스키마 검증이 완료됨
     // ✅ 타입 안전성 보장
@@ -147,4 +147,3 @@ export class InventoryEventsConsumer {
   }
 }
 */
-

--- a/packages/event-contracts/types/stream-config.types.ts
+++ b/packages/event-contracts/types/stream-config.types.ts
@@ -94,7 +94,7 @@ export interface StreamConfig<TEvents extends StreamEventTypes = StreamEventType
   /** Resolve the Kafka message key from a validated event payload. */
   partitionKey?: (payload: any) => string;
 
-  // Consumer 설정 (선택, forConsumer()에서 사용)
+  // Consumer 설정 (선택)
   consumer?: ConsumerConfig;
 }
 

--- a/scripts/events/event-handler-contract-audit.js
+++ b/scripts/events/event-handler-contract-audit.js
@@ -25,7 +25,7 @@
  *   node scripts/events/event-handler-contract-audit.js                  # 전체 앱
  *   node scripts/events/event-handler-contract-audit.js core membership  # 특정 앱
  *   node scripts/events/event-handler-contract-audit.js --json           # 기계 판독용
- *   node scripts/events/event-handler-contract-audit.js --allow-legacy   # 이주 중: @OnEvent 잔량 허용
+ *   node scripts/events/event-handler-contract-audit.js --allow-legacy   # @OnEvent 잔량 허용 (이제 쓸 일 없다)
  *
  * 종료 코드: 발견이 하나라도 있으면 1.
  */
@@ -131,7 +131,10 @@ function scanFile(rel) {
             code: 'LEGACY',
             where,
             method,
-            detail: '@OnEvent 은 토픽·이벤트명이 생문자열이다. @On(STREAM, "Event") 로 이주하라 (ADR-0029 §4).',
+            detail:
+              '@OnEvent 은 토픽·이벤트명이 생문자열이다. @On(STREAM, "Event") 로 이주하라 (ADR-0029 §4). ' +
+              '이 표면은 Task 7 에서 삭제됐으므로 여기 걸린다면 @nestjs/event-emitter 의 동명 데코레이터를 ' +
+              '잘못 import 한 것이다 — 그건 Kafka 소비와 아무 상관이 없고 핸들러가 영영 실행되지 않는다.',
           });
         } else {
           const streamArg = handler.args[0];

--- a/scripts/events/publisher-contract-audit.js
+++ b/scripts/events/publisher-contract-audit.js
@@ -24,7 +24,7 @@
  * 무방비 쓰기를 105건으로 과소집계했다가 실제 207건이었다).
  *
  * 이 게이트는 **순수 구문 검사**다. 스트림 상수가 실재하는지, 그 스트림이 앱의
- * `forRoot({streams})` 에 들어 있는지는 검사하지 않는다 — 앞의 것은 컴파일이, 뒤의 것은
+ * `forApp({publishes})` 에 들어 있는지는 검사하지 않는다 — 앞의 것은 컴파일이, 뒤의 것은
  * 부팅 시 DI 실패가 이미 시끄럽게 잡는다(ADR-0029 Consequences 표). 여기서 또 검사하면
  * 계약 로딩이라는 두 번째 진실이 생긴다.
  *
@@ -135,7 +135,8 @@ function scanFile(rel) {
           method,
           detail:
             '@InjectStreamPublisher 는 토픽 문자열과 이벤트 타입 제네릭을 따로 적게 한다. ' +
-            '@InjectPublisher(STREAM) + PublisherFor<typeof STREAM> 으로 이주하라 (ADR-0029 §4).',
+            '@InjectPublisher(STREAM) + PublisherFor<typeof STREAM> 으로 이주하라 (ADR-0029 §4). ' +
+            '이 표면은 Task 7 에서 삭제됐으므로 지금 걸린다면 되살아난 것이다.',
         });
       }
 


### PR DESCRIPTION
ADR-0029 워크스트림의 **contract phase**. Task 5 전량 배포 완료가 선행조건이고 충족됐다.

등록 표면이 `forApp` + `startConsumer` 둘뿐이 된다.

## 삭제

| 표면 | 대체 | 앱 사용처 |
|---|---|---|
| `EventsModule.forConsumer` | `startConsumer` (전송 설정을 그 안으로 인라인) | 0 |
| `EventsModule.forConsumerModule` | `forApp` | 6 → 0 |
| `@OnEvent` | `@On(STREAM, 'Event')` | 0 (5-A) |
| `@InjectStreamPublisher` | `@InjectPublisher(STREAM)` | 0 (6-B) |

남아 있던 `libs/events` 스펙 7개를 `@On` 으로 이주했다.

## `forRoot` → `forApp`

개명이다. `streams` → `publishes` 로 인자도 바꿨다 — 세 표면이 **같은 이름의 `streams` 로 각각 다른 뜻**(발행 능력 · 검증 맵 · Nest 가 버리는 subscribe 목록)을 받던 것이 ADR Context 의 첫 관측이므로, 표면이 하나로 줄면 이름이 뜻을 말해야 한다.

정책은 두 필드로 갈랐다. 옛 두 표면이 `validation: SchemaValidationOptions` 라는 같은 이름·같은 타입으로 다른 뜻을 받던 자리다:

```ts
validation?: Pick<SchemaValidationOptions, 'validateOnPublish' | 'throwOnValidationError'>  // 발행
policy?:     Pick<SchemaValidationOptions, 'validateOnConsume' | 'throwOnValidationError'>  // 소비
```

반대쪽 플래그를 쓰면 컴파일 에러다.

## 정책 이전이 선행이다

`forConsumerModule` 을 먼저 걷어내면 `EVENTS_CONSUMER_POLICY` 가 사라지고 notification·membership·wallet 의 `validateOnConsume: false` 가 기본값 `true` 로 **조용히 뒤집힌다.** 6개 앱의 `forConsumerModule({validation})` 과 channel-adapter 의 수기 provider 를 `forApp({policy})` 로 옮긴 뒤 삭제했다. 감사가 사후 확인: 검증 ON 5앱(analytics·channel-adapter·core·membership·search) = 기준선.

## 새 부팅 거부 1건 — 정책 중복 선언

`forApp` 은 BC 별로 여러 번 불릴 수 있다(core 4번). 둘이 `policy` 를 선언하면 `optionalGet` 이 경고 없이 하나만 돌려주고 어느 것이 이기는지는 모듈 등록 순서에 달렸다 — 검증이 조용히 켜지거나 꺼진다. `assertSinglePolicyDeclaration` 이 `ModulesContainer` 를 훑어 센다. ADR §3 의 기존 두 거부와 같은 종류다.

## 🔴 이 태스크가 드러낸 것 — 하네스 스펙 3개가 운영과 다른 배선을 검증하고 있었다

`round-trip` · `consume-validation` · `enqueue-validation` 은 `createNestMicroservice` 로 도는데 **그 경로에서는 `APP_INTERCEPTOR` 가 적용된다.** 운영 7개 앱은 하이브리드 `connectMicroservice` 라 적용되지 않는다(ADR §8). 즉 이 셋은 `forConsumerModule` 이 달아 주던 `APP_INTERCEPTOR` 로 검증·DLQ 를 얻고 있었고 — **라이브에 없던 배선을 초록으로 증명하고 있었다.** §8 이 고발한 모양 그대로다. `forConsumerModule` 삭제로 5개 테스트가 빨간불이 되면서 드러났고, 셋 다 운영과 같은 팩토리 `buildConsumerInterceptors` 를 명시적으로 얹도록 고쳤다.

## 부수 실측 — `forConsumerModule` 의 인자 5개가 한 번도 읽히지 않았다

`groupId`·`sessionTimeout`·`heartbeatInterval`·`maxPollInterval`·`autoCommit`. 6개 앱이 `groupId` 를 모듈과 `main.ts` 에 두 번 적고 있었고 효력이 있는 것은 `main.ts` 쪽뿐이었다(값은 전부 일치). 표면과 함께 사라진다.

## 동작 중립

- 앱별 `validateOnConsume` 값 전부 보존 (notification·wallet 의 `false` 포함)
- `forConsumerModule` 의 `APP_INTERCEPTOR`(SchemaValidation·ChainContext)는 되살리지 않았다 — 하이브리드에서 소비 경로에 닿은 적이 없고 셋 다 HTTP 에서 즉시 통과한다. 되살릴 수도 없다: `SchemaValidationInterceptor` 는 소비 스트림 목록을 요구하는데 그건 이 워크스트림이 지운 두 번째 진실이다
- 소비 앱 3개(analytics·search·notification)의 `KAFKA_CLIENT` 가 `forApp` 의 producer 설정을 받는다 (`allowAutoTopicCreation:false`, `idempotent:true`). DLQ 토픽은 `startConsumer` 가 부트스트랩하므로 영향 없음 — 유일하게 남는 실동작 차이다

## 대조군 (변이 5종, 전부 빨간불 재현 후 `cp` + `sha1sum -c` 로 원복)

| 변이 | 빨간불 |
|---|---|
| 가드 임계값 `> 1` → `> 2` | 2 tests |
| `buildConsumerInterceptors` 의 가드 호출 삭제(배선만 끊음) | 1 test |
| `forApp` 이 `policy` 없이도 provider 등록 | 대조군 1 test |
| `forApp` 이 인터셉터를 `APP_INTERCEPTOR` 로 추가 등록 | 1 test |
| `@On` 이 `EVENT_TYPE_FILTER` 를 안 남김 | 3 tests |

두 번째가 특히 필요했다 — 가드 함수를 직접 부르는 테스트 3개만으로는 그것이 **부팅 경로에 꽂혀 있다는 것**을 증명하지 못한다. 호출 한 줄을 지워도 셋 다 초록이었다.

## 게이트

- `npm run type-check` **162 = 기준선** (file+code 집합 완전 동일, 신규 0)
- `audit:event-handlers` exit 0 (87 핸들러 / `@OnEvent` 0)
- `audit:event-publishers` exit 0 (37 주입 / 옛 표면 0)
- `audit:consume-validation --gate` exit 0 (검증 ON 5앱 = 기준선)
- 10개 앱 `nest build` OK
- 전체 jest **실패 suite 18 = 기준선(집합 완전 동일)**, 통과 3079 → 3084 (신규 6 − 삭제 1)
- 변경 파일 eslint **신규 0** (60 → 52)

## 배포

마이그레이션 0 · 시크릿 0 · env 0 · 계약 변경 0. 앱 간 순서 없음.

두 번째 커밋은 문서다 — 삭제된 API 를 가르치던 `libs/events` 문서 9개. `docs/first-look.md` 만 본문을 두고 경고 헤더를 달았다(특정 시점의 평가 기록이라 고치면 거짓이 된다).

https://claude.ai/code/session_01Phyx7rWAAe7uVLp3FCU6uZ