### PR TITLE
fix(inventory): 가용재고 정의를 단일 모듈이 소유하게 하고 뷰의 transit_out 차감 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -467,6 +467,9 @@ apps/wallet/docs/FMS-TE-0046(Web_API-배치CMS).md
 
 # git worktrees (superpowers isolated workspaces)
 .worktrees/
+# Claude Code 의 EnterWorktree 는 여기에 만든다 — 무시하지 않으면 메인 체크아웃의
+# git status 에 워크트리 전체가 untracked 로 뜨고, 실수로 커밋되거나 지워질 수 있다.
+.claude/worktrees/
 
 # UI E2E 산출물 (playwright)
 web/almondyoung-storefront/test-results/

--- a/apps/core/drizzle/20260811214750_drop-transit-out-from-available-qty.sql
+++ b/apps/core/drizzle/20260811214750_drop-transit-out-from-available-qty.sql
@@ -1,0 +1,72 @@
+DROP VIEW "public"."stock_summary_view";--> statement-breakpoint
+CREATE VIEW "public"."stock_summary_view" AS (
+    SELECT
+        s.id as sku_id,
+        w.id as warehouse_id,
+        s.name as sku_name,
+        w.name as warehouse_name,
+
+        -- 물리적 재고
+        COALESCE(on_hand.qty, 0) as on_hand_qty,
+        COALESCE(defective.qty, 0) as defective_qty,
+        COALESCE(in_transfer.qty, 0) as in_transfer_qty,
+
+        -- 예약 상태
+        COALESCE(reserved.qty, 0) as reserved_qty,
+        -- 가용재고 = ON_HAND 합 − confirmed 예약 합 (ADR-0001).
+        -- transit_out 을 다시 빼지 말 것: 출발 창고에서만 빠지고 도착 창고에 더해지지 않아
+        -- 사내 이동만으로 전사 판매가능수량이 줄고, inbound_plan_items 기반이라 실제 이동
+        -- (stock_journals)이 끝나도 줄지 않는다. 등가성은 view-parity.integration.spec.ts 가 고정한다.
+        COALESCE(on_hand.qty, 0) - COALESCE(reserved.qty, 0) as available_qty,
+
+        -- 예정 상태
+        COALESCE(inbound_pending.qty, 0) as inbound_pending_qty,
+        0 as on_order_qty,
+        COALESCE(transit_out.qty, 0) as transfer_pending_qty,
+
+        -- 계산된 전망
+        COALESCE(on_hand.qty, 0) - COALESCE(reserved.qty, 0) + COALESCE(inbound_pending.qty, 0) as projected_available_qty,
+
+        NOW() as last_calculated_at
+
+    FROM skus s
+    CROSS JOIN warehouses w
+    LEFT JOIN (
+        SELECT sku_id, warehouse_id, SUM(qty) as qty
+        FROM stock_ledgers
+        WHERE stock_state = 'ON_HAND'
+        GROUP BY sku_id, warehouse_id
+    ) on_hand ON s.id = on_hand.sku_id AND w.id = on_hand.warehouse_id
+    LEFT JOIN (
+        SELECT sku_id, warehouse_id, SUM(qty) as qty
+        FROM stock_ledgers
+        WHERE stock_state = 'DEFECTIVE'
+        GROUP BY sku_id, warehouse_id
+    ) defective ON s.id = defective.sku_id AND w.id = defective.warehouse_id
+    LEFT JOIN (
+        SELECT sku_id, warehouse_id, SUM(qty) as qty
+        FROM stock_ledgers
+        WHERE stock_state = 'IN_TRANSFER'
+        GROUP BY sku_id, warehouse_id
+    ) in_transfer ON s.id = in_transfer.sku_id AND w.id = in_transfer.warehouse_id
+    LEFT JOIN (
+        SELECT sku_id, warehouse_id, SUM(quantity) as qty
+        FROM stock_reservations
+        WHERE status = 'confirmed'
+        GROUP BY sku_id, warehouse_id
+    ) reserved ON s.id = reserved.sku_id AND w.id = reserved.warehouse_id
+    LEFT JOIN (
+        SELECT ipi.sku_id, ip.destination_warehouse_id, SUM(ipi.expected_qty - ipi.received_qty) as qty
+        FROM inbound_plan_items ipi
+        INNER JOIN inbound_plans ip ON ipi.plan_id = ip.id
+        WHERE ipi.status = 'pending'
+        GROUP BY ipi.sku_id, ip.destination_warehouse_id
+    ) inbound_pending ON s.id = inbound_pending.sku_id AND w.id = inbound_pending.destination_warehouse_id
+    LEFT JOIN (
+        SELECT ipi.sku_id, ip.warehouse_id, SUM(ipi.expected_qty - ipi.received_qty) as qty
+        FROM inbound_plan_items ipi
+        INNER JOIN inbound_plans ip ON ipi.plan_id = ip.id
+        WHERE ipi.status = 'pending' AND ip.requires_transfer = true AND ip.warehouse_id != ip.destination_warehouse_id
+        GROUP BY ipi.sku_id, ip.warehouse_id
+    ) transit_out ON s.id = transit_out.sku_id AND w.id = transit_out.warehouse_id
+);

--- a/apps/core/drizzle/meta/20260811214750_snapshot.json
+++ b/apps/core/drizzle/meta/20260811214750_snapshot.json
@@ -1,0 +1,21273 @@
+{
+  "id": "c65eb3f4-5bd3-4eed-ae87-22a6e56f3675",
+  "prevId": "03bd6ed7-6562-478b-8600-117d77345edf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_prompt_presets": {
+      "name": "ai_prompt_presets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_name": {
+          "name": "owner_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_prompt_presets_scope": {
+          "name": "idx_ai_prompt_presets_scope",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_ai_prompt_presets_scope_title": {
+          "name": "uq_ai_prompt_presets_scope_title",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banner_groups": {
+      "name": "banner_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pc_width": {
+          "name": "pc_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pc_height": {
+          "name": "pc_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile_width": {
+          "name": "mobile_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile_height": {
+          "name": "mobile_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_banner_groups_code": {
+          "name": "idx_banner_groups_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banner_groups_category": {
+          "name": "idx_banner_groups_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banner_groups_active": {
+          "name": "idx_banner_groups_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banner_groups_deleted_at": {
+          "name": "idx_banner_groups_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "banner_groups_code_unique": {
+          "name": "banner_groups_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.banners": {
+      "name": "banners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "banner_group_id": {
+          "name": "banner_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pc_image_file_id": {
+          "name": "pc_image_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mobile_image_file_id": {
+          "name": "mobile_image_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_product_master_ids": {
+          "name": "linked_product_master_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "display_start_at": {
+          "name": "display_start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_end_at": {
+          "name": "display_end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_banners_group_id": {
+          "name": "idx_banners_group_id",
+          "columns": [
+            {
+              "expression": "banner_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banners_active": {
+          "name": "idx_banners_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banners_display_period": {
+          "name": "idx_banners_display_period",
+          "columns": [
+            {
+              "expression": "display_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banners_deleted_at": {
+          "name": "idx_banners_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_banners_group_sort": {
+          "name": "idx_banners_group_sort",
+          "columns": [
+            {
+              "expression": "banner_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "banners_banner_group_id_banner_groups_id_fk": {
+          "name": "banners_banner_group_id_banner_groups_id_fk",
+          "tableFrom": "banners",
+          "tableTo": "banner_groups",
+          "columnsFrom": [
+            "banner_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.category_tag_groups": {
+      "name": "category_tag_groups",
+      "schema": "",
+      "columns": {
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_group_id": {
+          "name": "tag_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "applies_to_descendants": {
+          "name": "applies_to_descendants",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_category_tag_groups_category": {
+          "name": "idx_category_tag_groups_category",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_category_tag_groups_group": {
+          "name": "idx_category_tag_groups_group",
+          "columns": [
+            {
+              "expression": "tag_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_category_tag_groups_display_order": {
+          "name": "idx_category_tag_groups_display_order",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "category_tag_groups_category_id_product_categories_id_fk": {
+          "name": "category_tag_groups_category_id_product_categories_id_fk",
+          "tableFrom": "category_tag_groups",
+          "tableTo": "product_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "category_tag_groups_tag_group_id_tag_groups_id_fk": {
+          "name": "category_tag_groups_tag_group_id_tag_groups_id_fk",
+          "tableFrom": "category_tag_groups",
+          "tableTo": "tag_groups",
+          "columnsFrom": [
+            "tag_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "category_tag_groups_category_id_tag_group_id_pk": {
+          "name": "category_tag_groups_category_id_tag_group_id_pk",
+          "columns": [
+            "category_id",
+            "tag_group_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_categories": {
+      "name": "channel_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channel_categories_order": {
+          "name": "idx_channel_categories_order",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_products": {
+      "name": "channel_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "channel_specific_data": {
+          "name": "channel_specific_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_channel_products_master": {
+          "name": "idx_channel_products_master",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_products_channel": {
+          "name": "idx_channel_products_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_products_active": {
+          "name": "idx_channel_products_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_master_channel": {
+          "name": "unique_master_channel",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_products_master_id_product_masters_id_fk": {
+          "name": "channel_products_master_id_product_masters_id_fk",
+          "tableFrom": "channel_products",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_products_channel_id_sales_channels_id_fk": {
+          "name": "channel_products_channel_id_sales_channels_id_fk",
+          "tableFrom": "channel_products",
+          "tableTo": "sales_channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_variant_listings": {
+      "name": "channel_variant_listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_channel_id": {
+          "name": "sales_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_item_id": {
+          "name": "channel_item_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_item_name": {
+          "name": "channel_item_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_option_name": {
+          "name": "channel_option_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_price": {
+          "name": "channel_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_product_url": {
+          "name": "channel_product_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_channel_variant_listing": {
+          "name": "uq_channel_variant_listing",
+          "columns": [
+            {
+              "expression": "sales_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_listings_variant": {
+          "name": "idx_channel_listings_variant",
+          "columns": [
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_listings_channel": {
+          "name": "idx_channel_listings_channel",
+          "columns": [
+            {
+              "expression": "sales_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_variant_listings_variant_id_product_variants_id_fk": {
+          "name": "channel_variant_listings_variant_id_product_variants_id_fk",
+          "tableFrom": "channel_variant_listings",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_variant_listings_sales_channel_id_sales_channels_id_fk": {
+          "name": "channel_variant_listings_sales_channel_id_sales_channels_id_fk",
+          "tableFrom": "channel_variant_listings",
+          "tableTo": "sales_channels",
+          "columnsFrom": [
+            "sales_channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notices": {
+      "name": "notices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "badge": {
+          "name": "badge",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "display_start_at": {
+          "name": "display_start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_end_at": {
+          "name": "display_end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_notices_category": {
+          "name": "idx_notices_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notices_active": {
+          "name": "idx_notices_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notices_pinned": {
+          "name": "idx_notices_pinned",
+          "columns": [
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notices_display_period": {
+          "name": "idx_notices_display_period",
+          "columns": [
+            {
+              "expression": "display_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notices_deleted_at": {
+          "name": "idx_notices_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notices_sort": {
+          "name": "idx_notices_sort",
+          "columns": [
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pricing_rules": {
+      "name": "pricing_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "layer": {
+          "name": "layer",
+          "type": "pricing_rule_layer",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "pricing_rule_scope_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_target_ids": {
+          "name": "scope_target_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "pricing_rule_operation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_value": {
+          "name": "operation_value",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_quantity": {
+          "name": "min_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_approval_history": {
+      "name": "product_approval_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_approval_history_version": {
+          "name": "idx_approval_history_version",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_approval_history_status": {
+          "name": "idx_approval_history_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_approval_history_date": {
+          "name": "idx_approval_history_date",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_approval_history_version_id_product_master_versions_id_fk": {
+          "name": "product_approval_history_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_approval_history",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_audit_log": {
+      "name": "product_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_audit_log_version": {
+          "name": "idx_audit_log_version",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_action": {
+          "name": "idx_audit_log_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_timestamp": {
+          "name": "idx_audit_log_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_log_user": {
+          "name": "idx_audit_log_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_bulk_images": {
+      "name": "product_bulk_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage": {
+          "name": "usage",
+          "type": "product_bulk_image_usage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "product_bulk_image_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_value": {
+          "name": "source_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "product_bulk_image_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_bulk_images_session_key_usage": {
+          "name": "uq_bulk_images_session_key_usage",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "image_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bulk_images_session_status": {
+          "name": "idx_bulk_images_session_status",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_bulk_images_session_id_product_bulk_sessions_id_fk": {
+          "name": "product_bulk_images_session_id_product_bulk_sessions_id_fk",
+          "tableFrom": "product_bulk_images",
+          "tableTo": "product_bulk_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_bulk_items": {
+      "name": "product_bulk_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_number": {
+          "name": "row_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_key": {
+          "name": "row_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "product_bulk_item_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_version_id": {
+          "name": "base_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_snapshot": {
+          "name": "base_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "product_bulk_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "conflict": {
+          "name": "conflict",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conflict_decision": {
+          "name": "conflict_decision",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_version_id": {
+          "name": "draft_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_status": {
+          "name": "publish_status",
+          "type": "product_bulk_item_publish_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_error": {
+          "name": "publish_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_bulk_items_session_row_key": {
+          "name": "uq_bulk_items_session_row_key",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "row_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bulk_items_session_status": {
+          "name": "idx_bulk_items_session_status",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_bulk_items_session_id_product_bulk_sessions_id_fk": {
+          "name": "product_bulk_items_session_id_product_bulk_sessions_id_fk",
+          "tableFrom": "product_bulk_items",
+          "tableTo": "product_bulk_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_bulk_sessions": {
+      "name": "product_bulk_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "export_id": {
+          "name": "export_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_file_id": {
+          "name": "source_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "product_bulk_session_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploaded'"
+        },
+        "phase_error": {
+          "name": "phase_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_rows": {
+          "name": "total_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_bulk_sessions_claim": {
+          "name": "idx_bulk_sessions_claim",
+          "columns": [
+            {
+              "expression": "phase",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_bulk_sessions_uploaded_by": {
+          "name": "idx_bulk_sessions_uploaded_by",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_bulk_sessions_export_id_product_form_exports_id_fk": {
+          "name": "product_bulk_sessions_export_id_product_form_exports_id_fk",
+          "tableFrom": "product_bulk_sessions",
+          "tableTo": "product_form_exports",
+          "columnsFrom": [
+            "export_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_categories": {
+      "name": "product_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "display_settings": {
+          "name": "display_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_config": {
+          "name": "seo_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_config": {
+          "name": "template_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_categories_parent_id": {
+          "name": "idx_categories_parent_id",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_categories_level": {
+          "name": "idx_categories_level",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_categories_path": {
+          "name": "idx_categories_path",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_categories_slug": {
+          "name": "idx_categories_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_categories_active": {
+          "name": "idx_categories_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_categories_sort_order": {
+          "name": "idx_categories_sort_order",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_categories_parent_id_product_categories_id_fk": {
+          "name": "product_categories_parent_id_product_categories_id_fk",
+          "tableFrom": "product_categories",
+          "tableTo": "product_categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "product_categories_slug_unique": {
+          "name": "product_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_form_export_items": {
+      "name": "product_form_export_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "export_id": {
+          "name": "export_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_key": {
+          "name": "row_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing_editable": {
+          "name": "pricing_editable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_form_export_items_master": {
+          "name": "uq_form_export_items_master",
+          "columns": [
+            {
+              "expression": "export_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_form_export_items_row_key": {
+          "name": "uq_form_export_items_row_key",
+          "columns": [
+            {
+              "expression": "export_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "row_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_form_export_items_export_id_product_form_exports_id_fk": {
+          "name": "product_form_export_items_export_id_product_form_exports_id_fk",
+          "tableFrom": "product_form_export_items",
+          "tableTo": "product_form_exports",
+          "columnsFrom": [
+            "export_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_form_exports": {
+      "name": "product_form_exports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_master_ids": {
+          "name": "requested_master_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "product_form_export_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_count": {
+          "name": "product_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_form_exports_claim": {
+          "name": "idx_form_exports_claim",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_form_exports_expires": {
+          "name": "idx_form_exports_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_form_exports_requested_by": {
+          "name": "idx_form_exports_requested_by",
+          "columns": [
+            {
+              "expression": "requested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_images": {
+      "name": "product_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_product_images_version": {
+          "name": "idx_product_images_version",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_product_images_primary": {
+          "name": "idx_product_images_primary",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_product_images_sort": {
+          "name": "idx_product_images_sort",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_product_primary_image": {
+          "name": "unique_product_primary_image",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"product_images\".\"is_primary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_images_version_id_product_master_versions_id_fk": {
+          "name": "product_images_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_master_categories": {
+      "name": "product_master_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_master_categories_master_version": {
+          "name": "idx_master_categories_master_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_master_categories_category": {
+          "name": "idx_master_categories_category",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_master_categories_primary": {
+          "name": "idx_master_categories_primary",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_master_category_version": {
+          "name": "unique_master_category_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_master_categories_master_id_product_masters_id_fk": {
+          "name": "product_master_categories_master_id_product_masters_id_fk",
+          "tableFrom": "product_master_categories",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_categories_category_id_product_categories_id_fk": {
+          "name": "product_master_categories_category_id_product_categories_id_fk",
+          "tableFrom": "product_master_categories",
+          "tableTo": "product_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_categories_version_id_product_master_versions_id_fk": {
+          "name": "product_master_categories_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_master_categories",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_master_option_groups": {
+      "name": "product_master_option_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_group_id": {
+          "name": "option_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_master_option_groups_master_version": {
+          "name": "idx_master_option_groups_master_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_master_option_group_version": {
+          "name": "unique_master_option_group_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "option_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_master_option_groups_master_id_product_masters_id_fk": {
+          "name": "product_master_option_groups_master_id_product_masters_id_fk",
+          "tableFrom": "product_master_option_groups",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_option_groups_option_group_id_product_option_groups_id_fk": {
+          "name": "product_master_option_groups_option_group_id_product_option_groups_id_fk",
+          "tableFrom": "product_master_option_groups",
+          "tableTo": "product_option_groups",
+          "columnsFrom": [
+            "option_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_option_groups_version_id_product_master_versions_id_fk": {
+          "name": "product_master_option_groups_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_master_option_groups",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_master_pricing_rules": {
+      "name": "product_master_pricing_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pricing_rule_id": {
+          "name": "pricing_rule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_master_pricing_rules_master_version": {
+          "name": "idx_master_pricing_rules_master_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_master_pricing_rule_version": {
+          "name": "unique_master_pricing_rule_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pricing_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_master_pricing_rules_master_id_product_masters_id_fk": {
+          "name": "product_master_pricing_rules_master_id_product_masters_id_fk",
+          "tableFrom": "product_master_pricing_rules",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_pricing_rules_pricing_rule_id_pricing_rules_id_fk": {
+          "name": "product_master_pricing_rules_pricing_rule_id_pricing_rules_id_fk",
+          "tableFrom": "product_master_pricing_rules",
+          "tableTo": "pricing_rules",
+          "columnsFrom": [
+            "pricing_rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_pricing_rules_version_id_product_master_versions_id_fk": {
+          "name": "product_master_pricing_rules_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_master_pricing_rules",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_master_purchase_constraints": {
+      "name": "product_master_purchase_constraints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_constraint_id": {
+          "name": "purchase_constraint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_master_purchase_constraints_master_version": {
+          "name": "idx_master_purchase_constraints_master_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_master_purchase_constraints_constraint": {
+          "name": "idx_master_purchase_constraints_constraint",
+          "columns": [
+            {
+              "expression": "purchase_constraint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_purchase_constraint_version": {
+          "name": "unique_purchase_constraint_version",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_master_purchase_constraint_version": {
+          "name": "unique_master_purchase_constraint_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_master_purchase_constraints_master_id_product_masters_id_fk": {
+          "name": "product_master_purchase_constraints_master_id_product_masters_id_fk",
+          "tableFrom": "product_master_purchase_constraints",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_purchase_constraints_version_id_product_master_versions_id_fk": {
+          "name": "product_master_purchase_constraints_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_master_purchase_constraints",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_purchase_constraints_purchase_constraint_id_product_purchase_constraints_id_fk": {
+          "name": "product_master_purchase_constraints_purchase_constraint_id_product_purchase_constraints_id_fk",
+          "tableFrom": "product_master_purchase_constraints",
+          "tableTo": "product_purchase_constraints",
+          "columnsFrom": [
+            "purchase_constraint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_master_variants": {
+      "name": "product_master_variants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_master_variants_master_version": {
+          "name": "idx_master_variants_master_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_master_variants_version": {
+          "name": "idx_master_variants_version",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_master_variant_version": {
+          "name": "unique_master_variant_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_master_variants_master_id_product_masters_id_fk": {
+          "name": "product_master_variants_master_id_product_masters_id_fk",
+          "tableFrom": "product_master_variants",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_variants_variant_id_product_variants_id_fk": {
+          "name": "product_master_variants_variant_id_product_variants_id_fk",
+          "tableFrom": "product_master_variants",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_variants_version_id_product_master_versions_id_fk": {
+          "name": "product_master_variants_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_master_variants",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_master_versions": {
+      "name": "product_master_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "product_master_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "draft_owner_id": {
+          "name": "draft_owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bulk_session_id": {
+          "name": "bulk_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'새 상품'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_title": {
+          "name": "seo_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_description": {
+          "name": "seo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_keywords": {
+          "name": "seo_keywords",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_html": {
+          "name": "description_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_wholesale_only": {
+          "name": "is_wholesale_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_membership_only": {
+          "name": "is_membership_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hide_membership_price_for_non_members": {
+          "name": "hide_membership_price_for_non_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_visible_to_members_only": {
+          "name": "is_visible_to_members_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_overseas": {
+          "name": "is_overseas",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "product_type": {
+          "name": "product_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'regular_sale'"
+        },
+        "fulfillment_kind": {
+          "name": "fulfillment_kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'physical'"
+        },
+        "product_code": {
+          "name": "product_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alternative_name": {
+          "name": "alternative_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "material": {
+          "name": "material",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_classification": {
+          "name": "sales_classification",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_classification": {
+          "name": "purchase_classification",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_method_id": {
+          "name": "shipping_method_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_group_code": {
+          "name": "shipping_group_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "market_price": {
+          "name": "market_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supply_price": {
+          "name": "supply_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age_restriction": {
+          "name": "age_restriction",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "min_quantity": {
+          "name": "min_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "max_quantity": {
+          "name": "max_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_start_date": {
+          "name": "sales_start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_end_date": {
+          "name": "sales_end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_status": {
+          "name": "approval_status",
+          "type": "product_master_version_approval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seller": {
+          "name": "seller",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_date": {
+          "name": "registration_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_versions_master_id": {
+          "name": "idx_versions_master_id",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_status": {
+          "name": "idx_versions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_master_version": {
+          "name": "idx_versions_master_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_name": {
+          "name": "idx_versions_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_brand": {
+          "name": "idx_versions_brand",
+          "columns": [
+            {
+              "expression": "brand",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_created_at": {
+          "name": "idx_versions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_product_type": {
+          "name": "idx_versions_product_type",
+          "columns": [
+            {
+              "expression": "product_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_product_code": {
+          "name": "idx_versions_product_code",
+          "columns": [
+            {
+              "expression": "product_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_approval_status": {
+          "name": "idx_versions_approval_status",
+          "columns": [
+            {
+              "expression": "approval_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_deleted_at": {
+          "name": "idx_versions_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_supplier": {
+          "name": "idx_versions_supplier",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_draft_owner": {
+          "name": "idx_versions_draft_owner",
+          "columns": [
+            {
+              "expression": "draft_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_sales_dates": {
+          "name": "idx_versions_sales_dates",
+          "columns": [
+            {
+              "expression": "sales_start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sales_end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_versions_bulk_session": {
+          "name": "idx_versions_bulk_session",
+          "columns": [
+            {
+              "expression": "bulk_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_master_active_version": {
+          "name": "unique_master_active_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"product_master_versions\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_active_product_code": {
+          "name": "unique_active_product_code",
+          "columns": [
+            {
+              "expression": "product_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"product_master_versions\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_master_version": {
+          "name": "unique_master_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_master_versions_master_id_product_masters_id_fk": {
+          "name": "product_master_versions_master_id_product_masters_id_fk",
+          "tableFrom": "product_master_versions",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_master_versions_parent_version_id_product_master_versions_id_fk": {
+          "name": "product_master_versions_parent_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_master_versions",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "parent_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_masters": {
+      "name": "product_masters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_masters_created_at": {
+          "name": "idx_masters_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_masters_deleted_at": {
+          "name": "idx_masters_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_option_group_displays": {
+      "name": "product_option_group_displays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "option_group_id": {
+          "name": "option_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ko-KR'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_option_group_displays_lookup": {
+          "name": "idx_option_group_displays_lookup",
+          "columns": [
+            {
+              "expression": "option_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_option_group_display": {
+          "name": "unique_option_group_display",
+          "columns": [
+            {
+              "expression": "option_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_option_group_displays_option_group_id_product_option_groups_id_fk": {
+          "name": "product_option_group_displays_option_group_id_product_option_groups_id_fk",
+          "tableFrom": "product_option_group_displays",
+          "tableTo": "product_option_groups",
+          "columnsFrom": [
+            "option_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_option_group_displays_master_id_product_masters_id_fk": {
+          "name": "product_option_group_displays_master_id_product_masters_id_fk",
+          "tableFrom": "product_option_group_displays",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_option_group_displays_version_id_product_master_versions_id_fk": {
+          "name": "product_option_group_displays_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_option_group_displays",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_option_groups": {
+      "name": "product_option_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_option_value_displays": {
+      "name": "product_option_value_displays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "option_value_id": {
+          "name": "option_value_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ko-KR'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color_code": {
+          "name": "color_code",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_option_value_displays_lookup": {
+          "name": "idx_option_value_displays_lookup",
+          "columns": [
+            {
+              "expression": "option_value_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_option_value_display": {
+          "name": "unique_option_value_display",
+          "columns": [
+            {
+              "expression": "option_value_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_option_value_displays_option_value_id_product_option_values_id_fk": {
+          "name": "product_option_value_displays_option_value_id_product_option_values_id_fk",
+          "tableFrom": "product_option_value_displays",
+          "tableTo": "product_option_values",
+          "columnsFrom": [
+            "option_value_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_option_value_displays_master_id_product_masters_id_fk": {
+          "name": "product_option_value_displays_master_id_product_masters_id_fk",
+          "tableFrom": "product_option_value_displays",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_option_value_displays_version_id_product_master_versions_id_fk": {
+          "name": "product_option_value_displays_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_option_value_displays",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_option_values": {
+      "name": "product_option_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "option_group_id": {
+          "name": "option_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_option_values_group": {
+          "name": "idx_option_values_group",
+          "columns": [
+            {
+              "expression": "option_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_option_values_option_group_id_product_option_groups_id_fk": {
+          "name": "product_option_values_option_group_id_product_option_groups_id_fk",
+          "tableFrom": "product_option_values",
+          "tableTo": "product_option_groups",
+          "columnsFrom": [
+            "option_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_purchase_constraints": {
+      "name": "product_purchase_constraints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requires_membership": {
+          "name": "requires_membership",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lifetime_quantity_limit": {
+          "name": "lifetime_quantity_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_product_purchase_constraints_lifetime_quantity_limit_positive": {
+          "name": "chk_product_purchase_constraints_lifetime_quantity_limit_positive",
+          "value": "\"lifetime_quantity_limit\" IS NULL OR \"lifetime_quantity_limit\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.product_tag_values": {
+      "name": "product_tag_values",
+      "schema": "",
+      "columns": {
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_value_id": {
+          "name": "tag_value_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_product_tag_values_master_version": {
+          "name": "idx_product_tag_values_master_version",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_product_tag_values_tag": {
+          "name": "idx_product_tag_values_tag",
+          "columns": [
+            {
+              "expression": "tag_value_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_tag_values_master_id_product_masters_id_fk": {
+          "name": "product_tag_values_master_id_product_masters_id_fk",
+          "tableFrom": "product_tag_values",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_tag_values_version_id_product_master_versions_id_fk": {
+          "name": "product_tag_values_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_tag_values",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_tag_values_tag_value_id_tag_values_id_fk": {
+          "name": "product_tag_values_tag_value_id_tag_values_id_fk",
+          "tableFrom": "product_tag_values",
+          "tableTo": "tag_values",
+          "columnsFrom": [
+            "tag_value_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "product_tag_values_master_id_version_id_tag_value_id_pk": {
+          "name": "product_tag_values_master_id_version_id_tag_value_id_pk",
+          "columns": [
+            "master_id",
+            "version_id",
+            "tag_value_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_variant_price_cache": {
+      "name": "product_variant_price_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_price": {
+          "name": "base_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "membership_price": {
+          "name": "membership_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tiered_prices": {
+          "name": "tiered_prices",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variant_price_cache_version": {
+          "name": "idx_variant_price_cache_version",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variant_price_cache_variant": {
+          "name": "idx_variant_price_cache_variant",
+          "columns": [
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_variant_price_cache_version_variant": {
+          "name": "unique_variant_price_cache_version_variant",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_variant_price_cache_version_id_product_master_versions_id_fk": {
+          "name": "product_variant_price_cache_version_id_product_master_versions_id_fk",
+          "tableFrom": "product_variant_price_cache",
+          "tableTo": "product_master_versions",
+          "columnsFrom": [
+            "version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_variant_price_cache_variant_id_product_variants_id_fk": {
+          "name": "product_variant_price_cache_variant_id_product_variants_id_fk",
+          "tableFrom": "product_variant_price_cache",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_variants": {
+      "name": "product_variants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "variant_name": {
+          "name": "variant_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "variant_code": {
+          "name": "variant_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variants_status": {
+          "name": "idx_variants_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variants_is_default": {
+          "name": "idx_variants_is_default",
+          "columns": [
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variants_created_at": {
+          "name": "idx_variants_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variants_code": {
+          "name": "idx_variants_code",
+          "columns": [
+            {
+              "expression": "variant_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.promotion_products": {
+      "name": "promotion_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "promotion_id": {
+          "name": "promotion_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "promotion_products_promotion_id_promotions_id_fk": {
+          "name": "promotion_products_promotion_id_promotions_id_fk",
+          "tableFrom": "promotion_products",
+          "tableTo": "promotions",
+          "columnsFrom": [
+            "promotion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "promotion_products_master_id_product_masters_id_fk": {
+          "name": "promotion_products_master_id_product_masters_id_fk",
+          "tableFrom": "promotion_products",
+          "tableTo": "product_masters",
+          "columnsFrom": [
+            "master_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "promotion_products_variant_id_product_variants_id_fk": {
+          "name": "promotion_products_variant_id_product_variants_id_fk",
+          "tableFrom": "promotion_products",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.promotions": {
+      "name": "promotions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_value": {
+          "name": "discount_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sales_channels": {
+      "name": "sales_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ONLINE'"
+        },
+        "site": {
+          "name": "site",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "api_endpoint": {
+          "name": "api_endpoint",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sales_channels_type": {
+          "name": "idx_sales_channels_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_channels_site": {
+          "name": "idx_sales_channels_site",
+          "columns": [
+            {
+              "expression": "site",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_channels_category": {
+          "name": "idx_sales_channels_category",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_channels_active": {
+          "name": "idx_sales_channels_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sales_channels_category_id_channel_categories_id_fk": {
+          "name": "sales_channels_category_id_channel_categories_id_fk",
+          "tableFrom": "sales_channels",
+          "tableTo": "channel_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_popups": {
+      "name": "site_popups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'rich_text'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pc_image_file_id": {
+          "name": "pc_image_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile_image_file_id": {
+          "name": "mobile_image_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_alt": {
+          "name": "image_alt",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notice_id": {
+          "name": "notice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pc_width": {
+          "name": "pc_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pc_height": {
+          "name": "pc_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile_width": {
+          "name": "mobile_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile_height": {
+          "name": "mobile_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "placement_paths": {
+          "name": "placement_paths",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "dismiss_mode": {
+          "name": "dismiss_mode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'today'"
+        },
+        "dismiss_days": {
+          "name": "dismiss_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismiss_version": {
+          "name": "dismiss_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "display_start_at": {
+          "name": "display_start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_end_at": {
+          "name": "display_end_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_site_popups_active": {
+          "name": "idx_site_popups_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_site_popups_display_period": {
+          "name": "idx_site_popups_display_period",
+          "columns": [
+            {
+              "expression": "display_start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_site_popups_deleted_at": {
+          "name": "idx_site_popups_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_site_popups_sort": {
+          "name": "idx_site_popups_sort",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "site_popups_notice_id_notices_id_fk": {
+          "name": "site_popups_notice_id_notices_id_fk",
+          "tableFrom": "site_popups",
+          "tableTo": "notices",
+          "columnsFrom": [
+            "notice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_groups": {
+      "name": "tag_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tag_groups_active": {
+          "name": "idx_tag_groups_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tag_groups_display_order": {
+          "name": "idx_tag_groups_display_order",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_values": {
+      "name": "tag_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tag_values_group_id": {
+          "name": "idx_tag_values_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tag_values_active": {
+          "name": "idx_tag_values_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tag_values_display_order": {
+          "name": "idx_tag_values_display_order",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_tag_values_group_name": {
+          "name": "unique_tag_values_group_name",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tag_values_group_id_tag_groups_id_fk": {
+          "name": "tag_values_group_id_tag_groups_id_fk",
+          "tableFrom": "tag_values",
+          "tableTo": "tag_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variant_option_values": {
+      "name": "variant_option_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_value_id": {
+          "name": "option_value_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_variant_options_variant": {
+          "name": "idx_variant_options_variant",
+          "columns": [
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variant_options_value": {
+          "name": "idx_variant_options_value",
+          "columns": [
+            {
+              "expression": "option_value_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_variant_option_values": {
+          "name": "unique_variant_option_values",
+          "columns": [
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "option_value_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "variant_option_values_variant_id_product_variants_id_fk": {
+          "name": "variant_option_values_variant_id_product_variants_id_fk",
+          "tableFrom": "variant_option_values",
+          "tableTo": "product_variants",
+          "columnsFrom": [
+            "variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "variant_option_values_option_value_id_product_option_values_id_fk": {
+          "name": "variant_option_values_option_value_id_product_option_values_id_fk",
+          "tableFrom": "variant_option_values",
+          "tableTo": "product_option_values",
+          "columnsFrom": [
+            "option_value_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "audit_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "audit_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'INFO'"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_name": {
+          "name": "resource_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes_before": {
+          "name": "changes_before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes_after": {
+          "name": "changes_after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module": {
+          "name": "module",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stack_trace": {
+          "name": "stack_trace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_timestamp": {
+          "name": "idx_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event_type": {
+          "name": "idx_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_resource_type": {
+          "name": "idx_audit_resource_type",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_resource_id": {
+          "name": "idx_audit_resource_id",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_module": {
+          "name": "idx_audit_module",
+          "columns": [
+            {
+              "expression": "module",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_severity": {
+          "name": "idx_audit_severity",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_user_id": {
+          "name": "idx_audit_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_correlation_id": {
+          "name": "idx_audit_correlation_id",
+          "columns": [
+            {
+              "expression": "correlation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_resource_search": {
+          "name": "idx_audit_resource_search",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_time_module": {
+          "name": "idx_audit_time_module",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "module",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.batch_inventory_session_balances": {
+      "name": "batch_inventory_session_balances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_location_id": {
+          "name": "source_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custody_type": {
+          "name": "custody_type",
+          "type": "batch_inventory_custody_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custody_ref": {
+          "name": "custody_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipment_line_id": {
+          "name": "shipment_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qty": {
+          "name": "qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_batch_inventory_session_balances_session": {
+          "name": "idx_batch_inventory_session_balances_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "custody_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_batch_inventory_session_balances_line": {
+          "name": "idx_batch_inventory_session_balances_line",
+          "columns": [
+            {
+              "expression": "shipment_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "batch_inventory_session_balances_session_id_batch_inventory_sessions_id_fk": {
+          "name": "batch_inventory_session_balances_session_id_batch_inventory_sessions_id_fk",
+          "tableFrom": "batch_inventory_session_balances",
+          "tableTo": "batch_inventory_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "batch_inventory_session_balances_sku_id_skus_id_fk": {
+          "name": "batch_inventory_session_balances_sku_id_skus_id_fk",
+          "tableFrom": "batch_inventory_session_balances",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "batch_inventory_session_balances_source_location_id_locations_id_fk": {
+          "name": "batch_inventory_session_balances_source_location_id_locations_id_fk",
+          "tableFrom": "batch_inventory_session_balances",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "source_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "batch_inventory_session_balances_shipment_line_id_shipment_lines_id_fk": {
+          "name": "batch_inventory_session_balances_shipment_line_id_shipment_lines_id_fk",
+          "tableFrom": "batch_inventory_session_balances",
+          "tableTo": "shipment_lines",
+          "columnsFrom": [
+            "shipment_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_batch_inventory_session_balance_grain": {
+          "name": "uq_batch_inventory_session_balance_grain",
+          "nullsNotDistinct": true,
+          "columns": [
+            "session_id",
+            "sku_id",
+            "source_location_id",
+            "custody_type",
+            "custody_ref",
+            "shipment_line_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_batch_inventory_session_balances_qty": {
+          "name": "ck_batch_inventory_session_balances_qty",
+          "value": "\"batch_inventory_session_balances\".\"qty\" >= 0"
+        },
+        "ck_batch_inventory_session_balances_version": {
+          "name": "ck_batch_inventory_session_balances_version",
+          "value": "\"batch_inventory_session_balances\".\"version\" > 0"
+        },
+        "ck_batch_inventory_session_balances_custody": {
+          "name": "ck_batch_inventory_session_balances_custody",
+          "value": "(\n        (\"batch_inventory_session_balances\".\"custody_type\" = 'AT_SOURCE' AND \"batch_inventory_session_balances\".\"source_location_id\" IS NOT NULL AND \"batch_inventory_session_balances\".\"custody_ref\" IS NULL AND \"batch_inventory_session_balances\".\"shipment_line_id\" IS NULL)\n        OR (\"batch_inventory_session_balances\".\"custody_type\" = 'BULK_CART' AND \"batch_inventory_session_balances\".\"source_location_id\" IS NOT NULL AND \"batch_inventory_session_balances\".\"custody_ref\" IS NOT NULL AND \"batch_inventory_session_balances\".\"shipment_line_id\" IS NULL)\n        OR (\"batch_inventory_session_balances\".\"custody_type\" IN ('WORKER', 'TOTE', 'SORTING', 'PACKING', 'PACKED') AND \"batch_inventory_session_balances\".\"source_location_id\" IS NOT NULL AND \"batch_inventory_session_balances\".\"custody_ref\" IS NOT NULL AND \"batch_inventory_session_balances\".\"shipment_line_id\" IS NOT NULL)\n        OR (\"batch_inventory_session_balances\".\"custody_type\" IN ('RETURN_PENDING', 'SETTLED') AND \"batch_inventory_session_balances\".\"source_location_id\" IS NOT NULL AND \"batch_inventory_session_balances\".\"custody_ref\" IS NULL AND \"batch_inventory_session_balances\".\"shipment_line_id\" IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.batch_inventory_session_events": {
+      "name": "batch_inventory_session_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_custody_type": {
+          "name": "from_custody_type",
+          "type": "batch_inventory_custody_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_custody_ref": {
+          "name": "from_custody_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_source_location_id": {
+          "name": "from_source_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_shipment_line_id": {
+          "name": "from_shipment_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_custody_type": {
+          "name": "to_custody_type",
+          "type": "batch_inventory_custody_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_custody_ref": {
+          "name": "to_custody_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_source_location_id": {
+          "name": "to_source_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_shipment_line_id": {
+          "name": "to_shipment_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_batch_inventory_session_events_from_location": {
+          "name": "idx_batch_inventory_session_events_from_location",
+          "columns": [
+            {
+              "expression": "from_source_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_batch_inventory_session_events_to_location": {
+          "name": "idx_batch_inventory_session_events_to_location",
+          "columns": [
+            {
+              "expression": "to_source_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_batch_inventory_session_events_from_line": {
+          "name": "idx_batch_inventory_session_events_from_line",
+          "columns": [
+            {
+              "expression": "from_shipment_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_batch_inventory_session_events_to_line": {
+          "name": "idx_batch_inventory_session_events_to_line",
+          "columns": [
+            {
+              "expression": "to_shipment_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "batch_inventory_session_events_session_id_batch_inventory_sessions_id_fk": {
+          "name": "batch_inventory_session_events_session_id_batch_inventory_sessions_id_fk",
+          "tableFrom": "batch_inventory_session_events",
+          "tableTo": "batch_inventory_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "batch_inventory_session_events_sku_id_skus_id_fk": {
+          "name": "batch_inventory_session_events_sku_id_skus_id_fk",
+          "tableFrom": "batch_inventory_session_events",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "batch_inventory_session_events_from_source_location_id_locations_id_fk": {
+          "name": "batch_inventory_session_events_from_source_location_id_locations_id_fk",
+          "tableFrom": "batch_inventory_session_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "from_source_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "batch_inventory_session_events_from_shipment_line_id_shipment_lines_id_fk": {
+          "name": "batch_inventory_session_events_from_shipment_line_id_shipment_lines_id_fk",
+          "tableFrom": "batch_inventory_session_events",
+          "tableTo": "shipment_lines",
+          "columnsFrom": [
+            "from_shipment_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "batch_inventory_session_events_to_source_location_id_locations_id_fk": {
+          "name": "batch_inventory_session_events_to_source_location_id_locations_id_fk",
+          "tableFrom": "batch_inventory_session_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "to_source_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "batch_inventory_session_events_to_shipment_line_id_shipment_lines_id_fk": {
+          "name": "batch_inventory_session_events_to_shipment_line_id_shipment_lines_id_fk",
+          "tableFrom": "batch_inventory_session_events",
+          "tableTo": "shipment_lines",
+          "columnsFrom": [
+            "to_shipment_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_batch_inventory_session_event_idempotency": {
+          "name": "uq_batch_inventory_session_event_idempotency",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_batch_inventory_session_events_qty_positive": {
+          "name": "ck_batch_inventory_session_events_qty_positive",
+          "value": "\"batch_inventory_session_events\".\"quantity\" > 0"
+        },
+        "ck_batch_inventory_session_events_sides": {
+          "name": "ck_batch_inventory_session_events_sides",
+          "value": "\"batch_inventory_session_events\".\"from_custody_type\" IS NOT NULL OR \"batch_inventory_session_events\".\"to_custody_type\" IS NOT NULL"
+        },
+        "ck_batch_inventory_session_events_from_grain": {
+          "name": "ck_batch_inventory_session_events_from_grain",
+          "value": "(\n        (\"batch_inventory_session_events\".\"from_custody_type\" IS NULL AND \"batch_inventory_session_events\".\"from_source_location_id\" IS NULL AND \"batch_inventory_session_events\".\"from_custody_ref\" IS NULL AND \"batch_inventory_session_events\".\"from_shipment_line_id\" IS NULL)\n        OR (\"batch_inventory_session_events\".\"from_custody_type\" IS NOT NULL AND (\n          (\"batch_inventory_session_events\".\"from_custody_type\" = 'AT_SOURCE' AND \"batch_inventory_session_events\".\"from_source_location_id\" IS NOT NULL AND \"batch_inventory_session_events\".\"from_custody_ref\" IS NULL AND \"batch_inventory_session_events\".\"from_shipment_line_id\" IS NULL)\n          OR (\"batch_inventory_session_events\".\"from_custody_type\" = 'BULK_CART' AND \"batch_inventory_session_events\".\"from_source_location_id\" IS NOT NULL AND \"batch_inventory_session_events\".\"from_custody_ref\" IS NOT NULL AND \"batch_inventory_session_events\".\"from_shipment_line_id\" IS NULL)\n          OR (\"batch_inventory_session_events\".\"from_custody_type\" IN ('WORKER', 'TOTE', 'SORTING', 'PACKING', 'PACKED') AND \"batch_inventory_session_events\".\"from_source_location_id\" IS NOT NULL AND \"batch_inventory_session_events\".\"from_custody_ref\" IS NOT NULL AND \"batch_inventory_session_events\".\"from_shipment_line_id\" IS NOT NULL)\n          OR (\"batch_inventory_session_events\".\"from_custody_type\" IN ('RETURN_PENDING', 'SETTLED') AND \"batch_inventory_session_events\".\"from_source_location_id\" IS NOT NULL AND \"batch_inventory_session_events\".\"from_custody_ref\" IS NULL AND \"batch_inventory_session_events\".\"from_shipment_line_id\" IS NOT NULL)\n        ))\n      )"
+        },
+        "ck_batch_inventory_session_events_to_grain": {
+          "name": "ck_batch_inventory_session_events_to_grain",
+          "value": "(\n        (\"batch_inventory_session_events\".\"to_custody_type\" IS NULL AND \"batch_inventory_session_events\".\"to_source_location_id\" IS NULL AND \"batch_inventory_session_events\".\"to_custody_ref\" IS NULL AND \"batch_inventory_session_events\".\"to_shipment_line_id\" IS NULL)\n        OR (\"batch_inventory_session_events\".\"to_custody_type\" IS NOT NULL AND (\n          (\"batch_inventory_session_events\".\"to_custody_type\" = 'AT_SOURCE' AND \"batch_inventory_session_events\".\"to_source_location_id\" IS NOT NULL AND \"batch_inventory_session_events\".\"to_custody_ref\" IS NULL AND \"batch_inventory_session_events\".\"to_shipment_line_id\" IS NULL)\n          OR (\"batch_inventory_session_events\".\"to_custody_type\" = 'BULK_CART' AND \"batch_inventory_session_events\".\"to_source_location_id\" IS NOT NULL AND \"batch_inventory_session_events\".\"to_custody_ref\" IS NOT NULL AND \"batch_inventory_session_events\".\"to_shipment_line_id\" IS NULL)\n          OR (\"batch_inventory_session_events\".\"to_custody_type\" IN ('WORKER', 'TOTE', 'SORTING', 'PACKING', 'PACKED') AND \"batch_inventory_session_events\".\"to_source_location_id\" IS NOT NULL AND \"batch_inventory_session_events\".\"to_custody_ref\" IS NOT NULL AND \"batch_inventory_session_events\".\"to_shipment_line_id\" IS NOT NULL)\n          OR (\"batch_inventory_session_events\".\"to_custody_type\" IN ('RETURN_PENDING', 'SETTLED') AND \"batch_inventory_session_events\".\"to_source_location_id\" IS NOT NULL AND \"batch_inventory_session_events\".\"to_custody_ref\" IS NULL AND \"batch_inventory_session_events\".\"to_shipment_line_id\" IS NOT NULL)\n        ))\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.batch_inventory_sessions": {
+      "name": "batch_inventory_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "batch_inventory_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "handed_in_qty": {
+          "name": "handed_in_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "settled_qty": {
+          "name": "settled_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "returned_qty": {
+          "name": "returned_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "shortage_qty": {
+          "name": "shortage_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recovery_reason": {
+          "name": "recovery_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_batch_inventory_sessions_active_batch": {
+          "name": "uq_batch_inventory_sessions_active_batch",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"batch_inventory_sessions\".\"status\" IN ('active', 'recovery_required')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_batch_inventory_sessions_status": {
+          "name": "idx_batch_inventory_sessions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "batch_inventory_sessions_batch_id_outbound_batches_id_fk": {
+          "name": "batch_inventory_sessions_batch_id_outbound_batches_id_fk",
+          "tableFrom": "batch_inventory_sessions",
+          "tableTo": "outbound_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_batch_inventory_sessions_version_positive": {
+          "name": "ck_batch_inventory_sessions_version_positive",
+          "value": "\"batch_inventory_sessions\".\"version\" > 0"
+        },
+        "ck_batch_inventory_sessions_quantities": {
+          "name": "ck_batch_inventory_sessions_quantities",
+          "value": "\"batch_inventory_sessions\".\"handed_in_qty\" >= 0 AND \"batch_inventory_sessions\".\"settled_qty\" >= 0 AND \"batch_inventory_sessions\".\"returned_qty\" >= 0 AND \"batch_inventory_sessions\".\"shortage_qty\" >= 0"
+        },
+        "ck_batch_inventory_sessions_settlement": {
+          "name": "ck_batch_inventory_sessions_settlement",
+          "value": "\"batch_inventory_sessions\".\"settled_qty\" + \"batch_inventory_sessions\".\"returned_qty\" + \"batch_inventory_sessions\".\"shortage_qty\" <= \"batch_inventory_sessions\".\"handed_in_qty\""
+        },
+        "ck_batch_inventory_sessions_recovery": {
+          "name": "ck_batch_inventory_sessions_recovery",
+          "value": "\"batch_inventory_sessions\".\"status\" <> 'recovery_required' OR \"batch_inventory_sessions\".\"recovery_reason\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.business_links": {
+      "name": "business_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_external_ref": {
+          "name": "source_external_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_external_ref": {
+          "name": "target_external_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relation_name": {
+          "name": "relation_name",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_business_links_source_id": {
+          "name": "idx_business_links_source_id",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_business_links_source_external_ref": {
+          "name": "idx_business_links_source_external_ref",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_external_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_business_links_target_id": {
+          "name": "idx_business_links_target_id",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_business_links_target_external_ref": {
+          "name": "idx_business_links_target_external_ref",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_external_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_business_links_relation_name": {
+          "name": "idx_business_links_relation_name",
+          "columns": [
+            {
+              "expression": "relation_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_business_links_occurred_at": {
+          "name": "idx_business_links_occurred_at",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "business_links_source_ref_required": {
+          "name": "business_links_source_ref_required",
+          "value": "\"business_links\".\"source_id\" IS NOT NULL OR \"business_links\".\"source_external_ref\" IS NOT NULL"
+        },
+        "business_links_target_ref_required": {
+          "name": "business_links_target_ref_required",
+          "value": "\"business_links\".\"target_id\" IS NOT NULL OR \"business_links\".\"target_external_ref\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delivery_profiles": {
+      "name": "delivery_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_delivery_days": {
+          "name": "avg_delivery_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_snapshot": {
+          "name": "sender_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_address_snapshot": {
+          "name": "origin_address_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "return_address_snapshot": {
+          "name": "return_address_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carrier_account_ref": {
+          "name": "carrier_account_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_fulfillment_modes": {
+          "name": "supported_fulfillment_modes",
+          "type": "fulfillment_mode[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handling_flags": {
+          "name": "handling_flags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispatch_attempt_sources": {
+      "name": "dispatch_attempt_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dispatch_attempt_id": {
+          "name": "dispatch_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_line_id": {
+          "name": "shipment_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_location_id": {
+          "name": "source_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qty": {
+          "name": "qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_event_id": {
+          "name": "stock_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_dispatch_attempt_sources_stock_event": {
+          "name": "uq_dispatch_attempt_sources_stock_event",
+          "columns": [
+            {
+              "expression": "stock_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispatch_attempt_sources\".\"stock_event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dispatch_attempt_sources_line": {
+          "name": "idx_dispatch_attempt_sources_line",
+          "columns": [
+            {
+              "expression": "shipment_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispatch_attempt_sources_dispatch_attempt_id_dispatch_attempts_id_fk": {
+          "name": "dispatch_attempt_sources_dispatch_attempt_id_dispatch_attempts_id_fk",
+          "tableFrom": "dispatch_attempt_sources",
+          "tableTo": "dispatch_attempts",
+          "columnsFrom": [
+            "dispatch_attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dispatch_attempt_sources_shipment_line_id_shipment_lines_id_fk": {
+          "name": "dispatch_attempt_sources_shipment_line_id_shipment_lines_id_fk",
+          "tableFrom": "dispatch_attempt_sources",
+          "tableTo": "shipment_lines",
+          "columnsFrom": [
+            "shipment_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dispatch_attempt_sources_source_location_id_locations_id_fk": {
+          "name": "dispatch_attempt_sources_source_location_id_locations_id_fk",
+          "tableFrom": "dispatch_attempt_sources",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "source_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dispatch_attempt_sources_stock_event_id_stock_events_id_fk": {
+          "name": "dispatch_attempt_sources_stock_event_id_stock_events_id_fk",
+          "tableFrom": "dispatch_attempt_sources",
+          "tableTo": "stock_events",
+          "columnsFrom": [
+            "stock_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_dispatch_attempt_sources_grain": {
+          "name": "uq_dispatch_attempt_sources_grain",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dispatch_attempt_id",
+            "shipment_line_id",
+            "source_location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_dispatch_attempt_sources_qty_positive": {
+          "name": "ck_dispatch_attempt_sources_qty_positive",
+          "value": "\"dispatch_attempt_sources\".\"qty\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.dispatch_attempts": {
+      "name": "dispatch_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_no": {
+          "name": "attempt_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dispatch_attempt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "waybill_id": {
+          "name": "waybill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_journal_id": {
+          "name": "stock_journal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reversal_journal_id": {
+          "name": "reversal_journal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carrier_accepted_at": {
+          "name": "carrier_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recalled_at": {
+          "name": "recalled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recovery_code": {
+          "name": "recovery_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_dispatch_attempts_stock_journal": {
+          "name": "uq_dispatch_attempts_stock_journal",
+          "columns": [
+            {
+              "expression": "stock_journal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispatch_attempts\".\"stock_journal_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_dispatch_attempts_reversal_journal": {
+          "name": "uq_dispatch_attempts_reversal_journal",
+          "columns": [
+            {
+              "expression": "reversal_journal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispatch_attempts\".\"reversal_journal_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dispatch_attempts_shipment_status": {
+          "name": "idx_dispatch_attempts_shipment_status",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispatch_attempts_shipment_id_shipments_id_fk": {
+          "name": "dispatch_attempts_shipment_id_shipments_id_fk",
+          "tableFrom": "dispatch_attempts",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dispatch_attempts_waybill_id_waybills_id_fk": {
+          "name": "dispatch_attempts_waybill_id_waybills_id_fk",
+          "tableFrom": "dispatch_attempts",
+          "tableTo": "waybills",
+          "columnsFrom": [
+            "waybill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dispatch_attempts_stock_journal_id_stock_journals_id_fk": {
+          "name": "dispatch_attempts_stock_journal_id_stock_journals_id_fk",
+          "tableFrom": "dispatch_attempts",
+          "tableTo": "stock_journals",
+          "columnsFrom": [
+            "stock_journal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dispatch_attempts_reversal_journal_id_stock_journals_id_fk": {
+          "name": "dispatch_attempts_reversal_journal_id_stock_journals_id_fk",
+          "tableFrom": "dispatch_attempts",
+          "tableTo": "stock_journals",
+          "columnsFrom": [
+            "reversal_journal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_dispatch_attempts_shipment_attempt": {
+          "name": "uq_dispatch_attempts_shipment_attempt",
+          "nullsNotDistinct": false,
+          "columns": [
+            "shipment_id",
+            "attempt_no"
+          ]
+        },
+        "uq_dispatch_attempts_idempotency": {
+          "name": "uq_dispatch_attempts_idempotency",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_dispatch_attempts_attempt_no_positive": {
+          "name": "ck_dispatch_attempts_attempt_no_positive",
+          "value": "\"dispatch_attempts\".\"attempt_no\" > 0"
+        },
+        "ck_dispatch_attempts_dispatched_at": {
+          "name": "ck_dispatch_attempts_dispatched_at",
+          "value": "\"dispatch_attempts\".\"status\" NOT IN ('dispatched', 'recalled') OR (\"dispatch_attempts\".\"dispatched_at\" IS NOT NULL AND \"dispatch_attempts\".\"stock_journal_id\" IS NOT NULL)"
+        },
+        "ck_dispatch_attempts_recalled_at": {
+          "name": "ck_dispatch_attempts_recalled_at",
+          "value": "\"dispatch_attempts\".\"status\" <> 'recalled' OR (\"dispatch_attempts\".\"recalled_at\" IS NOT NULL AND \"dispatch_attempts\".\"reversal_journal_id\" IS NOT NULL)"
+        },
+        "ck_dispatch_attempts_distinct_journals": {
+          "name": "ck_dispatch_attempts_distinct_journals",
+          "value": "\"dispatch_attempts\".\"stock_journal_id\" IS NULL OR \"dispatch_attempts\".\"reversal_journal_id\" IS NULL OR \"dispatch_attempts\".\"stock_journal_id\" <> \"dispatch_attempts\".\"reversal_journal_id\""
+        },
+        "ck_dispatch_attempts_recall_chronology": {
+          "name": "ck_dispatch_attempts_recall_chronology",
+          "value": "\"dispatch_attempts\".\"status\" <> 'recalled' OR \"dispatch_attempts\".\"recalled_at\" >= \"dispatch_attempts\".\"dispatched_at\""
+        },
+        "ck_dispatch_attempts_recall_carrier": {
+          "name": "ck_dispatch_attempts_recall_carrier",
+          "value": "\"dispatch_attempts\".\"status\" <> 'recalled' OR \"dispatch_attempts\".\"carrier_accepted_at\" IS NULL"
+        },
+        "ck_dispatch_attempts_carrier_acceptance": {
+          "name": "ck_dispatch_attempts_carrier_acceptance",
+          "value": "\"dispatch_attempts\".\"carrier_accepted_at\" IS NULL OR (\"dispatch_attempts\".\"dispatched_at\" IS NOT NULL AND \"dispatch_attempts\".\"carrier_accepted_at\" >= \"dispatch_attempts\".\"dispatched_at\")"
+        },
+        "ck_dispatch_attempts_recovery_code": {
+          "name": "ck_dispatch_attempts_recovery_code",
+          "value": "\"dispatch_attempts\".\"status\" <> 'recovery_required' OR \"dispatch_attempts\".\"recovery_code\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.exchange_request_items": {
+      "name": "exchange_request_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "exchange_request_id": {
+          "name": "exchange_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_order_line_id": {
+          "name": "sales_order_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "desired_variant_id": {
+          "name": "desired_variant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_exchange_request_items_request": {
+          "name": "idx_exchange_request_items_request",
+          "columns": [
+            {
+              "expression": "exchange_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_exchange_request_items_order_line": {
+          "name": "idx_exchange_request_items_order_line",
+          "columns": [
+            {
+              "expression": "sales_order_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exchange_request_items_exchange_request_id_exchange_requests_id_fk": {
+          "name": "exchange_request_items_exchange_request_id_exchange_requests_id_fk",
+          "tableFrom": "exchange_request_items",
+          "tableTo": "exchange_requests",
+          "columnsFrom": [
+            "exchange_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exchange_requests": {
+      "name": "exchange_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "exchange_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "exchange_reason_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_detail": {
+          "name": "reason_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_exchange_requests_sales_order": {
+          "name": "idx_exchange_requests_sales_order",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_exchange_requests_status": {
+          "name": "idx_exchange_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_exchange_requests_customer": {
+          "name": "idx_exchange_requests_customer",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "exchange_requests_sales_order_id_sales_orders_id_fk": {
+          "name": "exchange_requests_sales_order_id_sales_orders_id_fk",
+          "tableFrom": "exchange_requests",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "sales_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fulfillment_command_requests": {
+      "name": "fulfillment_command_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "command_type": {
+          "name": "command_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "fulfillment_command_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_snapshot": {
+          "name": "response_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_fulfillment_command_status": {
+          "name": "idx_fulfillment_command_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fulfillment_command_operation": {
+          "name": "idx_fulfillment_command_operation",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fulfillment_command_attempt": {
+          "name": "idx_fulfillment_command_attempt",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fulfillment_command_requests_attempt_id_dispatch_attempts_id_fk": {
+          "name": "fulfillment_command_requests_attempt_id_dispatch_attempts_id_fk",
+          "tableFrom": "fulfillment_command_requests",
+          "tableTo": "dispatch_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_fulfillment_command_idempotency": {
+          "name": "uq_fulfillment_command_idempotency",
+          "nullsNotDistinct": false,
+          "columns": [
+            "command_type",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_fulfillment_command_request_hash": {
+          "name": "ck_fulfillment_command_request_hash",
+          "value": "length(\"fulfillment_command_requests\".\"request_hash\") = 64"
+        },
+        "ck_fulfillment_command_completion": {
+          "name": "ck_fulfillment_command_completion",
+          "value": "\"fulfillment_command_requests\".\"status\" <> 'completed' OR (\"fulfillment_command_requests\".\"completed_at\" IS NOT NULL AND \"fulfillment_command_requests\".\"response_snapshot\" IS NOT NULL)"
+        },
+        "ck_fulfillment_command_failure": {
+          "name": "ck_fulfillment_command_failure",
+          "value": "\"fulfillment_command_requests\".\"status\" <> 'failed' OR \"fulfillment_command_requests\".\"last_error\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fulfillment_order_creation_backlogs": {
+      "name": "fulfillment_order_creation_backlogs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fulfillment_order_id": {
+          "name": "fulfillment_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "fulfillment_order_creation_backlog_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "waiting_variant_ids": {
+          "name": "waiting_variant_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_details": {
+          "name": "failure_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fo_creation_backlogs_status_next_attempt": {
+          "name": "idx_fo_creation_backlogs_status_next_attempt",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fo_creation_backlogs_fulfillment_order": {
+          "name": "idx_fo_creation_backlogs_fulfillment_order",
+          "columns": [
+            {
+              "expression": "fulfillment_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fo_creation_backlogs_waiting_variant_ids": {
+          "name": "idx_fo_creation_backlogs_waiting_variant_ids",
+          "columns": [
+            {
+              "expression": "waiting_variant_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fulfillment_order_creation_backlogs_sales_order_id_sales_orders_id_fk": {
+          "name": "fulfillment_order_creation_backlogs_sales_order_id_sales_orders_id_fk",
+          "tableFrom": "fulfillment_order_creation_backlogs",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "sales_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fulfillment_order_creation_backlogs_fulfillment_order_id_fulfillment_orders_id_fk": {
+          "name": "fulfillment_order_creation_backlogs_fulfillment_order_id_fulfillment_orders_id_fk",
+          "tableFrom": "fulfillment_order_creation_backlogs",
+          "tableTo": "fulfillment_orders",
+          "columnsFrom": [
+            "fulfillment_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fulfillment_order_creation_backlogs_sales_order_id_unique": {
+          "name": "fulfillment_order_creation_backlogs_sales_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sales_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fulfillment_order_items": {
+      "name": "fulfillment_order_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fulfillment_order_id": {
+          "name": "fulfillment_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_order_line_id": {
+          "name": "sales_order_line_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mapping_snapshot_id": {
+          "name": "mapping_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qty": {
+          "name": "qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reserved_qty": {
+          "name": "reserved_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "picked_qty": {
+          "name": "picked_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "shipped_qty": {
+          "name": "shipped_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "canceled_qty": {
+          "name": "canceled_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fulfillment_order_items_fo": {
+          "name": "idx_fulfillment_order_items_fo",
+          "columns": [
+            {
+              "expression": "fulfillment_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fulfillment_order_items_so": {
+          "name": "idx_fulfillment_order_items_so",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fulfillment_order_items_sku": {
+          "name": "idx_fulfillment_order_items_sku",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fulfillment_order_items_variant": {
+          "name": "idx_fulfillment_order_items_variant",
+          "columns": [
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fulfillment_order_items_fulfillment_order_id_fulfillment_orders_id_fk": {
+          "name": "fulfillment_order_items_fulfillment_order_id_fulfillment_orders_id_fk",
+          "tableFrom": "fulfillment_order_items",
+          "tableTo": "fulfillment_orders",
+          "columnsFrom": [
+            "fulfillment_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fulfillment_order_items_mapping_snapshot_id_product_sku_mapping_snapshots_id_fk": {
+          "name": "fulfillment_order_items_mapping_snapshot_id_product_sku_mapping_snapshots_id_fk",
+          "tableFrom": "fulfillment_order_items",
+          "tableTo": "product_sku_mapping_snapshots",
+          "columnsFrom": [
+            "mapping_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fulfillment_order_items_sku_id_skus_id_fk": {
+          "name": "fulfillment_order_items_sku_id_skus_id_fk",
+          "tableFrom": "fulfillment_order_items",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_fulfillment_order_items_qty_positive": {
+          "name": "ck_fulfillment_order_items_qty_positive",
+          "value": "\"fulfillment_order_items\".\"qty\" > 0"
+        },
+        "ck_fulfillment_order_items_progress_nonnegative": {
+          "name": "ck_fulfillment_order_items_progress_nonnegative",
+          "value": "\"fulfillment_order_items\".\"reserved_qty\" >= 0 AND \"fulfillment_order_items\".\"picked_qty\" >= 0 AND \"fulfillment_order_items\".\"shipped_qty\" >= 0 AND \"fulfillment_order_items\".\"canceled_qty\" >= 0"
+        },
+        "ck_fulfillment_order_items_settled_within_qty": {
+          "name": "ck_fulfillment_order_items_settled_within_qty",
+          "value": "\"fulfillment_order_items\".\"shipped_qty\" + \"fulfillment_order_items\".\"canceled_qty\" <= \"fulfillment_order_items\".\"qty\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.fulfillment_orders": {
+      "name": "fulfillment_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "fulfillment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "direct_ship_status": {
+          "name": "direct_ship_status",
+          "type": "direct_ship_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fulfillment_mode": {
+          "name": "fulfillment_mode",
+          "type": "fulfillment_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "task_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "total_items": {
+          "name": "total_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_qty": {
+          "name": "total_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_reserved_qty": {
+          "name": "total_reserved_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reservation_failure_reason": {
+          "name": "reservation_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reservation_failure_details": {
+          "name": "reservation_failure_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocated_at": {
+          "name": "allocated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipped_at": {
+          "name": "shipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_address": {
+          "name": "shipping_address",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_no": {
+          "name": "label_no",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_fulfillment_orders_sales_order": {
+          "name": "uq_fulfillment_orders_sales_order",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"fulfillment_orders\".\"sales_order_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fulfillment_orders_sales_order_id_sales_orders_id_fk": {
+          "name": "fulfillment_orders_sales_order_id_sales_orders_id_fk",
+          "tableFrom": "fulfillment_orders",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "sales_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fulfillment_orders_warehouse_id_warehouses_id_fk": {
+          "name": "fulfillment_orders_warehouse_id_warehouses_id_fk",
+          "tableFrom": "fulfillment_orders",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "fulfillment_orders_owner_id_holders_id_fk": {
+          "name": "fulfillment_orders_owner_id_holders_id_fk",
+          "tableFrom": "fulfillment_orders",
+          "tableTo": "holders",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.holders": {
+      "name": "holders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_our_asset": {
+          "name": "is_our_asset",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.holidays": {
+      "name": "holidays",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_plan_items": {
+      "name": "inbound_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_qty": {
+          "name": "expected_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_qty": {
+          "name": "received_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "inbound_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_inbound_plan_items_plan": {
+          "name": "idx_inbound_plan_items_plan",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbound_plan_items_sku": {
+          "name": "idx_inbound_plan_items_sku",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbound_plan_items_plan_id_inbound_plans_id_fk": {
+          "name": "inbound_plan_items_plan_id_inbound_plans_id_fk",
+          "tableFrom": "inbound_plan_items",
+          "tableTo": "inbound_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbound_plan_items_sku_id_skus_id_fk": {
+          "name": "inbound_plan_items_sku_id_skus_id_fk",
+          "tableFrom": "inbound_plan_items",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_plans": {
+      "name": "inbound_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "expected_date": {
+          "name": "expected_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_type": {
+          "name": "plan_type",
+          "type": "plan_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'destination'"
+        },
+        "parent_plan_id": {
+          "name": "parent_plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_purchase_order_id": {
+          "name": "linked_purchase_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_warehouse_id": {
+          "name": "destination_warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requires_transfer": {
+          "name": "requires_transfer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "inbound_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_inbound_plans_wh_date": {
+          "name": "idx_inbound_plans_wh_date",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expected_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbound_plans_destination": {
+          "name": "idx_inbound_plans_destination",
+          "columns": [
+            {
+              "expression": "destination_warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expected_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbound_plans_warehouse_type_status": {
+          "name": "idx_inbound_plans_warehouse_type_status",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbound_plans_parent": {
+          "name": "idx_inbound_plans_parent",
+          "columns": [
+            {
+              "expression": "parent_plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbound_plans_purchase_order": {
+          "name": "idx_inbound_plans_purchase_order",
+          "columns": [
+            {
+              "expression": "linked_purchase_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbound_plans_warehouse_id_warehouses_id_fk": {
+          "name": "inbound_plans_warehouse_id_warehouses_id_fk",
+          "tableFrom": "inbound_plans",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbound_plans_parent_plan_id_inbound_plans_id_fk": {
+          "name": "inbound_plans_parent_plan_id_inbound_plans_id_fk",
+          "tableFrom": "inbound_plans",
+          "tableTo": "inbound_plans",
+          "columnsFrom": [
+            "parent_plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inbound_plans_linked_purchase_order_id_purchase_orders_id_fk": {
+          "name": "inbound_plans_linked_purchase_order_id_purchase_orders_id_fk",
+          "tableFrom": "inbound_plans",
+          "tableTo": "purchase_orders",
+          "columnsFrom": [
+            "linked_purchase_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inbound_plans_destination_warehouse_id_warehouses_id_fk": {
+          "name": "inbound_plans_destination_warehouse_id_warehouses_id_fk",
+          "tableFrom": "inbound_plans",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "destination_warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_receipt_lines": {
+      "name": "inbound_receipt_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "receipt_id": {
+          "name": "receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_location_id": {
+          "name": "origin_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "returned_qty": {
+          "name": "returned_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "canceled_qty": {
+          "name": "canceled_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "putaway_from_origin_qty": {
+          "name": "putaway_from_origin_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "plan_item_id": {
+          "name": "plan_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_inbound_lines_receipt": {
+          "name": "idx_inbound_lines_receipt",
+          "columns": [
+            {
+              "expression": "receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbound_lines_sku": {
+          "name": "idx_inbound_lines_sku",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbound_receipt_lines_receipt_id_inbound_receipts_id_fk": {
+          "name": "inbound_receipt_lines_receipt_id_inbound_receipts_id_fk",
+          "tableFrom": "inbound_receipt_lines",
+          "tableTo": "inbound_receipts",
+          "columnsFrom": [
+            "receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbound_receipt_lines_sku_id_skus_id_fk": {
+          "name": "inbound_receipt_lines_sku_id_skus_id_fk",
+          "tableFrom": "inbound_receipt_lines",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "inbound_receipt_lines_origin_location_id_locations_id_fk": {
+          "name": "inbound_receipt_lines_origin_location_id_locations_id_fk",
+          "tableFrom": "inbound_receipt_lines",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "origin_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_receipt_lines_event_id_stock_events_id_fk": {
+          "name": "inbound_receipt_lines_event_id_stock_events_id_fk",
+          "tableFrom": "inbound_receipt_lines",
+          "tableTo": "stock_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_receipt_lines_plan_item_id_inbound_plan_items_id_fk": {
+          "name": "inbound_receipt_lines_plan_item_id_inbound_plan_items_id_fk",
+          "tableFrom": "inbound_receipt_lines",
+          "tableTo": "inbound_plan_items",
+          "columnsFrom": [
+            "plan_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_receipts": {
+      "name": "inbound_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "method": {
+          "name": "method",
+          "type": "inbound_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "inbound_receipt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "total_quantity": {
+          "name": "total_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "journal_id": {
+          "name": "journal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_inbound_receipts_wh_time": {
+          "name": "idx_inbound_receipts_wh_time",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbound_receipts_warehouse_id_warehouses_id_fk": {
+          "name": "inbound_receipts_warehouse_id_warehouses_id_fk",
+          "tableFrom": "inbound_receipts",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbound_receipts_location_id_locations_id_fk": {
+          "name": "inbound_receipts_location_id_locations_id_fk",
+          "tableFrom": "inbound_receipts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_receipts_journal_id_stock_journals_id_fk": {
+          "name": "inbound_receipts_journal_id_stock_journals_id_fk",
+          "tableFrom": "inbound_receipts",
+          "tableTo": "stock_journals",
+          "columnsFrom": [
+            "journal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_work_logs": {
+      "name": "inbound_work_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "inbound_work_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "receipt_id": {
+          "name": "receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_item_id": {
+          "name": "plan_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_location_id": {
+          "name": "from_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_location_id": {
+          "name": "to_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "inbound_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_inbound_work_time": {
+          "name": "idx_inbound_work_time",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbound_work_logs_receipt_id_inbound_receipts_id_fk": {
+          "name": "inbound_work_logs_receipt_id_inbound_receipts_id_fk",
+          "tableFrom": "inbound_work_logs",
+          "tableTo": "inbound_receipts",
+          "columnsFrom": [
+            "receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_work_logs_line_id_inbound_receipt_lines_id_fk": {
+          "name": "inbound_work_logs_line_id_inbound_receipt_lines_id_fk",
+          "tableFrom": "inbound_work_logs",
+          "tableTo": "inbound_receipt_lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_work_logs_plan_item_id_inbound_plan_items_id_fk": {
+          "name": "inbound_work_logs_plan_item_id_inbound_plan_items_id_fk",
+          "tableFrom": "inbound_work_logs",
+          "tableTo": "inbound_plan_items",
+          "columnsFrom": [
+            "plan_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_work_logs_sku_id_skus_id_fk": {
+          "name": "inbound_work_logs_sku_id_skus_id_fk",
+          "tableFrom": "inbound_work_logs",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_work_logs_warehouse_id_warehouses_id_fk": {
+          "name": "inbound_work_logs_warehouse_id_warehouses_id_fk",
+          "tableFrom": "inbound_work_logs",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_work_logs_from_location_id_locations_id_fk": {
+          "name": "inbound_work_logs_from_location_id_locations_id_fk",
+          "tableFrom": "inbound_work_logs",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "from_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_work_logs_to_location_id_locations_id_fk": {
+          "name": "inbound_work_logs_to_location_id_locations_id_fk",
+          "tableFrom": "inbound_work_logs",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "to_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "inbound_work_logs_event_id_stock_events_id_fk": {
+          "name": "inbound_work_logs_event_id_stock_events_id_fk",
+          "tableFrom": "inbound_work_logs",
+          "tableTo": "stock_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inspection_issues": {
+      "name": "inspection_issues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "foi_id": {
+          "name": "foi_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "qty": {
+          "name": "qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inspector_user_id": {
+          "name": "inspector_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_inspection_issues_foi": {
+          "name": "idx_inspection_issues_foi",
+          "columns": [
+            {
+              "expression": "foi_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inspection_issues_shipment": {
+          "name": "idx_inspection_issues_shipment",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inspection_issues_foi_id_fulfillment_order_items_id_fk": {
+          "name": "inspection_issues_foi_id_fulfillment_order_items_id_fk",
+          "tableFrom": "inspection_issues",
+          "tableTo": "fulfillment_order_items",
+          "columnsFrom": [
+            "foi_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inspection_issues_shipment_id_shipments_id_fk": {
+          "name": "inspection_issues_shipment_id_shipments_id_fk",
+          "tableFrom": "inspection_issues",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inventory_idempotency_requests": {
+      "name": "inventory_idempotency_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_inv_idem_requests_endpoint_key": {
+          "name": "uq_inv_idem_requests_endpoint_key",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inv_idem_requests_created_at": {
+          "name": "idx_inv_idem_requests_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_columns": {
+      "name": "location_columns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_name": {
+          "name": "column_name",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_columns_warehouse_name": {
+          "name": "idx_columns_warehouse_name",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "column_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_columns_warehouse_id_warehouses_id_fk": {
+          "name": "location_columns_warehouse_id_warehouses_id_fk",
+          "tableFrom": "location_columns",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_columns_warehouse_id_column_name_unique": {
+          "name": "location_columns_warehouse_id_column_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "warehouse_id",
+            "column_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_racks": {
+      "name": "location_racks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rack_number": {
+          "name": "rack_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_bin_start": {
+          "name": "default_bin_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_bin_end": {
+          "name": "default_bin_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "auto_generate_bins": {
+          "name": "auto_generate_bins",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "physical_width": {
+          "name": "physical_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "physical_height": {
+          "name": "physical_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_racks_column_number": {
+          "name": "idx_racks_column_number",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rack_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_racks_column_id_location_columns_id_fk": {
+          "name": "location_racks_column_id_location_columns_id_fk",
+          "tableFrom": "location_racks",
+          "tableTo": "location_columns",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_racks_column_id_rack_number_unique": {
+          "name": "location_racks_column_id_rack_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "column_id",
+            "rack_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "location_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rack_id": {
+          "name": "rack_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bin_identifier": {
+          "name": "bin_identifier",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity_limit": {
+          "name": "capacity_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fifo_rank": {
+          "name": "fifo_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_expiry_separated": {
+          "name": "is_expiry_separated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "system_role": {
+          "name": "system_role",
+          "type": "system_location_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_locations_warehouse_type": {
+          "name": "idx_locations_warehouse_type",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_locations_rack_bin": {
+          "name": "idx_locations_rack_bin",
+          "columns": [
+            {
+              "expression": "rack_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bin_identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_warehouse_id_warehouses_id_fk": {
+          "name": "locations_warehouse_id_warehouses_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "locations_rack_id_location_racks_id_fk": {
+          "name": "locations_rack_id_location_racks_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "location_racks",
+          "columnsFrom": [
+            "rack_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "locations_warehouse_id_code_unique": {
+          "name": "locations_warehouse_id_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "warehouse_id",
+            "code"
+          ]
+        },
+        "locations_warehouse_id_system_role_unique": {
+          "name": "locations_warehouse_id_system_role_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "warehouse_id",
+            "system_role"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_locations_type": {
+          "name": "ck_locations_type",
+          "value": "(\n        (location_type = 'standard' AND rack_id IS NOT NULL AND bin_identifier IS NOT NULL)\n        OR \n        (location_type = 'zone' AND rack_id IS NULL AND bin_identifier IS NULL)\n    )"
+        },
+        "ck_locations_system_role": {
+          "name": "ck_locations_system_role",
+          "value": "( (is_system = true AND system_role IS NOT NULL) OR (is_system = false AND system_role IS NULL) )"
+        },
+        "ck_locations_system_zone": {
+          "name": "ck_locations_system_zone",
+          "value": "( is_system = false OR location_type = 'zone' )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.merge_groups": {
+      "name": "merge_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_email": {
+          "name": "customer_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipping_address_hash": {
+          "name": "shipping_address_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_shipping_fee": {
+          "name": "total_shipping_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "order_count": {
+          "name": "order_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movement_job_lines": {
+      "name": "movement_job_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_location_id": {
+          "name": "from_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_location_id": {
+          "name": "to_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_movement_lines_job": {
+          "name": "idx_movement_lines_job",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_movement_lines_sku": {
+          "name": "idx_movement_lines_sku",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "movement_job_lines_job_id_movement_jobs_id_fk": {
+          "name": "movement_job_lines_job_id_movement_jobs_id_fk",
+          "tableFrom": "movement_job_lines",
+          "tableTo": "movement_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "movement_job_lines_sku_id_skus_id_fk": {
+          "name": "movement_job_lines_sku_id_skus_id_fk",
+          "tableFrom": "movement_job_lines",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "movement_job_lines_from_location_id_locations_id_fk": {
+          "name": "movement_job_lines_from_location_id_locations_id_fk",
+          "tableFrom": "movement_job_lines",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "from_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "movement_job_lines_to_location_id_locations_id_fk": {
+          "name": "movement_job_lines_to_location_id_locations_id_fk",
+          "tableFrom": "movement_job_lines",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "to_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "movement_job_lines_event_id_stock_events_id_fk": {
+          "name": "movement_job_lines_event_id_stock_events_id_fk",
+          "tableFrom": "movement_job_lines",
+          "tableTo": "stock_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movement_jobs": {
+      "name": "movement_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_quantity": {
+          "name": "total_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "journal_id": {
+          "name": "journal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_movement_jobs_wh_time": {
+          "name": "idx_movement_jobs_wh_time",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "movement_jobs_warehouse_id_warehouses_id_fk": {
+          "name": "movement_jobs_warehouse_id_warehouses_id_fk",
+          "tableFrom": "movement_jobs",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "movement_jobs_journal_id_stock_journals_id_fk": {
+          "name": "movement_jobs_journal_id_stock_journals_id_fk",
+          "tableFrom": "movement_jobs",
+          "tableTo": "stock_journals",
+          "columnsFrom": [
+            "journal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movement_work_logs": {
+      "name": "movement_work_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MOVE'"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_location_id": {
+          "name": "from_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_location_id": {
+          "name": "to_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_movement_work_time": {
+          "name": "idx_movement_work_time",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "movement_work_logs_job_id_movement_jobs_id_fk": {
+          "name": "movement_work_logs_job_id_movement_jobs_id_fk",
+          "tableFrom": "movement_work_logs",
+          "tableTo": "movement_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "movement_work_logs_line_id_movement_job_lines_id_fk": {
+          "name": "movement_work_logs_line_id_movement_job_lines_id_fk",
+          "tableFrom": "movement_work_logs",
+          "tableTo": "movement_job_lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "movement_work_logs_sku_id_skus_id_fk": {
+          "name": "movement_work_logs_sku_id_skus_id_fk",
+          "tableFrom": "movement_work_logs",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "movement_work_logs_warehouse_id_warehouses_id_fk": {
+          "name": "movement_work_logs_warehouse_id_warehouses_id_fk",
+          "tableFrom": "movement_work_logs",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "movement_work_logs_from_location_id_locations_id_fk": {
+          "name": "movement_work_logs_from_location_id_locations_id_fk",
+          "tableFrom": "movement_work_logs",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "from_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "movement_work_logs_to_location_id_locations_id_fk": {
+          "name": "movement_work_logs_to_location_id_locations_id_fk",
+          "tableFrom": "movement_work_logs",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "to_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "movement_work_logs_event_id_stock_events_id_fk": {
+          "name": "movement_work_logs_event_id_stock_events_id_fk",
+          "tableFrom": "movement_work_logs",
+          "tableTo": "stock_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_events": {
+      "name": "order_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type_order",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_events_order_id_sales_orders_id_fk": {
+          "name": "order_events_order_id_sales_orders_id_fk",
+          "tableFrom": "order_events",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "order_events_event_id_unique": {
+          "name": "order_events_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outbound_batch_work_items": {
+      "name": "outbound_batch_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "outbound_batch_work_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "picker_id": {
+          "name": "picker_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picker_claimed_at": {
+          "name": "picker_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picker_released_at": {
+          "name": "picker_released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "packer_id": {
+          "name": "packer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "packer_claimed_at": {
+          "name": "packer_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "packer_released_at": {
+          "name": "packer_released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handed_off_at": {
+          "name": "handed_off_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_version": {
+          "name": "lease_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "exclusion_reason": {
+          "name": "exclusion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recovery_reason": {
+          "name": "recovery_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waiting_operation_id": {
+          "name": "waiting_operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_outbound_work_item_active_shipment": {
+          "name": "uq_outbound_work_item_active_shipment",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"outbound_batch_work_items\".\"status\" NOT IN ('completed', 'excluded')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outbound_work_items_batch_status": {
+          "name": "idx_outbound_work_items_batch_status",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outbound_work_items_waiting_operation": {
+          "name": "idx_outbound_work_items_waiting_operation",
+          "columns": [
+            {
+              "expression": "waiting_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outbound_batch_work_items_batch_id_outbound_batches_id_fk": {
+          "name": "outbound_batch_work_items_batch_id_outbound_batches_id_fk",
+          "tableFrom": "outbound_batch_work_items",
+          "tableTo": "outbound_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "outbound_batch_work_items_shipment_id_shipments_id_fk": {
+          "name": "outbound_batch_work_items_shipment_id_shipments_id_fk",
+          "tableFrom": "outbound_batch_work_items",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "outbound_batch_work_items_waiting_operation_id_shipment_operations_id_fk": {
+          "name": "outbound_batch_work_items_waiting_operation_id_shipment_operations_id_fk",
+          "tableFrom": "outbound_batch_work_items",
+          "tableTo": "shipment_operations",
+          "columnsFrom": [
+            "waiting_operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_outbound_work_items_lease_version": {
+          "name": "ck_outbound_work_items_lease_version",
+          "value": "\"outbound_batch_work_items\".\"lease_version\" >= 0"
+        },
+        "ck_outbound_work_items_exclusion": {
+          "name": "ck_outbound_work_items_exclusion",
+          "value": "\"outbound_batch_work_items\".\"status\" <> 'excluded' OR \"outbound_batch_work_items\".\"exclusion_reason\" IS NOT NULL"
+        },
+        "ck_outbound_work_items_recovery": {
+          "name": "ck_outbound_work_items_recovery",
+          "value": "\"outbound_batch_work_items\".\"status\" <> 'short_pick_recovery' OR \"outbound_batch_work_items\".\"recovery_reason\" IS NOT NULL"
+        },
+        "ck_outbound_work_items_completion": {
+          "name": "ck_outbound_work_items_completion",
+          "value": "\"outbound_batch_work_items\".\"status\" <> 'completed' OR \"outbound_batch_work_items\".\"completed_at\" IS NOT NULL"
+        },
+        "ck_outbound_work_items_picker_release": {
+          "name": "ck_outbound_work_items_picker_release",
+          "value": "\"outbound_batch_work_items\".\"picker_released_at\" IS NULL OR (\"outbound_batch_work_items\".\"picker_claimed_at\" IS NOT NULL AND \"outbound_batch_work_items\".\"picker_released_at\" >= \"outbound_batch_work_items\".\"picker_claimed_at\")"
+        },
+        "ck_outbound_work_items_packer_release": {
+          "name": "ck_outbound_work_items_packer_release",
+          "value": "\"outbound_batch_work_items\".\"packer_released_at\" IS NULL OR (\"outbound_batch_work_items\".\"packer_claimed_at\" IS NOT NULL AND \"outbound_batch_work_items\".\"packer_released_at\" >= \"outbound_batch_work_items\".\"packer_claimed_at\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.outbound_batches": {
+      "name": "outbound_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "batch_number": {
+          "name": "batch_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "batch_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "picking_method": {
+          "name": "picking_method",
+          "type": "picking_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cart_capacity": {
+          "name": "cart_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_picking_at": {
+          "name": "scheduled_picking_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_outbound_batches_warehouse_status": {
+          "name": "idx_outbound_batches_warehouse_status",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outbound_batches_number": {
+          "name": "idx_outbound_batches_number",
+          "columns": [
+            {
+              "expression": "batch_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outbound_batches_warehouse_id_warehouses_id_fk": {
+          "name": "outbound_batches_warehouse_id_warehouses_id_fk",
+          "tableFrom": "outbound_batches",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "outbound_batches_batch_number_unique": {
+          "name": "outbound_batches_batch_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "batch_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_outbound_batches_cart_capacity": {
+          "name": "ck_outbound_batches_cart_capacity",
+          "value": "\"outbound_batches\".\"picking_method\"::text <> 'multi_order' OR (\"outbound_batches\".\"cart_capacity\" IS NOT NULL AND \"outbound_batches\".\"cart_capacity\" >= 1)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.picking_plan_members": {
+      "name": "picking_plan_members",
+      "schema": "",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_version": {
+          "name": "reservation_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retired_at": {
+          "name": "retired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retire_reason": {
+          "name": "retire_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_by_operation_id": {
+          "name": "retired_by_operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retired_by_operation_type": {
+          "name": "retired_by_operation_type",
+          "type": "shipment_operation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_picking_plan_members_shipment": {
+          "name": "idx_picking_plan_members_shipment",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_picking_plan_members_active_shipment": {
+          "name": "idx_picking_plan_members_active_shipment",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"picking_plan_members\".\"retired_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "picking_plan_members_plan_id_picking_plans_id_fk": {
+          "name": "picking_plan_members_plan_id_picking_plans_id_fk",
+          "tableFrom": "picking_plan_members",
+          "tableTo": "picking_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "picking_plan_members_shipment_id_shipments_id_fk": {
+          "name": "picking_plan_members_shipment_id_shipments_id_fk",
+          "tableFrom": "picking_plan_members",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fk_picking_plan_member_retirement_operation": {
+          "name": "fk_picking_plan_member_retirement_operation",
+          "tableFrom": "picking_plan_members",
+          "tableTo": "shipment_operations",
+          "columnsFrom": [
+            "retired_by_operation_id",
+            "retired_by_operation_type"
+          ],
+          "columnsTo": [
+            "id",
+            "type"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "picking_plan_members_plan_id_shipment_id_pk": {
+          "name": "picking_plan_members_plan_id_shipment_id_pk",
+          "columns": [
+            "plan_id",
+            "shipment_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_picking_plan_member_versions": {
+          "name": "ck_picking_plan_member_versions",
+          "value": "\"picking_plan_members\".\"manifest_version\" > 0 AND \"picking_plan_members\".\"reservation_version\" > 0"
+        },
+        "ck_picking_plan_member_retirement": {
+          "name": "ck_picking_plan_member_retirement",
+          "value": "(\n        \"picking_plan_members\".\"retired_at\" IS NULL\n        AND \"picking_plan_members\".\"retire_reason\" IS NULL\n        AND \"picking_plan_members\".\"retired_by_operation_id\" IS NULL\n        AND \"picking_plan_members\".\"retired_by_operation_type\" IS NULL\n      ) OR (\n        \"picking_plan_members\".\"retired_at\" IS NOT NULL\n        AND \"picking_plan_members\".\"retire_reason\" IS NOT NULL\n        AND length(btrim(\"picking_plan_members\".\"retire_reason\")) > 0\n        AND \"picking_plan_members\".\"retired_by_operation_id\" IS NOT NULL\n        AND \"picking_plan_members\".\"retired_by_operation_type\" IS NOT NULL\n        AND \"picking_plan_members\".\"retired_by_operation_type\" = 'short_pick'\n        AND \"picking_plan_members\".\"retired_at\" >= \"picking_plan_members\".\"created_at\"\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.picking_plans": {
+      "name": "picking_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "picking_strategy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "picking_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invalidated_at": {
+          "name": "invalidated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invalidation_reason": {
+          "name": "invalidation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_picking_plans_batch_status": {
+          "name": "idx_picking_plans_batch_status",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "picking_plans_batch_id_outbound_batches_id_fk": {
+          "name": "picking_plans_batch_id_outbound_batches_id_fk",
+          "tableFrom": "picking_plans",
+          "tableTo": "outbound_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_picking_plans_batch_version": {
+          "name": "uq_picking_plans_batch_version",
+          "nullsNotDistinct": false,
+          "columns": [
+            "batch_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_picking_plans_version_positive": {
+          "name": "ck_picking_plans_version_positive",
+          "value": "\"picking_plans\".\"version\" > 0"
+        },
+        "ck_picking_plans_invalidation": {
+          "name": "ck_picking_plans_invalidation",
+          "value": "\"picking_plans\".\"status\" <> 'invalidated' OR (\"picking_plans\".\"invalidated_at\" IS NOT NULL AND \"picking_plans\".\"invalidation_reason\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.picking_source_allocations": {
+      "name": "picking_source_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_line_id": {
+          "name": "shipment_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_location_id": {
+          "name": "source_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qty": {
+          "name": "qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_stock_version": {
+          "name": "source_stock_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_picking_source_allocations_line": {
+          "name": "idx_picking_source_allocations_line",
+          "columns": [
+            {
+              "expression": "shipment_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "picking_source_allocations_plan_id_picking_plans_id_fk": {
+          "name": "picking_source_allocations_plan_id_picking_plans_id_fk",
+          "tableFrom": "picking_source_allocations",
+          "tableTo": "picking_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "picking_source_allocations_shipment_line_id_shipment_lines_id_fk": {
+          "name": "picking_source_allocations_shipment_line_id_shipment_lines_id_fk",
+          "tableFrom": "picking_source_allocations",
+          "tableTo": "shipment_lines",
+          "columnsFrom": [
+            "shipment_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "picking_source_allocations_source_location_id_locations_id_fk": {
+          "name": "picking_source_allocations_source_location_id_locations_id_fk",
+          "tableFrom": "picking_source_allocations",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "source_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_picking_source_allocations_grain": {
+          "name": "uq_picking_source_allocations_grain",
+          "nullsNotDistinct": false,
+          "columns": [
+            "plan_id",
+            "shipment_line_id",
+            "source_location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_picking_source_allocations_qty_positive": {
+          "name": "ck_picking_source_allocations_qty_positive",
+          "value": "\"picking_source_allocations\".\"qty\" > 0"
+        },
+        "ck_picking_source_allocations_stock_version": {
+          "name": "ck_picking_source_allocations_stock_version",
+          "value": "\"picking_source_allocations\".\"source_stock_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.product_matchings": {
+      "name": "product_matchings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku_group_id": {
+          "name": "sku_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "matching_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "matching_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "matching_strategy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_resolved": {
+          "name": "is_resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pre_stock_sellable": {
+          "name": "pre_stock_sellable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "always_sellable_zero_stock": {
+          "name": "always_sellable_zero_stock",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_product_matchings_master_id": {
+          "name": "idx_product_matchings_master_id",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_matchings_sku_group_id_sku_groups_id_fk": {
+          "name": "product_matchings_sku_group_id_sku_groups_id_fk",
+          "tableFrom": "product_matchings",
+          "tableTo": "sku_groups",
+          "columnsFrom": [
+            "sku_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "product_matchings_variant_id_unique": {
+          "name": "product_matchings_variant_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "variant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_sellable_quantity_projections": {
+      "name": "product_sellable_quantity_projections",
+      "schema": "",
+      "columns": {
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matching_id": {
+          "name": "matching_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sellable_quantity": {
+          "name": "sellable_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stock_bound_quantity": {
+          "name": "stock_bound_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_sellable": {
+          "name": "is_sellable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coming_soon_date": {
+          "name": "coming_soon_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_product_sellable_qty_sellable": {
+          "name": "idx_product_sellable_qty_sellable",
+          "columns": [
+            {
+              "expression": "is_sellable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_product_sellable_qty_updated_at": {
+          "name": "idx_product_sellable_qty_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_sku_mapping_items": {
+      "name": "product_sku_mapping_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "mapping_id": {
+          "name": "mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qty_per_product": {
+          "name": "qty_per_product",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_product_sku_mapping_items_mapping": {
+          "name": "idx_product_sku_mapping_items_mapping",
+          "columns": [
+            {
+              "expression": "mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_product_sku_mapping_items_mapping_variant": {
+          "name": "uq_product_sku_mapping_items_mapping_variant",
+          "columns": [
+            {
+              "expression": "mapping_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_sku_mapping_items_mapping_id_product_sku_mappings_id_fk": {
+          "name": "product_sku_mapping_items_mapping_id_product_sku_mappings_id_fk",
+          "tableFrom": "product_sku_mapping_items",
+          "tableTo": "product_sku_mappings",
+          "columnsFrom": [
+            "mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_sku_mapping_items_sku_id_skus_id_fk": {
+          "name": "product_sku_mapping_items_sku_id_skus_id_fk",
+          "tableFrom": "product_sku_mapping_items",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_sku_mapping_snapshots": {
+      "name": "product_sku_mapping_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_version": {
+          "name": "source_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_data": {
+          "name": "snapshot_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mapping_id": {
+          "name": "mapping_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_product_sku_mapping_snapshots_product": {
+          "name": "idx_product_sku_mapping_snapshots_product",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_sku_mapping_snapshots_warehouse_id_warehouses_id_fk": {
+          "name": "product_sku_mapping_snapshots_warehouse_id_warehouses_id_fk",
+          "tableFrom": "product_sku_mapping_snapshots",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "product_sku_mapping_snapshots_sku_id_skus_id_fk": {
+          "name": "product_sku_mapping_snapshots_sku_id_skus_id_fk",
+          "tableFrom": "product_sku_mapping_snapshots",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "product_sku_mapping_snapshots_mapping_id_product_sku_mappings_id_fk": {
+          "name": "product_sku_mapping_snapshots_mapping_id_product_sku_mappings_id_fk",
+          "tableFrom": "product_sku_mapping_snapshots",
+          "tableTo": "product_sku_mappings",
+          "columnsFrom": [
+            "mapping_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_sku_mappings": {
+      "name": "product_sku_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_product_sku_mappings_product_warehouse": {
+          "name": "idx_product_sku_mappings_product_warehouse",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_product_sku_mappings_active": {
+          "name": "idx_product_sku_mappings_active",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_sku_mappings_warehouse_id_warehouses_id_fk": {
+          "name": "product_sku_mappings_warehouse_id_warehouses_id_fk",
+          "tableFrom": "product_sku_mappings",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_variant_sku_links": {
+      "name": "product_variant_sku_links",
+      "schema": "",
+      "columns": {
+        "product_matching_id": {
+          "name": "product_matching_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_variant_sku_links_product_matching_id_product_matchings_id_fk": {
+          "name": "product_variant_sku_links_product_matching_id_product_matchings_id_fk",
+          "tableFrom": "product_variant_sku_links",
+          "tableTo": "product_matchings",
+          "columnsFrom": [
+            "product_matching_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_variant_sku_links_sku_id_skus_id_fk": {
+          "name": "product_variant_sku_links_sku_id_skus_id_fk",
+          "tableFrom": "product_variant_sku_links",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "product_variant_sku_links_product_matching_id_sku_id_pk": {
+          "name": "product_variant_sku_links_product_matching_id_sku_id_pk",
+          "columns": [
+            "product_matching_id",
+            "sku_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_order_cart": {
+      "name": "purchase_order_cart",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "po_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_order_cart_sku_id_skus_id_fk": {
+          "name": "purchase_order_cart_sku_id_skus_id_fk",
+          "tableFrom": "purchase_order_cart",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "purchase_order_cart_supplier_id_suppliers_id_fk": {
+          "name": "purchase_order_cart_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_order_cart",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_order_lines": {
+      "name": "purchase_order_lines",
+      "schema": "",
+      "columns": {
+        "po_id": {
+          "name": "po_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_order_lines_po_id_purchase_orders_id_fk": {
+          "name": "purchase_order_lines_po_id_purchase_orders_id_fk",
+          "tableFrom": "purchase_order_lines",
+          "tableTo": "purchase_orders",
+          "columnsFrom": [
+            "po_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "purchase_order_lines_sku_id_skus_id_fk": {
+          "name": "purchase_order_lines_sku_id_skus_id_fk",
+          "tableFrom": "purchase_order_lines",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "purchase_order_lines_po_id_sku_id_pk": {
+          "name": "purchase_order_lines_po_id_sku_id_pk",
+          "columns": [
+            "po_id",
+            "sku_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "po_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_arrival": {
+          "name": "expected_arrival",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "po_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "source_warehouse_id": {
+          "name": "source_warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_warehouse_id": {
+          "name": "destination_warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requires_transfer": {
+          "name": "requires_transfer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "audit_status": {
+          "name": "audit_status",
+          "type": "po_audit_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submitted_for_audit_at": {
+          "name": "submitted_for_audit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_for_audit_by": {
+          "name": "submitted_for_audit_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audited_at": {
+          "name": "audited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audited_by": {
+          "name": "audited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_notes": {
+          "name": "audit_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_source_warehouse_id_warehouses_id_fk": {
+          "name": "purchase_orders_source_warehouse_id_warehouses_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "source_warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_destination_warehouse_id_warehouses_id_fk": {
+          "name": "purchase_orders_destination_warehouse_id_warehouses_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "destination_warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.return_items": {
+      "name": "return_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "return_id": {
+          "name": "return_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_quantity": {
+          "name": "requested_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_quantity": {
+          "name": "received_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "qc_passed_quantity": {
+          "name": "qc_passed_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "qc_failed_quantity": {
+          "name": "qc_failed_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "restocked_quantity": {
+          "name": "restocked_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "disposed_quantity": {
+          "name": "disposed_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qc_status": {
+          "name": "qc_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "qc_reason": {
+          "name": "qc_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "return_items_return_idx": {
+          "name": "return_items_return_idx",
+          "columns": [
+            {
+              "expression": "return_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "return_items_sku_idx": {
+          "name": "return_items_sku_idx",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "return_items_qc_status_idx": {
+          "name": "return_items_qc_status_idx",
+          "columns": [
+            {
+              "expression": "qc_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "return_items_return_id_returns_id_fk": {
+          "name": "return_items_return_id_returns_id_fk",
+          "tableFrom": "return_items",
+          "tableTo": "returns",
+          "columnsFrom": [
+            "return_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "return_items_sku_id_skus_id_fk": {
+          "name": "return_items_sku_id_skus_id_fk",
+          "tableFrom": "return_items",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "return_items_location_id_locations_id_fk": {
+          "name": "return_items_location_id_locations_id_fk",
+          "tableFrom": "return_items",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.return_refund_attempts": {
+      "name": "return_refund_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "return_request_id": {
+          "name": "return_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_number": {
+          "name": "attempt_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "return_refund_attempt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "wallet_outcome": {
+          "name": "wallet_outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_return_refund_attempt_pending": {
+          "name": "uq_return_refund_attempt_pending",
+          "columns": [
+            {
+              "expression": "return_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"return_refund_attempts\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_return_refund_attempts_request": {
+          "name": "idx_return_refund_attempts_request",
+          "columns": [
+            {
+              "expression": "return_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "return_refund_attempts_return_request_id_return_requests_id_fk": {
+          "name": "return_refund_attempts_return_request_id_return_requests_id_fk",
+          "tableFrom": "return_refund_attempts",
+          "tableTo": "return_requests",
+          "columnsFrom": [
+            "return_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_return_refund_attempt_number": {
+          "name": "uq_return_refund_attempt_number",
+          "nullsNotDistinct": false,
+          "columns": [
+            "return_request_id",
+            "attempt_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.return_request_items": {
+      "name": "return_request_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "return_request_id": {
+          "name": "return_request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_order_line_id": {
+          "name": "sales_order_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_line_id": {
+          "name": "shipment_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempt_id": {
+          "name": "dispatch_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "return_reason_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_return_request_items_request": {
+          "name": "idx_return_request_items_request",
+          "columns": [
+            {
+              "expression": "return_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_return_request_items_order_line": {
+          "name": "idx_return_request_items_order_line",
+          "columns": [
+            {
+              "expression": "sales_order_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_return_request_items_shipment_line": {
+          "name": "idx_return_request_items_shipment_line",
+          "columns": [
+            {
+              "expression": "shipment_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_return_request_items_dispatch_attempt": {
+          "name": "idx_return_request_items_dispatch_attempt",
+          "columns": [
+            {
+              "expression": "dispatch_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "return_request_items_return_request_id_return_requests_id_fk": {
+          "name": "return_request_items_return_request_id_return_requests_id_fk",
+          "tableFrom": "return_request_items",
+          "tableTo": "return_requests",
+          "columnsFrom": [
+            "return_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "return_request_items_shipment_line_id_shipment_lines_id_fk": {
+          "name": "return_request_items_shipment_line_id_shipment_lines_id_fk",
+          "tableFrom": "return_request_items",
+          "tableTo": "shipment_lines",
+          "columnsFrom": [
+            "shipment_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "return_request_items_dispatch_attempt_id_dispatch_attempts_id_fk": {
+          "name": "return_request_items_dispatch_attempt_id_dispatch_attempts_id_fk",
+          "tableFrom": "return_request_items",
+          "tableTo": "dispatch_attempts",
+          "columnsFrom": [
+            "dispatch_attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_return_request_items_quantity_positive": {
+          "name": "ck_return_request_items_quantity_positive",
+          "value": "\"return_request_items\".\"quantity\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.return_requests": {
+      "name": "return_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "return_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "return_reason_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_detail": {
+          "name": "reason_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "return_address": {
+          "name": "return_address",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collected_at": {
+          "name": "collected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_return_requests_sales_order": {
+          "name": "idx_return_requests_sales_order",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_return_requests_status": {
+          "name": "idx_return_requests_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_return_requests_customer": {
+          "name": "idx_return_requests_customer",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "return_requests_sales_order_id_sales_orders_id_fk": {
+          "name": "return_requests_sales_order_id_sales_orders_id_fk",
+          "tableFrom": "return_requests",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "sales_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.returns": {
+      "name": "returns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "return_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'requested'"
+        },
+        "return_reason": {
+          "name": "return_reason",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qc_inspected_at": {
+          "name": "qc_inspected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qc_inspected_by": {
+          "name": "qc_inspected_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qc_notes": {
+          "name": "qc_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restock_quantity": {
+          "name": "restock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispose_quantity": {
+          "name": "dispose_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "returns_warehouse_idx": {
+          "name": "returns_warehouse_idx",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "returns_status_idx": {
+          "name": "returns_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "returns_order_idx": {
+          "name": "returns_order_idx",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "returns_order_id_sales_orders_id_fk": {
+          "name": "returns_order_id_sales_orders_id_fk",
+          "tableFrom": "returns",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "returns_shipment_id_shipments_id_fk": {
+          "name": "returns_shipment_id_shipments_id_fk",
+          "tableFrom": "returns",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "returns_warehouse_id_warehouses_id_fk": {
+          "name": "returns_warehouse_id_warehouses_id_fk",
+          "tableFrom": "returns",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sales_order_amendments": {
+      "name": "sales_order_amendments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amendment_kind": {
+          "name": "amendment_kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approved'"
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deltas": {
+          "name": "deltas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sales_order_amendments_sales_order_id": {
+          "name": "idx_sales_order_amendments_sales_order_id",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_order_amendments_kind": {
+          "name": "idx_sales_order_amendments_kind",
+          "columns": [
+            {
+              "expression": "amendment_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_order_amendments_occurred_at": {
+          "name": "idx_sales_order_amendments_occurred_at",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sales_order_amendments_sales_order_id_sales_orders_id_fk": {
+          "name": "sales_order_amendments_sales_order_id_sales_orders_id_fk",
+          "tableFrom": "sales_order_amendments",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "sales_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sales_order_amendments_kind_check": {
+          "name": "sales_order_amendments_kind_check",
+          "value": "\"sales_order_amendments\".\"amendment_kind\" IN ('commercial', 'fulfillment_only')"
+        },
+        "sales_order_amendments_decision_check": {
+          "name": "sales_order_amendments_decision_check",
+          "value": "\"sales_order_amendments\".\"decision\" IN ('approved', 'rejected', 'pending')"
+        },
+        "sales_order_amendments_deltas_array_check": {
+          "name": "sales_order_amendments_deltas_array_check",
+          "value": "jsonb_typeof(\"sales_order_amendments\".\"deltas\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sales_order_cancellations": {
+      "name": "sales_order_cancellations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancellation_scope": {
+          "name": "cancellation_scope",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'applied'"
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_detail": {
+          "name": "reason_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_by": {
+          "name": "cancelled_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effects": {
+          "name": "effects",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sales_order_cancellations_sales_order_id": {
+          "name": "idx_sales_order_cancellations_sales_order_id",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_order_cancellations_scope": {
+          "name": "idx_sales_order_cancellations_scope",
+          "columns": [
+            {
+              "expression": "cancellation_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_order_cancellations_occurred_at": {
+          "name": "idx_sales_order_cancellations_occurred_at",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_sales_order_full_cancellation": {
+          "name": "uniq_sales_order_full_cancellation",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sales_order_cancellations\".\"cancellation_scope\" = 'full'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sales_order_cancellations_sales_order_id_sales_orders_id_fk": {
+          "name": "sales_order_cancellations_sales_order_id_sales_orders_id_fk",
+          "tableFrom": "sales_order_cancellations",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "sales_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sales_order_cancellations_scope_check": {
+          "name": "sales_order_cancellations_scope_check",
+          "value": "\"sales_order_cancellations\".\"cancellation_scope\" IN ('full', 'partial')"
+        },
+        "sales_order_cancellations_status_check": {
+          "name": "sales_order_cancellations_status_check",
+          "value": "\"sales_order_cancellations\".\"status\" IN ('applied')"
+        },
+        "sales_order_cancellations_effects_array_check": {
+          "name": "sales_order_cancellations_effects_array_check",
+          "value": "jsonb_typeof(\"sales_order_cancellations\".\"effects\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sales_order_lines": {
+      "name": "sales_order_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_matching_id": {
+          "name": "product_matching_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mapping_snapshot_id": {
+          "name": "mapping_snapshot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fulfillment_kind": {
+          "name": "fulfillment_kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_shipping": {
+          "name": "requires_shipping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_order_item_id": {
+          "name": "channel_order_item_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_product_id": {
+          "name": "channel_product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "order_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "suggested_quantity": {
+          "name": "suggested_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unavailable_sku_ids": {
+          "name": "unavailable_sku_ids",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deducted_at": {
+          "name": "deducted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sales_order_lines_sales_order_id": {
+          "name": "idx_sales_order_lines_sales_order_id",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_order_lines_snapshot": {
+          "name": "idx_sales_order_lines_snapshot",
+          "columns": [
+            {
+              "expression": "mapping_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_order_lines_variant": {
+          "name": "idx_sales_order_lines_variant",
+          "columns": [
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_order_lines_channel_order_item": {
+          "name": "idx_sales_order_lines_channel_order_item",
+          "columns": [
+            {
+              "expression": "channel_order_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_order_lines_channel_product": {
+          "name": "idx_sales_order_lines_channel_product",
+          "columns": [
+            {
+              "expression": "channel_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_sales_order_lines_order_channel_item": {
+          "name": "uq_sales_order_lines_order_channel_item",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_order_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sales_order_lines\".\"channel_order_item_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sales_order_lines_sales_order_id_sales_orders_id_fk": {
+          "name": "sales_order_lines_sales_order_id_sales_orders_id_fk",
+          "tableFrom": "sales_order_lines",
+          "tableTo": "sales_orders",
+          "columnsFrom": [
+            "sales_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sales_order_lines_product_matching_id_product_matchings_id_fk": {
+          "name": "sales_order_lines_product_matching_id_product_matchings_id_fk",
+          "tableFrom": "sales_order_lines",
+          "tableTo": "product_matchings",
+          "columnsFrom": [
+            "product_matching_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sales_order_lines_mapping_snapshot_id_product_sku_mapping_snapshots_id_fk": {
+          "name": "sales_order_lines_mapping_snapshot_id_product_sku_mapping_snapshots_id_fk",
+          "tableFrom": "sales_order_lines",
+          "tableTo": "product_sku_mapping_snapshots",
+          "columnsFrom": [
+            "mapping_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sales_orders": {
+      "name": "sales_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "channel_order_id": {
+          "name": "channel_order_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_channel": {
+          "name": "sales_channel",
+          "type": "sales_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_email": {
+          "name": "customer_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_phone": {
+          "name": "customer_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_address": {
+          "name": "shipping_address",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipping_address_hash": {
+          "name": "shipping_address_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_fee": {
+          "name": "shipping_fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "merge_group_id": {
+          "name": "merge_group_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_merged": {
+          "name": "is_merged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_intent_id": {
+          "name": "wallet_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_date": {
+          "name": "order_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sales_orders_order_date": {
+          "name": "idx_sales_orders_order_date",
+          "columns": [
+            {
+              "expression": "order_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sales_orders_sales_channel_channel_order_id_unique": {
+          "name": "sales_orders_sales_channel_channel_order_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sales_channel",
+            "channel_order_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sales_variant_policies": {
+      "name": "sales_variant_policies",
+      "schema": "",
+      "columns": {
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inventory_management": {
+          "name": "inventory_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pre_stock_sellable": {
+          "name": "pre_stock_sellable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "always_sellable_zero_stock": {
+          "name": "always_sellable_zero_stock",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "availability_override": {
+          "name": "availability_override",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coming_soon_date": {
+          "name": "coming_soon_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "setting_key",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_warehouse_id_warehouses_id_fk": {
+          "name": "settings_warehouse_id_warehouses_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shipment_lines": {
+      "name": "shipment_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fulfillment_order_item_id": {
+          "name": "fulfillment_order_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qty": {
+          "name": "qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reserved_qty": {
+          "name": "reserved_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "inspected_qty": {
+          "name": "inspected_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "line_version": {
+          "name": "line_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_from_line_id": {
+          "name": "created_from_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forced": {
+          "name": "forced",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_shipment_lines_shipment": {
+          "name": "idx_shipment_lines_shipment",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_shipment_lines_created_from_line": {
+          "name": "idx_shipment_lines_created_from_line",
+          "columns": [
+            {
+              "expression": "created_from_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shipment_lines_shipment_id_shipments_id_fk": {
+          "name": "shipment_lines_shipment_id_shipments_id_fk",
+          "tableFrom": "shipment_lines",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shipment_lines_fulfillment_order_item_id_fulfillment_order_items_id_fk": {
+          "name": "shipment_lines_fulfillment_order_item_id_fulfillment_order_items_id_fk",
+          "tableFrom": "shipment_lines",
+          "tableTo": "fulfillment_order_items",
+          "columnsFrom": [
+            "fulfillment_order_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "shipment_lines_sku_id_skus_id_fk": {
+          "name": "shipment_lines_sku_id_skus_id_fk",
+          "tableFrom": "shipment_lines",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "shipment_lines_created_from_line_id_shipment_lines_id_fk": {
+          "name": "shipment_lines_created_from_line_id_shipment_lines_id_fk",
+          "tableFrom": "shipment_lines",
+          "tableTo": "shipment_lines",
+          "columnsFrom": [
+            "created_from_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_shipment_lines_shipment_foi": {
+          "name": "uq_shipment_lines_shipment_foi",
+          "nullsNotDistinct": false,
+          "columns": [
+            "shipment_id",
+            "fulfillment_order_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_shipment_lines_qty_positive": {
+          "name": "ck_shipment_lines_qty_positive",
+          "value": "\"shipment_lines\".\"qty\" > 0"
+        },
+        "ck_shipment_lines_inspected_range": {
+          "name": "ck_shipment_lines_inspected_range",
+          "value": "\"shipment_lines\".\"inspected_qty\" >= 0 AND \"shipment_lines\".\"inspected_qty\" <= \"shipment_lines\".\"qty\""
+        },
+        "ck_shipment_lines_reserved_range": {
+          "name": "ck_shipment_lines_reserved_range",
+          "value": "\"shipment_lines\".\"reserved_qty\" >= 0 AND \"shipment_lines\".\"reserved_qty\" <= \"shipment_lines\".\"qty\""
+        },
+        "ck_shipment_lines_line_version_positive": {
+          "name": "ck_shipment_lines_line_version_positive",
+          "value": "\"shipment_lines\".\"line_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.shipment_operation_members": {
+      "name": "shipment_operation_members",
+      "schema": "",
+      "columns": {
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "shipment_operation_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_manifest_version": {
+          "name": "before_manifest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_manifest_version": {
+          "name": "after_manifest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before_manifest_snapshot": {
+          "name": "before_manifest_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_manifest_snapshot": {
+          "name": "after_manifest_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_shipment_operation_members_shipment": {
+          "name": "idx_shipment_operation_members_shipment",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shipment_operation_members_operation_id_shipment_operations_id_fk": {
+          "name": "shipment_operation_members_operation_id_shipment_operations_id_fk",
+          "tableFrom": "shipment_operation_members",
+          "tableTo": "shipment_operations",
+          "columnsFrom": [
+            "operation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "shipment_operation_members_shipment_id_shipments_id_fk": {
+          "name": "shipment_operation_members_shipment_id_shipments_id_fk",
+          "tableFrom": "shipment_operation_members",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "shipment_operation_members_operation_id_shipment_id_role_pk": {
+          "name": "shipment_operation_members_operation_id_shipment_id_role_pk",
+          "columns": [
+            "operation_id",
+            "shipment_id",
+            "role"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_shipment_operation_member_versions": {
+          "name": "ck_shipment_operation_member_versions",
+          "value": "(\"shipment_operation_members\".\"before_manifest_version\" IS NULL OR \"shipment_operation_members\".\"before_manifest_version\" > 0)\n        AND (\"shipment_operation_members\".\"after_manifest_version\" IS NULL OR \"shipment_operation_members\".\"after_manifest_version\" > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.shipment_operations": {
+      "name": "shipment_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "shipment_operation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "shipment_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "operator_id": {
+          "name": "operator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cs_case_id": {
+          "name": "cs_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_manifest_snapshot": {
+          "name": "before_manifest_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after_manifest_snapshot": {
+          "name": "after_manifest_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_shipment_operation_status": {
+          "name": "idx_shipment_operation_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_shipment_operation_idempotency": {
+          "name": "uq_shipment_operation_idempotency",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "idempotency_key"
+          ]
+        },
+        "uq_shipment_operations_id_type": {
+          "name": "uq_shipment_operations_id_type",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_shipment_operation_request_hash": {
+          "name": "ck_shipment_operation_request_hash",
+          "value": "length(\"shipment_operations\".\"request_hash\") = 64"
+        },
+        "ck_shipment_operation_completion": {
+          "name": "ck_shipment_operation_completion",
+          "value": "\"shipment_operations\".\"status\" <> 'completed' OR \"shipment_operations\".\"completed_at\" IS NOT NULL"
+        },
+        "ck_shipment_operation_error_context": {
+          "name": "ck_shipment_operation_error_context",
+          "value": "\"shipment_operations\".\"status\" NOT IN ('failed', 'recovery_required') OR \"shipment_operations\".\"last_error\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.shipment_tote_assignments": {
+      "name": "shipment_tote_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tote_id": {
+          "name": "tote_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_shipment_tote_assignments_active_tote": {
+          "name": "uq_shipment_tote_assignments_active_tote",
+          "columns": [
+            {
+              "expression": "tote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"shipment_tote_assignments\".\"released_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_shipment_tote_assignments_active_pair": {
+          "name": "uq_shipment_tote_assignments_active_pair",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"shipment_tote_assignments\".\"released_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_shipment_tote_assignments_shipment": {
+          "name": "idx_shipment_tote_assignments_shipment",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shipment_tote_assignments_shipment_id_shipments_id_fk": {
+          "name": "shipment_tote_assignments_shipment_id_shipments_id_fk",
+          "tableFrom": "shipment_tote_assignments",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "shipment_tote_assignments_tote_id_totes_id_fk": {
+          "name": "shipment_tote_assignments_tote_id_totes_id_fk",
+          "tableFrom": "shipment_tote_assignments",
+          "tableTo": "totes",
+          "columnsFrom": [
+            "tote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_shipment_tote_assignments_release": {
+          "name": "ck_shipment_tote_assignments_release",
+          "value": "\"shipment_tote_assignments\".\"released_at\" IS NULL OR \"shipment_tote_assignments\".\"released_at\" >= \"shipment_tote_assignments\".\"assigned_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.shipment_tracking": {
+      "name": "shipment_tracking",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispatch_attempt_id": {
+          "name": "dispatch_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "shipment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_shipment_tracking_attempt": {
+          "name": "idx_shipment_tracking_attempt",
+          "columns": [
+            {
+              "expression": "dispatch_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_shipment_tracking_provider_event": {
+          "name": "uq_shipment_tracking_provider_event",
+          "columns": [
+            {
+              "expression": "dispatch_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"shipment_tracking\".\"provider_event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shipment_tracking_shipment_id_shipments_id_fk": {
+          "name": "shipment_tracking_shipment_id_shipments_id_fk",
+          "tableFrom": "shipment_tracking",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shipment_tracking_dispatch_attempt_id_dispatch_attempts_id_fk": {
+          "name": "shipment_tracking_dispatch_attempt_id_dispatch_attempts_id_fk",
+          "tableFrom": "shipment_tracking",
+          "tableTo": "dispatch_attempts",
+          "columnsFrom": [
+            "dispatch_attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shipments": {
+      "name": "shipments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opened_for_fulfillment_order_id": {
+          "name": "opened_for_fulfillment_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "shipment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "shipping_profile_id": {
+          "name": "shipping_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_snapshot": {
+          "name": "recipient_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reservation_version": {
+          "name": "reservation_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "opened_by": {
+          "name": "opened_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "planned_at": {
+          "name": "planned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipped_at": {
+          "name": "shipped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recovery_code": {
+          "name": "recovery_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_shipments_opened_for_fo": {
+          "name": "idx_shipments_opened_for_fo",
+          "columns": [
+            {
+              "expression": "opened_for_fulfillment_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_shipments_shipping_profile": {
+          "name": "idx_shipments_shipping_profile",
+          "columns": [
+            {
+              "expression": "shipping_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_shipments_warehouse_status": {
+          "name": "idx_shipments_warehouse_status",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shipments_warehouse_id_warehouses_id_fk": {
+          "name": "shipments_warehouse_id_warehouses_id_fk",
+          "tableFrom": "shipments",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "shipments_opened_for_fulfillment_order_id_fulfillment_orders_id_fk": {
+          "name": "shipments_opened_for_fulfillment_order_id_fulfillment_orders_id_fk",
+          "tableFrom": "shipments",
+          "tableTo": "fulfillment_orders",
+          "columnsFrom": [
+            "opened_for_fulfillment_order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "shipments_shipping_profile_id_delivery_profiles_id_fk": {
+          "name": "shipments_shipping_profile_id_delivery_profiles_id_fk",
+          "tableFrom": "shipments",
+          "tableTo": "delivery_profiles",
+          "columnsFrom": [
+            "shipping_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_shipments_manifest_version_positive": {
+          "name": "ck_shipments_manifest_version_positive",
+          "value": "\"shipments\".\"manifest_version\" > 0"
+        },
+        "ck_shipments_reservation_version_positive": {
+          "name": "ck_shipments_reservation_version_positive",
+          "value": "\"shipments\".\"reservation_version\" > 0"
+        },
+        "ck_shipments_recovery_code": {
+          "name": "ck_shipments_recovery_code",
+          "value": "\"shipments\".\"status\"::text <> 'recovery_required' OR \"shipments\".\"recovery_code\" IS NOT NULL"
+        },
+        "ck_shipments_superseded_at": {
+          "name": "ck_shipments_superseded_at",
+          "value": "\"shipments\".\"status\"::text <> 'superseded' OR \"shipments\".\"superseded_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sku_barcodes": {
+      "name": "sku_barcodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "barcode": {
+          "name": "barcode",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "packing_unit": {
+          "name": "packing_unit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sku_barcodes_sku_id_skus_id_fk": {
+          "name": "sku_barcodes_sku_id_skus_id_fk",
+          "tableFrom": "sku_barcodes",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sku_barcodes_barcode_unique": {
+          "name": "sku_barcodes_barcode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "barcode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_sku_barcodes_packing_unit_positive": {
+          "name": "ck_sku_barcodes_packing_unit_positive",
+          "value": "\"sku_barcodes\".\"packing_unit\" IS NULL OR \"sku_barcodes\".\"packing_unit\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sku_categories": {
+      "name": "sku_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sku_categories_sku_id_skus_id_fk": {
+          "name": "sku_categories_sku_id_skus_id_fk",
+          "tableFrom": "sku_categories",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sku_categories_category_id_categories_id_fk": {
+          "name": "sku_categories_category_id_categories_id_fk",
+          "tableFrom": "sku_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sku_groups": {
+      "name": "sku_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sku_groups_code": {
+          "name": "idx_sku_groups_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sku_groups_name": {
+          "name": "idx_sku_groups_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sku_groups_code_unique": {
+          "name": "sku_groups_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sku_images": {
+      "name": "sku_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sku_images_sku_id": {
+          "name": "idx_sku_images_sku_id",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sku_images_primary": {
+          "name": "idx_sku_images_primary",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sku_images_sort": {
+          "name": "idx_sku_images_sort",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sku_images_sku_id_skus_id_fk": {
+          "name": "sku_images_sku_id_skus_id_fk",
+          "tableFrom": "sku_images",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sku_location_movements": {
+      "name": "sku_location_movements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "barcode": {
+          "name": "barcode",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_location_id": {
+          "name": "from_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_location_id": {
+          "name": "to_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "moved_by": {
+          "name": "moved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "movement_timestamp": {
+          "name": "movement_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_movement_sku": {
+          "name": "idx_movement_sku",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_movement_barcode": {
+          "name": "idx_movement_barcode",
+          "columns": [
+            {
+              "expression": "barcode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_movement_timestamp": {
+          "name": "idx_movement_timestamp",
+          "columns": [
+            {
+              "expression": "movement_timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sku_location_movements_sku_id_skus_id_fk": {
+          "name": "sku_location_movements_sku_id_skus_id_fk",
+          "tableFrom": "sku_location_movements",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sku_location_movements_from_location_id_locations_id_fk": {
+          "name": "sku_location_movements_from_location_id_locations_id_fk",
+          "tableFrom": "sku_location_movements",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "from_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "sku_location_movements_to_location_id_locations_id_fk": {
+          "name": "sku_location_movements_to_location_id_locations_id_fk",
+          "tableFrom": "sku_location_movements",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "to_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sku_managers": {
+      "name": "sku_managers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "designer_id": {
+          "name": "designer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_manager_id": {
+          "name": "purchase_manager_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_manager_id": {
+          "name": "registration_manager_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sku_managers_sku_id_skus_id_fk": {
+          "name": "sku_managers_sku_id_skus_id_fk",
+          "tableFrom": "sku_managers",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sku_managers_sku_id_unique": {
+          "name": "sku_managers_sku_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sku_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sku_suppliers": {
+      "name": "sku_suppliers",
+      "schema": "",
+      "columns": {
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_sku": {
+          "name": "supplier_sku",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sku_suppliers_sku_id_skus_id_fk": {
+          "name": "sku_suppliers_sku_id_skus_id_fk",
+          "tableFrom": "sku_suppliers",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sku_suppliers_supplier_id_suppliers_id_fk": {
+          "name": "sku_suppliers_supplier_id_suppliers_id_fk",
+          "tableFrom": "sku_suppliers",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "sku_suppliers_sku_id_supplier_id_pk": {
+          "name": "sku_suppliers_sku_id_supplier_id_pk",
+          "columns": [
+            "sku_id",
+            "supplier_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skus": {
+      "name": "skus",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "holder_id": {
+          "name": "holder_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'019d0001-0000-7000-a000-000000000001'"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "option_key": {
+          "name": "option_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_type": {
+          "name": "stock_type",
+          "type": "stock_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'physical'"
+        },
+        "delivery_profile_id": {
+          "name": "delivery_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_1m": {
+          "name": "sale_1m",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sale_3m": {
+          "name": "sale_3m",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safety_stock": {
+          "name": "safety_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "business_product_name": {
+          "name": "business_product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_declaration_number": {
+          "name": "import_declaration_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logistics_partner_id": {
+          "name": "logistics_partner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer_star": {
+          "name": "manufacturer_star",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_weight": {
+          "name": "product_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dimension_width": {
+          "name": "dimension_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dimension_height": {
+          "name": "dimension_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dimension_depth": {
+          "name": "dimension_depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_material": {
+          "name": "product_material",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "korean_name": {
+          "name": "korean_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_discount_quantity": {
+          "name": "max_discount_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "packaging_importer_name": {
+          "name": "packaging_importer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_description": {
+          "name": "product_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moq": {
+          "name": "moq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo2": {
+          "name": "memo2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo3": {
+          "name": "memo3",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_image_url": {
+          "name": "main_image_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_date_management": {
+          "name": "expiry_date_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiry_start_date": {
+          "name": "expiry_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiry_end_date": {
+          "name": "expiry_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturing_date_management": {
+          "name": "manufacturing_date_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_general_inventory": {
+          "name": "is_general_inventory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "validity_start_date": {
+          "name": "validity_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validity_end_date": {
+          "name": "validity_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_location_id": {
+          "name": "primary_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secondary_location_id": {
+          "name": "secondary_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_group_code": {
+          "name": "variant_group_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skus_safety_stock": {
+          "name": "idx_skus_safety_stock",
+          "columns": [
+            {
+              "expression": "safety_stock",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skus_variant_group": {
+          "name": "idx_skus_variant_group",
+          "columns": [
+            {
+              "expression": "variant_group_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skus_primary_location": {
+          "name": "idx_skus_primary_location",
+          "columns": [
+            {
+              "expression": "primary_location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skus_weight": {
+          "name": "idx_skus_weight",
+          "columns": [
+            {
+              "expression": "product_weight",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skus_moq": {
+          "name": "idx_skus_moq",
+          "columns": [
+            {
+              "expression": "moq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skus_group_id": {
+          "name": "idx_skus_group_id",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skus_holder_id_holders_id_fk": {
+          "name": "skus_holder_id_holders_id_fk",
+          "tableFrom": "skus",
+          "tableTo": "holders",
+          "columnsFrom": [
+            "holder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skus_group_id_sku_groups_id_fk": {
+          "name": "skus_group_id_sku_groups_id_fk",
+          "tableFrom": "skus",
+          "tableTo": "sku_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "skus_delivery_profile_id_delivery_profiles_id_fk": {
+          "name": "skus_delivery_profile_id_delivery_profiles_id_fk",
+          "tableFrom": "skus",
+          "tableTo": "delivery_profiles",
+          "columnsFrom": [
+            "delivery_profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "skus_logistics_partner_id_suppliers_id_fk": {
+          "name": "skus_logistics_partner_id_suppliers_id_fk",
+          "tableFrom": "skus",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "logistics_partner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "skus_primary_location_id_locations_id_fk": {
+          "name": "skus_primary_location_id_locations_id_fk",
+          "tableFrom": "skus",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "primary_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "skus_secondary_location_id_locations_id_fk": {
+          "name": "skus_secondary_location_id_locations_id_fk",
+          "tableFrom": "skus",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "secondary_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skus_code_unique": {
+          "name": "skus_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stock_events": {
+      "name": "stock_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "journal_id": {
+          "name": "journal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_warehouse_id": {
+          "name": "from_warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_location_id": {
+          "name": "from_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_warehouse_id": {
+          "name": "to_warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_location_id": {
+          "name": "to_location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_state": {
+          "name": "from_state",
+          "type": "stock_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_state": {
+          "name": "to_state",
+          "type": "stock_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transition_type": {
+          "name": "transition_type",
+          "type": "transition_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_status": {
+          "name": "event_status",
+          "type": "event_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'POSTED'"
+        },
+        "reversal_of_event_id": {
+          "name": "reversal_of_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_by_event_id": {
+          "name": "voided_by_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ix_stock_events_grain_time": {
+          "name": "ix_stock_events_grain_time",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_stock_events_reversal_of_event": {
+          "name": "uq_stock_events_reversal_of_event",
+          "columns": [
+            {
+              "expression": "reversal_of_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stock_events\".\"reversal_of_event_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stock_events_journal_id_stock_journals_id_fk": {
+          "name": "stock_events_journal_id_stock_journals_id_fk",
+          "tableFrom": "stock_events",
+          "tableTo": "stock_journals",
+          "columnsFrom": [
+            "journal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_events_sku_id_skus_id_fk": {
+          "name": "stock_events_sku_id_skus_id_fk",
+          "tableFrom": "stock_events",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_events_from_warehouse_id_warehouses_id_fk": {
+          "name": "stock_events_from_warehouse_id_warehouses_id_fk",
+          "tableFrom": "stock_events",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "from_warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_events_from_location_id_locations_id_fk": {
+          "name": "stock_events_from_location_id_locations_id_fk",
+          "tableFrom": "stock_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "from_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "stock_events_to_warehouse_id_warehouses_id_fk": {
+          "name": "stock_events_to_warehouse_id_warehouses_id_fk",
+          "tableFrom": "stock_events",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "to_warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_events_to_location_id_locations_id_fk": {
+          "name": "stock_events_to_location_id_locations_id_fk",
+          "tableFrom": "stock_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "to_location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stock_events_idempotency_key_unique": {
+          "name": "stock_events_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_events_qty_positive": {
+          "name": "ck_events_qty_positive",
+          "value": "\"stock_events\".\"quantity\" > 0"
+        },
+        "ck_events_states_diff": {
+          "name": "ck_events_states_diff",
+          "value": "(\"stock_events\".\"from_state\" is distinct from \"stock_events\".\"to_state\") \n          OR (\"stock_events\".\"from_location_id\" is distinct from \"stock_events\".\"to_location_id\")\n          OR (\"stock_events\".\"from_warehouse_id\" is distinct from \"stock_events\".\"to_warehouse_id\")"
+        },
+        "ck_events_side_present": {
+          "name": "ck_events_side_present",
+          "value": "(\"stock_events\".\"from_state\" is not null) or (\"stock_events\".\"to_state\" is not null)"
+        },
+        "ck_events_fromloc_has_wh": {
+          "name": "ck_events_fromloc_has_wh",
+          "value": "(\"stock_events\".\"from_location_id\" is null) or (\"stock_events\".\"from_warehouse_id\" is not null)"
+        },
+        "ck_events_toloc_has_wh": {
+          "name": "ck_events_toloc_has_wh",
+          "value": "(\"stock_events\".\"to_location_id\" is null) or (\"stock_events\".\"to_warehouse_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.stock_journals": {
+      "name": "stock_journals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stock_journals_idempotency_key_unique": {
+          "name": "stock_journals_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stock_ledgers": {
+      "name": "stock_ledgers",
+      "schema": "",
+      "columns": {
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_state": {
+          "name": "stock_state",
+          "type": "stock_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qty": {
+          "name": "qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ix_ledgers_lookup": {
+          "name": "ix_ledgers_lookup",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stock_ledgers_sku_id_skus_id_fk": {
+          "name": "stock_ledgers_sku_id_skus_id_fk",
+          "tableFrom": "stock_ledgers",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stock_ledgers_warehouse_id_warehouses_id_fk": {
+          "name": "stock_ledgers_warehouse_id_warehouses_id_fk",
+          "tableFrom": "stock_ledgers",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_ledgers_location_id_locations_id_fk": {
+          "name": "stock_ledgers_location_id_locations_id_fk",
+          "tableFrom": "stock_ledgers",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stock_ledgers_sku_id_warehouse_id_location_id_stock_state_pk": {
+          "name": "stock_ledgers_sku_id_warehouse_id_location_id_stock_state_pk",
+          "columns": [
+            "sku_id",
+            "warehouse_id",
+            "location_id",
+            "stock_state"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_ledgers_non_negative": {
+          "name": "ck_ledgers_non_negative",
+          "value": "\"stock_ledgers\".\"qty\" >= 0"
+        },
+        "ck_stock_ledgers_version_positive": {
+          "name": "ck_stock_ledgers_version_positive",
+          "value": "\"stock_ledgers\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.stock_reservations": {
+      "name": "stock_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fulfillment_order_item_id": {
+          "name": "fulfillment_order_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipment_line_id": {
+          "name": "shipment_line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "reservation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "timeout_at": {
+          "name": "timeout_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_reason": {
+          "name": "state_reason",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invalidated_at": {
+          "name": "invalidated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stock_reservations_target_idx": {
+          "name": "stock_reservations_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stock_reservations_sku_warehouse_idx": {
+          "name": "stock_reservations_sku_warehouse_idx",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stock_reservations_status_idx": {
+          "name": "stock_reservations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stock_reservations_shipment_line": {
+          "name": "idx_stock_reservations_shipment_line",
+          "columns": [
+            {
+              "expression": "shipment_line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stock_reservations_requested_at": {
+          "name": "idx_stock_reservations_requested_at",
+          "columns": [
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stock_reservations_fulfillment_order_item_id_fulfillment_order_items_id_fk": {
+          "name": "stock_reservations_fulfillment_order_item_id_fulfillment_order_items_id_fk",
+          "tableFrom": "stock_reservations",
+          "tableTo": "fulfillment_order_items",
+          "columnsFrom": [
+            "fulfillment_order_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stock_reservations_shipment_line_id_shipment_lines_id_fk": {
+          "name": "stock_reservations_shipment_line_id_shipment_lines_id_fk",
+          "tableFrom": "stock_reservations",
+          "tableTo": "shipment_lines",
+          "columnsFrom": [
+            "shipment_line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stock_reservations_sku_id_skus_id_fk": {
+          "name": "stock_reservations_sku_id_skus_id_fk",
+          "tableFrom": "stock_reservations",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stock_reservations_warehouse_id_warehouses_id_fk": {
+          "name": "stock_reservations_warehouse_id_warehouses_id_fk",
+          "tableFrom": "stock_reservations",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_stock_reservations_quantity_positive": {
+          "name": "ck_stock_reservations_quantity_positive",
+          "value": "\"stock_reservations\".\"quantity\" > 0"
+        },
+        "ck_stock_reservations_invalidation": {
+          "name": "ck_stock_reservations_invalidation",
+          "value": "\"stock_reservations\".\"invalidated_at\" IS NULL OR \"stock_reservations\".\"state_reason\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.stocktaking_adjustments": {
+      "name": "stocktaking_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_event_id": {
+          "name": "stock_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adjustment_quantity": {
+          "name": "adjustment_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adjustment_type": {
+          "name": "adjustment_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "applied_by": {
+          "name": "applied_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_adjustment_session": {
+          "name": "idx_adjustment_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_adjustment_line": {
+          "name": "idx_adjustment_line",
+          "columns": [
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stocktaking_adjustments_session_id_stocktaking_sessions_id_fk": {
+          "name": "stocktaking_adjustments_session_id_stocktaking_sessions_id_fk",
+          "tableFrom": "stocktaking_adjustments",
+          "tableTo": "stocktaking_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stocktaking_adjustments_line_id_stocktaking_lines_id_fk": {
+          "name": "stocktaking_adjustments_line_id_stocktaking_lines_id_fk",
+          "tableFrom": "stocktaking_adjustments",
+          "tableTo": "stocktaking_lines",
+          "columnsFrom": [
+            "line_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stocktaking_adjustments_stock_event_id_stock_events_id_fk": {
+          "name": "stocktaking_adjustments_stock_event_id_stock_events_id_fk",
+          "tableFrom": "stocktaking_adjustments",
+          "tableTo": "stock_events",
+          "columnsFrom": [
+            "stock_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_stocktaking_adjustment_line": {
+          "name": "uq_stocktaking_adjustment_line",
+          "nullsNotDistinct": false,
+          "columns": [
+            "line_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stocktaking_lines": {
+      "name": "stocktaking_lines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_quantity": {
+          "name": "expected_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counted_quantity": {
+          "name": "counted_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variance": {
+          "name": "variance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scanned_barcode": {
+          "name": "scanned_barcode",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "counted_at": {
+          "name": "counted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counted_by": {
+          "name": "counted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_stocktaking_line_session": {
+          "name": "idx_stocktaking_line_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stocktaking_line_sku": {
+          "name": "idx_stocktaking_line_sku",
+          "columns": [
+            {
+              "expression": "sku_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_stocktaking_line_location": {
+          "name": "idx_stocktaking_line_location",
+          "columns": [
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stocktaking_lines_session_id_stocktaking_sessions_id_fk": {
+          "name": "stocktaking_lines_session_id_stocktaking_sessions_id_fk",
+          "tableFrom": "stocktaking_lines",
+          "tableTo": "stocktaking_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stocktaking_lines_sku_id_skus_id_fk": {
+          "name": "stocktaking_lines_sku_id_skus_id_fk",
+          "tableFrom": "stocktaking_lines",
+          "tableTo": "skus",
+          "columnsFrom": [
+            "sku_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "stocktaking_lines_location_id_locations_id_fk": {
+          "name": "stocktaking_lines_location_id_locations_id_fk",
+          "tableFrom": "stocktaking_lines",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_stocktaking_line_session_sku_location": {
+          "name": "uq_stocktaking_line_session_sku_location",
+          "nullsNotDistinct": true,
+          "columns": [
+            "session_id",
+            "sku_id",
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stocktaking_sessions": {
+      "name": "stocktaking_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_name": {
+          "name": "session_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stocktaking_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_by": {
+          "name": "started_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stocktaking_sessions_warehouse_id_warehouses_id_fk": {
+          "name": "stocktaking_sessions_warehouse_id_warehouses_id_fk",
+          "tableFrom": "stocktaking_sessions",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_categories": {
+      "name": "supplier_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "supplier_categories_name_unique": {
+          "name": "supplier_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_category_mappings": {
+      "name": "supplier_category_mappings",
+      "schema": "",
+      "columns": {
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "supplier_category_mappings_supplier_id_suppliers_id_fk": {
+          "name": "supplier_category_mappings_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_category_mappings",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "supplier_category_mappings_category_id_supplier_categories_id_fk": {
+          "name": "supplier_category_mappings_category_id_supplier_categories_id_fk",
+          "tableFrom": "supplier_category_mappings",
+          "tableTo": "supplier_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "supplier_category_mappings_supplier_id_category_id_pk": {
+          "name": "supplier_category_mappings_supplier_id_category_id_pk",
+          "columns": [
+            "supplier_id",
+            "category_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fax": {
+          "name": "fax",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zipcode": {
+          "name": "zipcode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address1": {
+          "name": "address1",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address2": {
+          "name": "address2",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_reg_no": {
+          "name": "business_reg_no",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ceo_name": {
+          "name": "ceo_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_direct_delivery": {
+          "name": "is_direct_delivery",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order_cutoff_time": {
+          "name": "order_cutoff_time",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_name": {
+          "name": "bank_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_account_no": {
+          "name": "bank_account_no",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_account_holder": {
+          "name": "bank_account_holder",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_manager_id": {
+          "name": "purchase_manager_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_warehouse_id": {
+          "name": "default_warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "suppliers_default_warehouse_id_warehouses_id_fk": {
+          "name": "suppliers_default_warehouse_id_warehouses_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "default_warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.totes": {
+      "name": "totes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "barcode": {
+          "name": "barcode",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "tote_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_totes_warehouse_status": {
+          "name": "idx_totes_warehouse_status",
+          "columns": [
+            {
+              "expression": "warehouse_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "totes_warehouse_id_warehouses_id_fk": {
+          "name": "totes_warehouse_id_warehouses_id_fk",
+          "tableFrom": "totes",
+          "tableTo": "warehouses",
+          "columnsFrom": [
+            "warehouse_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_totes_barcode": {
+          "name": "uq_totes_barcode",
+          "nullsNotDistinct": false,
+          "columns": [
+            "barcode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_totes_version_positive": {
+          "name": "ck_totes_version_positive",
+          "value": "\"totes\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.warehouses": {
+      "name": "warehouses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "warehouse_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'domestic'"
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supported_picking_strategies": {
+          "name": "supported_picking_strategies",
+          "type": "picking_strategy[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waybills": {
+      "name": "waybills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "waybill_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "carrier": {
+          "name": "carrier",
+          "type": "carrier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "waybill_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tracking_no": {
+          "name": "tracking_no",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cust_ord_no": {
+          "name": "cust_ord_no",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_data": {
+          "name": "label_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_hash": {
+          "name": "recipient_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voided_at": {
+          "name": "voided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_waybills_shipment": {
+          "name": "idx_waybills_shipment",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_waybills_status": {
+          "name": "idx_waybills_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_waybills_tracking_no": {
+          "name": "idx_waybills_tracking_no",
+          "columns": [
+            {
+              "expression": "tracking_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_waybills_shipment_active": {
+          "name": "uq_waybills_shipment_active",
+          "columns": [
+            {
+              "expression": "shipment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"waybills\".\"status\" NOT IN ('voided', 'failed', 'abandoned')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_waybills_tracking_live": {
+          "name": "uq_waybills_tracking_live",
+          "columns": [
+            {
+              "expression": "tracking_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"waybills\".\"tracking_no\" IS NOT NULL AND \"waybills\".\"status\" NOT IN ('voided', 'failed', 'abandoned')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "waybills_shipment_id_shipments_id_fk": {
+          "name": "waybills_shipment_id_shipments_id_fk",
+          "tableFrom": "waybills",
+          "tableTo": "shipments",
+          "columnsFrom": [
+            "shipment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ck_waybills_tracking_present": {
+          "name": "ck_waybills_tracking_present",
+          "value": "\"waybills\".\"status\" NOT IN ('allocated', 'registered', 'used') OR \"waybills\".\"tracking_no\" IS NOT NULL"
+        },
+        "ck_waybills_manual_status": {
+          "name": "ck_waybills_manual_status",
+          "value": "\"waybills\".\"source\" <> 'manual' OR \"waybills\".\"status\" IN ('registered', 'used', 'voided')"
+        },
+        "ck_waybills_attempts": {
+          "name": "ck_waybills_attempts",
+          "value": "\"waybills\".\"attempts\" >= 0"
+        },
+        "ck_waybills_recipient_hash": {
+          "name": "ck_waybills_recipient_hash",
+          "value": "length(\"waybills\".\"recipient_hash\") = 64"
+        },
+        "ck_waybills_manifest_version": {
+          "name": "ck_waybills_manifest_version",
+          "value": "\"waybills\".\"manifest_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.digital_asset_file_versions": {
+      "name": "digital_asset_file_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_note": {
+          "name": "release_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "released_by": {
+          "name": "released_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_dafv_asset": {
+          "name": "idx_dafv_asset",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_dafv_asset_version": {
+          "name": "uniq_dafv_asset_version",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "digital_asset_file_versions_asset_id_digital_assets_id_fk": {
+          "name": "digital_asset_file_versions_asset_id_digital_assets_id_fk",
+          "tableFrom": "digital_asset_file_versions",
+          "tableTo": "digital_assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.digital_asset_ownerships": {
+      "name": "digital_asset_ownerships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "exercised_at": {
+          "name": "exercised_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_dao_customer": {
+          "name": "idx_dao_customer",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dao_asset": {
+          "name": "idx_dao_asset",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dao_order": {
+          "name": "idx_dao_order",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uniq_dao_customer_asset_order": {
+          "name": "uniq_dao_customer_asset_order",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "digital_asset_ownerships_asset_id_digital_assets_id_fk": {
+          "name": "digital_asset_ownerships_asset_id_digital_assets_id_fk",
+          "tableFrom": "digital_asset_ownerships",
+          "tableTo": "digital_assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.digital_assets": {
+      "name": "digital_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_file_version_id": {
+          "name": "current_file_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_digital_assets_name": {
+          "name": "idx_digital_assets_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_digital_assets_created_at": {
+          "name": "idx_digital_assets_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_digital_assets_deleted_at": {
+          "name": "idx_digital_assets_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "digital_assets_current_file_version_id_digital_asset_file_versions_id_fk": {
+          "name": "digital_assets_current_file_version_id_digital_asset_file_versions_id_fk",
+          "tableFrom": "digital_assets",
+          "tableTo": "digital_asset_file_versions",
+          "columnsFrom": [
+            "current_file_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_variant_digital_asset_links": {
+      "name": "product_variant_digital_asset_links",
+      "schema": "",
+      "columns": {
+        "variant_id": {
+          "name": "variant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_pvdal_variant": {
+          "name": "idx_pvdal_variant",
+          "columns": [
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pvdal_asset": {
+          "name": "idx_pvdal_asset",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_variant_digital_asset_links_asset_id_digital_assets_id_fk": {
+          "name": "product_variant_digital_asset_links_asset_id_digital_assets_id_fk",
+          "tableFrom": "product_variant_digital_asset_links",
+          "tableTo": "digital_assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "product_variant_digital_asset_links_variant_id_asset_id_pk": {
+          "name": "product_variant_digital_asset_links_variant_id_asset_id_pk",
+          "columns": [
+            "variant_id",
+            "asset_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cs_case_comment_attachments": {
+      "name": "cs_case_comment_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cs_case_id": {
+          "name": "cs_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cs_attachment_case_id": {
+          "name": "idx_cs_attachment_case_id",
+          "columns": [
+            {
+              "expression": "cs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cs_attachment_comment_id": {
+          "name": "idx_cs_attachment_comment_id",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cs_case_comment_mentions": {
+      "name": "cs_case_comment_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentioned_user_id": {
+          "name": "mentioned_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cs_mention_user": {
+          "name": "idx_cs_mention_user",
+          "columns": [
+            {
+              "expression": "mentioned_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_cs_comment_mention": {
+          "name": "uq_cs_comment_mention",
+          "nullsNotDistinct": false,
+          "columns": [
+            "comment_id",
+            "mentioned_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cs_case_comments": {
+      "name": "cs_case_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cs_case_id": {
+          "name": "cs_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cs_case_comments_case_id": {
+          "name": "idx_cs_case_comments_case_id",
+          "columns": [
+            {
+              "expression": "cs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cs_case_events": {
+      "name": "cs_case_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cs_case_id": {
+          "name": "cs_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(48)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cs_case_events_case_id": {
+          "name": "idx_cs_case_events_case_id",
+          "columns": [
+            {
+              "expression": "cs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cs_case_labels": {
+      "name": "cs_case_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cs_case_id": {
+          "name": "cs_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cs_case_labels_case_id": {
+          "name": "idx_cs_case_labels_case_id",
+          "columns": [
+            {
+              "expression": "cs_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_cs_case_label": {
+          "name": "uq_cs_case_label",
+          "nullsNotDistinct": false,
+          "columns": [
+            "cs_case_id",
+            "label_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cs_cases": {
+      "name": "cs_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_channel": {
+          "name": "source_channel",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'kakao'"
+        },
+        "external_thread_ref": {
+          "name": "external_thread_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cs_cases_status": {
+          "name": "idx_cs_cases_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cs_cases_customer_id": {
+          "name": "idx_cs_cases_customer_id",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cs_cases_assigned_to": {
+          "name": "idx_cs_cases_assigned_to",
+          "columns": [
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cs_cases_source_channel": {
+          "name": "idx_cs_cases_source_channel",
+          "columns": [
+            {
+              "expression": "source_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cs_cases_created_at": {
+          "name": "idx_cs_cases_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cs_labels": {
+      "name": "cs_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#888888'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_cs_labels_name": {
+          "name": "uq_cs_labels_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "event.outbox_events": {
+      "name": "outbox_events",
+      "schema": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_type": {
+          "name": "aggregate_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "partition_key": {
+          "name": "partition_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "outbox_status_idx": {
+          "name": "outbox_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_processing_started_idx": {
+          "name": "outbox_processing_started_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processing_started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_topic_idx": {
+          "name": "outbox_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_status_next_attempt_idx": {
+          "name": "outbox_status_next_attempt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_partition_created_idx": {
+          "name": "outbox_partition_created_idx",
+          "columns": [
+            {
+              "expression": "partition_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_event_outbox_topic_event_idempotency": {
+          "name": "uq_event_outbox_topic_event_idempotency",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "event.event_resource_links": {
+      "name": "event_resource_links",
+      "schema": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(26)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "erl_chain_idx": {
+          "name": "erl_chain_idx",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "erl_resource_idx": {
+          "name": "erl_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "erl_event_idx": {
+          "name": "erl_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.role_scope_mapping": {
+      "name": "role_scope_mapping",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_scope_unique_idx": {
+          "name": "role_scope_unique_idx",
+          "columns": [
+            {
+              "expression": "role_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_scope_mapping_scope_id_scopes_id_fk": {
+          "name": "role_scope_mapping_scope_id_scopes_id_fk",
+          "tableFrom": "role_scope_mapping",
+          "tableTo": "scopes",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.scopes": {
+      "name": "scopes",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microservice_name": {
+          "name": "microservice_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scopes_key_unique": {
+          "name": "scopes_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.product_master_version_approval_status": {
+      "name": "product_master_version_approval_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.product_master_version_status": {
+      "name": "product_master_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "inactive",
+        "active"
+      ]
+    },
+    "public.pricing_rule_layer": {
+      "name": "pricing_rule_layer",
+      "schema": "public",
+      "values": [
+        "base_price",
+        "membership_price",
+        "tiered_price"
+      ]
+    },
+    "public.pricing_rule_operation_type": {
+      "name": "pricing_rule_operation_type",
+      "schema": "public",
+      "values": [
+        "offset",
+        "scale",
+        "override"
+      ]
+    },
+    "public.pricing_rule_scope_type": {
+      "name": "pricing_rule_scope_type",
+      "schema": "public",
+      "values": [
+        "all_variants",
+        "with_option",
+        "variants"
+      ]
+    },
+    "public.product_bulk_image_source_kind": {
+      "name": "product_bulk_image_source_kind",
+      "schema": "public",
+      "values": [
+        "file_id",
+        "file_name"
+      ]
+    },
+    "public.product_bulk_image_status": {
+      "name": "product_bulk_image_status",
+      "schema": "public",
+      "values": [
+        "resolved",
+        "awaiting_upload"
+      ]
+    },
+    "public.product_bulk_image_usage": {
+      "name": "product_bulk_image_usage",
+      "schema": "public",
+      "values": [
+        "main",
+        "description"
+      ]
+    },
+    "public.product_bulk_item_kind": {
+      "name": "product_bulk_item_kind",
+      "schema": "public",
+      "values": [
+        "create",
+        "update"
+      ]
+    },
+    "public.product_bulk_item_publish_status": {
+      "name": "product_bulk_item_publish_status",
+      "schema": "public",
+      "values": [
+        "idle",
+        "pending",
+        "published",
+        "failed"
+      ]
+    },
+    "public.product_bulk_item_status": {
+      "name": "product_bulk_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invalid",
+        "drafted",
+        "excluded",
+        "failed"
+      ]
+    },
+    "public.product_bulk_session_phase": {
+      "name": "product_bulk_session_phase",
+      "schema": "public",
+      "values": [
+        "uploaded",
+        "validating",
+        "review",
+        "awaiting_images",
+        "drafting",
+        "drafted",
+        "publishing",
+        "published",
+        "canceled",
+        "failed"
+      ]
+    },
+    "public.product_form_export_status": {
+      "name": "product_form_export_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.audit_event_type": {
+      "name": "audit_event_type",
+      "schema": "public",
+      "values": [
+        "USER_LOGIN",
+        "USER_LOGOUT",
+        "USER_ACTION",
+        "STOCK_CREATED",
+        "STOCK_UPDATED",
+        "STOCK_DELETED",
+        "STOCK_RESERVED",
+        "STOCK_UNRESERVED",
+        "STOCK_MOVED",
+        "ORDER_CREATED",
+        "ORDER_CONFIRMED",
+        "ORDER_CANCELLED",
+        "ORDER_MERGED",
+        "FULFILLMENT_CREATED",
+        "FULFILLMENT_READY",
+        "FULFILLMENT_SHIPPED",
+        "SKU_CREATED",
+        "SKU_UPDATED",
+        "SKU_DELETED",
+        "PRODUCT_MATCHED",
+        "PRODUCT_MATCHING_RESOLVED",
+        "SYSTEM_STARTUP",
+        "SYSTEM_ERROR",
+        "SYSTEM_WARNING",
+        "CONFIG_CHANGED",
+        "POLICY_CHANGED"
+      ]
+    },
+    "public.audit_severity": {
+      "name": "audit_severity",
+      "schema": "public",
+      "values": [
+        "INFO",
+        "WARN",
+        "ERROR",
+        "CRITICAL"
+      ]
+    },
+    "public.batch_inventory_custody_type": {
+      "name": "batch_inventory_custody_type",
+      "schema": "public",
+      "values": [
+        "AT_SOURCE",
+        "WORKER",
+        "BULK_CART",
+        "TOTE",
+        "SORTING",
+        "PACKING",
+        "PACKED",
+        "RETURN_PENDING",
+        "SETTLED"
+      ]
+    },
+    "public.batch_inventory_session_status": {
+      "name": "batch_inventory_session_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "settled",
+        "recovery_required",
+        "canceled"
+      ]
+    },
+    "public.batch_status": {
+      "name": "batch_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "picking",
+        "completed",
+        "canceled"
+      ]
+    },
+    "public.carrier": {
+      "name": "carrier",
+      "schema": "public",
+      "values": [
+        "CJ",
+        "HANJIN",
+        "LOTTE",
+        "LOGEN",
+        "KDEXP",
+        "CJGLS"
+      ]
+    },
+    "public.direct_ship_status": {
+      "name": "direct_ship_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "forwarded",
+        "completed",
+        "canceled"
+      ]
+    },
+    "public.dispatch_attempt_status": {
+      "name": "dispatch_attempt_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "dispatched",
+        "recalled",
+        "recovery_required"
+      ]
+    },
+    "public.event_status": {
+      "name": "event_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "POSTED",
+        "VOIDED"
+      ]
+    },
+    "public.event_type_order": {
+      "name": "event_type_order",
+      "schema": "public",
+      "values": [
+        "ORDER_CREATED",
+        "ORDER_CONFIRMED",
+        "ORDER_MODIFIED",
+        "ORDER_CANCELLED",
+        "ORDER_REFUND_CREATED"
+      ]
+    },
+    "public.exchange_reason_code": {
+      "name": "exchange_reason_code",
+      "schema": "public",
+      "values": [
+        "defective",
+        "not_as_described",
+        "change_of_mind",
+        "wrong_item",
+        "damaged_in_shipping",
+        "other"
+      ]
+    },
+    "public.exchange_request_status": {
+      "name": "exchange_request_status",
+      "schema": "public",
+      "values": [
+        "requested",
+        "approved",
+        "rejected",
+        "collection_pending",
+        "collected",
+        "inspected",
+        "refund_pending",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.fulfillment_command_request_status": {
+      "name": "fulfillment_command_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.fulfillment_mode": {
+      "name": "fulfillment_mode",
+      "schema": "public",
+      "values": [
+        "in_house",
+        "3pl",
+        "drop_ship"
+      ]
+    },
+    "public.fulfillment_order_creation_backlog_status": {
+      "name": "fulfillment_order_creation_backlog_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "awaiting_matching",
+        "completed",
+        "not_required",
+        "failed"
+      ]
+    },
+    "public.fulfillment_status": {
+      "name": "fulfillment_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "partially_reserved",
+        "ready",
+        "processing",
+        "shipped",
+        "partially_shipped",
+        "completed",
+        "canceled",
+        "recovery_required"
+      ]
+    },
+    "public.inbound_method": {
+      "name": "inbound_method",
+      "schema": "public",
+      "values": [
+        "individual",
+        "simple",
+        "simple_fullscan",
+        "planned"
+      ]
+    },
+    "public.inbound_receipt_status": {
+      "name": "inbound_receipt_status",
+      "schema": "public",
+      "values": [
+        "posted",
+        "voided"
+      ]
+    },
+    "public.inbound_status": {
+      "name": "inbound_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "applied",
+        "receiving",
+        "confirmed"
+      ]
+    },
+    "public.inbound_work_type": {
+      "name": "inbound_work_type",
+      "schema": "public",
+      "values": [
+        "INBOUND",
+        "PUTAWAY",
+        "RETURN",
+        "CANCEL"
+      ]
+    },
+    "public.location_type": {
+      "name": "location_type",
+      "schema": "public",
+      "values": [
+        "standard",
+        "zone"
+      ]
+    },
+    "public.matching_priority": {
+      "name": "matching_priority",
+      "schema": "public",
+      "values": [
+        "normal",
+        "high"
+      ]
+    },
+    "public.matching_status": {
+      "name": "matching_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "matched",
+        "ignored"
+      ]
+    },
+    "public.matching_strategy": {
+      "name": "matching_strategy",
+      "schema": "public",
+      "values": [
+        "void",
+        "variant"
+      ]
+    },
+    "public.order_item_status": {
+      "name": "order_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "matched",
+        "stock_deducted",
+        "stock_unavailable",
+        "cancelled"
+      ]
+    },
+    "public.order_status": {
+      "name": "order_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "processing",
+        "shipped",
+        "delivered",
+        "cancelled",
+        "timeout"
+      ]
+    },
+    "public.outbound_batch_work_item_status": {
+      "name": "outbound_batch_work_item_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "picking",
+        "ready_to_pack",
+        "packing",
+        "completed",
+        "short_pick_recovery",
+        "excluded"
+      ]
+    },
+    "public.picking_method": {
+      "name": "picking_method",
+      "schema": "public",
+      "values": [
+        "individual",
+        "total_picking",
+        "multi_order"
+      ]
+    },
+    "public.picking_plan_status": {
+      "name": "picking_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "invalidated",
+        "completed",
+        "canceled"
+      ]
+    },
+    "public.picking_strategy": {
+      "name": "picking_strategy",
+      "schema": "public",
+      "values": [
+        "discrete",
+        "aggregate_then_sort",
+        "pick_to_tote"
+      ]
+    },
+    "public.plan_type": {
+      "name": "plan_type",
+      "schema": "public",
+      "values": [
+        "source",
+        "destination"
+      ]
+    },
+    "public.po_audit_status": {
+      "name": "po_audit_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending_audit",
+        "approved",
+        "rejected"
+      ]
+    },
+    "public.po_status": {
+      "name": "po_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "confirmed",
+        "received"
+      ]
+    },
+    "public.po_type": {
+      "name": "po_type",
+      "schema": "public",
+      "values": [
+        "domestic",
+        "foreign"
+      ]
+    },
+    "public.reservation_status": {
+      "name": "reservation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "confirmed",
+        "released",
+        "active"
+      ]
+    },
+    "public.return_reason_code": {
+      "name": "return_reason_code",
+      "schema": "public",
+      "values": [
+        "defective",
+        "not_as_described",
+        "change_of_mind",
+        "wrong_item",
+        "damaged_in_shipping",
+        "other"
+      ]
+    },
+    "public.return_refund_attempt_status": {
+      "name": "return_refund_attempt_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "succeeded",
+        "failed"
+      ]
+    },
+    "public.return_request_status": {
+      "name": "return_request_status",
+      "schema": "public",
+      "values": [
+        "requested",
+        "approved",
+        "rejected",
+        "collection_pending",
+        "collected",
+        "inspected",
+        "refund_pending",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.return_status": {
+      "name": "return_status",
+      "schema": "public",
+      "values": [
+        "requested",
+        "received",
+        "qc_passed",
+        "qc_failed",
+        "disposed"
+      ]
+    },
+    "public.sales_channel": {
+      "name": "sales_channel",
+      "schema": "public",
+      "values": [
+        "medusa",
+        "naver",
+        "coupang",
+        "3pl"
+      ]
+    },
+    "public.setting_key": {
+      "name": "setting_key",
+      "schema": "public",
+      "values": [
+        "use_sub_barcode",
+        "use_expiry_separation"
+      ]
+    },
+    "public.shipment_operation_member_role": {
+      "name": "shipment_operation_member_role",
+      "schema": "public",
+      "values": [
+        "source",
+        "target"
+      ]
+    },
+    "public.shipment_operation_status": {
+      "name": "shipment_operation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "failed",
+        "recovery_required"
+      ]
+    },
+    "public.shipment_operation_type": {
+      "name": "shipment_operation_type",
+      "schema": "public",
+      "values": [
+        "split",
+        "consolidate",
+        "recipient_revision",
+        "cancel",
+        "reopen",
+        "plan",
+        "replan",
+        "short_pick",
+        "recall"
+      ]
+    },
+    "public.shipment_status": {
+      "name": "shipment_status",
+      "schema": "public",
+      "values": [
+        "shipped",
+        "in_transit",
+        "delivered",
+        "failed",
+        "canceled",
+        "draft",
+        "planned",
+        "superseded",
+        "recovery_required"
+      ]
+    },
+    "public.source_type": {
+      "name": "source_type",
+      "schema": "public",
+      "values": [
+        "direct",
+        "in_house",
+        "overseas"
+      ]
+    },
+    "public.stock_state": {
+      "name": "stock_state",
+      "schema": "public",
+      "values": [
+        "ON_HAND",
+        "DEFECTIVE",
+        "IN_TRANSFER"
+      ]
+    },
+    "public.stock_type": {
+      "name": "stock_type",
+      "schema": "public",
+      "values": [
+        "physical",
+        "infinite",
+        "drop_shipped",
+        "consignment"
+      ]
+    },
+    "public.stocktaking_status": {
+      "name": "stocktaking_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "in_progress",
+        "completed",
+        "cancelled"
+      ]
+    },
+    "public.system_location_role": {
+      "name": "system_location_role",
+      "schema": "public",
+      "values": [
+        "inbound_default",
+        "return_default",
+        "outbound_rework"
+      ]
+    },
+    "public.task_priority": {
+      "name": "task_priority",
+      "schema": "public",
+      "values": [
+        "normal",
+        "high",
+        "urgent"
+      ]
+    },
+    "public.task_status": {
+      "name": "task_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "picking",
+        "packed",
+        "shipped",
+        "canceled"
+      ]
+    },
+    "public.tote_status": {
+      "name": "tote_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "in_use",
+        "damaged",
+        "retired"
+      ]
+    },
+    "public.transition_type": {
+      "name": "transition_type",
+      "schema": "public",
+      "values": [
+        "RECEIVE",
+        "SHIP",
+        "MOVE",
+        "MARK_DEFECT",
+        "REWORK_GOOD",
+        "SCRAP",
+        "ADJUST_UP",
+        "ADJUST_DOWN"
+      ]
+    },
+    "public.unavailable_reason": {
+      "name": "unavailable_reason",
+      "schema": "public",
+      "values": [
+        "pb",
+        "foreign",
+        "low_margin"
+      ]
+    },
+    "public.warehouse_type": {
+      "name": "warehouse_type",
+      "schema": "public",
+      "values": [
+        "domestic",
+        "overseas",
+        "bonded",
+        "return"
+      ]
+    },
+    "public.waybill_source": {
+      "name": "waybill_source",
+      "schema": "public",
+      "values": [
+        "carrier",
+        "manual"
+      ]
+    },
+    "public.waybill_status": {
+      "name": "waybill_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "allocated",
+        "registered",
+        "used",
+        "voided",
+        "failed",
+        "abandoned"
+      ]
+    }
+  },
+  "schemas": {
+    "event": "event",
+    "auth": "auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.stock_summary_view": {
+      "columns": {
+        "sku_id": {
+          "name": "sku_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warehouse_id": {
+          "name": "warehouse_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku_name": {
+          "name": "sku_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warehouse_name": {
+          "name": "warehouse_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "on_hand_qty": {
+          "name": "on_hand_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "defective_qty": {
+          "name": "defective_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "in_transfer_qty": {
+          "name": "in_transfer_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reserved_qty": {
+          "name": "reserved_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "available_qty": {
+          "name": "available_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "inbound_pending_qty": {
+          "name": "inbound_pending_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "on_order_qty": {
+          "name": "on_order_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transfer_pending_qty": {
+          "name": "transfer_pending_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "projected_available_qty": {
+          "name": "projected_available_qty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_calculated_at": {
+          "name": "last_calculated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "\n    SELECT\n        s.id as sku_id,\n        w.id as warehouse_id,\n        s.name as sku_name,\n        w.name as warehouse_name,\n\n        -- 물리적 재고\n        COALESCE(on_hand.qty, 0) as on_hand_qty,\n        COALESCE(defective.qty, 0) as defective_qty,\n        COALESCE(in_transfer.qty, 0) as in_transfer_qty,\n\n        -- 예약 상태\n        COALESCE(reserved.qty, 0) as reserved_qty,\n        -- 가용재고 = ON_HAND 합 − confirmed 예약 합 (ADR-0001).\n        -- transit_out 을 다시 빼지 말 것: 출발 창고에서만 빠지고 도착 창고에 더해지지 않아\n        -- 사내 이동만으로 전사 판매가능수량이 줄고, inbound_plan_items 기반이라 실제 이동\n        -- (stock_journals)이 끝나도 줄지 않는다. 등가성은 view-parity.integration.spec.ts 가 고정한다.\n        COALESCE(on_hand.qty, 0) - COALESCE(reserved.qty, 0) as available_qty,\n\n        -- 예정 상태\n        COALESCE(inbound_pending.qty, 0) as inbound_pending_qty,\n        0 as on_order_qty,\n        COALESCE(transit_out.qty, 0) as transfer_pending_qty,\n\n        -- 계산된 전망\n        COALESCE(on_hand.qty, 0) - COALESCE(reserved.qty, 0) + COALESCE(inbound_pending.qty, 0) as projected_available_qty,\n\n        NOW() as last_calculated_at\n\n    FROM skus s\n    CROSS JOIN warehouses w\n    LEFT JOIN (\n        SELECT sku_id, warehouse_id, SUM(qty) as qty\n        FROM stock_ledgers\n        WHERE stock_state = 'ON_HAND'\n        GROUP BY sku_id, warehouse_id\n    ) on_hand ON s.id = on_hand.sku_id AND w.id = on_hand.warehouse_id\n    LEFT JOIN (\n        SELECT sku_id, warehouse_id, SUM(qty) as qty\n        FROM stock_ledgers\n        WHERE stock_state = 'DEFECTIVE'\n        GROUP BY sku_id, warehouse_id\n    ) defective ON s.id = defective.sku_id AND w.id = defective.warehouse_id\n    LEFT JOIN (\n        SELECT sku_id, warehouse_id, SUM(qty) as qty\n        FROM stock_ledgers\n        WHERE stock_state = 'IN_TRANSFER'\n        GROUP BY sku_id, warehouse_id\n    ) in_transfer ON s.id = in_transfer.sku_id AND w.id = in_transfer.warehouse_id\n    LEFT JOIN (\n        SELECT sku_id, warehouse_id, SUM(quantity) as qty\n        FROM stock_reservations\n        WHERE status = 'confirmed'\n        GROUP BY sku_id, warehouse_id\n    ) reserved ON s.id = reserved.sku_id AND w.id = reserved.warehouse_id\n    LEFT JOIN (\n        SELECT ipi.sku_id, ip.destination_warehouse_id, SUM(ipi.expected_qty - ipi.received_qty) as qty\n        FROM inbound_plan_items ipi\n        INNER JOIN inbound_plans ip ON ipi.plan_id = ip.id\n        WHERE ipi.status = 'pending'\n        GROUP BY ipi.sku_id, ip.destination_warehouse_id\n    ) inbound_pending ON s.id = inbound_pending.sku_id AND w.id = inbound_pending.destination_warehouse_id\n    LEFT JOIN (\n        SELECT ipi.sku_id, ip.warehouse_id, SUM(ipi.expected_qty - ipi.received_qty) as qty\n        FROM inbound_plan_items ipi\n        INNER JOIN inbound_plans ip ON ipi.plan_id = ip.id\n        WHERE ipi.status = 'pending' AND ip.requires_transfer = true AND ip.warehouse_id != ip.destination_warehouse_id\n        GROUP BY ipi.sku_id, ip.warehouse_id\n    ) transit_out ON s.id = transit_out.sku_id AND w.id = transit_out.warehouse_id\n",
+      "name": "stock_summary_view",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/core/drizzle/meta/_journal.json
+++ b/apps/core/drizzle/meta/_journal.json
@@ -456,6 +456,13 @@
       "when": 1786336249171,
       "tag": "20260810043049_add-site-popups",
       "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "7",
+      "when": 1786484870311,
+      "tag": "20260811214750_drop-transit-out-from-available-qty",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/core/src/modules/inventory/core/services/ledger-reconciliation.integration.spec.ts
+++ b/apps/core/src/modules/inventory/core/services/ledger-reconciliation.integration.spec.ts
@@ -11,6 +11,8 @@ import { InventoryCommandService } from './inventory-command.service';
 import { LocationService } from './location.service';
 import { ProductSellableQuantityService } from '../../product-sellable-quantity/services/product-sellable-quantity.service';
 import { LedgerReconciliationService } from './ledger-reconciliation.service';
+import { seedPickableShipment } from '../../../fulfillment/services/__support__/logistics-fixtures';
+import { readWarehouseAvailability } from '../../shared/availability/warehouse-availability';
 
 const DATABASE_URL = process.env.DATABASE_URL;
 const describeIfDb = DATABASE_URL ? describe : describe.skip;
@@ -170,19 +172,58 @@ describeIfDb('ledger reconciliation (DB integration, rollback-only)', () => {
 
   it('reconcileReservations 는 예약>ON_HAND grain 을 잡는다', async () => {
     await inRollbackTx(async (tx) => {
-      // fixture: ON_HAND 4, confirmed 예약 10 → shortfall 6
-      const s = await seed(tx, 4);
-      await tx.insert(wmsTables.stockReservations).values({
-        targetType: 'FULFILLMENT_ORDER',
-        targetId: randomUUID(),
-        skuId: s.sku.id,
-        warehouseId: s.wh.id,
-        quantity: 10,
-        status: 'confirmed',
-      });
-      const report = await recon.reconcileReservations({ skuId: s.sku.id, warehouseId: s.wh.id }, tx);
+      // 픽스처: ON_HAND 4 + confirmed 예약 4 → 예약을 10 으로 올려 shortfall 6 을 만든다.
+      // 예약을 손으로 INSERT 하지 않는 이유: shipment_line_id 가 NOT NULL + FK → shipment_lines
+      // 라(Task 25 계약) 유효한 예약 하나에 FO → FOI → shipment → shipment_line 체인이 필요하다.
+      const fx = await seedPickableShipment(tx, 4);
+      await tx
+        .update(wmsTables.stockReservations)
+        .set({ quantity: 10 })
+        .where(eq(wmsTables.stockReservations.shipmentLineId, fx.shipmentLineId));
+
+      const report = await recon.reconcileReservations({ skuId: fx.skuId, warehouseId: fx.warehouseId }, tx);
       expect(report.totalDriftGrains).toBe(1);
       expect(report.drifts[0].shortfall).toBe(6);
+    });
+  });
+
+  // ── availability 모듈과의 등가 고정 ──────────────────────────────
+  // reconcileReservations 의 CTE 는 전 카탈로그 집합 스캔이라 (sku,warehouse) 스칼라 판독인
+  // availability 모듈로 대체할 수 없다. 중복 자체는 남기고, 두 산식이 조용히 갈라지는 것만 막는다.
+
+  it('모듈이 음수 가용을 보는 grain 을 대사도 같은 수치로 잡는다', async () => {
+    await inRollbackTx(async (tx) => {
+      const fx = await seedPickableShipment(tx, 2);
+      await tx
+        .update(wmsTables.stockReservations)
+        .set({ quantity: 5 })
+        .where(eq(wmsTables.stockReservations.shipmentLineId, fx.shipmentLineId));
+
+      const fromModule = await readWarehouseAvailability(tx, fx.skuId, fx.warehouseId);
+      expect(fromModule.available).toBe(-3);
+
+      const report = await recon.reconcileReservations({ skuId: fx.skuId, warehouseId: fx.warehouseId }, tx);
+      expect(report.totalDriftGrains).toBe(1);
+      expect(report.drifts[0]).toMatchObject({
+        skuId: fx.skuId,
+        warehouseId: fx.warehouseId,
+        onHandQty: fromModule.onHand,
+        reservedQty: fromModule.reserved,
+        shortfall: -fromModule.available,
+      });
+    });
+  });
+
+  it('모듈 가용이 정확히 0 이면 대사는 아무것도 잡지 않는다', async () => {
+    await inRollbackTx(async (tx) => {
+      // 픽스처 기본값이 ON_HAND = 예약 = 5 → 가용 0 (경계값)
+      const fx = await seedPickableShipment(tx, 5);
+
+      const fromModule = await readWarehouseAvailability(tx, fx.skuId, fx.warehouseId);
+      expect(fromModule.available).toBe(0);
+
+      const report = await recon.reconcileReservations({ skuId: fx.skuId, warehouseId: fx.warehouseId }, tx);
+      expect(report.totalDriftGrains).toBe(0);
     });
   });
 });

--- a/apps/core/src/modules/inventory/core/services/ledger-reconciliation.service.ts
+++ b/apps/core/src/modules/inventory/core/services/ledger-reconciliation.service.ts
@@ -148,7 +148,10 @@ export class LedgerReconciliationService {
 
   /**
    * (sku,warehouse) 예약 불변식 대사 — ON_HAND 원장 합 < confirmed 예약 합 grain 만 반환.
-   * raw 합 직접 집계(뷰 availableQty 의 transit_out 반영 금지 → 거짓 경보 방지).
+   *
+   * 전 카탈로그 집합 스캔이라 (sku,warehouse) 스칼라 판독인 availability 모듈로 대체하지 않는다.
+   * 두 산식이 같은 결론을 내는지는 ledger-reconciliation.integration.spec.ts 의
+   * "모듈이 음수 가용을 보는 grain 을 대사도 같은 수치로 잡는다" 가 고정한다.
    */
   async reconcileReservations(
     filter?: { warehouseId?: string; skuId?: string },

--- a/apps/core/src/modules/inventory/schema/inventory.schema.ts
+++ b/apps/core/src/modules/inventory/schema/inventory.schema.ts
@@ -979,7 +979,11 @@ export const stockSummary = pgView('stock_summary_view', {
 
         -- 예약 상태
         COALESCE(reserved.qty, 0) as reserved_qty,
-        COALESCE(on_hand.qty, 0) - COALESCE(reserved.qty, 0) - COALESCE(transit_out.qty, 0) as available_qty,
+        -- 가용재고 = ON_HAND 합 − confirmed 예약 합 (ADR-0001).
+        -- transit_out 을 다시 빼지 말 것: 출발 창고에서만 빠지고 도착 창고에 더해지지 않아
+        -- 사내 이동만으로 전사 판매가능수량이 줄고, inbound_plan_items 기반이라 실제 이동
+        -- (stock_journals)이 끝나도 줄지 않는다. 등가성은 view-parity.integration.spec.ts 가 고정한다.
+        COALESCE(on_hand.qty, 0) - COALESCE(reserved.qty, 0) as available_qty,
 
         -- 예정 상태
         COALESCE(inbound_pending.qty, 0) as inbound_pending_qty,

--- a/apps/core/src/modules/inventory/shared/availability/view-parity.integration.spec.ts
+++ b/apps/core/src/modules/inventory/shared/availability/view-parity.integration.spec.ts
@@ -1,0 +1,124 @@
+import * as postgres from 'postgres';
+import { drizzle, PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { sql } from 'drizzle-orm';
+import { randomUUID } from 'crypto';
+import { eq } from 'drizzle-orm';
+import { wmsSchema, wmsTables, DbTx } from '../../schema/inventory.schema';
+import { seedPickableShipment } from '../../../fulfillment/services/__support__/logistics-fixtures';
+import { readWarehouseAvailability } from './warehouse-availability';
+
+/**
+ * stock_summary_view.available_qty 가 가용재고 정본 정의와 일치하는지 고정한다.
+ *
+ * 이 스펙이 존재하는 이유: 뷰는 오래 `on_hand − reserved − transit_out` 이었고,
+ * transit_out 은 (a) 출발 창고에서만 빼고 도착 창고에 더하지 않아 사내 이동만으로
+ * 전사 판매가능수량을 줄였으며 (b) inbound_plan_items 를 읽는데 실제 창고간이동은
+ * stock_journals 를 써서 이동이 끝나도 줄지 않았다. 그 항을 제거한 뒤,
+ * 아무도 다시 넣지 못하게 이 테스트가 막는다.
+ *
+ * 실행: COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- <이 파일의 패턴>
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+class Rollback extends Error {}
+
+describeIfDb('stock_summary_view ↔ availability 모듈 등가 (DB integration)', () => {
+  jest.setTimeout(120_000);
+  let client: postgres.Sql;
+  let db: PostgresJsDatabase<typeof wmsSchema>;
+
+  beforeAll(() => {
+    client = postgres(DATABASE_URL as string, { max: 1 });
+    db = drizzle(client, { schema: wmsSchema });
+  });
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  const inRollback = async (fn: (trx: DbTx) => Promise<void>) => {
+    await db
+      .transaction(async (t) => {
+        await fn(t as unknown as DbTx);
+        throw new Rollback();
+      })
+      .catch((e) => {
+        if (!(e instanceof Rollback)) throw e;
+      });
+  };
+
+  const readView = async (trx: DbTx, skuId: string, warehouseId: string): Promise<number> => {
+    const rows = (await trx.execute(sql`
+      SELECT available_qty FROM stock_summary_view
+       WHERE sku_id = ${skuId} AND warehouse_id = ${warehouseId}
+    `)) as unknown as { available_qty: number | string }[];
+    return Number(rows[0]?.available_qty ?? 0);
+  };
+
+  it('이전 예정(pending 창고간 inbound plan)이 있어도 뷰와 모듈이 일치한다', async () => {
+    await inRollback(async (trx) => {
+      // 기반: ON_HAND 10 + confirmed 예약 10 → 예약을 지워 ON_HAND 10 / 예약 0 으로 만든다.
+      const fx = await seedPickableShipment(trx, 10);
+      await trx
+        .delete(wmsTables.stockReservations)
+        .where(eq(wmsTables.stockReservations.shipmentLineId, fx.shipmentLineId));
+
+      // 도착 창고 + 발주(=inbound_plans.linkedPurchaseOrderId 가 NOT NULL FK 라 필요)
+      const [destWarehouse] = await trx
+        .insert(wmsTables.warehouses)
+        .values({ name: `it-dest-${randomUUID().slice(0, 8)}` })
+        .returning();
+      const [po] = await trx
+        .insert(wmsTables.purchaseOrders)
+        .values({
+          type: 'domestic',
+          sourceWarehouseId: fx.warehouseId,
+          destinationWarehouseId: destWarehouse.id,
+          requiresTransfer: true,
+        })
+        .returning();
+
+      // 출발 창고 → 도착 창고 이전 예정 4개. 이 행이 옛 transit_out 항을 만들던 데이터다.
+      const [plan] = await trx
+        .insert(wmsTables.inboundPlans)
+        .values({
+          warehouseId: fx.warehouseId,
+          destinationWarehouseId: destWarehouse.id,
+          linkedPurchaseOrderId: po.id,
+          requiresTransfer: true,
+          status: 'pending',
+        })
+        .returning();
+      await trx.insert(wmsTables.inboundPlanItems).values({
+        planId: plan.id,
+        skuId: fx.skuId,
+        expectedQty: 4,
+        receivedQty: 0,
+        status: 'pending',
+      });
+
+      const fromModule = await readWarehouseAvailability(trx, fx.skuId, fx.warehouseId);
+      const fromView = await readView(trx, fx.skuId, fx.warehouseId);
+
+      expect(fromModule.available).toBe(10);
+      expect(fromView).toBe(10); // 이전 예정은 가용에서 빼지 않는다
+    });
+  });
+
+  it('예약이 있으면 뷰와 모듈이 같은 값을 낸다', async () => {
+    await inRollback(async (trx) => {
+      // 기반: ON_HAND 10 + confirmed 예약 10 → 예약을 3 으로 낮춘다.
+      const fx = await seedPickableShipment(trx, 10);
+      await trx
+        .update(wmsTables.stockReservations)
+        .set({ quantity: 3 })
+        .where(eq(wmsTables.stockReservations.shipmentLineId, fx.shipmentLineId));
+
+      const fromModule = await readWarehouseAvailability(trx, fx.skuId, fx.warehouseId);
+      const fromView = await readView(trx, fx.skuId, fx.warehouseId);
+
+      expect(fromView).toBe(fromModule.available);
+      expect(fromView).toBe(7);
+    });
+  });
+});

--- a/apps/core/src/modules/inventory/shared/availability/warehouse-availability.integration.spec.ts
+++ b/apps/core/src/modules/inventory/shared/availability/warehouse-availability.integration.spec.ts
@@ -1,0 +1,111 @@
+import * as postgres from 'postgres';
+import { drizzle, PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { randomUUID } from 'crypto';
+import { eq } from 'drizzle-orm';
+import { wmsSchema, wmsTables, DbTx } from '../../schema/inventory.schema';
+import { seedPickableShipment } from '../../../fulfillment/services/__support__/logistics-fixtures';
+import { readWarehouseAvailability } from './warehouse-availability';
+
+/**
+ * 가용재고 정본 판독의 실 DB 검증. rollback 전용 트랜잭션.
+ *
+ * 실행: COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- warehouse-availability.integration
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+class Rollback extends Error {}
+
+describeIfDb('readWarehouseAvailability (DB integration, rollback-only)', () => {
+  jest.setTimeout(120_000);
+  let client: postgres.Sql;
+  let db: PostgresJsDatabase<typeof wmsSchema>;
+
+  beforeAll(() => {
+    client = postgres(DATABASE_URL as string, { max: 1 });
+    db = drizzle(client, { schema: wmsSchema });
+  });
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  const inRollback = async (fn: (trx: DbTx) => Promise<void>) => {
+    await db
+      .transaction(async (t) => {
+        await fn(t as unknown as DbTx);
+        throw new Rollback();
+      })
+      .catch((e) => {
+        if (!(e instanceof Rollback)) throw e;
+      });
+  };
+
+  /**
+   * ON_HAND 원장 + confirmed 예약을 심고 grain 을 돌려준다.
+   *
+   * 예약을 손으로 INSERT 하지 않는 이유: `stock_reservations.shipment_line_id` 가
+   * NOT NULL + FK → `shipment_lines` 라(Task 25 계약) 유효한 예약 하나에
+   * fulfillment_orders → items → shipments → shipment_lines 4단 체인이 필요하다.
+   * `seedPickableShipment` 이 그 체인 + ON_HAND 원장 + confirmed 예약을 한 번에 만든다.
+   */
+  const seed = async (
+    trx: DbTx,
+    opts: { onHand: number; reserved: number },
+  ): Promise<{ skuId: string; warehouseId: string; locationId: string }> => {
+    const fx = await seedPickableShipment(trx, opts.onHand);
+    // 픽스처는 예약 = ON_HAND 로 심는다. 원하는 예약 수량으로 낮추거나(0 이면 삭제) 맞춘다.
+    if (opts.reserved === 0) {
+      await trx
+        .delete(wmsTables.stockReservations)
+        .where(eq(wmsTables.stockReservations.shipmentLineId, fx.shipmentLineId));
+    } else if (opts.reserved !== opts.onHand) {
+      await trx
+        .update(wmsTables.stockReservations)
+        .set({ quantity: opts.reserved })
+        .where(eq(wmsTables.stockReservations.shipmentLineId, fx.shipmentLineId));
+    }
+    return { skuId: fx.skuId, warehouseId: fx.warehouseId, locationId: fx.locationId };
+  };
+
+  it('ON_HAND 합 − confirmed 예약 합을 반환한다', async () => {
+    await inRollback(async (trx) => {
+      const { skuId, warehouseId } = await seed(trx, { onHand: 10, reserved: 4 });
+      const result = await readWarehouseAvailability(trx, skuId, warehouseId);
+      expect(result).toEqual({ onHand: 10, reserved: 4, available: 6 });
+    });
+  });
+
+  it('원장도 예약도 없으면 0 을 반환한다 (null 이 아니라)', async () => {
+    await inRollback(async (trx) => {
+      const result = await readWarehouseAvailability(trx, randomUUID(), randomUUID());
+      expect(result).toEqual({ onHand: 0, reserved: 0, available: 0 });
+    });
+  });
+
+  it('released 예약은 차감하지 않는다', async () => {
+    await inRollback(async (trx) => {
+      const { skuId, warehouseId } = await seed(trx, { onHand: 10, reserved: 4 });
+      await trx
+        .update(wmsTables.stockReservations)
+        .set({ status: 'released' })
+        .where(eq(wmsTables.stockReservations.skuId, skuId));
+      const result = await readWarehouseAvailability(trx, skuId, warehouseId);
+      expect(result.available).toBe(10);
+    });
+  });
+
+  it('ON_HAND 가 아닌 원장 상태는 합산하지 않는다', async () => {
+    await inRollback(async (trx) => {
+      const { skuId, warehouseId, locationId } = await seed(trx, { onHand: 10, reserved: 0 });
+      await trx.insert(wmsTables.stockLedgers).values({
+        skuId,
+        warehouseId,
+        locationId,
+        stockState: 'DEFECTIVE',
+        qty: 99,
+      });
+      const result = await readWarehouseAvailability(trx, skuId, warehouseId);
+      expect(result.onHand).toBe(10);
+    });
+  });
+});

--- a/apps/core/src/modules/inventory/shared/availability/warehouse-availability.spec.ts
+++ b/apps/core/src/modules/inventory/shared/availability/warehouse-availability.spec.ts
@@ -1,0 +1,33 @@
+import { computeAvailable, violatesAvailability } from './warehouse-availability';
+
+describe('computeAvailable — 가용재고 정본 정의', () => {
+  it('가용 = ON_HAND 합 − confirmed 예약 합', () => {
+    expect(computeAvailable(10, 4)).toBe(6);
+  });
+
+  it('예약이 ON_HAND 를 넘으면 음수를 그대로 반환한다 (clamp 는 호출자 책임)', () => {
+    expect(computeAvailable(3, 5)).toBe(-2);
+  });
+
+  it('예약이 0 이면 ON_HAND 그대로', () => {
+    expect(computeAvailable(7, 0)).toBe(7);
+  });
+});
+
+describe('violatesAvailability — 차감 가능 여부', () => {
+  it('차감 후 가용이 음수가 되면 위반', () => {
+    expect(violatesAvailability(10, 6, 5)).toBe(true); // (10-5) - 6 = -1
+  });
+
+  it('차감 후 가용이 정확히 0 이면 통과', () => {
+    expect(violatesAvailability(10, 6, 4)).toBe(false); // (10-4) - 6 = 0
+  });
+
+  it('예약 0 이면 ON_HAND 전량 차감이 통과', () => {
+    expect(violatesAvailability(10, 0, 10)).toBe(false);
+  });
+
+  it('차감 0 은 예약이 이미 초과 상태여도 통과한다 (새 위반을 만들지 않으므로)', () => {
+    expect(violatesAvailability(3, 5, 0)).toBe(true);
+  });
+});

--- a/apps/core/src/modules/inventory/shared/availability/warehouse-availability.ts
+++ b/apps/core/src/modules/inventory/shared/availability/warehouse-availability.ts
@@ -1,0 +1,59 @@
+import { sql } from 'drizzle-orm';
+import { DbTx } from '../../schema/inventory.schema';
+
+/**
+ * 창고 grain 가용재고의 유일한 정의.
+ *
+ * 정본 규칙 (CLAUDE.md · ADR-0001): 가용재고 = ON_HAND 원장 합 − confirmed 예약 합.
+ * 다른 항(이동예정·입고예정 등)을 여기에 더하거나 빼지 않는다. 다른 관점이 필요하면
+ * 조용한 변형이 아니라 이름 붙은 별도 판독으로 만든다.
+ *
+ * Nest 프로바이더가 아니라 순수 함수 leaf 다 — core↔store DI 순환을 피하려고
+ * `shared/locks/reservation-invariant.ts` 가 이미 택한 형태를 따른다.
+ */
+export interface WarehouseAvailability {
+  onHand: number;
+  reserved: number;
+  available: number;
+}
+
+/** 정본 산식. 음수를 clamp 하지 않는다 — 표시용 clamp 는 호출자 책임이다. */
+export function computeAvailable(onHand: number, reserved: number): number {
+  return onHand - reserved;
+}
+
+/** `removingQty` 만큼 ON_HAND 를 빼면 가용이 음수가 되는가. */
+export function violatesAvailability(onHand: number, reserved: number, removingQty: number): boolean {
+  return computeAvailable(onHand - removingQty, reserved) < 0;
+}
+
+interface AvailabilityRow {
+  on_hand: number | string;
+  reserved: number | string;
+}
+
+/**
+ * 창고 grain ON_HAND 원장 합·confirmed 예약 합을 **단일 statement** 로 읽는다.
+ *
+ * 두 값을 각각 읽으면 READ COMMITTED 에서 그 사이에 SHIP 소진이 커밋될 수 있어
+ * torn read(초과예약)가 난다. 한 statement 안의 두 스칼라 서브쿼리는 같은 스냅샷을 본다.
+ */
+export async function readWarehouseAvailability(
+  trx: DbTx,
+  skuId: string,
+  warehouseId: string,
+): Promise<WarehouseAvailability> {
+  // execute() 원시 결과 타이핑 — reservation-invariant.ts / ledger-reconciliation.service.ts 와
+  // 동일한 문서화된 캐스트.
+  const rows = (await trx.execute(sql`
+    SELECT
+      COALESCE((SELECT SUM(qty) FROM stock_ledgers
+                 WHERE sku_id = ${skuId} AND warehouse_id = ${warehouseId} AND stock_state = 'ON_HAND'), 0) AS on_hand,
+      COALESCE((SELECT SUM(quantity) FROM stock_reservations
+                 WHERE sku_id = ${skuId} AND warehouse_id = ${warehouseId} AND status = 'confirmed'), 0) AS reserved
+  `)) as unknown as AvailabilityRow[];
+
+  const onHand = Number(rows[0]?.on_hand ?? 0);
+  const reserved = Number(rows[0]?.reserved ?? 0);
+  return { onHand, reserved, available: computeAvailable(onHand, reserved) };
+}

--- a/apps/core/src/modules/inventory/shared/locks/reservation-invariant.spec.ts
+++ b/apps/core/src/modules/inventory/shared/locks/reservation-invariant.spec.ts
@@ -1,5 +1,7 @@
 import { violatesReservationInvariant } from './reservation-invariant';
 
+// 이 술어는 이제 availability 모듈의 violatesAvailability 를 그대로 노출한다.
+// 아래 케이스는 위임 전 동작을 그대로 기술한 것 — 위임이 동작을 바꾸지 않음을 고정한다.
 describe('violatesReservationInvariant', () => {
   it('차감 후 ON_HAND 가 예약보다 적으면 위반', () => {
     expect(violatesReservationInvariant(10, 6, 5)).toBe(true); // 10-5=5 < 6
@@ -9,5 +11,8 @@ describe('violatesReservationInvariant', () => {
   });
   it('예약 0 이면 항상 통과', () => {
     expect(violatesReservationInvariant(10, 0, 10)).toBe(false);
+  });
+  it('차감 0 이어도 이미 초과 상태면 위반으로 본다', () => {
+    expect(violatesReservationInvariant(3, 5, 0)).toBe(true);
   });
 });

--- a/apps/core/src/modules/inventory/shared/locks/reservation-invariant.ts
+++ b/apps/core/src/modules/inventory/shared/locks/reservation-invariant.ts
@@ -1,29 +1,28 @@
 import { ConflictException } from '@nestjs/common';
-import { sql } from 'drizzle-orm';
 import { DbTx } from '../../schema/inventory.schema';
+import { readWarehouseAvailability, violatesAvailability } from '../availability/warehouse-availability';
 
 /**
- * 창고 grain ON_HAND 원장 합·confirmed 예약 합 (단일 statement 원자 읽기 — torn read 방지, 작업 10 I-1).
- * store·command·stocktaking 공용 leaf — core↔store 순환을 피하려고 InventoryCommandService 에서 추출.
+ * 예약 불변식 — 가용재고 정의는 availability 모듈이 소유한다. 여기는 그 정의를
+ * "ON_HAND 를 뺄 수 있는가"라는 질문으로 감싸는 얇은 층이다.
+ *
+ * export 이름은 호출처 5곳(stock-event.store · inventory-command · stocktaking)을
+ * 건드리지 않으려고 유지한다.
  */
+
+/** 창고 grain ON_HAND 원장 합·confirmed 예약 합 (단일 statement 원자 읽기 — torn read 방지). */
 export async function readWarehouseReservationBalance(
   trx: DbTx,
   skuId: string,
   warehouseId: string,
 ): Promise<{ onHand: number; reserved: number }> {
-  const rows = (await trx.execute(sql`
-    SELECT
-      COALESCE((SELECT SUM(qty) FROM stock_ledgers
-                 WHERE sku_id = ${skuId} AND warehouse_id = ${warehouseId} AND stock_state = 'ON_HAND'), 0) AS on_hand,
-      COALESCE((SELECT SUM(quantity) FROM stock_reservations
-                 WHERE sku_id = ${skuId} AND warehouse_id = ${warehouseId} AND status = 'confirmed'), 0) AS reserved
-  `)) as unknown as { on_hand: number | string; reserved: number | string }[];
-  return { onHand: Number(rows[0]?.on_hand ?? 0), reserved: Number(rows[0]?.reserved ?? 0) };
+  const { onHand, reserved } = await readWarehouseAvailability(trx, skuId, warehouseId);
+  return { onHand, reserved };
 }
 
 /** 차감/이동 후 창고 ON_HAND 합이 confirmed 예약 합보다 적어지면 true. */
 export function violatesReservationInvariant(onHandSum: number, reservedSum: number, removingQty: number): boolean {
-  return onHandSum - removingQty < reservedSum;
+  return violatesAvailability(onHandSum, reservedSum, removingQty);
 }
 
 /** 락 획득 후 호출. 창고 합산 예약 불변식 위반 시 409(ConflictException). */

--- a/apps/core/src/modules/inventory/shared/services/barcode.service.ts
+++ b/apps/core/src/modules/inventory/shared/services/barcode.service.ts
@@ -10,13 +10,6 @@ export interface BarcodeParseResult {
   data?: any;
 }
 
-export interface SkuScanResult {
-  skuId: string;
-  skuName: string;
-  availableQty: number;
-  locationCode?: string;
-}
-
 @Injectable()
 export class BarcodeService {
   private readonly logger = new Logger(BarcodeService.name);
@@ -71,53 +64,6 @@ export class BarcodeService {
       type: 'unknown',
       id: trimmed,
     };
-  }
-
-  async scanSku(barcode: string, warehouseId: string, tx?: DbTx): Promise<SkuScanResult> {
-    return this.dbService.run(async (trx) => {
-      const parsed = this.parseBarcode(barcode);
-
-      let skuId: string;
-      if (parsed.type === 'sku') {
-        skuId = parsed.id;
-      } else if (parsed.type === 'unknown') {
-        // UUID인 경우 SKU ID로 간주
-        skuId = parsed.id;
-      } else {
-        throw new BadRequestException(`Invalid SKU barcode: ${barcode}`);
-      }
-
-      const sku = await trx.query.skus.findFirst({
-        where: eq(wmsTables.skus.id, skuId),
-      });
-
-      if (!sku) {
-        throw new BadRequestException(`SKU not found: ${skuId}`);
-      }
-
-      // stocks 테이블 대신 stockLedgers에서 ON_HAND 상태 재고 조회
-      const stockLedgers = await trx.query.stockLedgers.findMany({
-        where: and(
-          eq(wmsTables.stockLedgers.skuId, skuId),
-          eq(wmsTables.stockLedgers.warehouseId, warehouseId),
-          eq(wmsTables.stockLedgers.stockState, 'ON_HAND'),
-        ),
-      });
-
-      const availableQty = stockLedgers.reduce((sum, ledger) => sum + ledger.qty, 0);
-
-      // TODO: Get location from location service
-      const locationCode = undefined;
-
-      this.logger.log(`SKU scanned: ${sku.name} (${availableQty} available)`);
-
-      return {
-        skuId: sku.id,
-        skuName: sku.name,
-        availableQty,
-        locationCode,
-      };
-    }, tx);
   }
 
   generateSkuBarcode(skuId: string): string {

--- a/apps/core/src/modules/inventory/shared/services/barcode.service.ts
+++ b/apps/core/src/modules/inventory/shared/services/barcode.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, Logger, BadRequestException } from '@nestjs/common';
 import { InjectTypedDb, DbService } from '@app/db';
-import { wmsTables, wmsSchema, DbTx } from '../../schema/inventory.schema';
-import { and, eq } from 'drizzle-orm';
+import { wmsSchema, DbTx } from '../../schema/inventory.schema';
 import * as bwipjs from 'bwip-js';
 
 export interface BarcodeParseResult {

--- a/apps/core/src/modules/inventory/shared/services/unified-reservation.service.ts
+++ b/apps/core/src/modules/inventory/shared/services/unified-reservation.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, BadRequestException, ConflictException, Logger } from '@nestjs/common';
 import { DbService } from '@app/db';
 import { wmsTables, wmsSchema, DbTx } from '../../schema/inventory.schema';
-import { eq, and, sum, sql } from 'drizzle-orm';
+import { eq, and, sum } from 'drizzle-orm';
 import { ProductSellableQuantityService } from '../../product-sellable-quantity/services/product-sellable-quantity.service';
 import { acquireStockAvailabilityLock } from '../locks/stock-availability-lock';
+import { readWarehouseAvailability } from '../availability/warehouse-availability';
 
 export interface ReserveStockDto {
   // Task 25 contract: V2 예약은 shipment-line 단위만 (FO-target 생성 경로는 은퇴). shipmentLineId 필수.
@@ -249,16 +250,9 @@ export class UnifiedReservationService {
   private async getAvailableStock(skuId: string, warehouseId: string, tx?: DbTx): Promise<number> {
     const db = tx ?? this.db.db;
 
-    // 단일 스냅샷: on_hand 와 reserved 를 한 statement 로 계산 → READ COMMITTED 에서 SHIP 소진 등
-    // 비-락 경로가 두 읽기 사이 커밋될 때의 torn read(초과예약) 차단.
-    const rows = (await db.execute(sql`
-      SELECT
-        COALESCE((SELECT SUM(qty) FROM stock_ledgers
-                   WHERE sku_id = ${skuId} AND warehouse_id = ${warehouseId} AND stock_state = 'ON_HAND'), 0)
-        - COALESCE((SELECT SUM(quantity) FROM stock_reservations
-                     WHERE sku_id = ${skuId} AND warehouse_id = ${warehouseId} AND status = 'confirmed'), 0)
-          AS available
-    `)) as unknown as { available: number | string }[];
-    return Number(rows[0]?.available ?? 0);
+    // 기존 시그니처 유지를 위한 좁히기 — 이 메서드의 tx 전파 형태 변경은 별건(ADR-0025).
+    // 산식·단일 statement 원자성은 availability 모듈이 소유한다.
+    const { available } = await readWarehouseAvailability(db as DbTx, skuId, warehouseId);
+    return available;
   }
 }

--- a/apps/core/src/modules/inventory/shared/shared.module.ts
+++ b/apps/core/src/modules/inventory/shared/shared.module.ts
@@ -5,7 +5,6 @@ import { TransactionService } from './services/transaction.service';
 import { AuditService } from './services/audit.service';
 import { MetricsService } from './services/metrics.service';
 import { HealthService } from './services/health.service';
-// import { StockAvailabilityService } from './services/stock-availability.service';
 import { UnifiedReservationService } from './services/unified-reservation.service';
 import { ReservationLifecycleService } from './services/reservation-lifecycle.service';
 import { MetricsController } from './controllers/metrics.controller';
@@ -23,7 +22,6 @@ import { ProductSellableQuantityModule } from '../product-sellable-quantity/prod
     AuditService,
     MetricsService,
     HealthService,
-    // StockAvailabilityService,
     UnifiedReservationService,
     ReservationLifecycleService,
   ],
@@ -34,7 +32,6 @@ import { ProductSellableQuantityModule } from '../product-sellable-quantity/prod
     AuditService,
     MetricsService,
     HealthService,
-    // StockAvailabilityService,
     UnifiedReservationService,
     ReservationLifecycleService,
   ],

--- a/docs/superpowers/plans/2026-08-12-inventory-availability-module.md
+++ b/docs/superpowers/plans/2026-08-12-inventory-availability-module.md
@@ -895,112 +895,91 @@ transfer_pending_qty 표시 컬럼은 유지(ADR-0005 §5 destructive 회피)."
 
 ---
 
-## Task 6: 야간 대사 CTE 를 등가 테스트로 고정
+## Task 6: 야간 대사를 등가 테스트로 고정하고, 같은 파일의 깨진 테스트를 고친다
 
-`ledger-reconciliation.reconcileReservations` 의 CTE 는 전 카탈로그 집합 스캔이라 (sku, warehouse) 단위 스칼라 함수로 대체할 수 없다. 중복은 남기되, **조용히 갈라지는 것은 막는다.**
+`ledger-reconciliation.reconcileReservations` 의 CTE 는 전 카탈로그 집합 스캔이라 (sku, warehouse) 단위 스칼라 함수로 대체할 수 없다. 중복은 남기되 **조용히 갈라지는 것은 막는다.**
+
+**별도 스펙 파일을 만들지 않는다.** `ledger-reconciliation.integration.spec.ts` 에 이미 하니스(rollback tx · `seed()` · `recon` 인스턴스)가 있고, 그 파일에 **사전 존재 실패 1건**도 있다. 한 파일에서 둘 다 처리하는 것이 하니스 중복을 만들지 않는 길이다.
 
 **Files:**
-- Modify: `apps/core/src/modules/inventory/core/services/ledger-reconciliation.service.ts:150-151` (주석)
-- Create: `apps/core/src/modules/inventory/shared/availability/reconciliation-parity.integration.spec.ts`
+- Modify: `apps/core/src/modules/inventory/core/services/ledger-reconciliation.integration.spec.ts`
+- Modify: `apps/core/src/modules/inventory/core/services/ledger-reconciliation.service.ts:149-152` (낡은 주석)
 
 **Interfaces:**
-- Consumes: `readWarehouseAvailability` (Task 1), `LedgerReconciliationService.reconcileReservations`
+- Consumes: `readWarehouseAvailability` (Task 1), 기존 스펙의 `seed()` · `inRollbackTx()` · `recon`
 - Produces: 없음
 
-- [ ] **Step 1: 등가 테스트를 쓴다**
+### 배경 — 이 파일의 사전 존재 실패
 
-Create `apps/core/src/modules/inventory/shared/availability/reconciliation-parity.integration.spec.ts`:
+`reconcileReservations 는 예약>ON_HAND grain 을 잡는다` 케이스가 **develop 시점부터 실패한다**(7건 중 1건). 원인은 `stock_reservations` 를 손으로 INSERT 하면서 `shipment_line_id` 를 빠뜨린 것 — 그 컬럼은 **NOT NULL + FK → `shipment_lines`** 다(`inventory.schema.ts:1445-1447`, Task 25 계약).
+
+이 계획이 만든 실패가 아니다. 다만 같은 파일에 등가 테스트를 추가하는 김에 같은 픽스처로 고친다.
+
+- [ ] **Step 1: 사전 존재 실패를 재현한다**
+
+```bash
+COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- ledger-reconciliation.integration
+```
+
+Expected: **7건 중 1건 실패.** 실패 메시지에 `insert into "stock_reservations"` 와 `shipment_line_id` 가 보여야 한다. 그 출력을 보고서에 남긴다.
+
+다른 양상으로 실패하면 전제가 바뀐 것이므로 멈추고 보고한다.
+
+- [ ] **Step 2: 깨진 테스트를 픽스처로 고친다**
+
+`ledger-reconciliation.integration.spec.ts` 의 `reconcileReservations 는 예약>ON_HAND grain 을 잡는다` 케이스를 다음으로 교체한다. 기존 `seed()` 는 원장만 만들므로, 예약은 `seedPickableShipment` 로 만든다:
 
 ```typescript
-import * as postgres from 'postgres';
-import { drizzle, PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import { sql } from 'drizzle-orm';
-import { randomUUID } from 'crypto';
-import { DbService } from '@app/db';
-import { wmsSchema, DbTx } from '../../schema/inventory.schema';
-import { readWarehouseAvailability } from './warehouse-availability';
-import { LedgerReconciliationService } from '../../core/services/ledger-reconciliation.service';
+  it('reconcileReservations 는 예약>ON_HAND grain 을 잡는다', async () => {
+    await inRollbackTx(async (tx) => {
+      // 픽스처: ON_HAND 4 + confirmed 예약 4 → 예약을 10 으로 올려 shortfall 6 을 만든다.
+      // 예약을 손으로 INSERT 하지 않는 이유: shipment_line_id 가 NOT NULL + FK → shipment_lines
+      // 라(Task 25 계약) 유효한 예약 하나에 FO → FOI → shipment → shipment_line 체인이 필요하다.
+      const fx = await seedPickableShipment(tx, 4);
+      await tx
+        .update(wmsTables.stockReservations)
+        .set({ quantity: 10 })
+        .where(eq(wmsTables.stockReservations.shipmentLineId, fx.shipmentLineId));
 
-/**
- * 야간 대사의 CTE 와 availability 모듈이 같은 결론을 내는지 고정한다.
- *
- * CTE 는 전 카탈로그 집합 스캔이라 (sku,warehouse) 스칼라 함수로 대체할 수 없다.
- * 따라서 중복 자체는 남기고, 두 산식이 갈라지는 것만 이 테스트가 막는다.
- *
- * 실행: COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- <이 파일의 패턴>
- */
-const DATABASE_URL = process.env.DATABASE_URL;
-const describeIfDb = DATABASE_URL ? describe : describe.skip;
-class Rollback extends Error {}
-
-describeIfDb('야간 대사 CTE ↔ availability 모듈 등가 (DB integration)', () => {
-  jest.setTimeout(120_000);
-  let client: postgres.Sql;
-  let db: PostgresJsDatabase<typeof wmsSchema>;
-
-  beforeAll(() => {
-    client = postgres(DATABASE_URL as string, { max: 1 });
-    db = drizzle(client, { schema: wmsSchema });
+      const report = await recon.reconcileReservations({ skuId: fx.skuId, warehouseId: fx.warehouseId }, tx);
+      expect(report.totalDriftGrains).toBe(1);
+      expect(report.drifts[0].shortfall).toBe(6);
+    });
   });
+```
 
-  afterAll(async () => {
-    await client.end();
-  });
+파일 상단 import 에 다음을 추가한다 (이미 있으면 중복 추가하지 않는다):
 
-  const inRollback = async (fn: (trx: DbTx) => Promise<void>) => {
-    await db
-      .transaction(async (t) => {
-        await fn(t as unknown as DbTx);
-        throw new Rollback();
-      })
-      .catch((e) => {
-        if (!(e instanceof Rollback)) throw e;
-      });
-  };
+```typescript
+import { eq } from 'drizzle-orm';
+import { seedPickableShipment } from '../../../fulfillment/services/__support__/logistics-fixtures';
+```
 
-  const buildService = (trx: DbTx): LedgerReconciliationService => {
-    // ADR-0025 단일 러너 최소 대역: spec 은 항상 rollback tx 를 전파한다.
-    const dbService = {
-      db,
-      run: <T>(fn: (t: DbTx) => Promise<T>, tx?: DbTx): Promise<T> => fn(tx ?? trx),
-    } as unknown as DbService<typeof wmsSchema>;
-    return new LedgerReconciliationService(dbService, { setReservationDrift: () => undefined } as never);
-  };
+- [ ] **Step 3: 등가 테스트 2건을 같은 파일에 추가한다**
 
-  const seedOverReserved = async (trx: DbTx): Promise<{ skuId: string; warehouseId: string }> => {
-    const skuId = randomUUID();
-    const warehouseId = randomUUID();
-    await trx.execute(sql`
-      INSERT INTO warehouses (id, name, code)
-      VALUES (${warehouseId}, ${'IT-WH'}, ${`IT-${warehouseId.slice(0, 8)}`})
-    `);
-    await trx.execute(sql`
-      INSERT INTO skus (id, name, code) VALUES (${skuId}, ${'IT-SKU'}, ${`IT-${skuId.slice(0, 8)}`})
-    `);
-    await trx.execute(sql`
-      INSERT INTO stock_ledgers (sku_id, warehouse_id, stock_state, qty)
-      VALUES (${skuId}, ${warehouseId}, 'ON_HAND', ${2})
-    `);
-    await trx.execute(sql`
-      INSERT INTO stock_reservations (sku_id, warehouse_id, quantity, status, target_type)
-      VALUES (${skuId}, ${warehouseId}, ${5}, 'confirmed', 'SHIPMENT_LINE')
-    `);
-    return { skuId, warehouseId };
-  };
+같은 `describe` 블록 안, Step 2 로 고친 케이스 바로 뒤에 넣는다:
 
-  it('모듈이 음수 가용을 보는 grain 을 대사도 drift 로 잡는다', async () => {
-    await inRollback(async (trx) => {
-      const { skuId, warehouseId } = await seedOverReserved(trx);
+```typescript
+  // ── availability 모듈과의 등가 고정 ──────────────────────────────
+  // reconcileReservations 의 CTE 는 전 카탈로그 집합 스캔이라 (sku,warehouse) 스칼라 판독인
+  // availability 모듈로 대체할 수 없다. 중복 자체는 남기고, 두 산식이 조용히 갈라지는 것만 막는다.
 
-      const fromModule = await readWarehouseAvailability(trx, skuId, warehouseId);
+  it('모듈이 음수 가용을 보는 grain 을 대사도 같은 수치로 잡는다', async () => {
+    await inRollbackTx(async (tx) => {
+      const fx = await seedPickableShipment(tx, 2);
+      await tx
+        .update(wmsTables.stockReservations)
+        .set({ quantity: 5 })
+        .where(eq(wmsTables.stockReservations.shipmentLineId, fx.shipmentLineId));
+
+      const fromModule = await readWarehouseAvailability(tx, fx.skuId, fx.warehouseId);
       expect(fromModule.available).toBe(-3);
 
-      const report = await buildService(trx).reconcileReservations({ skuId, warehouseId }, trx);
-
+      const report = await recon.reconcileReservations({ skuId: fx.skuId, warehouseId: fx.warehouseId }, tx);
       expect(report.totalDriftGrains).toBe(1);
       expect(report.drifts[0]).toMatchObject({
-        skuId,
-        warehouseId,
+        skuId: fx.skuId,
+        warehouseId: fx.warehouseId,
         onHandQty: fromModule.onHand,
         reservedQty: fromModule.reserved,
         shortfall: -fromModule.available,
@@ -1008,77 +987,79 @@ describeIfDb('야간 대사 CTE ↔ availability 모듈 등가 (DB integration)'
     });
   });
 
-  it('모듈 가용이 0 이상이면 대사는 아무것도 잡지 않는다', async () => {
-    await inRollback(async (trx) => {
-      const skuId = randomUUID();
-      const warehouseId = randomUUID();
-      await trx.execute(sql`
-        INSERT INTO warehouses (id, name, code)
-        VALUES (${warehouseId}, ${'IT-WH'}, ${`IT-${warehouseId.slice(0, 8)}`})
-      `);
-      await trx.execute(sql`
-        INSERT INTO skus (id, name, code) VALUES (${skuId}, ${'IT-SKU'}, ${`IT-${skuId.slice(0, 8)}`})
-      `);
-      await trx.execute(sql`
-        INSERT INTO stock_ledgers (sku_id, warehouse_id, stock_state, qty)
-        VALUES (${skuId}, ${warehouseId}, 'ON_HAND', ${5})
-      `);
-      await trx.execute(sql`
-        INSERT INTO stock_reservations (sku_id, warehouse_id, quantity, status, target_type)
-        VALUES (${skuId}, ${warehouseId}, ${5}, 'confirmed', 'SHIPMENT_LINE')
-      `);
+  it('모듈 가용이 정확히 0 이면 대사는 아무것도 잡지 않는다', async () => {
+    await inRollbackTx(async (tx) => {
+      // 픽스처 기본값이 ON_HAND = 예약 = 5 → 가용 0 (경계값)
+      const fx = await seedPickableShipment(tx, 5);
 
-      const fromModule = await readWarehouseAvailability(trx, skuId, warehouseId);
+      const fromModule = await readWarehouseAvailability(tx, fx.skuId, fx.warehouseId);
       expect(fromModule.available).toBe(0);
 
-      const report = await buildService(trx).reconcileReservations({ skuId, warehouseId }, trx);
+      const report = await recon.reconcileReservations({ skuId: fx.skuId, warehouseId: fx.warehouseId }, tx);
       expect(report.totalDriftGrains).toBe(0);
     });
   });
-});
 ```
 
-> `LedgerReconciliationService` 의 생성자 인자 개수·순서를 실제 파일에서 확인하고
-> `buildService` 를 맞춘다. 메트릭 대역의 메서드 이름도 실제 것으로 바꾼다
-> (`ledger-reconciliation.service.ts` 의 `this.metrics.` 호출을 보고 결정).
+파일 상단 import 에 추가한다:
 
-- [ ] **Step 2: 테스트를 돌린다**
+```typescript
+import { readWarehouseAvailability } from '../../shared/availability/warehouse-availability';
+```
+
+> **주의:** `recon` 인스턴스와 `inRollbackTx` 는 이 파일에 이미 있는 것을 쓴다. **새 하니스를 만들지 마라.**
+> 기존 메트릭 대역이 `setLedgerDrift` 만 가지고 있어 `scheduledReconcile` 경로에서는 부족할 수 있으나,
+> 이 테스트들은 `reconcileReservations` 를 직접 부르므로 메트릭을 건드리지 않는다.
+
+- [ ] **Step 4: 세 테스트가 전부 통과하는지 확인한다**
 
 ```bash
-COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- reconciliation-parity.integration
+COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- ledger-reconciliation.integration
 ```
 
-Expected: PASS (2 tests). 생성자 대역이 안 맞으면 Step 1 주의사항대로 고치고 다시 돌린다.
+Expected: **9건 전부 통과** (기존 6건 + 고친 1건 + 새 2건). 사전 존재 실패가 사라져야 한다.
 
-- [ ] **Step 3: 낡은 주석을 갱신한다**
+- [ ] **Step 5: 낡은 주석을 갱신한다**
 
-`ledger-reconciliation.service.ts:150-151` 의 주석을 바꾼다:
+`ledger-reconciliation.service.ts:149-152` 의 주석에서 `transit_out` 을 근거로 든 문장을 지운다 — Task 5 가 뷰에서 그 항을 제거해 근거가 사라졌다:
 
 ```typescript
   /**
    * (sku,warehouse) 예약 불변식 대사 — ON_HAND 원장 합 < confirmed 예약 합 grain 만 반환.
    *
-   * 전 카탈로그 집합 스캔이라 (sku,warehouse) 스칼라 판독인 availability 모듈로
-   * 대체하지 않는다. 두 산식이 같은 결론을 내는지는
-   * shared/availability/reconciliation-parity.integration.spec.ts 가 고정한다.
+   * 전 카탈로그 집합 스캔이라 (sku,warehouse) 스칼라 판독인 availability 모듈로 대체하지 않는다.
+   * 두 산식이 같은 결론을 내는지는 ledger-reconciliation.integration.spec.ts 의
+   * "모듈이 음수 가용을 보는 grain 을 대사도 같은 수치로 잡는다" 가 고정한다.
    */
 ```
 
-기존의 *"raw 합 직접 집계(뷰 availableQty 의 transit_out 반영 금지 → 거짓 경보 방지)"* 는 Task 5 로 근거가 사라졌으므로 지운다.
+기존의 *"raw 합 직접 집계(뷰 availableQty 의 transit_out 반영 금지 → 거짓 경보 방지)"* 문장을 제거한다.
 
-- [ ] **Step 4: 커밋**
+- [ ] **Step 6: 검증 3종**
 
 ```bash
 npx nest build core
-git add apps/core/src/modules/inventory/core/services/ledger-reconciliation.service.ts \
-        apps/core/src/modules/inventory/shared/availability/reconciliation-parity.integration.spec.ts
-git commit -m "test(inventory): 야간 대사 CTE 와 availability 모듈의 등가를 고정
+npm run type-check
+npx eslint apps/core/src/modules/inventory/core/services/ledger-reconciliation.integration.spec.ts apps/core/src/modules/inventory/core/services/ledger-reconciliation.service.ts
+```
+
+Expected: 빌드 성공 / `type-check` 162 이하 / eslint 새 에러 0 (사전 존재 에러가 있으면 건드리지 말고 개수만 보고).
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add apps/core/src/modules/inventory/core/services/ledger-reconciliation.integration.spec.ts \
+        apps/core/src/modules/inventory/core/services/ledger-reconciliation.service.ts
+git commit -m "test(inventory): 야간 대사와 availability 모듈의 등가를 고정하고 깨진 예약 테스트 수정
 
 집합 스캔이라 스칼라 모듈로 대체 불가 — 중복은 남기되 조용한 분기를 막는다.
+
+같은 파일의 사전 존재 실패도 함께 수정: 예약을 손으로 INSERT 하며 shipment_line_id
+(NOT NULL + FK, Task 25 계약)를 빠뜨려 develop 부터 RED 였다. seedPickableShipment 로 교체.
+
 transit_out 회피를 근거로 들던 낡은 주석 제거(Task 5 로 근거 소멸)."
 ```
 
----
 
 ## 마무리: 전체 검증
 

--- a/docs/superpowers/plans/2026-08-12-inventory-availability-module.md
+++ b/docs/superpowers/plans/2026-08-12-inventory-availability-module.md
@@ -61,7 +61,7 @@
 2. `transit_out` 은 `inbound_plan_items` 를 읽는데, 실제 창고간이동은 `stock_journals`(`sourceType: 'warehouse_transfer'`)를 쓴다. `transfer.service.ts` 에 `inboundPlan` 이라는 단어가 **0회** 등장한다 — 두 시스템은 연결돼 있지 않다. 따라서 이동이 실행돼도 `transit_out` 은 줄지 않고 **영구히** 차감된 채 남는다.
 3. `IN_TRANSFER` 원장 상태는 `transferShip`/`transferReceive` 가 **한 트랜잭션 안**에서 실행되므로 잔량이 남지 않는다(`stock-event.service.ts:117-156`, 통합 스펙 `transfer.service.integration.spec.ts:18` 이 "IN_TRANSFER 잔량 0"을 성공 기준으로 명시). 즉 원장에 "운송 중"이라는 기간이 없다.
 
-**오버셀 위험 없음 (중요) — 그러나 논증은 "표시만 바뀐다"가 아니다.** 예약 승인은 `unified-reservation.service.ts:81` → `getAvailableStock`(`:250`, Task 3 이후 `readWarehouseAvailability` 로 위임)이 판정하며 **애초에 `transit_out` 을 보지 않는다.** 여기서 안전하다고 결론 내는 근거는 "예약 승인이 뷰를 안 본다"가 아니라 **"뷰가 이제 예약 문턱과 같은 값이 됐다"** 는 것이다 — 뷰는 이전에는 문턱보다 낮았고(팔 수 있는 걸 못 팔던 상태), 이제 문턱과 일치한다. 문턱을 넘기는 방향의 변화가 아니므로 오버셀은 나지 않는다.
+**오버셀 위험 없음 (중요) — 그러나 논증은 "표시만 바뀐다"가 아니다.** 예약 승인은 `unified-reservation.service.ts:82` → `getAvailableStock`(`:250`, Task 3 이후 `readWarehouseAvailability` 로 위임)이 판정하며 **애초에 `transit_out` 을 보지 않는다.** 여기서 안전하다고 결론 내는 근거는 "예약 승인이 뷰를 안 본다"가 아니라 **"뷰가 이제 예약 문턱과 같은 값이 됐다"** 는 것이다 — 뷰는 이전에는 문턱보다 낮았고(팔 수 있는 걸 못 팔던 상태), 이제 문턱과 일치한다. 문턱을 넘기는 방향의 변화가 아니므로 오버셀은 나지 않는다.
 
 이 뷰 값을 소비하는 것은 storefront 표시만이 아니다. **`product-sellable-quantity` 투영이 `psq_` prefix inventory item 으로 Medusa 에 밀리고**(`apps/channel-adapter/src/adapters/medusa/medusa.client.ts`, `apps/medusa/src/utils/medusa-inventory-projection.ts`), Medusa 는 `manage_inventory=true` 로 그 수량을 실제 판매 가능 재고로 잡아 예약분을 차감한다(`product-sellable-quantity.calculator.ts:158` 주석: *"Medusa 가 manage_inventory=true 로 잡고 예약분을 차감해…"*). 즉 `transit_out` 제거는 storefront 에 **더 큰 숫자를 보여주는 것**이 아니라 **더 많이 팔 수 있게 만드는 것**이다 — 결론(오버셀 무위험)은 유효하지만 그 이유는 "뷰가 예약 문턱과 같아졌다"이지 "표시만 바뀐다"가 아니다.
 

--- a/docs/superpowers/plans/2026-08-12-inventory-availability-module.md
+++ b/docs/superpowers/plans/2026-08-12-inventory-availability-module.md
@@ -61,7 +61,11 @@
 2. `transit_out` 은 `inbound_plan_items` 를 읽는데, 실제 창고간이동은 `stock_journals`(`sourceType: 'warehouse_transfer'`)를 쓴다. `transfer.service.ts` 에 `inboundPlan` 이라는 단어가 **0회** 등장한다 — 두 시스템은 연결돼 있지 않다. 따라서 이동이 실행돼도 `transit_out` 은 줄지 않고 **영구히** 차감된 채 남는다.
 3. `IN_TRANSFER` 원장 상태는 `transferShip`/`transferReceive` 가 **한 트랜잭션 안**에서 실행되므로 잔량이 남지 않는다(`stock-event.service.ts:117-156`, 통합 스펙 `transfer.service.integration.spec.ts:18` 이 "IN_TRANSFER 잔량 0"을 성공 기준으로 명시). 즉 원장에 "운송 중"이라는 기간이 없다.
 
-**오버셀 위험 없음 (중요):** 예약 승인은 `unified-reservation.service.ts:81` → `getAvailableStock`(`:249`)이 판정하며 **애초에 `transit_out` 을 보지 않는다.** 뷰에서 `transit_out` 을 빼는 것은 예약 승인 문턱을 전혀 건드리지 않고, storefront 표시를 예약 seam 이 실제로 허용하는 값과 일치시킬 뿐이다.
+**오버셀 위험 없음 (중요) — 그러나 논증은 "표시만 바뀐다"가 아니다.** 예약 승인은 `unified-reservation.service.ts:81` → `getAvailableStock`(`:250`, Task 3 이후 `readWarehouseAvailability` 로 위임)이 판정하며 **애초에 `transit_out` 을 보지 않는다.** 여기서 안전하다고 결론 내는 근거는 "예약 승인이 뷰를 안 본다"가 아니라 **"뷰가 이제 예약 문턱과 같은 값이 됐다"** 는 것이다 — 뷰는 이전에는 문턱보다 낮았고(팔 수 있는 걸 못 팔던 상태), 이제 문턱과 일치한다. 문턱을 넘기는 방향의 변화가 아니므로 오버셀은 나지 않는다.
+
+이 뷰 값을 소비하는 것은 storefront 표시만이 아니다. **`product-sellable-quantity` 투영이 `psq_` prefix inventory item 으로 Medusa 에 밀리고**(`apps/channel-adapter/src/adapters/medusa/medusa.client.ts`, `apps/medusa/src/utils/medusa-inventory-projection.ts`), Medusa 는 `manage_inventory=true` 로 그 수량을 실제 판매 가능 재고로 잡아 예약분을 차감한다(`product-sellable-quantity.calculator.ts:158` 주석: *"Medusa 가 manage_inventory=true 로 잡고 예약분을 차감해…"*). 즉 `transit_out` 제거는 storefront 에 **더 큰 숫자를 보여주는 것**이 아니라 **더 많이 팔 수 있게 만드는 것**이다 — 결론(오버셀 무위험)은 유효하지만 그 이유는 "뷰가 예약 문턱과 같아졌다"이지 "표시만 바뀐다"가 아니다.
+
+그리고 그 차이가 운영 결과를 바꾼다: pending 창고간 이전 계획 수량이 이제 **판매 가능**해진다. 그 수량이 팔리면 이전(transfer) 실행이 `inventory-command.service.ts:325`(`transferShip`) 의 `assertReservationInvariant` 에서 **409 로 막힌다.** 조용한 오버셀이 아니라 **이전 작업 실패**로 표면화된다 — 이건 이 계획이 "범위 밖"으로 명시해 둔 창고간이동 custody 모델 부재의 증상이며, 그 판단 자체는 타당하지만 운영자가 예상하지 못하면 이 변경의 회귀로 오진할 수 있다.
 
 ### 선행 시도의 흔적
 
@@ -1105,6 +1109,14 @@ Expected: `warehouse-availability.ts` 와 `ledger-reconciliation.service.ts` 두
 
 **마이그레이션 1건** (Task 5). `apps/core/drizzle/<ts>_drop-transit-out-from-available-qty.sql`.
 
+**소비자 전수 (뷰 `available_qty` 를 읽는 곳):**
+
+- `product-sellable-quantity` 투영 — Medusa `psq_` prefix inventory item 을 통해 **실제 판매 가능 여부**를 게이트한다(표시가 아니라 판매 차단 지점, 위 배경 절 참조).
+- `fulfillment-order-reservation-retry.worker.ts:84` — 재시도 후보 선정(`available_qty > 0`).
+- `purchase-order.service.ts:822` — 발주 제안 부족분 계산.
+- `apps/core/src/modules/inventory/stock-projection/services/stock-projection.reader.ts` — admin 재고 화면. `:102` 품절 필터(`quantityState === 'out_of_stock'` → `availableQty <= 0`), `:134, :165, :206, :284, :291` 목록/SKU 합계/창고별 상세의 "가용 수량" 표시. 배포 후 **pending 창고간 이전이 있던 SKU 가 품절 필터에서 빠질 수 있다** — 결함이 아니라 의도된 값 변화다.
+- `apps/core/src/modules/fulfillment/services/__support__/logistics-assertions.ts:45` (`availableFromView`) — 테스트 하니스. 파일 자체 주석대로 "뷰 산술 회귀 + transit_out=0 전제"만 검증하는 보조 판독이며 진짜 drift 검출은 별도 담당.
+
 **순서: `migrate → deploy`.**
 
 - 뷰의 **컬럼 목록은 그대로**이므로 옛 task 가 새 뷰를 만나도 깨지지 않는다 (`available_qty` 값만 커진다). expand phase 규칙(CLAUDE.md: "expand 는 migrate → deploy")이 적용된다.
@@ -1118,12 +1130,32 @@ npm run db:migrate -- --stage live --deployment lcnine-services --yes
 
 그 다음 `sst deploy`.
 
+**`DROP VIEW` 잠금 완화 (운영 적용 시 선택할 수 있는 것 — 아래는 권고이지 이미 로컬에 적용된 마이그레이션 SQL 파일을 바꾸라는 뜻이 아니다):**
+
+- `stock_summary_view` 는 `skus CROSS JOIN warehouses` 다. `purchase-order.service.ts:822`(발주 제안 전수 스캔)와 `stock-projection.reader.ts`(목록 count)처럼 필터 없이 뷰를 훑는 질의가 진행 중일 때 `DROP VIEW` 는 ACCESS EXCLUSIVE 락을 기다리며 블록하고, 뒤이어 들어오는 모든 뷰 질의가 그 뒤에 줄을 선다.
+- **저트래픽 시간대에 적용**하기를 권한다.
+- 마이그레이션 문(`DROP VIEW` / `CREATE VIEW`) 앞에 `SET LOCAL lock_timeout = '5s';` 를 붙이는 선택지가 있다 — 5초 안에 락을 못 얻으면 그 문만 에러로 실패한다. 마이그레이션은 파일 단위 트랜잭션이라 **부분 적용이 없으므로** 실패하면 그냥 재실행하면 된다(뷰가 여전히 옛 정의로 남아 있을 뿐, 중간 상태로 깨지지 않는다).
+
+**배포 전 실측 (영향 SKU 수 상한을 미리 잰다):**
+
+```sql
+SELECT count(DISTINCT ipi.sku_id)
+  FROM inbound_plan_items ipi
+  JOIN inbound_plans ip ON ip.id = ipi.plan_id
+ WHERE ipi.status = 'pending'
+   AND ip.requires_transfer
+   AND ip.warehouse_id <> ip.destination_warehouse_id;
+```
+
+0 이면 이 변경의 라이브 영향은 사실상 없다는 뜻이고, 크면 아래 관측 항목 5번(이전 실행 409)을 실제로 기다려야 한다.
+
 **배포 후 관측 항목:**
 
-1. **판매가능수량 상승.** `transit_out > 0` 이던 SKU 의 storefront 노출 수량이 오른다. 상승분 = 그 SKU 의 pending 창고간 inbound plan 잔량. 이건 의도된 변화다.
-2. **오버셀 없음 확인.** 예약 승인은 `unified-reservation` 이 자체 산식으로 하며 transit_out 을 본 적이 없다. 배포 후 `ledger-reconciliation` 야간 대사(`0 3 * * *`)의 `totalDriftGrains` 가 0 을 유지하는지 확인한다. 올라가면 이 전제가 틀린 것이므로 즉시 보고.
+1. **판매가능수량 상승.** `transit_out > 0` 이던 SKU 의 판매 가능 수량이 오른다(storefront 노출뿐 아니라 Medusa 실제 판매 게이트가 오른다 — 위 소비자 전수 참조). 상승분 = 그 SKU 의 pending 창고간 inbound plan 잔량. 이건 의도된 변화다.
+2. **오버셀 없음 확인.** 예약 승인은 `unified-reservation` 이 자체 산식으로 하며 transit_out 을 본 적이 없다 — 새 뷰 값은 그 문턱과 같아졌을 뿐 넘기지 않는다. 배포 후 `ledger-reconciliation` 야간 대사(`0 3 * * *`)의 `totalDriftGrains` 가 0 을 유지하는지 확인한다. 올라가면 이 전제가 틀린 것이므로 즉시 보고.
 3. **예약 재시도 워커.** `fulfillment-order-reservation-retry.worker.ts:84` 가 `available_qty > 0` 로 후보를 고른다. 후보 수가 늘 수 있다 — 정상이다(전에는 transit_out 때문에 부당하게 탈락하던 라인들).
 4. **발주 제안.** `purchase-order.service.ts:822` 의 `available_qty < 10` 조건에 걸리는 SKU 가 준다 — 정상이다(전에는 부풀려진 부족분이었다).
+5. **창고간 이전 실행 409 증가.** pending 이전 계획 수량이 판매돼 나가면 그 물량의 실제 `transferShip` 실행이 `inventory-command.service.ts:325` 의 `assertReservationInvariant` 에서 409 로 막힐 수 있다. **이건 새 결함이 아니라 위 오버셀 무위험 논증에서 이미 예상된 증상이다** — 창고간이동 custody 모델 부재(이 계획의 "범위 밖")가 이제 관측 가능해진 것뿐이다. 배포 전 실측 쿼리 결과가 0 이 아니었다면 이 항목을 특히 주시한다.
 
 **롤백:** 뷰를 되돌리는 역마이그레이션은 만들지 않는다. 문제가 생기면 원인을 먼저 규명한다 — `transit_out` 복원은 위 4가지 결함을 되살리는 것이라 롤백이 아니라 회귀다.
 
@@ -1135,3 +1167,8 @@ npm run db:migrate -- --stage live --deployment lcnine-services --yes
 2. **custody 오버레이의 창고 grain 확장.** 숏피킹으로 예약이 해제되고 custody 가 `RETURN_PENDING` 인 구간에 "예약은 되지만 피킹 때 409" 인 틈이 있다. Task 1 의 모듈이 이 오버레이가 들어갈 자리다.
 3. **갇힌 batch 세션 탐지.** `recovery_required` 세션의 체류 시간을 보는 크론이 없다. 야간 대사의 `SESSION_CONSERVATION` 은 수량 보존만 보고 체류 시간을 보지 않아, 완벽히 보존된 채 영원히 열린 세션은 통과한다.
 4. **`new BatchControlledStockGuard()` 기본 인자 제거** (3곳). 프로바이더 등록 누락이 조용히 통과하는 구조.
+5. **사전 존재 RED 통합 스펙 5 suite 정리.** 3계열: (a) `shipment_line_id` NOT NULL 누락 — `unified-reservation.service.lifecycle.integration`, `reverse-event-guard.integration` (b) `locations` 의 `ck_locations_type` 위반 — `unified-reservation.service.lock.integration`, `stocktaking-uniques.integration` (c) 스펙 하니스의 `DbService` 대역에 `run` 없음(`{ db } as unknown as DbService`) — `inventory-command.service.adjust.integration`. **(a) 계열은 Task 25 계약 이후 구조적으로 불가능해진 경로를 테스트 중이라 "고침"이 아니라 "폐기 또는 재작성" 판단이 필요하다.** 이 5건이 닫히면 `reserveStock` 의 예약 문턱 동작을 초록 실행으로 재확인할 수 있다.
+6. **`projected_available_qty` 파리티 미고정.** `inventory.schema.ts:994` 가 `on_hand − reserved + inbound_pending` 으로 정본 산식을 뷰 안에서 다시 유도하는데 어떤 테스트도 고정하지 않는다 — 이 브랜치가 없애려던 바로 그 실패 양상이다. `view-parity.integration.spec.ts` 에 `projected === available + inboundPending` 단언 한 줄.
+7. **파리티 스펙의 분기 탐지 폭.** `view-parity` 픽스처에 `DEFECTIVE`/`IN_TRANSFER` 원장 행이 없어, 누군가 모듈에 `DEFECTIVE` 를 더해도 초록으로 통과한다.
+8. **죽은 산식 변형 1벌 잔존 (계획의 "6벌" 인벤토리 누락분).** `apps/core/src/modules/inventory/core/rules/stock-update.rules.ts`(153줄) + `stock-rule.types.ts`(48줄)는 import 하는 파일이 0곳(`stock-rule.types.ts` 는 같은 디렉터리의 `stock-update.rules.ts` 자체 import 1건뿐)인데 내용은 `RECEIVE/SHIP/MOVE/ADJUST_UP/ADJUST_DOWN` 마다 `availableQty: '+'` 를 쓰는 **옛 `stocks` 테이블식 가용재고 변이 모델**이다. Task 4 가 지운 `scanSku` 와 같은 부류(잘못된 산식이 되살아날 씨앗).
+9. **`transfer_pending_qty` 오배선.** `stock-projection.reader.ts:212` 가 이 값을 `returnPendingQuantity`(회송 예정)라는 다른 이름으로 내보낸다(사전 존재 오배선). 이전 예정 정보가 이제 가용수량에 녹아 있지도, 제대로 표시되지도 않는다.

--- a/docs/superpowers/plans/2026-08-12-inventory-availability-module.md
+++ b/docs/superpowers/plans/2026-08-12-inventory-availability-module.md
@@ -21,7 +21,21 @@
 - 스키마 export 이름: `wmsTables` / `wmsSchema` / `DbTx` — `apps/core/src/modules/inventory/schema/inventory.schema.ts` 에서 import. (`inventoryTables` / `inventorySchema` 는 같은 객체의 별칭이다: `:4257-4258`)
 - 가용재고 정본 정의(CLAUDE.md, ADR-0001): **가용재고 = ON_HAND 원장 합 − confirmed 예약 합**. 다른 항을 추가하지 않는다.
 - 통합 테스트는 `DATABASE_URL` 이 있을 때만 실행한다(`const describeIfDb = DATABASE_URL ? describe : describe.skip`). 스펙 골격은 `apps/core/src/modules/inventory/core/services/transfer.service.integration.spec.ts:1-60` 을 그대로 따른다.
-- **통합 테스트 실행은 반드시 레포 러너로 한다** — `npm run test:core:integration:local -- <좁히는-패턴>`. `scripts/local/test-core-integration-local.sh` 가 compose postgres(5432, 논리 DB `core`) 기동 → core 마이그레이션 → `jest --runInBand` 를 한 번에 한다. `DATABASE_URL` 을 손으로 잡거나 별도 컨테이너를 띄우지 말 것. 레시피: `docs/local-dev.md:186-206`.
+- **통합 테스트 실행은 반드시 레포 러너로 한다** — `scripts/local/test-core-integration-local.sh` 가 compose postgres(5432, 논리 DB `core`) 기동 → core 마이그레이션 → `jest --runInBand` 를 한 번에 한다. `DATABASE_URL` 을 손으로 잡거나 별도 컨테이너를 띄우지 말 것. 레시피: `docs/local-dev.md:186-206`.
+- 🔴 **워크트리에서는 `COMPOSE_PROJECT_NAME=almondyoung-server` 를 반드시 붙인다:**
+  ```bash
+  COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- <좁히는-패턴>
+  ```
+  붙이지 않으면 `docker compose` 가 **워크트리 디렉터리명으로 별도 프로젝트**를 만들어 5432 에 두 번째 postgres 를 띄우려다 `port is already allocated` 로 실패한다. 실패 후 찌꺼기 네트워크/볼륨이 남으면 `docker compose -p <워크트리명> down -v` 로 정리한다.
+- 🔴 **예약 행(`stock_reservations`)은 손으로 INSERT 하지 않는다.** `shipment_line_id` 가 **NOT NULL + FK → `shipment_lines`** 라(`inventory.schema.ts:1445-1447`, Task 25 계약), 유효한 예약 하나를 만들려면 `fulfillment_orders → fulfillment_order_items → shipments → shipment_lines` 4단 체인이 필요하다. 대신 **기존 픽스처를 쓴다**:
+  ```typescript
+  import { seedPickableShipment } from '../../../fulfillment/services/__support__/logistics-fixtures';
+  const fx = await seedPickableShipment(trx, 10);
+  // fx: { skuId, warehouseId, locationId, shipmentLineId, qty, ... }
+  // 이미 심어진 것: ON_HAND stock_ledgers qty=10  +  confirmed stock_reservations quantity=10
+  ```
+  수량 조합이 필요하면 시드 후 `UPDATE` 로 조정한다(예약 4로 낮추기, `status='released'` 로 바꾸기, `DEFECTIVE` 원장 행 추가 등). inventory 스펙이 fulfillment `__support__` 를 import 하는 선례는 이미 여럿 있다(`transfer.service.integration.spec.ts:1` 등).
+- ⚠️ **사전 존재 실패 1건**: `apps/core/src/modules/inventory/core/services/ledger-reconciliation.integration.spec.ts` 의 `reconcileReservations 는 예약>ON_HAND grain 을 잡는다` 케이스가 `shipment_line_id` 누락으로 **develop 에서 이미 실패한다**(7건 중 1건). 이 계획이 만든 것이 아니다. Task 6 에서 같은 픽스처로 고친다.
 - ⚠️ **패턴을 반드시 좁힌다.** 패턴 없이 돌리면 `*.integration.spec.ts` 전체가 매칭되어 membership/wallet 등 다른 논리 DB 를 기대하는 스펙까지 걸려 실패한다.
 - ⚠️ **워크트리 경로가 `--testPathPattern` 을 오염시킨다.** 경로 부분일치이므로 브랜치/워크트리 이름에 든 단어가 패턴과 겹치면 의도보다 훨씬 많은 스펙이 잡힌다. 범위를 확실히 하려면 `--runTestsByPath` 로 파일을 직접 지정한다.
 - 커밋 메시지는 한국어 본문 + conventional prefix (레포 관행: `fix:`, `feat:`, `docs:`).
@@ -226,13 +240,15 @@ import * as postgres from 'postgres';
 import { drizzle, PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { sql } from 'drizzle-orm';
 import { randomUUID } from 'crypto';
-import { wmsSchema, DbTx } from '../../schema/inventory.schema';
+import { eq } from 'drizzle-orm';
+import { wmsSchema, wmsTables, DbTx } from '../../schema/inventory.schema';
+import { seedPickableShipment } from '../../../fulfillment/services/__support__/logistics-fixtures';
 import { readWarehouseAvailability } from './warehouse-availability';
 
 /**
  * 가용재고 정본 판독의 실 DB 검증. rollback 전용 트랜잭션.
  *
- * 실행: npm run test:core:integration:local -- warehouse-availability.integration
+ * 실행: COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- warehouse-availability.integration
  */
 const DATABASE_URL = process.env.DATABASE_URL;
 const describeIfDb = DATABASE_URL ? describe : describe.skip;
@@ -263,31 +279,31 @@ describeIfDb('readWarehouseAvailability (DB integration, rollback-only)', () => 
       });
   };
 
-  /** ON_HAND 원장 1행 + confirmed 예약 1행을 심고 (skuId, warehouseId) 를 돌려준다. */
+  /**
+   * ON_HAND 원장 + confirmed 예약을 심고 grain 을 돌려준다.
+   *
+   * 예약을 손으로 INSERT 하지 않는 이유: `stock_reservations.shipment_line_id` 가
+   * NOT NULL + FK → `shipment_lines` 라(Task 25 계약) 유효한 예약 하나에
+   * fulfillment_orders → items → shipments → shipment_lines 4단 체인이 필요하다.
+   * `seedPickableShipment` 이 그 체인 + ON_HAND 원장 + confirmed 예약을 한 번에 만든다.
+   */
   const seed = async (
     trx: DbTx,
     opts: { onHand: number; reserved: number },
-  ): Promise<{ skuId: string; warehouseId: string }> => {
-    const skuId = randomUUID();
-    const warehouseId = randomUUID();
-
-    await trx.execute(sql`
-      INSERT INTO warehouses (id, name, code) VALUES (${warehouseId}, ${'IT-WH'}, ${`IT-${warehouseId.slice(0, 8)}`})
-    `);
-    await trx.execute(sql`
-      INSERT INTO skus (id, name, code) VALUES (${skuId}, ${'IT-SKU'}, ${`IT-${skuId.slice(0, 8)}`})
-    `);
-    await trx.execute(sql`
-      INSERT INTO stock_ledgers (sku_id, warehouse_id, stock_state, qty)
-      VALUES (${skuId}, ${warehouseId}, 'ON_HAND', ${opts.onHand})
-    `);
-    if (opts.reserved > 0) {
-      await trx.execute(sql`
-        INSERT INTO stock_reservations (sku_id, warehouse_id, quantity, status, target_type)
-        VALUES (${skuId}, ${warehouseId}, ${opts.reserved}, 'confirmed', 'SHIPMENT_LINE')
-      `);
+  ): Promise<{ skuId: string; warehouseId: string; locationId: string }> => {
+    const fx = await seedPickableShipment(trx, opts.onHand);
+    // 픽스처는 예약 = ON_HAND 로 심는다. 원하는 예약 수량으로 낮추거나(0 이면 삭제) 맞춘다.
+    if (opts.reserved === 0) {
+      await trx
+        .delete(wmsTables.stockReservations)
+        .where(eq(wmsTables.stockReservations.shipmentLineId, fx.shipmentLineId));
+    } else if (opts.reserved !== opts.onHand) {
+      await trx
+        .update(wmsTables.stockReservations)
+        .set({ quantity: opts.reserved })
+        .where(eq(wmsTables.stockReservations.shipmentLineId, fx.shipmentLineId));
     }
-    return { skuId, warehouseId };
+    return { skuId: fx.skuId, warehouseId: fx.warehouseId, locationId: fx.locationId };
   };
 
   it('ON_HAND 합 − confirmed 예약 합을 반환한다', async () => {
@@ -308,9 +324,10 @@ describeIfDb('readWarehouseAvailability (DB integration, rollback-only)', () => 
   it('released 예약은 차감하지 않는다', async () => {
     await inRollback(async (trx) => {
       const { skuId, warehouseId } = await seed(trx, { onHand: 10, reserved: 4 });
-      await trx.execute(sql`
-        UPDATE stock_reservations SET status = 'released' WHERE sku_id = ${skuId}
-      `);
+      await trx
+        .update(wmsTables.stockReservations)
+        .set({ status: 'released' })
+        .where(eq(wmsTables.stockReservations.skuId, skuId));
       const result = await readWarehouseAvailability(trx, skuId, warehouseId);
       expect(result.available).toBe(10);
     });
@@ -318,11 +335,14 @@ describeIfDb('readWarehouseAvailability (DB integration, rollback-only)', () => 
 
   it('ON_HAND 가 아닌 원장 상태는 합산하지 않는다', async () => {
     await inRollback(async (trx) => {
-      const { skuId, warehouseId } = await seed(trx, { onHand: 10, reserved: 0 });
-      await trx.execute(sql`
-        INSERT INTO stock_ledgers (sku_id, warehouse_id, stock_state, qty)
-        VALUES (${skuId}, ${warehouseId}, 'DEFECTIVE', ${99})
-      `);
+      const { skuId, warehouseId, locationId } = await seed(trx, { onHand: 10, reserved: 0 });
+      await trx.insert(wmsTables.stockLedgers).values({
+        skuId,
+        warehouseId,
+        locationId,
+        stockState: 'DEFECTIVE',
+        qty: 99,
+      });
       const result = await readWarehouseAvailability(trx, skuId, warehouseId);
       expect(result.onHand).toBe(10);
     });
@@ -330,15 +350,16 @@ describeIfDb('readWarehouseAvailability (DB integration, rollback-only)', () => 
 });
 ```
 
-> **주의:** `seed()` 의 `INSERT` 컬럼 목록은 스키마와 정확히 맞아야 한다. 실행 전
-> `apps/core/src/modules/inventory/schema/inventory.schema.ts` 에서 `warehouses`, `skus`,
-> `stockLedgers`, `stockReservations` 의 **NOT NULL 이고 기본값 없는 컬럼**을 확인하고
-> 빠진 것이 있으면 INSERT 에 추가한다. Step 6 이 이걸 즉시 드러낸다.
+> **주의:** `seedPickableShipment` 의 반환 필드 이름을 실제 시그니처에서 확인하고 맞춘다
+> (`apps/core/src/modules/fulfillment/services/__support__/logistics-fixtures.ts` 의
+> `PickableShipmentFixture`). 픽스처가 만드는 것: warehouse · holder · deliveryProfile · sku ·
+> location · **ON_HAND `stock_ledgers` qty** · **confirmed `stock_reservations` quantity** ·
+> batch · work item · waybill. 전부 rollback 트랜잭션 안이라 DB 에 남지 않는다.
 
 - [ ] **Step 6: 통합 테스트를 돌린다**
 
 ```bash
-npm run test:core:integration:local -- warehouse-availability.integration
+COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- warehouse-availability.integration
 ```
 
 러너가 compose postgres 기동과 마이그레이션까지 처리한다.
@@ -479,7 +500,7 @@ npx jest --testPathPattern="reservation-invariant" --runInBand
 Expected: PASS
 
 ```bash
-npm run test:core:integration:local -- unified-reservation.service.(lock|lifecycle).integration
+COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- unified-reservation.service.(lock|lifecycle).integration
 ```
 
 Expected: PASS — 예약 생애주기·락 통합 스펙이 불변식 경로를 실제로 태운다.
@@ -511,7 +532,7 @@ git commit -m "refactor(inventory): 예약 불변식 판독을 availability 모�
 새 테스트를 쓰지 않는다. `unified-reservation.service.lifecycle.integration.spec.ts` 와 `.lock.integration.spec.ts` 가 이미 이 경로를 태운다. 먼저 초록인지 확인한다:
 
 ```bash
-npm run test:core:integration:local -- unified-reservation.service..*.integration
+COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- unified-reservation.service..*.integration
 ```
 
 Expected: PASS. **여기서 실패하면 Task 3 을 진행하지 않는다** — 기준선이 없으면 위임의 안전성을 증명할 수 없다.
@@ -547,7 +568,7 @@ import { readWarehouseAvailability } from '../availability/warehouse-availabilit
 - [ ] **Step 3: 통합 테스트를 다시 돌린다**
 
 ```bash
-npm run test:core:integration:local -- unified-reservation.service..*.integration
+COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- unified-reservation.service..*.integration
 ```
 
 Expected: PASS — Step 1 과 동일한 결과
@@ -651,7 +672,7 @@ import { readWarehouseAvailability } from './warehouse-availability';
  * stock_journals 를 써서 이동이 끝나도 줄지 않았다. 그 항을 제거한 뒤,
  * 아무도 다시 넣지 못하게 이 테스트가 막는다.
  *
- * 실행: npm run test:core:integration:local -- <이 파일의 패턴>
+ * 실행: COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- <이 파일의 패턴>
  */
 const DATABASE_URL = process.env.DATABASE_URL;
 const describeIfDb = DATABASE_URL ? describe : describe.skip;
@@ -764,7 +785,7 @@ describeIfDb('stock_summary_view ↔ availability 모듈 등가 (DB integration)
 - [ ] **Step 2: 첫 번째 테스트가 실패하는지 확인한다**
 
 ```bash
-npm run test:core:integration:local -- view-parity.integration
+COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- view-parity.integration
 ```
 
 Expected: 첫 테스트 FAIL — `expect(fromView).toBe(10)` 이 `6` 을 받는다 (10 − 0 − 4). 두 번째 테스트는 PASS.
@@ -815,7 +836,7 @@ CREATE VIEW stock_summary_view AS
 - [ ] **Step 5: 마이그레이션을 적용하고 테스트를 다시 돌린다**
 
 ```bash
-npm run test:core:integration:local -- view-parity.integration
+COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- view-parity.integration
 ```
 
 러너가 jest 전에 `drizzle-kit migrate` 를 돌리므로 새 마이그레이션이 자동 적용된다.
@@ -829,7 +850,7 @@ Expected: PASS (2 tests)
 - [ ] **Step 6: 뷰를 읽는 다른 경로의 회귀를 확인한다**
 
 ```bash
-npm run test:core:integration:local -- (product-sellable-quantity|logistics|fulfillment).*integration
+COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- (product-sellable-quantity|logistics|fulfillment).*integration
 ```
 
 Expected: PASS. 실패가 나면 **`transit_out` 을 되돌리지 말고** 실패 내용을 보고한다 — 어떤 스펙이 옛 산식을 전제하고 있었다는 뜻이고, 그 전제 자체가 검토 대상이다.
@@ -888,7 +909,7 @@ import { LedgerReconciliationService } from '../../core/services/ledger-reconcil
  * CTE 는 전 카탈로그 집합 스캔이라 (sku,warehouse) 스칼라 함수로 대체할 수 없다.
  * 따라서 중복 자체는 남기고, 두 산식이 갈라지는 것만 이 테스트가 막는다.
  *
- * 실행: npm run test:core:integration:local -- <이 파일의 패턴>
+ * 실행: COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- <이 파일의 패턴>
  */
 const DATABASE_URL = process.env.DATABASE_URL;
 const describeIfDb = DATABASE_URL ? describe : describe.skip;
@@ -1006,7 +1027,7 @@ describeIfDb('야간 대사 CTE ↔ availability 모듈 등가 (DB integration)'
 - [ ] **Step 2: 테스트를 돌린다**
 
 ```bash
-npm run test:core:integration:local -- reconciliation-parity.integration
+COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- reconciliation-parity.integration
 ```
 
 Expected: PASS (2 tests). 생성자 대역이 안 맞으면 Step 1 주의사항대로 고치고 다시 돌린다.
@@ -1054,7 +1075,7 @@ Expected: PASS
 - [ ] **Step 2: 전체 통합 테스트**
 
 ```bash
-npm run test:core:integration:local -- apps/core/src/modules/(inventory|fulfillment).*integration
+COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- apps/core/src/modules/(inventory|fulfillment).*integration
 ```
 
 Expected: PASS

--- a/docs/superpowers/plans/2026-08-12-inventory-availability-module.md
+++ b/docs/superpowers/plans/2026-08-12-inventory-availability-module.md
@@ -670,7 +670,9 @@ import * as postgres from 'postgres';
 import { drizzle, PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { sql } from 'drizzle-orm';
 import { randomUUID } from 'crypto';
-import { wmsSchema, DbTx } from '../../schema/inventory.schema';
+import { eq } from 'drizzle-orm';
+import { wmsSchema, wmsTables, DbTx } from '../../schema/inventory.schema';
+import { seedPickableShipment } from '../../../fulfillment/services/__support__/logistics-fixtures';
 import { readWarehouseAvailability } from './warehouse-availability';
 
 /**
@@ -723,35 +725,48 @@ describeIfDb('stock_summary_view ↔ availability 모듈 등가 (DB integration)
 
   it('이전 예정(pending 창고간 inbound plan)이 있어도 뷰와 모듈이 일치한다', async () => {
     await inRollback(async (trx) => {
-      const skuId = randomUUID();
-      const sourceWarehouseId = randomUUID();
-      const destWarehouseId = randomUUID();
-      const planId = randomUUID();
+      // 기반: ON_HAND 10 + confirmed 예약 10 → 예약을 지워 ON_HAND 10 / 예약 0 으로 만든다.
+      const fx = await seedPickableShipment(trx, 10);
+      await trx
+        .delete(wmsTables.stockReservations)
+        .where(eq(wmsTables.stockReservations.shipmentLineId, fx.shipmentLineId));
 
-      await trx.execute(sql`
-        INSERT INTO warehouses (id, name, code)
-        VALUES (${sourceWarehouseId}, ${'IT-SRC'}, ${`IT-S-${sourceWarehouseId.slice(0, 6)}`}),
-               (${destWarehouseId}, ${'IT-DST'}, ${`IT-D-${destWarehouseId.slice(0, 6)}`})
-      `);
-      await trx.execute(sql`
-        INSERT INTO skus (id, name, code) VALUES (${skuId}, ${'IT-SKU'}, ${`IT-${skuId.slice(0, 8)}`})
-      `);
-      await trx.execute(sql`
-        INSERT INTO stock_ledgers (sku_id, warehouse_id, stock_state, qty)
-        VALUES (${skuId}, ${sourceWarehouseId}, 'ON_HAND', ${10})
-      `);
-      // 출발 창고 → 도착 창고 이전 예정 4개 (이것이 옛 transit_out 항을 만들던 데이터)
-      await trx.execute(sql`
-        INSERT INTO inbound_plans (id, warehouse_id, destination_warehouse_id, requires_transfer)
-        VALUES (${planId}, ${sourceWarehouseId}, ${destWarehouseId}, true)
-      `);
-      await trx.execute(sql`
-        INSERT INTO inbound_plan_items (plan_id, sku_id, expected_qty, received_qty, status)
-        VALUES (${planId}, ${skuId}, ${4}, ${0}, 'pending')
-      `);
+      // 도착 창고 + 발주(=inbound_plans.linkedPurchaseOrderId 가 NOT NULL FK 라 필요)
+      const [destWarehouse] = await trx
+        .insert(wmsTables.warehouses)
+        .values({ name: `it-dest-${randomUUID().slice(0, 8)}` })
+        .returning();
+      const [po] = await trx
+        .insert(wmsTables.purchaseOrders)
+        .values({
+          type: 'domestic',
+          sourceWarehouseId: fx.warehouseId,
+          destinationWarehouseId: destWarehouse.id,
+          requiresTransfer: true,
+        })
+        .returning();
 
-      const fromModule = await readWarehouseAvailability(trx, skuId, sourceWarehouseId);
-      const fromView = await readView(trx, skuId, sourceWarehouseId);
+      // 출발 창고 → 도착 창고 이전 예정 4개. 이 행이 옛 transit_out 항을 만들던 데이터다.
+      const [plan] = await trx
+        .insert(wmsTables.inboundPlans)
+        .values({
+          warehouseId: fx.warehouseId,
+          destinationWarehouseId: destWarehouse.id,
+          linkedPurchaseOrderId: po.id,
+          requiresTransfer: true,
+          status: 'pending',
+        })
+        .returning();
+      await trx.insert(wmsTables.inboundPlanItems).values({
+        planId: plan.id,
+        skuId: fx.skuId,
+        expectedQty: 4,
+        receivedQty: 0,
+        status: 'pending',
+      });
+
+      const fromModule = await readWarehouseAvailability(trx, fx.skuId, fx.warehouseId);
+      const fromView = await readView(trx, fx.skuId, fx.warehouseId);
 
       expect(fromModule.available).toBe(10);
       expect(fromView).toBe(10); // 이전 예정은 가용에서 빼지 않는다
@@ -760,27 +775,15 @@ describeIfDb('stock_summary_view ↔ availability 모듈 등가 (DB integration)
 
   it('예약이 있으면 뷰와 모듈이 같은 값을 낸다', async () => {
     await inRollback(async (trx) => {
-      const skuId = randomUUID();
-      const warehouseId = randomUUID();
+      // 기반: ON_HAND 10 + confirmed 예약 10 → 예약을 3 으로 낮춘다.
+      const fx = await seedPickableShipment(trx, 10);
+      await trx
+        .update(wmsTables.stockReservations)
+        .set({ quantity: 3 })
+        .where(eq(wmsTables.stockReservations.shipmentLineId, fx.shipmentLineId));
 
-      await trx.execute(sql`
-        INSERT INTO warehouses (id, name, code)
-        VALUES (${warehouseId}, ${'IT-WH'}, ${`IT-${warehouseId.slice(0, 8)}`})
-      `);
-      await trx.execute(sql`
-        INSERT INTO skus (id, name, code) VALUES (${skuId}, ${'IT-SKU'}, ${`IT-${skuId.slice(0, 8)}`})
-      `);
-      await trx.execute(sql`
-        INSERT INTO stock_ledgers (sku_id, warehouse_id, stock_state, qty)
-        VALUES (${skuId}, ${warehouseId}, 'ON_HAND', ${10})
-      `);
-      await trx.execute(sql`
-        INSERT INTO stock_reservations (sku_id, warehouse_id, quantity, status, target_type)
-        VALUES (${skuId}, ${warehouseId}, ${3}, 'confirmed', 'SHIPMENT_LINE')
-      `);
-
-      const fromModule = await readWarehouseAvailability(trx, skuId, warehouseId);
-      const fromView = await readView(trx, skuId, warehouseId);
+      const fromModule = await readWarehouseAvailability(trx, fx.skuId, fx.warehouseId);
+      const fromView = await readView(trx, fx.skuId, fx.warehouseId);
 
       expect(fromView).toBe(fromModule.available);
       expect(fromView).toBe(7);
@@ -789,8 +792,13 @@ describeIfDb('stock_summary_view ↔ availability 모듈 등가 (DB integration)
 });
 ```
 
-> `inbound_plans` / `inbound_plan_items` 의 INSERT 컬럼도 Task 1 Step 5 와 같은 방식으로
-> 스키마의 NOT NULL 컬럼을 확인해 보완한다.
+> **실측 확인된 제약 (2026-08-12):**
+> - `inbound_plans.linked_purchase_order_id` 는 **NOT NULL + FK → `purchase_orders`** 라 발주 행이 먼저 필요하다.
+> - `purchase_orders` 의 필수 컬럼은 `type`(enum `po_type`: `domestic` | `foreign`), `source_warehouse_id`, `destination_warehouse_id` 뿐이다. 그 위로 더 올라가는 FK 체인은 없다.
+> - `inbound_status` enum: `pending` | `applied` | `receiving` | `confirmed`.
+>
+> 실행 전 `PickableShipmentFixture` 의 반환 필드 이름을 실제 시그니처에서 다시 확인하고 맞춘다
+> (`apps/core/src/modules/fulfillment/services/__support__/logistics-fixtures.ts:250`).
 
 - [ ] **Step 2: 첫 번째 테스트가 실패하는지 확인한다**
 

--- a/docs/superpowers/plans/2026-08-12-inventory-availability-module.md
+++ b/docs/superpowers/plans/2026-08-12-inventory-availability-module.md
@@ -535,7 +535,17 @@ git commit -m "refactor(inventory): 예약 불변식 판독을 availability 모�
 COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- unified-reservation.service..*.integration
 ```
 
-Expected: PASS. **여기서 실패하면 Task 3 을 진행하지 않는다** — 기준선이 없으면 위임의 안전성을 증명할 수 없다.
+🔴 **실측: 이 두 스펙은 develop 시점부터 이미 RED 다** (2026-08-12 확인). 원인은 이 계획과 무관:
+- `…lifecycle.integration` → 비-`SHIPMENT_LINE` 예약을 만드는데 `stock_reservations.shipment_line_id` 가 NOT NULL (Task 25 계약 이후 구조적으로 불가능해진 경로를 테스트 중)
+- `…lock.integration` → `locations` 의 `ck_locations_type` 체크 제약 위반 (별개 원인)
+
+따라서 "초록이어야 진행" 게이트는 성립하지 않는다. 대신 **위임 전후 동등성**을 기준으로 삼는다:
+
+1. 위임 전 두 스펙을 돌려 **실패 메시지와 실패 케이스 수를 기록**한다.
+2. 위임 후 다시 돌려 **같은 케이스가 같은 메시지로 실패하는지** 확인한다.
+3. 실패 양상이 달라지면 위임이 무언가를 바꾼 것이다 — 멈추고 보고한다.
+
+⛔ **`git stash` 를 쓰지 말 것.** stash 스택은 이 머신의 다른 워크트리와 공유된다. 전후 비교가 필요하면 임시 WIP 커밋을 쓰고 끝나면 `git reset --soft` 로 되돌린다.
 
 - [ ] **Step 2: private 메서드를 위임으로 교체한다**
 
@@ -571,7 +581,7 @@ import { readWarehouseAvailability } from '../availability/warehouse-availabilit
 COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- unified-reservation.service..*.integration
 ```
 
-Expected: PASS — Step 1 과 동일한 결과
+Expected: **Step 1 에서 기록한 것과 동일한 실패 양상** (같은 케이스, 같은 메시지). 새로 깨지거나 새로 통과하는 케이스가 있으면 위임이 동작을 바꾼 것이므로 보고한다.
 
 - [ ] **Step 4: 커밋**
 

--- a/docs/superpowers/plans/2026-08-12-inventory-availability-module.md
+++ b/docs/superpowers/plans/2026-08-12-inventory-availability-module.md
@@ -1,0 +1,1117 @@
+# 가용재고 소유 모듈 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 코드 6곳에 흩어진 "가용재고" 산식을 단일 모듈이 소유하게 만들고, TS 로 대체할 수 없는 SQL 집합 경로는 등가성 테스트로 고정한다.
+
+**Architecture:** `inventory/shared/availability/` 에 Nest 프로바이더가 아닌 **순수 함수 모듈**을 둔다 (`shared/locks/reservation-invariant.ts` 와 같은 형태 — DI 순환을 피하려고 이미 채택된 패턴이다). 스칼라 호출자 3곳은 이 모듈에 위임한다. 집합 기반 SQL 호출자(뷰·야간 대사)는 SQL 로 남되, **모듈과 값이 일치하는지 검증하는 통합 테스트**를 붙여 조용한 분기를 불가능하게 만든다. 뷰의 `transit_out` 차감 항은 제거한다.
+
+**Tech Stack:** NestJS, Drizzle ORM (postgres.js), Jest, PostgreSQL 16
+
+**리뷰 제안과 다른 점 (의도된 이탈):** 원 제안은 (a) 뷰가 "판매가능수량의 권위이기를 그만두게" 하고 (b) `transit_out` 을 *이름 붙은 두 번째 판독*으로 남기라고 했다. 이 계획은 둘 다 다르게 간다.
+
+- (a) 뷰에서 권위를 빼려면 `product-sellable-quantity`·재시도 워커·발주 제안 세 곳의 **집합 SQL 을 스칼라 호출로 바꿔야 하고** 그러면 N+1 이 된다. 대신 **뷰를 모듈과 일치시키고 등가 테스트로 고정**한다. 정의는 한 곳(모듈)이 소유하고, 뷰는 그 정의의 집합 표현이 된다.
+- (b) `transit_out` 을 보존하지 않고 제거한다. 조사 결과 이 항은 실제 창고간이동(`stock_journals`)을 추적하지 않고 `inbound_plan_items` 를 읽으며, 출발 창고에서만 차감한다. 즉 "이름 붙일 가치가 있는 두 번째 관점"이 아니라 **틀린 항**이다. 근거는 아래 배경 참조.
+
+## Global Constraints
+
+- 레이어 규약(CLAUDE.md): Controller → Service → Reader/Manager → Repository. 이 계획이 만드는 것은 Repository 아래 **leaf 순수 함수 모듈**이며 Nest 프로바이더로 등록하지 않는다.
+- 트랜잭션 전파(ADR-0025): 공개 함수는 `tx?: DbTx` 를 마지막 인자로, 내부 헬퍼는 `tx: DbTx` 필수. 클래스별 `inTx` 헬퍼 금지, `DbService.run` 단일 러너만 사용. 이 모듈의 함수들은 **항상 `trx: DbTx` 를 첫 인자로 필수**로 받는다 (`reservation-invariant.ts` 와 동일).
+- Inventory 쿼리 규약(CLAUDE.md): `db.query.*` 금지, `with` 관계 금지, `any`/`as` 캐스팅 금지. 단 `trx.execute(sql\`...\`)` 의 원시 결과 타이핑은 `reservation-invariant.ts:20` 과 `ledger-reconciliation.service.ts:180` 에 이미 **문서화된 캐스트**로 존재하므로 같은 형태를 따른다.
+- 스키마 export 이름: `wmsTables` / `wmsSchema` / `DbTx` — `apps/core/src/modules/inventory/schema/inventory.schema.ts` 에서 import. (`inventoryTables` / `inventorySchema` 는 같은 객체의 별칭이다: `:4257-4258`)
+- 가용재고 정본 정의(CLAUDE.md, ADR-0001): **가용재고 = ON_HAND 원장 합 − confirmed 예약 합**. 다른 항을 추가하지 않는다.
+- 통합 테스트는 `DATABASE_URL` 이 있을 때만 실행한다(`const describeIfDb = DATABASE_URL ? describe : describe.skip`). 스펙 골격은 `apps/core/src/modules/inventory/core/services/transfer.service.integration.spec.ts:1-60` 을 그대로 따른다.
+- **통합 테스트 실행은 반드시 레포 러너로 한다** — `npm run test:core:integration:local -- <좁히는-패턴>`. `scripts/local/test-core-integration-local.sh` 가 compose postgres(5432, 논리 DB `core`) 기동 → core 마이그레이션 → `jest --runInBand` 를 한 번에 한다. `DATABASE_URL` 을 손으로 잡거나 별도 컨테이너를 띄우지 말 것. 레시피: `docs/local-dev.md:186-206`.
+- ⚠️ **패턴을 반드시 좁힌다.** 패턴 없이 돌리면 `*.integration.spec.ts` 전체가 매칭되어 membership/wallet 등 다른 논리 DB 를 기대하는 스펙까지 걸려 실패한다.
+- ⚠️ **워크트리 경로가 `--testPathPattern` 을 오염시킨다.** 경로 부분일치이므로 브랜치/워크트리 이름에 든 단어가 패턴과 겹치면 의도보다 훨씬 많은 스펙이 잡힌다. 범위를 확실히 하려면 `--runTestsByPath` 로 파일을 직접 지정한다.
+- 커밋 메시지는 한국어 본문 + conventional prefix (레포 관행: `fix:`, `feat:`, `docs:`).
+
+---
+
+## 배경 — 왜 이 작업인가
+
+`apps/core` 아키텍처 리뷰(2026-08-11) 제안 3. 실측으로 확인된 사실:
+
+| 구현 | 산식 | 성격 |
+|---|---|---|
+| `inventory.schema.ts:982` (`stock_summary_view`) | `on_hand − reserved − transit_out` | **의미 분기** |
+| `unified-reservation.service.ts:249` | `on_hand − reserved` (raw SQL) | 중복 |
+| `shared/locks/reservation-invariant.ts:11` | `on_hand`, `reserved` 개별 반환 | 중복 |
+| `ledger-reconciliation.service.ts:159` | `on_hand − reserved` (raw CTE) | 중복 (뷰를 명시적으로 거부) |
+| `batch-controlled-stock.guard.ts:76` | `on_hand − batch_controlled` (로케이션 grain) | **다른 grain — 통합 대상 아님** |
+| `barcode.service.ts:107` | `on_hand` 합 (예약 미차감) | **죽은 코드** (호출자 0) |
+
+`transit_out` 에 대해 조사에서 추가로 드러난 것:
+
+1. 출발 창고에서만 차감하고 도착 창고에 더하지 않는다. 판매가능수량은 전 창고를 합산하므로(`product-sellable-quantity.service.ts:139`, 창고 필터 없음), **사내 이동 계획을 잡는 것만으로 회사 전체 판매가능수량이 줄어든다.**
+2. `transit_out` 은 `inbound_plan_items` 를 읽는데, 실제 창고간이동은 `stock_journals`(`sourceType: 'warehouse_transfer'`)를 쓴다. `transfer.service.ts` 에 `inboundPlan` 이라는 단어가 **0회** 등장한다 — 두 시스템은 연결돼 있지 않다. 따라서 이동이 실행돼도 `transit_out` 은 줄지 않고 **영구히** 차감된 채 남는다.
+3. `IN_TRANSFER` 원장 상태는 `transferShip`/`transferReceive` 가 **한 트랜잭션 안**에서 실행되므로 잔량이 남지 않는다(`stock-event.service.ts:117-156`, 통합 스펙 `transfer.service.integration.spec.ts:18` 이 "IN_TRANSFER 잔량 0"을 성공 기준으로 명시). 즉 원장에 "운송 중"이라는 기간이 없다.
+
+**오버셀 위험 없음 (중요):** 예약 승인은 `unified-reservation.service.ts:81` → `getAvailableStock`(`:249`)이 판정하며 **애초에 `transit_out` 을 보지 않는다.** 뷰에서 `transit_out` 을 빼는 것은 예약 승인 문턱을 전혀 건드리지 않고, storefront 표시를 예약 seam 이 실제로 허용하는 값과 일치시킬 뿐이다.
+
+### 선행 시도의 흔적
+
+`shared/shared.module.ts:7,25,35` 에 `StockAvailabilityService` 가 **주석 처리**된 채 남아 있다. 과거에 Nest 프로바이더로 같은 통합을 시도했다가 중단된 흔적이다. 이 계획이 순수 함수 모듈을 택한 이유가 이것이다 — `reservation-invariant.ts` 헤더 주석이 밝히듯 *"core↔store 순환을 피하려고 추출"* 한 선례가 이미 작동 중이다. Task 1 에서 이 죽은 주석도 함께 제거한다.
+
+## 범위 밖 (명시적 제외)
+
+- **창고간이동 custody 모델 신설.** 이동 기간 동안 재고를 작업에 묶는 모델(출고작업의 `batch_inventory_sessions` 에 해당하는 것)이 창고간이동에는 없다. 별도 설계가 필요하며 이 계획은 그 자리를 비워둘 뿐 채우지 않는다.
+- **custody 오버레이의 창고 grain 확장.** `batch-controlled-stock.guard.ts` 는 `sourceLocationId` 필수(로케이션 grain)이고 가용재고는 창고 grain 이다. 숏피킹으로 예약이 해제되고 custody 가 `RETURN_PENDING` 으로 남는 구간에 "예약 가능하지만 피킹 시점에 `BATCH_CONTROLLED_STOCK` 409" 가 나는 틈이 있다. 이 계획은 그 틈을 **좁히지 않는다.** Task 1 이 만드는 모듈이 나중에 그 오버레이가 들어갈 자리가 된다.
+- **`BatchControlledStockGuard` 의 `new BatchControlledStockGuard()` 기본 인자 제거** (`stock-event.store.ts:74`, `inventory-command.service.ts:23`, `location-resolution.strategy.ts:29`). 별건 정리.
+
+## 파일 구조
+
+| 파일 | 책임 |
+|---|---|
+| `inventory/shared/availability/warehouse-availability.ts` (신설) | 창고 grain 가용재고의 **유일한 정의**. 순수 계산 함수 + 단일 statement 원자 판독. |
+| `inventory/shared/availability/warehouse-availability.spec.ts` (신설) | 순수 계산 함수 단위 테스트. |
+| `inventory/shared/availability/warehouse-availability.integration.spec.ts` (신설) | 판독 함수의 실 DB 검증 + **뷰·야간대사와의 등가성 고정**. |
+| `inventory/shared/locks/reservation-invariant.ts` (수정) | 판독을 모듈에 위임. 불변식 술어를 모듈의 계산 함수로 표현. |
+| `inventory/shared/services/unified-reservation.service.ts` (수정) | `getAvailableStock` 을 모듈 위임으로 축소. |
+| `inventory/shared/services/barcode.service.ts` (수정) | 죽은 `scanSku` 삭제. |
+| `inventory/schema/inventory.schema.ts` (수정) | 뷰 `available_qty` 에서 `transit_out` 항 제거. |
+| `apps/core/drizzle/<ts>_drop-transit-out-from-available-qty.sql` (생성) | 뷰 재정의 마이그레이션. |
+| `inventory/core/services/ledger-reconciliation.service.ts` (수정) | 낡은 주석 갱신. CTE 자체는 유지(전 카탈로그 집합 스캔이라 스칼라 함수로 대체 불가). |
+
+---
+
+## Task 1: 가용재고 모듈 신설
+
+호출자를 하나도 바꾸지 않는다. 정의를 담을 자리를 먼저 만들고 테스트로 고정한다.
+
+**Files:**
+- Create: `apps/core/src/modules/inventory/shared/availability/warehouse-availability.ts`
+- Create: `apps/core/src/modules/inventory/shared/availability/warehouse-availability.spec.ts`
+- Create: `apps/core/src/modules/inventory/shared/availability/warehouse-availability.integration.spec.ts`
+- Modify: `apps/core/src/modules/inventory/shared/shared.module.ts:7,25,35` (죽은 `StockAvailabilityService` 주석 제거)
+
+**Interfaces:**
+- Consumes: `DbTx`, `wmsTables`, `wmsSchema` from `apps/core/src/modules/inventory/schema/inventory.schema`
+- Produces:
+  - `interface WarehouseAvailability { onHand: number; reserved: number; available: number }`
+  - `function computeAvailable(onHand: number, reserved: number): number`
+  - `function violatesAvailability(onHand: number, reserved: number, removingQty: number): boolean`
+  - `async function readWarehouseAvailability(trx: DbTx, skuId: string, warehouseId: string): Promise<WarehouseAvailability>`
+
+- [ ] **Step 1: 실패하는 단위 테스트를 쓴다**
+
+Create `apps/core/src/modules/inventory/shared/availability/warehouse-availability.spec.ts`:
+
+```typescript
+import { computeAvailable, violatesAvailability } from './warehouse-availability';
+
+describe('computeAvailable — 가용재고 정본 정의', () => {
+  it('가용 = ON_HAND 합 − confirmed 예약 합', () => {
+    expect(computeAvailable(10, 4)).toBe(6);
+  });
+
+  it('예약이 ON_HAND 를 넘으면 음수를 그대로 반환한다 (clamp 는 호출자 책임)', () => {
+    expect(computeAvailable(3, 5)).toBe(-2);
+  });
+
+  it('예약이 0 이면 ON_HAND 그대로', () => {
+    expect(computeAvailable(7, 0)).toBe(7);
+  });
+});
+
+describe('violatesAvailability — 차감 가능 여부', () => {
+  it('차감 후 가용이 음수가 되면 위반', () => {
+    expect(violatesAvailability(10, 6, 5)).toBe(true); // (10-5) - 6 = -1
+  });
+
+  it('차감 후 가용이 정확히 0 이면 통과', () => {
+    expect(violatesAvailability(10, 6, 4)).toBe(false); // (10-4) - 6 = 0
+  });
+
+  it('예약 0 이면 ON_HAND 전량 차감이 통과', () => {
+    expect(violatesAvailability(10, 0, 10)).toBe(false);
+  });
+
+  it('차감 0 은 예약이 이미 초과 상태여도 통과한다 (새 위반을 만들지 않으므로)', () => {
+    expect(violatesAvailability(3, 5, 0)).toBe(true);
+  });
+});
+```
+
+마지막 케이스는 **현재 동작을 그대로 기술한 것**이다. `reservation-invariant.ts:31` 의 `onHandSum - removingQty < reservedSum` 은 `removingQty=0` 이고 이미 초과 상태(3 < 5)면 `true` 를 낸다. Task 2 가 동작을 바꾸지 않음을 이 케이스가 보장한다.
+
+- [ ] **Step 2: 실패를 확인한다**
+
+```bash
+npx jest --testPathPattern="warehouse-availability\.spec" --runInBand
+```
+
+Expected: FAIL — `Cannot find module './warehouse-availability'`
+
+- [ ] **Step 3: 모듈을 구현한다**
+
+Create `apps/core/src/modules/inventory/shared/availability/warehouse-availability.ts`:
+
+```typescript
+import { sql } from 'drizzle-orm';
+import { DbTx } from '../../schema/inventory.schema';
+
+/**
+ * 창고 grain 가용재고의 유일한 정의.
+ *
+ * 정본 규칙 (CLAUDE.md · ADR-0001): 가용재고 = ON_HAND 원장 합 − confirmed 예약 합.
+ * 다른 항(이동예정·입고예정 등)을 여기에 더하거나 빼지 않는다. 다른 관점이 필요하면
+ * 조용한 변형이 아니라 이름 붙은 별도 판독으로 만든다.
+ *
+ * Nest 프로바이더가 아니라 순수 함수 leaf 다 — core↔store DI 순환을 피하려고
+ * `shared/locks/reservation-invariant.ts` 가 이미 택한 형태를 따른다.
+ */
+export interface WarehouseAvailability {
+  onHand: number;
+  reserved: number;
+  available: number;
+}
+
+/** 정본 산식. 음수를 clamp 하지 않는다 — 표시용 clamp 는 호출자 책임이다. */
+export function computeAvailable(onHand: number, reserved: number): number {
+  return onHand - reserved;
+}
+
+/** `removingQty` 만큼 ON_HAND 를 빼면 가용이 음수가 되는가. */
+export function violatesAvailability(onHand: number, reserved: number, removingQty: number): boolean {
+  return computeAvailable(onHand - removingQty, reserved) < 0;
+}
+
+interface AvailabilityRow {
+  on_hand: number | string;
+  reserved: number | string;
+}
+
+/**
+ * 창고 grain ON_HAND 원장 합·confirmed 예약 합을 **단일 statement** 로 읽는다.
+ *
+ * 두 값을 각각 읽으면 READ COMMITTED 에서 그 사이에 SHIP 소진이 커밋될 수 있어
+ * torn read(초과예약)가 난다. 한 statement 안의 두 스칼라 서브쿼리는 같은 스냅샷을 본다.
+ */
+export async function readWarehouseAvailability(
+  trx: DbTx,
+  skuId: string,
+  warehouseId: string,
+): Promise<WarehouseAvailability> {
+  // execute() 원시 결과 타이핑 — reservation-invariant.ts / ledger-reconciliation.service.ts 와
+  // 동일한 문서화된 캐스트.
+  const rows = (await trx.execute(sql`
+    SELECT
+      COALESCE((SELECT SUM(qty) FROM stock_ledgers
+                 WHERE sku_id = ${skuId} AND warehouse_id = ${warehouseId} AND stock_state = 'ON_HAND'), 0) AS on_hand,
+      COALESCE((SELECT SUM(quantity) FROM stock_reservations
+                 WHERE sku_id = ${skuId} AND warehouse_id = ${warehouseId} AND status = 'confirmed'), 0) AS reserved
+  `)) as unknown as AvailabilityRow[];
+
+  const onHand = Number(rows[0]?.on_hand ?? 0);
+  const reserved = Number(rows[0]?.reserved ?? 0);
+  return { onHand, reserved, available: computeAvailable(onHand, reserved) };
+}
+```
+
+- [ ] **Step 4: 단위 테스트 통과를 확인한다**
+
+```bash
+npx jest --testPathPattern="warehouse-availability\.spec" --runInBand
+```
+
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: 통합 테스트를 쓴다**
+
+Create `apps/core/src/modules/inventory/shared/availability/warehouse-availability.integration.spec.ts`:
+
+```typescript
+import * as postgres from 'postgres';
+import { drizzle, PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { sql } from 'drizzle-orm';
+import { randomUUID } from 'crypto';
+import { wmsSchema, DbTx } from '../../schema/inventory.schema';
+import { readWarehouseAvailability } from './warehouse-availability';
+
+/**
+ * 가용재고 정본 판독의 실 DB 검증. rollback 전용 트랜잭션.
+ *
+ * 실행: npm run test:core:integration:local -- warehouse-availability.integration
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+class Rollback extends Error {}
+
+describeIfDb('readWarehouseAvailability (DB integration, rollback-only)', () => {
+  jest.setTimeout(120_000);
+  let client: postgres.Sql;
+  let db: PostgresJsDatabase<typeof wmsSchema>;
+
+  beforeAll(() => {
+    client = postgres(DATABASE_URL as string, { max: 1 });
+    db = drizzle(client, { schema: wmsSchema });
+  });
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  const inRollback = async (fn: (trx: DbTx) => Promise<void>) => {
+    await db
+      .transaction(async (t) => {
+        await fn(t as unknown as DbTx);
+        throw new Rollback();
+      })
+      .catch((e) => {
+        if (!(e instanceof Rollback)) throw e;
+      });
+  };
+
+  /** ON_HAND 원장 1행 + confirmed 예약 1행을 심고 (skuId, warehouseId) 를 돌려준다. */
+  const seed = async (
+    trx: DbTx,
+    opts: { onHand: number; reserved: number },
+  ): Promise<{ skuId: string; warehouseId: string }> => {
+    const skuId = randomUUID();
+    const warehouseId = randomUUID();
+
+    await trx.execute(sql`
+      INSERT INTO warehouses (id, name, code) VALUES (${warehouseId}, ${'IT-WH'}, ${`IT-${warehouseId.slice(0, 8)}`})
+    `);
+    await trx.execute(sql`
+      INSERT INTO skus (id, name, code) VALUES (${skuId}, ${'IT-SKU'}, ${`IT-${skuId.slice(0, 8)}`})
+    `);
+    await trx.execute(sql`
+      INSERT INTO stock_ledgers (sku_id, warehouse_id, stock_state, qty)
+      VALUES (${skuId}, ${warehouseId}, 'ON_HAND', ${opts.onHand})
+    `);
+    if (opts.reserved > 0) {
+      await trx.execute(sql`
+        INSERT INTO stock_reservations (sku_id, warehouse_id, quantity, status, target_type)
+        VALUES (${skuId}, ${warehouseId}, ${opts.reserved}, 'confirmed', 'SHIPMENT_LINE')
+      `);
+    }
+    return { skuId, warehouseId };
+  };
+
+  it('ON_HAND 합 − confirmed 예약 합을 반환한다', async () => {
+    await inRollback(async (trx) => {
+      const { skuId, warehouseId } = await seed(trx, { onHand: 10, reserved: 4 });
+      const result = await readWarehouseAvailability(trx, skuId, warehouseId);
+      expect(result).toEqual({ onHand: 10, reserved: 4, available: 6 });
+    });
+  });
+
+  it('원장도 예약도 없으면 0 을 반환한다 (null 이 아니라)', async () => {
+    await inRollback(async (trx) => {
+      const result = await readWarehouseAvailability(trx, randomUUID(), randomUUID());
+      expect(result).toEqual({ onHand: 0, reserved: 0, available: 0 });
+    });
+  });
+
+  it('released 예약은 차감하지 않는다', async () => {
+    await inRollback(async (trx) => {
+      const { skuId, warehouseId } = await seed(trx, { onHand: 10, reserved: 4 });
+      await trx.execute(sql`
+        UPDATE stock_reservations SET status = 'released' WHERE sku_id = ${skuId}
+      `);
+      const result = await readWarehouseAvailability(trx, skuId, warehouseId);
+      expect(result.available).toBe(10);
+    });
+  });
+
+  it('ON_HAND 가 아닌 원장 상태는 합산하지 않는다', async () => {
+    await inRollback(async (trx) => {
+      const { skuId, warehouseId } = await seed(trx, { onHand: 10, reserved: 0 });
+      await trx.execute(sql`
+        INSERT INTO stock_ledgers (sku_id, warehouse_id, stock_state, qty)
+        VALUES (${skuId}, ${warehouseId}, 'DEFECTIVE', ${99})
+      `);
+      const result = await readWarehouseAvailability(trx, skuId, warehouseId);
+      expect(result.onHand).toBe(10);
+    });
+  });
+});
+```
+
+> **주의:** `seed()` 의 `INSERT` 컬럼 목록은 스키마와 정확히 맞아야 한다. 실행 전
+> `apps/core/src/modules/inventory/schema/inventory.schema.ts` 에서 `warehouses`, `skus`,
+> `stockLedgers`, `stockReservations` 의 **NOT NULL 이고 기본값 없는 컬럼**을 확인하고
+> 빠진 것이 있으면 INSERT 에 추가한다. Step 6 이 이걸 즉시 드러낸다.
+
+- [ ] **Step 6: 통합 테스트를 돌린다**
+
+```bash
+npm run test:core:integration:local -- warehouse-availability.integration
+```
+
+러너가 compose postgres 기동과 마이그레이션까지 처리한다.
+
+Expected: PASS (4 tests). NOT NULL 위반이 나면 Step 5 주의사항대로 `seed()` 를 고치고 다시 돌린다.
+
+- [ ] **Step 7: 죽은 `StockAvailabilityService` 주석을 제거한다**
+
+`apps/core/src/modules/inventory/shared/shared.module.ts` 에서 세 줄을 삭제한다:
+
+```typescript
+// import { StockAvailabilityService } from './services/stock-availability.service';   ← 삭제 (line 7)
+    // StockAvailabilityService,                                                       ← 삭제 (providers, line 25)
+    // StockAvailabilityService,                                                       ← 삭제 (exports, line 35)
+```
+
+이제 그 자리를 이 모듈이 채웠으므로 주석은 오해만 남긴다.
+
+- [ ] **Step 8: 타입체크 후 커밋**
+
+```bash
+npx nest build core
+```
+
+Expected: 성공 (에러 0)
+
+```bash
+git add apps/core/src/modules/inventory/shared/availability/ \
+        apps/core/src/modules/inventory/shared/shared.module.ts
+git commit -m "feat(inventory): 가용재고 정본 정의를 소유할 모듈 신설
+
+창고 grain 가용재고 = ON_HAND 원장 합 − confirmed 예약 합 (ADR-0001).
+호출자는 아직 바꾸지 않는다 — 정의를 담을 자리를 먼저 만들고 테스트로 고정.
+중단된 StockAvailabilityService 주석은 이 모듈이 대체하므로 제거."
+```
+
+---
+
+## Task 2: `reservation-invariant` 를 모듈에 위임
+
+**Files:**
+- Modify: `apps/core/src/modules/inventory/shared/locks/reservation-invariant.ts` (전면)
+- Modify: `apps/core/src/modules/inventory/shared/locks/reservation-invariant.spec.ts` (전면)
+
+**Interfaces:**
+- Consumes: `readWarehouseAvailability`, `violatesAvailability` (Task 1)
+- Produces: 기존 export 이름 3개를 **그대로 유지**한다 — `readWarehouseReservationBalance`, `violatesReservationInvariant`, `assertReservationInvariant`. 호출처 5곳(`stock-event.store.ts:600`, `inventory-command.service.ts:325,566`, `stocktaking.service.ts:550`)을 건드리지 않기 위해서다.
+
+- [ ] **Step 1: 기존 spec 을 모듈 위임 확인용으로 다시 쓴다**
+
+Replace `apps/core/src/modules/inventory/shared/locks/reservation-invariant.spec.ts` 전체:
+
+```typescript
+import { violatesReservationInvariant } from './reservation-invariant';
+
+// 이 술어는 이제 availability 모듈의 violatesAvailability 를 그대로 노출한다.
+// 아래 케이스는 위임 전 동작을 그대로 기술한 것 — 위임이 동작을 바꾸지 않음을 고정한다.
+describe('violatesReservationInvariant', () => {
+  it('차감 후 ON_HAND 가 예약보다 적으면 위반', () => {
+    expect(violatesReservationInvariant(10, 6, 5)).toBe(true); // 10-5=5 < 6
+  });
+  it('차감 후 ON_HAND 가 예약과 같으면 통과', () => {
+    expect(violatesReservationInvariant(10, 6, 4)).toBe(false); // 10-4=6 >= 6
+  });
+  it('예약 0 이면 항상 통과', () => {
+    expect(violatesReservationInvariant(10, 0, 10)).toBe(false);
+  });
+  it('차감 0 이어도 이미 초과 상태면 위반으로 본다', () => {
+    expect(violatesReservationInvariant(3, 5, 0)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: 새 케이스가 실패하는지 확인한다**
+
+```bash
+npx jest --testPathPattern="reservation-invariant\.spec" --runInBand
+```
+
+Expected: PASS (4 tests) — 네 번째 케이스는 기존 구현으로도 통과한다. 이 단계는 **기존 동작을 고정하는 것**이 목적이므로 통과가 정상이다. 만약 실패하면 기존 동작을 잘못 읽은 것이니 Step 3 을 진행하지 말고 멈춘다.
+
+- [ ] **Step 3: 위임으로 다시 쓴다**
+
+Replace `apps/core/src/modules/inventory/shared/locks/reservation-invariant.ts` 전체:
+
+```typescript
+import { ConflictException } from '@nestjs/common';
+import { DbTx } from '../../schema/inventory.schema';
+import { readWarehouseAvailability, violatesAvailability } from '../availability/warehouse-availability';
+
+/**
+ * 예약 불변식 — 가용재고 정의는 availability 모듈이 소유한다. 여기는 그 정의를
+ * "ON_HAND 를 뺄 수 있는가"라는 질문으로 감싸는 얇은 층이다.
+ *
+ * export 이름은 호출처 5곳(stock-event.store · inventory-command · stocktaking)을
+ * 건드리지 않으려고 유지한다.
+ */
+
+/** 창고 grain ON_HAND 원장 합·confirmed 예약 합 (단일 statement 원자 읽기 — torn read 방지). */
+export async function readWarehouseReservationBalance(
+  trx: DbTx,
+  skuId: string,
+  warehouseId: string,
+): Promise<{ onHand: number; reserved: number }> {
+  const { onHand, reserved } = await readWarehouseAvailability(trx, skuId, warehouseId);
+  return { onHand, reserved };
+}
+
+/** 차감/이동 후 창고 ON_HAND 합이 confirmed 예약 합보다 적어지면 true. */
+export function violatesReservationInvariant(onHandSum: number, reservedSum: number, removingQty: number): boolean {
+  return violatesAvailability(onHandSum, reservedSum, removingQty);
+}
+
+/** 락 획득 후 호출. 창고 합산 예약 불변식 위반 시 409(ConflictException). */
+export async function assertReservationInvariant(
+  trx: DbTx,
+  skuId: string,
+  warehouseId: string,
+  removingQty: number,
+): Promise<void> {
+  const { onHand, reserved } = await readWarehouseReservationBalance(trx, skuId, warehouseId);
+  if (violatesReservationInvariant(onHand, reserved, removingQty)) {
+    throw new ConflictException(
+      `예약된 재고는 감소/이동할 수 없습니다. 창고 ON_HAND ${onHand} − ${removingQty} < 예약 ${reserved}`,
+    );
+  }
+}
+```
+
+> 에러 메시지 문구는 **글자 그대로 유지**한다. 운영 로그·프론트 문자열 매칭이 있을 수 있다.
+
+- [ ] **Step 4: 단위 테스트와 기존 통합 테스트를 돌린다**
+
+```bash
+npx jest --testPathPattern="reservation-invariant" --runInBand
+```
+
+Expected: PASS
+
+```bash
+npm run test:core:integration:local -- unified-reservation.service.(lock|lifecycle).integration
+```
+
+Expected: PASS — 예약 생애주기·락 통합 스펙이 불변식 경로를 실제로 태운다.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+npx nest build core
+git add apps/core/src/modules/inventory/shared/locks/reservation-invariant.ts \
+        apps/core/src/modules/inventory/shared/locks/reservation-invariant.spec.ts
+git commit -m "refactor(inventory): 예약 불변식 판독을 availability 모듈에 위임
+
+산식 중복 1벌 제거. export 이름과 에러 문구는 유지 — 호출처 5곳 무변경."
+```
+
+---
+
+## Task 3: `unified-reservation.getAvailableStock` 을 모듈에 위임
+
+**Files:**
+- Modify: `apps/core/src/modules/inventory/shared/services/unified-reservation.service.ts:249-263`
+
+**Interfaces:**
+- Consumes: `readWarehouseAvailability` (Task 1)
+- Produces: 없음 (private 메서드 내부 교체)
+
+- [ ] **Step 1: 현재 동작을 고정하는 통합 테스트를 확인한다**
+
+새 테스트를 쓰지 않는다. `unified-reservation.service.lifecycle.integration.spec.ts` 와 `.lock.integration.spec.ts` 가 이미 이 경로를 태운다. 먼저 초록인지 확인한다:
+
+```bash
+npm run test:core:integration:local -- unified-reservation.service..*.integration
+```
+
+Expected: PASS. **여기서 실패하면 Task 3 을 진행하지 않는다** — 기준선이 없으면 위임의 안전성을 증명할 수 없다.
+
+- [ ] **Step 2: private 메서드를 위임으로 교체한다**
+
+`apps/core/src/modules/inventory/shared/services/unified-reservation.service.ts:249-263` 의 `getAvailableStock` 본문 전체를 다음으로 바꾼다:
+
+```typescript
+  private async getAvailableStock(skuId: string, warehouseId: string, tx?: DbTx): Promise<number> {
+    const db = tx ?? this.db.db;
+    // 산식·단일 statement 원자성은 availability 모듈이 소유한다.
+    const { available } = await readWarehouseAvailability(db as DbTx, skuId, warehouseId);
+    return available;
+  }
+```
+
+파일 상단 import 에 추가:
+
+```typescript
+import { readWarehouseAvailability } from '../availability/warehouse-availability';
+```
+
+> `db as DbTx` 캐스팅이 필요한 이유: 기존 코드가 `tx ?? this.db.db` 로 트랜잭션과 베이스
+> 커넥션을 같은 변수에 담고 있다. `readWarehouseAvailability` 는 `DbTx` 를 받으므로 좁히기가
+> 필요하다. **범위 밖 리팩터링을 하지 말 것** — 이 함수의 tx 전파 형태를 바꾸는 것은 별건이다.
+> 캐스팅 위 주석으로 사유를 남긴다:
+>
+> ```typescript
+> // 기존 시그니처 유지를 위한 좁히기 — 이 메서드의 tx 전파 형태 변경은 별건(ADR-0025).
+> ```
+
+- [ ] **Step 3: 통합 테스트를 다시 돌린다**
+
+```bash
+npm run test:core:integration:local -- unified-reservation.service..*.integration
+```
+
+Expected: PASS — Step 1 과 동일한 결과
+
+- [ ] **Step 4: 커밋**
+
+```bash
+npx nest build core
+git add apps/core/src/modules/inventory/shared/services/unified-reservation.service.ts
+git commit -m "refactor(inventory): 예약 승인 가용 판독을 availability 모듈에 위임
+
+산식 중복 1벌 제거. 예약 승인 문턱은 불변."
+```
+
+---
+
+## Task 4: 죽은 `barcode.scanSku` 삭제
+
+`scanSku` 는 예약을 차감하지 않은 ON_HAND 합을 `availableQty` 라는 이름으로 반환한다. **호출자가 0곳**이므로 라이브 버그가 아니라 죽은 코드다. 고치는 게 아니라 지운다.
+
+**Files:**
+- Modify: `apps/core/src/modules/inventory/shared/services/barcode.service.ts:76-120` (메서드 삭제)
+
+**Interfaces:**
+- Consumes: 없음
+- Produces: 없음
+
+- [ ] **Step 1: 정말 죽었는지 다시 확인한다**
+
+```bash
+grep -rn "scanSku\|SkuScanResult" --include=*.ts apps/ | grep -v node_modules
+```
+
+Expected: `barcode.service.ts` 안의 선언만 나온다. **다른 파일이 하나라도 나오면 이 Task 를 건너뛰고 보고한다.**
+
+- [ ] **Step 2: 메서드와 전용 타입을 삭제한다**
+
+`apps/core/src/modules/inventory/shared/services/barcode.service.ts` 에서:
+- `async scanSku(...)` 메서드 전체 (`:76` 부터 닫는 `}` 까지) 삭제
+- `SkuScanResult` 인터페이스/타입 선언 삭제 (Step 1 에서 이 파일 안에만 있음을 확인했다)
+- 삭제 후 쓰이지 않게 된 import 제거 (`nest build core` 가 잡아준다)
+
+- [ ] **Step 3: 빌드로 미사용 참조가 없는지 확인한다**
+
+```bash
+npx nest build core
+```
+
+Expected: 성공 (에러 0)
+
+```bash
+npx jest --testPathPattern="barcode" --runInBand
+```
+
+Expected: PASS 또는 "no tests found" — 둘 다 정상
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add apps/core/src/modules/inventory/shared/services/barcode.service.ts
+git commit -m "fix(inventory): 죽은 barcode.scanSku 삭제
+
+예약을 차감하지 않은 ON_HAND 합을 availableQty 로 반환하던 메서드.
+호출자 0곳이라 라이브 영향은 없었으나, 가용재고 산식의 잘못된 7번째 변형으로
+되살아날 위험이 있어 제거한다."
+```
+
+---
+
+## Task 5: 뷰 `available_qty` 에서 `transit_out` 제거
+
+이 Task 만이 **라이브 동작을 바꾼다.** 마이그레이션 1건이 나온다.
+
+**Files:**
+- Modify: `apps/core/src/modules/inventory/schema/inventory.schema.ts:982` (뷰 정의)
+- Create: `apps/core/drizzle/<timestamp>_drop-transit-out-from-available-qty.sql` (생성됨)
+- Create: `apps/core/src/modules/inventory/shared/availability/view-parity.integration.spec.ts`
+
+**Interfaces:**
+- Consumes: `readWarehouseAvailability` (Task 1)
+- Produces: 없음 — 뷰의 컬럼 목록은 그대로다. `available_qty` 의 **값**만 바뀐다.
+
+- [ ] **Step 1: 뷰와 모듈이 어긋나는 것을 증명하는 테스트를 쓴다**
+
+Create `apps/core/src/modules/inventory/shared/availability/view-parity.integration.spec.ts`:
+
+```typescript
+import * as postgres from 'postgres';
+import { drizzle, PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { sql } from 'drizzle-orm';
+import { randomUUID } from 'crypto';
+import { wmsSchema, DbTx } from '../../schema/inventory.schema';
+import { readWarehouseAvailability } from './warehouse-availability';
+
+/**
+ * stock_summary_view.available_qty 가 가용재고 정본 정의와 일치하는지 고정한다.
+ *
+ * 이 스펙이 존재하는 이유: 뷰는 오래 `on_hand − reserved − transit_out` 이었고,
+ * transit_out 은 (a) 출발 창고에서만 빼고 도착 창고에 더하지 않아 사내 이동만으로
+ * 전사 판매가능수량을 줄였으며 (b) inbound_plan_items 를 읽는데 실제 창고간이동은
+ * stock_journals 를 써서 이동이 끝나도 줄지 않았다. 그 항을 제거한 뒤,
+ * 아무도 다시 넣지 못하게 이 테스트가 막는다.
+ *
+ * 실행: npm run test:core:integration:local -- <이 파일의 패턴>
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+class Rollback extends Error {}
+
+describeIfDb('stock_summary_view ↔ availability 모듈 등가 (DB integration)', () => {
+  jest.setTimeout(120_000);
+  let client: postgres.Sql;
+  let db: PostgresJsDatabase<typeof wmsSchema>;
+
+  beforeAll(() => {
+    client = postgres(DATABASE_URL as string, { max: 1 });
+    db = drizzle(client, { schema: wmsSchema });
+  });
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  const inRollback = async (fn: (trx: DbTx) => Promise<void>) => {
+    await db
+      .transaction(async (t) => {
+        await fn(t as unknown as DbTx);
+        throw new Rollback();
+      })
+      .catch((e) => {
+        if (!(e instanceof Rollback)) throw e;
+      });
+  };
+
+  const readView = async (trx: DbTx, skuId: string, warehouseId: string): Promise<number> => {
+    const rows = (await trx.execute(sql`
+      SELECT available_qty FROM stock_summary_view
+       WHERE sku_id = ${skuId} AND warehouse_id = ${warehouseId}
+    `)) as unknown as { available_qty: number | string }[];
+    return Number(rows[0]?.available_qty ?? 0);
+  };
+
+  it('이전 예정(pending 창고간 inbound plan)이 있어도 뷰와 모듈이 일치한다', async () => {
+    await inRollback(async (trx) => {
+      const skuId = randomUUID();
+      const sourceWarehouseId = randomUUID();
+      const destWarehouseId = randomUUID();
+      const planId = randomUUID();
+
+      await trx.execute(sql`
+        INSERT INTO warehouses (id, name, code)
+        VALUES (${sourceWarehouseId}, ${'IT-SRC'}, ${`IT-S-${sourceWarehouseId.slice(0, 6)}`}),
+               (${destWarehouseId}, ${'IT-DST'}, ${`IT-D-${destWarehouseId.slice(0, 6)}`})
+      `);
+      await trx.execute(sql`
+        INSERT INTO skus (id, name, code) VALUES (${skuId}, ${'IT-SKU'}, ${`IT-${skuId.slice(0, 8)}`})
+      `);
+      await trx.execute(sql`
+        INSERT INTO stock_ledgers (sku_id, warehouse_id, stock_state, qty)
+        VALUES (${skuId}, ${sourceWarehouseId}, 'ON_HAND', ${10})
+      `);
+      // 출발 창고 → 도착 창고 이전 예정 4개 (이것이 옛 transit_out 항을 만들던 데이터)
+      await trx.execute(sql`
+        INSERT INTO inbound_plans (id, warehouse_id, destination_warehouse_id, requires_transfer)
+        VALUES (${planId}, ${sourceWarehouseId}, ${destWarehouseId}, true)
+      `);
+      await trx.execute(sql`
+        INSERT INTO inbound_plan_items (plan_id, sku_id, expected_qty, received_qty, status)
+        VALUES (${planId}, ${skuId}, ${4}, ${0}, 'pending')
+      `);
+
+      const fromModule = await readWarehouseAvailability(trx, skuId, sourceWarehouseId);
+      const fromView = await readView(trx, skuId, sourceWarehouseId);
+
+      expect(fromModule.available).toBe(10);
+      expect(fromView).toBe(10); // 이전 예정은 가용에서 빼지 않는다
+    });
+  });
+
+  it('예약이 있으면 뷰와 모듈이 같은 값을 낸다', async () => {
+    await inRollback(async (trx) => {
+      const skuId = randomUUID();
+      const warehouseId = randomUUID();
+
+      await trx.execute(sql`
+        INSERT INTO warehouses (id, name, code)
+        VALUES (${warehouseId}, ${'IT-WH'}, ${`IT-${warehouseId.slice(0, 8)}`})
+      `);
+      await trx.execute(sql`
+        INSERT INTO skus (id, name, code) VALUES (${skuId}, ${'IT-SKU'}, ${`IT-${skuId.slice(0, 8)}`})
+      `);
+      await trx.execute(sql`
+        INSERT INTO stock_ledgers (sku_id, warehouse_id, stock_state, qty)
+        VALUES (${skuId}, ${warehouseId}, 'ON_HAND', ${10})
+      `);
+      await trx.execute(sql`
+        INSERT INTO stock_reservations (sku_id, warehouse_id, quantity, status, target_type)
+        VALUES (${skuId}, ${warehouseId}, ${3}, 'confirmed', 'SHIPMENT_LINE')
+      `);
+
+      const fromModule = await readWarehouseAvailability(trx, skuId, warehouseId);
+      const fromView = await readView(trx, skuId, warehouseId);
+
+      expect(fromView).toBe(fromModule.available);
+      expect(fromView).toBe(7);
+    });
+  });
+});
+```
+
+> `inbound_plans` / `inbound_plan_items` 의 INSERT 컬럼도 Task 1 Step 5 와 같은 방식으로
+> 스키마의 NOT NULL 컬럼을 확인해 보완한다.
+
+- [ ] **Step 2: 첫 번째 테스트가 실패하는지 확인한다**
+
+```bash
+npm run test:core:integration:local -- view-parity.integration
+```
+
+Expected: 첫 테스트 FAIL — `expect(fromView).toBe(10)` 이 `6` 을 받는다 (10 − 0 − 4). 두 번째 테스트는 PASS.
+
+**이 실패가 `transit_out` 버그의 재현이다.** 실패 출력을 확인하고 넘어간다.
+
+- [ ] **Step 3: 뷰 정의에서 `transit_out` 항을 뺀다**
+
+`apps/core/src/modules/inventory/schema/inventory.schema.ts:982` 한 줄을 바꾼다:
+
+```sql
+-- 변경 전
+COALESCE(on_hand.qty, 0) - COALESCE(reserved.qty, 0) - COALESCE(transit_out.qty, 0) as available_qty,
+
+-- 변경 후
+COALESCE(on_hand.qty, 0) - COALESCE(reserved.qty, 0) as available_qty,
+```
+
+**`transit_out` 서브쿼리와 `transfer_pending_qty` 컬럼(`:987`)은 그대로 둔다.** 표시용 정보로서는 유효하고, 컬럼을 없애면 destructive 변경이 되어 expand-contract 분할이 필요해진다(ADR-0005 §5). 이 Task 는 `available_qty` 의 **값**만 바꾼다.
+
+`:982` 바로 위에 주석을 추가한다:
+
+```sql
+-- 가용재고 = ON_HAND 합 − confirmed 예약 합 (ADR-0001).
+-- transit_out 을 다시 빼지 말 것: 출발 창고에서만 빠지고 도착 창고에 더해지지 않아
+-- 사내 이동만으로 전사 판매가능수량이 줄고, inbound_plan_items 기반이라 실제 이동
+-- (stock_journals)이 끝나도 줄지 않는다. 등가성은 view-parity.integration.spec.ts 가 고정한다.
+```
+
+- [ ] **Step 4: 마이그레이션을 생성하고 SQL 을 검토한다**
+
+```bash
+npm run db:generate:core -- --name drop-transit-out-from-available-qty
+```
+
+생성된 `apps/core/drizzle/<timestamp>_drop-transit-out-from-available-qty.sql` 을 연다.
+
+**drizzle-kit 이 뷰 변경을 감지하지 못해 빈 파일이거나 뷰 문이 없을 수 있다.** 그런 경우 이 마이그레이션은 **아직 어디에도 적용되지 않았으므로** 직접 SQL 을 작성해 넣는다 (CLAUDE.md 의 "이미 적용된 마이그레이션을 손대지 말라"는 규칙은 미적용 파일에는 해당하지 않는다):
+
+```sql
+DROP VIEW IF EXISTS stock_summary_view;
+CREATE VIEW stock_summary_view AS
+-- inventory.schema.ts 의 stockSummary 정의와 글자 그대로 같은 SELECT 를 붙여넣는다
+```
+
+붙여넣을 SELECT 는 `inventory.schema.ts` 의 `pgView('stock_summary_view', {...}).as(sql\`...\`)` 안 내용이다. **schema.ts 와 마이그레이션 SQL 이 한 글자도 다르지 않아야 한다** — 다르면 Step 5 의 등가 테스트가 잡아준다.
+
+- [ ] **Step 5: 마이그레이션을 적용하고 테스트를 다시 돌린다**
+
+```bash
+npm run test:core:integration:local -- view-parity.integration
+```
+
+러너가 jest 전에 `drizzle-kit migrate` 를 돌리므로 새 마이그레이션이 자동 적용된다.
+
+Expected: PASS (2 tests)
+
+> ⚠️ 로컬 `core` DB 는 재사용되는 실 DB 다(throwaway 아님). 뷰 재정의는 `DROP VIEW` → `CREATE VIEW`
+> 이므로 되돌리려면 마이그레이션을 되돌려야 한다. 이 Task 를 되감아야 하면
+> `docker compose down -v && docker compose up -d && npm run db:migrate:local` 로 초기화한다.
+
+- [ ] **Step 6: 뷰를 읽는 다른 경로의 회귀를 확인한다**
+
+```bash
+npm run test:core:integration:local -- (product-sellable-quantity|logistics|fulfillment).*integration
+```
+
+Expected: PASS. 실패가 나면 **`transit_out` 을 되돌리지 말고** 실패 내용을 보고한다 — 어떤 스펙이 옛 산식을 전제하고 있었다는 뜻이고, 그 전제 자체가 검토 대상이다.
+
+- [ ] **Step 7: 커밋 (schema + migration 한 커밋)**
+
+```bash
+npx nest build core
+git add apps/core/src/modules/inventory/schema/inventory.schema.ts \
+        apps/core/drizzle/ \
+        apps/core/src/modules/inventory/shared/availability/view-parity.integration.spec.ts
+git commit -m "fix(inventory): stock_summary_view.available_qty 에서 transit_out 차감 제거
+
+transit_out 은 (1) 출발 창고에서만 빠지고 도착 창고에 더해지지 않아 사내 이동만으로
+전사 판매가능수량이 줄었고, (2) inbound_plan_items 를 읽는데 실제 창고간이동은
+stock_journals 를 써서 이동이 끝나도 줄지 않았다.
+
+예약 승인은 unified-reservation 이 자체 산식으로 판정하며 애초에 transit_out 을
+보지 않았다 — 따라서 승인 문턱은 불변이고 오버셀 위험은 없다. storefront 표시가
+예약 seam 이 실제로 허용하는 값과 일치하게 된다.
+
+transfer_pending_qty 표시 컬럼은 유지(ADR-0005 §5 destructive 회피)."
+```
+
+---
+
+## Task 6: 야간 대사 CTE 를 등가 테스트로 고정
+
+`ledger-reconciliation.reconcileReservations` 의 CTE 는 전 카탈로그 집합 스캔이라 (sku, warehouse) 단위 스칼라 함수로 대체할 수 없다. 중복은 남기되, **조용히 갈라지는 것은 막는다.**
+
+**Files:**
+- Modify: `apps/core/src/modules/inventory/core/services/ledger-reconciliation.service.ts:150-151` (주석)
+- Create: `apps/core/src/modules/inventory/shared/availability/reconciliation-parity.integration.spec.ts`
+
+**Interfaces:**
+- Consumes: `readWarehouseAvailability` (Task 1), `LedgerReconciliationService.reconcileReservations`
+- Produces: 없음
+
+- [ ] **Step 1: 등가 테스트를 쓴다**
+
+Create `apps/core/src/modules/inventory/shared/availability/reconciliation-parity.integration.spec.ts`:
+
+```typescript
+import * as postgres from 'postgres';
+import { drizzle, PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { sql } from 'drizzle-orm';
+import { randomUUID } from 'crypto';
+import { DbService } from '@app/db';
+import { wmsSchema, DbTx } from '../../schema/inventory.schema';
+import { readWarehouseAvailability } from './warehouse-availability';
+import { LedgerReconciliationService } from '../../core/services/ledger-reconciliation.service';
+
+/**
+ * 야간 대사의 CTE 와 availability 모듈이 같은 결론을 내는지 고정한다.
+ *
+ * CTE 는 전 카탈로그 집합 스캔이라 (sku,warehouse) 스칼라 함수로 대체할 수 없다.
+ * 따라서 중복 자체는 남기고, 두 산식이 갈라지는 것만 이 테스트가 막는다.
+ *
+ * 실행: npm run test:core:integration:local -- <이 파일의 패턴>
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+class Rollback extends Error {}
+
+describeIfDb('야간 대사 CTE ↔ availability 모듈 등가 (DB integration)', () => {
+  jest.setTimeout(120_000);
+  let client: postgres.Sql;
+  let db: PostgresJsDatabase<typeof wmsSchema>;
+
+  beforeAll(() => {
+    client = postgres(DATABASE_URL as string, { max: 1 });
+    db = drizzle(client, { schema: wmsSchema });
+  });
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  const inRollback = async (fn: (trx: DbTx) => Promise<void>) => {
+    await db
+      .transaction(async (t) => {
+        await fn(t as unknown as DbTx);
+        throw new Rollback();
+      })
+      .catch((e) => {
+        if (!(e instanceof Rollback)) throw e;
+      });
+  };
+
+  const buildService = (trx: DbTx): LedgerReconciliationService => {
+    // ADR-0025 단일 러너 최소 대역: spec 은 항상 rollback tx 를 전파한다.
+    const dbService = {
+      db,
+      run: <T>(fn: (t: DbTx) => Promise<T>, tx?: DbTx): Promise<T> => fn(tx ?? trx),
+    } as unknown as DbService<typeof wmsSchema>;
+    return new LedgerReconciliationService(dbService, { setReservationDrift: () => undefined } as never);
+  };
+
+  const seedOverReserved = async (trx: DbTx): Promise<{ skuId: string; warehouseId: string }> => {
+    const skuId = randomUUID();
+    const warehouseId = randomUUID();
+    await trx.execute(sql`
+      INSERT INTO warehouses (id, name, code)
+      VALUES (${warehouseId}, ${'IT-WH'}, ${`IT-${warehouseId.slice(0, 8)}`})
+    `);
+    await trx.execute(sql`
+      INSERT INTO skus (id, name, code) VALUES (${skuId}, ${'IT-SKU'}, ${`IT-${skuId.slice(0, 8)}`})
+    `);
+    await trx.execute(sql`
+      INSERT INTO stock_ledgers (sku_id, warehouse_id, stock_state, qty)
+      VALUES (${skuId}, ${warehouseId}, 'ON_HAND', ${2})
+    `);
+    await trx.execute(sql`
+      INSERT INTO stock_reservations (sku_id, warehouse_id, quantity, status, target_type)
+      VALUES (${skuId}, ${warehouseId}, ${5}, 'confirmed', 'SHIPMENT_LINE')
+    `);
+    return { skuId, warehouseId };
+  };
+
+  it('모듈이 음수 가용을 보는 grain 을 대사도 drift 로 잡는다', async () => {
+    await inRollback(async (trx) => {
+      const { skuId, warehouseId } = await seedOverReserved(trx);
+
+      const fromModule = await readWarehouseAvailability(trx, skuId, warehouseId);
+      expect(fromModule.available).toBe(-3);
+
+      const report = await buildService(trx).reconcileReservations({ skuId, warehouseId }, trx);
+
+      expect(report.totalDriftGrains).toBe(1);
+      expect(report.drifts[0]).toMatchObject({
+        skuId,
+        warehouseId,
+        onHandQty: fromModule.onHand,
+        reservedQty: fromModule.reserved,
+        shortfall: -fromModule.available,
+      });
+    });
+  });
+
+  it('모듈 가용이 0 이상이면 대사는 아무것도 잡지 않는다', async () => {
+    await inRollback(async (trx) => {
+      const skuId = randomUUID();
+      const warehouseId = randomUUID();
+      await trx.execute(sql`
+        INSERT INTO warehouses (id, name, code)
+        VALUES (${warehouseId}, ${'IT-WH'}, ${`IT-${warehouseId.slice(0, 8)}`})
+      `);
+      await trx.execute(sql`
+        INSERT INTO skus (id, name, code) VALUES (${skuId}, ${'IT-SKU'}, ${`IT-${skuId.slice(0, 8)}`})
+      `);
+      await trx.execute(sql`
+        INSERT INTO stock_ledgers (sku_id, warehouse_id, stock_state, qty)
+        VALUES (${skuId}, ${warehouseId}, 'ON_HAND', ${5})
+      `);
+      await trx.execute(sql`
+        INSERT INTO stock_reservations (sku_id, warehouse_id, quantity, status, target_type)
+        VALUES (${skuId}, ${warehouseId}, ${5}, 'confirmed', 'SHIPMENT_LINE')
+      `);
+
+      const fromModule = await readWarehouseAvailability(trx, skuId, warehouseId);
+      expect(fromModule.available).toBe(0);
+
+      const report = await buildService(trx).reconcileReservations({ skuId, warehouseId }, trx);
+      expect(report.totalDriftGrains).toBe(0);
+    });
+  });
+});
+```
+
+> `LedgerReconciliationService` 의 생성자 인자 개수·순서를 실제 파일에서 확인하고
+> `buildService` 를 맞춘다. 메트릭 대역의 메서드 이름도 실제 것으로 바꾼다
+> (`ledger-reconciliation.service.ts` 의 `this.metrics.` 호출을 보고 결정).
+
+- [ ] **Step 2: 테스트를 돌린다**
+
+```bash
+npm run test:core:integration:local -- reconciliation-parity.integration
+```
+
+Expected: PASS (2 tests). 생성자 대역이 안 맞으면 Step 1 주의사항대로 고치고 다시 돌린다.
+
+- [ ] **Step 3: 낡은 주석을 갱신한다**
+
+`ledger-reconciliation.service.ts:150-151` 의 주석을 바꾼다:
+
+```typescript
+  /**
+   * (sku,warehouse) 예약 불변식 대사 — ON_HAND 원장 합 < confirmed 예약 합 grain 만 반환.
+   *
+   * 전 카탈로그 집합 스캔이라 (sku,warehouse) 스칼라 판독인 availability 모듈로
+   * 대체하지 않는다. 두 산식이 같은 결론을 내는지는
+   * shared/availability/reconciliation-parity.integration.spec.ts 가 고정한다.
+   */
+```
+
+기존의 *"raw 합 직접 집계(뷰 availableQty 의 transit_out 반영 금지 → 거짓 경보 방지)"* 는 Task 5 로 근거가 사라졌으므로 지운다.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+npx nest build core
+git add apps/core/src/modules/inventory/core/services/ledger-reconciliation.service.ts \
+        apps/core/src/modules/inventory/shared/availability/reconciliation-parity.integration.spec.ts
+git commit -m "test(inventory): 야간 대사 CTE 와 availability 모듈의 등가를 고정
+
+집합 스캔이라 스칼라 모듈로 대체 불가 — 중복은 남기되 조용한 분기를 막는다.
+transit_out 회피를 근거로 들던 낡은 주석 제거(Task 5 로 근거 소멸)."
+```
+
+---
+
+## 마무리: 전체 검증
+
+- [ ] **Step 1: 전체 단위 테스트**
+
+```bash
+npx jest --testPathPattern="apps/core/src/modules/inventory" --runInBand
+```
+
+Expected: PASS
+
+- [ ] **Step 2: 전체 통합 테스트**
+
+```bash
+npm run test:core:integration:local -- apps/core/src/modules/(inventory|fulfillment).*integration
+```
+
+Expected: PASS
+
+- [ ] **Step 3: 빌드 · 타입체크 · 린트**
+
+```bash
+npx nest build core
+npm run type-check
+npm run lint
+```
+
+Expected: `nest build core` 에러 0.
+
+`npm run type-check` 는 **기존 부채가 남아 있어 0 이 아니다.** 절대 수치를 외워서 비교하지 말고, 작업 시작 전 `git stash && npm run type-check 2>&1 | tail -1` 로 기준선을 직접 재고 그 값과 비교한다. 이 작업이 **늘리지 않았는지**만 확인하면 된다. (`tail` 로 자른 출력에 개수를 매기지 말 것 — 과거 그 착각으로 오보한 적이 있다.)
+
+- [ ] **Step 4: 산식이 정말 줄었는지 센다**
+
+```bash
+grep -rn "stock_state = 'ON_HAND'" --include=*.ts apps/core/src/modules/inventory | grep -i "reserv" 
+```
+
+Expected: `warehouse-availability.ts` 와 `ledger-reconciliation.service.ts` 두 곳만. 다른 파일이 나오면 놓친 산식이다.
+
+---
+
+## 배포 노트
+
+**마이그레이션 1건** (Task 5). `apps/core/drizzle/<ts>_drop-transit-out-from-available-qty.sql`.
+
+**순서: `migrate → deploy`.**
+
+- 뷰의 **컬럼 목록은 그대로**이므로 옛 task 가 새 뷰를 만나도 깨지지 않는다 (`available_qty` 값만 커진다). expand phase 규칙(CLAUDE.md: "expand 는 migrate → deploy")이 적용된다.
+- 반대 순서로 하면 새 코드(등가 테스트 전제)가 옛 뷰를 만난다 — 런타임에 깨지진 않지만 무의미한 창이 생긴다.
+
+**적용 명령** (AWS `dev` stage 는 폐기됐으므로 live 기준):
+
+```bash
+npm run db:migrate -- --stage live --deployment lcnine-services --yes
+```
+
+그 다음 `sst deploy`.
+
+**배포 후 관측 항목:**
+
+1. **판매가능수량 상승.** `transit_out > 0` 이던 SKU 의 storefront 노출 수량이 오른다. 상승분 = 그 SKU 의 pending 창고간 inbound plan 잔량. 이건 의도된 변화다.
+2. **오버셀 없음 확인.** 예약 승인은 `unified-reservation` 이 자체 산식으로 하며 transit_out 을 본 적이 없다. 배포 후 `ledger-reconciliation` 야간 대사(`0 3 * * *`)의 `totalDriftGrains` 가 0 을 유지하는지 확인한다. 올라가면 이 전제가 틀린 것이므로 즉시 보고.
+3. **예약 재시도 워커.** `fulfillment-order-reservation-retry.worker.ts:84` 가 `available_qty > 0` 로 후보를 고른다. 후보 수가 늘 수 있다 — 정상이다(전에는 transit_out 때문에 부당하게 탈락하던 라인들).
+4. **발주 제안.** `purchase-order.service.ts:822` 의 `available_qty < 10` 조건에 걸리는 SKU 가 준다 — 정상이다(전에는 부풀려진 부족분이었다).
+
+**롤백:** 뷰를 되돌리는 역마이그레이션은 만들지 않는다. 문제가 생기면 원인을 먼저 규명한다 — `transit_out` 복원은 위 4가지 결함을 되살리는 것이라 롤백이 아니라 회귀다.
+
+---
+
+## 후속 (별건)
+
+1. **창고간이동 custody 모델.** 이동 기간 동안 재고를 작업에 묶는 모델이 없다. 출고작업의 `batch_inventory_sessions` 에 해당하는 것. 두 갈래 — (a) `transferShip`/`transferReceive` 를 트랜잭션 분리해 `IN_TRANSFER` 를 존속시키거나, (b) 세션 오버레이 방식. 설계 논의 필요.
+2. **custody 오버레이의 창고 grain 확장.** 숏피킹으로 예약이 해제되고 custody 가 `RETURN_PENDING` 인 구간에 "예약은 되지만 피킹 때 409" 인 틈이 있다. Task 1 의 모듈이 이 오버레이가 들어갈 자리다.
+3. **갇힌 batch 세션 탐지.** `recovery_required` 세션의 체류 시간을 보는 크론이 없다. 야간 대사의 `SESSION_CONSERVATION` 은 수량 보존만 보고 체류 시간을 보지 않아, 완벽히 보존된 채 영원히 열린 세션은 통과한다.
+4. **`new BatchControlledStockGuard()` 기본 인자 제거** (3곳). 프로바이더 등록 누락이 조용히 통과하는 구조.


### PR DESCRIPTION
## 배경

`apps/core` 에서 **가용재고(available stock)의 정의가 6벌로 갈라져 있었다.** 정본 규칙은 `CLAUDE.md` 와 ADR-0001 이 못박는다 — **가용재고 = ON_HAND 원장 합 − confirmed 예약 합.**

| 위치 | 산식 | 성격 |
|---|---|---|
| `inventory.schema.ts:982` (`stock_summary_view`) | `on_hand − reserved − transit_out` | **의미 분기** |
| `unified-reservation.service.ts:249` | `on_hand − reserved` (raw SQL) | 중복 |
| `shared/locks/reservation-invariant.ts` | 같은 raw SQL | 중복 |
| `ledger-reconciliation.service.ts` | 같은 산식 (raw CTE, 전 카탈로그 집합 스캔) | 중복 |
| `batch-controlled-stock.guard.ts` | `on_hand − batch_controlled` (로케이션 grain) | 다른 grain — 통합 대상 아님 |
| `barcode.service.ts:107` | `on_hand` 합 (예약 미차감) | 죽은 코드 (호출자 0) |

그중 하나(`ledger-reconciliation`)는 **"다른 하나가 틀렸기 때문에" 존재한다고 주석에 적혀 있었다** — `뷰 availableQty 의 transit_out 반영 금지 → 거짓 경보 방지`.

## `transit_out` 이 틀린 항인 근거 (실측)

1. **출발 창고에서만 차감하고 도착 창고에 더하지 않는다.** 판매가능수량은 전 창고를 합산하므로(`product-sellable-quantity.service.ts`, 창고 필터 없음), **사내 이동 계획을 잡는 것만으로 회사 전체 판매가능수량이 줄었다.**
2. **실제 이동을 추적하지도 않는다.** `transit_out` 은 `inbound_plan_items` 를 읽는데 창고간이동은 `stock_journals`(`sourceType: 'warehouse_transfer'`)를 쓴다. `transfer.service.ts` 에 `inboundPlan` 이라는 단어가 **0회** 등장한다 — 두 시스템은 연결돼 있지 않아 이동이 끝나도 차감이 풀리지 않는다.

## 변경 내용

| # | 내용 | 커밋 |
|---|---|---|
| 1 | 정본 모듈 신설 `shared/availability/warehouse-availability.ts` | `0a1e29b12` |
| 2 | `reservation-invariant` 판독 위임 (중복 −1) | `c23dae6f9` |
| 3 | `unified-reservation.getAvailableStock` 위임 (중복 −1) | `a8c786b02` |
| 4 | 죽은 `barcode.scanSku` 삭제 + 미사용 import 정리 | `1352da220`, `62fc313bd` |
| 5 | **뷰 `available_qty` 에서 `transit_out` 제거 + 마이그레이션 1건** | `e94b198a5` |
| 6 | 야간 대사 등가 고정 + 같은 파일의 사전 존재 실패 수정 | `f8880eb3d` |
| — | `.claude/worktrees/` gitignore 추가 (별건, 아래 참조) | `5692f0832` |

**결과: 산식 6벌 → 실질 2벌.** 정본 모듈 1개 + 대체 불가한 집합 스캔 CTE 1개(등가 테스트로 고정). 뷰는 모듈과 값이 일치하도록 맞췄다.

### 왜 CTE 는 남겼나

`reconcileReservations` 의 CTE 는 **전 카탈로그 집합 스캔**이라 `(sku, warehouse)` 스칼라 함수로 바꾸면 N+1 이 된다. 없애는 대신 **등가 테스트로 묶었다** — `shortfall: -fromModule.available` 로 두 산식의 값을 직접 연결해, 어느 한쪽에 항이 추가되거나 부호가 뒤집히면 즉시 깨진다.

## 🔴 배포 — 라이브 동작이 바뀐다

**마이그레이션 1건.** 시크릿 0 · env 0 · 이벤트 계약 0.

**순서: `migrate → deploy`** (expand phase). 뷰의 컬럼 목록·순서·타입이 불변이라 롤링 중 옛 태스크가 새 뷰를 만나도 안전하다.

### 오버셀 위험은 없다 — 다만 논증에 주의

- ❌ *"예약 승인이 뷰를 안 보므로 안전하다"*
- ✅ **"뷰가 이제 예약 문턱과 같아졌다."** 이전에는 뷰가 문턱보다 **낮아서** 팔 수 있는 것을 못 팔고 있었다.

`product-sellable-quantity` 는 표시가 아니라 **실판매 게이트**다 — `psq_` inventory item 으로 Medusa 에 투영되고 Medusa 가 `manage_inventory=true` 로 체크아웃을 막는다. 즉 이 변경은 **팔 수 있는 양을 올린다.** 문턱을 넘기는 방향이 아니라 문턱에 맞추는 방향이라 오버셀은 나지 않는다.

### 예상 증상 — 회귀로 오진하지 말 것

**pending 창고간 이전분이 판매 가능해진다.** 그게 팔리면 이전 실행이 `inventory-command.service.ts:325` 의 `assertReservationInvariant` 에서 **409 로 막힌다.** 조용한 오버셀이 아니라 이전 작업 실패로 표면화된다. 이는 범위 밖에 둔 "창고간이동 custody 모델 부재"의 증상이다.

**배포 전 영향 상한 실측:**

```sql
SELECT count(DISTINCT ipi.sku_id)
  FROM inbound_plan_items ipi
  JOIN inbound_plans ip ON ip.id = ipi.plan_id
 WHERE ipi.status = 'pending'
   AND ip.requires_transfer
   AND ip.warehouse_id <> ip.destination_warehouse_id;
```

0 이면 라이브 영향이 사실상 없다. 크면 위 409 를 실제로 기다려야 한다.

### 배포 후 관측

1. 판매가능수량 상승 (`transit_out > 0` 이던 SKU) — 의도된 변화
2. 야간 대사 `totalDriftGrains` 가 0 유지 — 올라가면 즉시 보고
3. 예약 재시도 워커 후보 증가 — 정상 (전에는 부당 탈락)
4. 발주 제안 대상 감소 — 정상 (전에는 부풀려진 부족분)
5. **admin 재고 화면 품절 필터에서 빠지는 SKU** (`stock-projection.reader.ts:102`) — 의도된 값 변화
6. **창고간 이전 실행 409 증가** — 위 예상 증상

### `DROP VIEW` 잠금 창

뷰가 `skus CROSS JOIN warehouses` 라 필터 없이 훑는 소비자가 있다(`purchase-order.service.ts:822` 등). 저트래픽 시간대 적용을 권한다. 필요하면 `SET LOCAL lock_timeout = '5s';` — 파일 단위 트랜잭션이라 실패해도 부분 적용 없이 재실행 가능하다.

## 검증

- `nest build core` 성공
- `type-check` **161** (기준선 162, 증가 없음)
- 이 브랜치의 스펙: 통합 30/30 · 단위 11/11
- 회귀: `(product-sellable-quantity|logistics|fulfillment).*integration` **25 suite / 186 test 전부 통과**
- 마이그레이션 SQL ↔ `schema.ts` 뷰 정의 **2996자 byte-identical** (리뷰에서 독립 검증)
- 뷰 컬럼 14개 목록·순서 불변 — 라이브 `pg_get_viewdef` 대조

### 사전 존재 RED (이 PR 이 만든 것이 아님)

develop 시점부터 RED 인 통합 스펙이 있었다. 이 PR 이 그중 1건(`ledger-reconciliation`)을 닫아 **6 → 5 suite** 가 됐다. 남은 5건은 전부 이 PR 이 건드리지 않은 파일이고 뷰를 참조하지 않는다:

| 계열 | 스펙 |
|---|---|
| `shipment_line_id` NOT NULL 누락 | `unified-reservation.lifecycle`, `reverse-event-guard` |
| `locations` `ck_locations_type` 위반 | `unified-reservation.lock`, `stocktaking-uniques` |
| 하니스 `DbService` 대역에 `run` 없음 | `inventory-command.service.adjust` |

## 범위 밖 (의도적)

- **창고간이동 custody 모델 신설.** 출고작업은 `batch_inventory_sessions` 로 작업 중 재고를 묶지만, 창고간이동에는 그 모델이 없다 — `transferShip`/`transferReceive` 가 한 트랜잭션이라 `IN_TRANSFER` 잔량이 존재하지 않는다. 별도 설계 필요.
- **custody 오버레이의 창고 grain 확장.** `batch-controlled-stock.guard` 는 로케이션 grain 이고 가용재고는 창고 grain 이다. 숏피킹 구간에 "예약은 되지만 피킹 때 409" 인 틈이 있다. 이번 모듈이 그 오버레이가 들어갈 자리다.

## 후속 티켓 (계획서에 목록화)

1. 사전 존재 RED 5 suite 정리 — `shipment_line_id` 계열 3건은 Task 25 계약 이후 **구조적으로 불가능해진 경로**를 테스트 중이라 "고침"이 아니라 "폐기 또는 재작성" 판단이 필요하다
2. `projected_available_qty` 파리티 미고정 (`inventory.schema.ts:994` 가 정본 산식을 뷰 안에서 재유도)
3. 파리티 스펙의 분기 탐지 폭 (`DEFECTIVE`/`IN_TRANSFER` 케이스 부재)
4. 죽은 산식 변형 1벌 잔존 — `core/rules/stock-update.rules.ts` (import 0곳, 옛 `stocks` 테이블식 `availableQty` 변이 모델)
5. `transfer_pending_qty` 오배선 — `stock-projection.reader.ts` 가 `returnPendingQuantity` 로 내보낸다

## 곁다리 커밋 1건

`5692f0832` — `.claude/worktrees/` 를 gitignore 에 추가. `.worktrees/` 패턴은 있었으나 실제 생성 경로와 어긋나 메인 체크아웃의 `git status` 에 워크트리 전체가 untracked 로 떴다. 이 PR 작업 중 실제로 워크트리가 통째로 삭제되는 사고가 났다(복구 완료, 손실 0). `.claude/` 전체가 아니라 `worktrees` 하위만 무시해 추후 `settings.json` 등을 올릴 여지는 남겼다.

## 참고

계획서: `docs/superpowers/plans/2026-08-12-inventory-availability-module.md` (배포 노트·후속 목록 포함)
