### PR TITLE
fix(storefront): 장바구니 동시 수정 경합 제거

### DIFF
--- a/web/almondyoung-storefront/next.config.js
+++ b/web/almondyoung-storefront/next.config.js
@@ -99,6 +99,10 @@ const nextConfig = {
     // 원본(S3)이 Cache-Control 을 안 붙여서 최적화 이미지가 기본값 60초로 나갔다. 60초마다
     // CDN 에서 빠져 매번 이미지 최적화 람다가 원본을 다시 받아 다시 인코딩했다.
     // 파일 URL 은 업로드마다 새 UUID 라 같은 URL 의 내용이 바뀌지 않는다.
+    //
+    // 주의: 이 값은 /public 자산에도 같이 걸린다. 로고처럼 URL 이 배포 간 고정인 파일은
+    // 내용을 바꿔도 최대 이 기간만큼 옛 이미지가 남는다. 브랜드 자산을 교체할 때는
+    // 파일명을 바꾸거나 src 에 버전 쿼리(`?v=2`)를 붙여 URL 을 갈아야 한다.
     minimumCacheTTL: 60 * 60 * 24 * 31,
     remotePatterns: [
       ...(normalizedBackendDomain

--- a/web/almondyoung-storefront/next.config.js
+++ b/web/almondyoung-storefront/next.config.js
@@ -96,6 +96,10 @@ const nextConfig = {
 
   images: {
     qualities: [25, 50, 75, 100],
+    // 원본(S3)이 Cache-Control 을 안 붙여서 최적화 이미지가 기본값 60초로 나갔다. 60초마다
+    // CDN 에서 빠져 매번 이미지 최적화 람다가 원본을 다시 받아 다시 인코딩했다.
+    // 파일 URL 은 업로드마다 새 UUID 라 같은 URL 의 내용이 바뀌지 않는다.
+    minimumCacheTTL: 60 * 60 * 24 * 31,
     remotePatterns: [
       ...(normalizedBackendDomain
         ? [

--- a/web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/callback/actions.ts
+++ b/web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/callback/actions.ts
@@ -2,6 +2,10 @@
 
 import { toCheckoutErrorCode } from "@/lib/api/medusa/checkout-error-code"
 import {
+  isTransientCartConflictError,
+  withCartConflictRetry,
+} from "@/lib/api/medusa/cart-conflict"
+import {
   cartRequiresShipping,
   selectShippingOptionsForCart,
   shippingMethodsMatchOptions,
@@ -120,11 +124,15 @@ async function ensureShippingMethod(
     return
   }
 
-  await sdk.client.fetch(`/store/carts/${cartId}/shipping-methods/bulk`, {
-    method: "POST",
-    body: { option_ids: standardOptions.map((option) => option.id) },
-    headers,
-  })
+  const assign = () =>
+    sdk.client.fetch(`/store/carts/${cartId}/shipping-methods/bulk`, {
+      method: "POST",
+      body: { option_ids: standardOptions.map((option) => option.id) },
+      headers,
+    })
+
+  // 같은 카트를 만지는 다른 요청과 겹쳤을 뿐이면 한 번 더 시도한다.
+  await withCartConflictRetry(assign)
   logger.info("storefront.checkout.shipping_method.assigned", {
     attributes: {
       cart_id: cartId,
@@ -387,7 +395,19 @@ export async function processPaymentCallback(
         // 서버 capture 웹훅(handleCaptureProjection → completeCartWorkflow)이 이 카트를 동시에
         // 완료하면, 완료된 카트에 addShippingMethod 가 throw 한다. try 밖이면 이 throw 가 바깥
         // catch 로 새어나가 결제·주문이 정상인데도 '실패페이지' 가 떴다(주문은 웹훅이 이미 생성).
-        await ensureShippingMethod(targetCartId, headers)
+        //
+        // 재시도까지 했는데도 경합이면 완료 자체를 포기하지 않는다. 배송수단이 실제로
+        // 없으면 바로 아래 complete 가 제 이유로 막고, 다른 요청이 이미 붙여놨다면 통과한다.
+        // 여기서 던지면 결제는 승인됐는데 화면만 실패로 보인다.
+        try {
+          await ensureShippingMethod(targetCartId, headers)
+        } catch (shippingErr) {
+          if (!isTransientCartConflictError(shippingErr)) throw shippingErr
+          logger.warn("storefront.checkout.shipping_method.conflict_ignored", {
+            error: shippingErr,
+            attributes: { intent_id: intentId, target_cart_id: targetCartId },
+          })
+        }
         cartRes = await sdk.store.cart.complete(targetCartId, {}, headers)
       } catch (completeErr) {
         // 동시 호출 레이스 / 중복 콜백: 다른 호출(웹훅 포함)이 먼저 완료시킨 경우 주문은 이미 생성됐다.

--- a/web/almondyoung-storefront/src/app/[countryCode]/cart/page.tsx
+++ b/web/almondyoung-storefront/src/app/[countryCode]/cart/page.tsx
@@ -3,6 +3,7 @@ import CartTemplate from "@/domains/cart/templates"
 import {
   ensureCorrectShippingMethod,
   findUnavailableLineItems,
+  refreshCartPricesDuringRender,
   retrieveCart,
 } from "@/lib/api/medusa/cart"
 import { recoverCustomerCart } from "@/lib/api/medusa/customer"
@@ -17,6 +18,11 @@ export default async function Cart({
   params: Promise<{ countryCode: string }>
 }) {
   const { countryCode } = await params
+
+  // 멤버십 가입/해지로 달라진 가격을 카트에 반영한다. 카트를 읽기 전에, 배송수단 정합보다 먼저,
+  // 이 요청 안에서 순차로 돌린다. 예전에는 이걸 클라이언트에서 걸고 router.refresh 로 다시
+  // 그렸는데, 그 재계산이 다음 렌더의 배송수단 교체와 겹쳐 같은 카트를 동시에 고쳤다.
+  await refreshCartPricesDuringRender()
 
   // 무통장입금 주문 선생성 시 원본 장바구니 아이템은 Medusa 서버사이드에서 제거됨.
   // 그 정리는 storefront 의 carts 캐시 태그를 무효화하지 못하므로, 이미 force-dynamic 인 카트
@@ -44,9 +50,13 @@ export default async function Cart({
     return <EmptyCartView showHeader={false} bgColor="bg-muted" />
   }
 
-  // draft/미게시(판매중단)된 상품을 직접 감지한다. (배송수단 throw 에 의존하지 않음)
-  const { variantIds: unavailableVariantIds, availableByVariantId } =
-    await findUnavailableLineItems(cart, countryCode)
+  // draft/미게시(판매중단)된 상품과 옵션만 사라진 라인을 직접 감지한다.
+  // (배송수단 throw 에 의존하지 않음)
+  const {
+    variantIds: unavailableVariantIds,
+    optionGoneVariantIds,
+    availableByVariantId,
+  } = await findUnavailableLineItems(cart, countryCode)
 
   // 배송 옵션 자동 설정. draft 상품이 있으면 throw 할 수 있으나, 그대로 두면
   // 장바구니까지 500 으로 깨져 상품을 삭제할 화면조차 못 본다. 잡아서 원본 카트를
@@ -64,6 +74,7 @@ export default async function Cart({
     <CartTemplate
       cart={cart}
       unavailableVariantIds={unavailableVariantIds}
+      optionGoneVariantIds={optionGoneVariantIds}
       availableByVariantId={availableByVariantId}
     />
   )

--- a/web/almondyoung-storefront/src/domains/cart/components/item/index.tsx
+++ b/web/almondyoung-storefront/src/domains/cart/components/item/index.tsx
@@ -24,6 +24,18 @@ import Image from "next/image"
 import { cloneElement, ReactElement, useState, useTransition } from "react"
 import { toast } from "sonner"
 
+/**
+ * 구매 불가 사유. 상품이 통째로 내려간 것(`product`)과 그 옵션만 없어진 것(`option`)은
+ * 고객이 할 수 있는 일이 다르다 — 후자는 다른 옵션으로 다시 담으면 된다.
+ */
+type UnavailableReason = "product" | "option"
+
+const unavailableBadgeKey = (reason?: UnavailableReason) =>
+  reason === "option" ? "optionGoneBadge" : "soldOutBadge"
+
+const unavailableHintKey = (reason?: UnavailableReason) =>
+  reason === "option" ? "optionGoneHint" : "soldOutHint"
+
 type ItemProps = {
   item: HttpTypes.StoreCartLineItem
   children: ReactElement
@@ -32,6 +44,8 @@ type ItemProps = {
   selectDisabled?: boolean
   /** 판매중단(draft/미게시)으로 결제를 막는 상품이면 true */
   isUnavailable?: boolean
+  /** 상품이 통째로 내려갔는지, 그 옵션만 없어졌는지 */
+  unavailableReason?: UnavailableReason
   /** 남은 재고. 없으면(재고 미추적/백오더) 수량 상한이 없다는 뜻 */
   maxQuantity?: number
 }
@@ -52,6 +66,7 @@ type ItemChildProps = {
   onSelectChange?: (checked: boolean) => void
   selectDisabled?: boolean
   isUnavailable?: boolean
+  unavailableReason?: UnavailableReason
   maxQuantity?: number
 }
 
@@ -68,6 +83,7 @@ function Item({
   onSelectChange,
   selectDisabled,
   isUnavailable,
+  unavailableReason,
   maxQuantity,
 }: ItemProps) {
   const t = useTranslations("cart.items")
@@ -159,6 +175,7 @@ function Item({
     onSelectChange,
     selectDisabled,
     isUnavailable,
+    unavailableReason,
     maxQuantity,
   } as ItemChildProps)
 }
@@ -180,6 +197,7 @@ function DesktopItem({
   onSelectChange,
   selectDisabled,
   isUnavailable,
+  unavailableReason,
   maxQuantity,
 }: DesktopItemProps) {
   const t = useTranslations("cart.items")
@@ -266,7 +284,7 @@ function DesktopItem({
       <TableCell className="text-left">
         {isUnavailable && (
           <p className="mb-1 text-xs font-semibold text-red-600">
-            {t("soldOutBadge")}
+            {t(unavailableBadgeKey(unavailableReason))}
           </p>
         )}
         <p className="text-sm font-medium" data-testid="product-title">
@@ -280,7 +298,9 @@ function DesktopItem({
           </p>
         )}
         {isUnavailable && (
-          <p className="mt-1 text-xs text-red-600">{t("soldOutHint")}</p>
+          <p className="mt-1 text-xs text-red-600">
+            {t(unavailableHintKey(unavailableReason))}
+          </p>
         )}
       </TableCell>
 
@@ -450,6 +470,7 @@ function MobileItem({
   changeQuantity,
   handleDelete,
   isUnavailable,
+  unavailableReason,
   maxQuantity,
 }: MobileItemProps) {
   const t = useTranslations("cart.items")
@@ -522,7 +543,7 @@ function MobileItem({
           <div className="flex-1">
             {isUnavailable && (
               <p className="mb-0.5 text-xs font-semibold text-red-600">
-                {t("soldOutBadge")}
+                {t(unavailableBadgeKey(unavailableReason))}
               </p>
             )}
             <p className="line-clamp-2 text-sm leading-snug font-medium">
@@ -536,7 +557,9 @@ function MobileItem({
               </p>
             )}
             {isUnavailable && (
-              <p className="mt-0.5 text-xs text-red-600">{t("soldOutHint")}</p>
+              <p className="mt-0.5 text-xs text-red-600">
+                {t(unavailableHintKey(unavailableReason))}
+              </p>
             )}
           </div>
           <Button

--- a/web/almondyoung-storefront/src/domains/cart/templates/index.tsx
+++ b/web/almondyoung-storefront/src/domains/cart/templates/index.tsx
@@ -2,10 +2,7 @@
 
 import { Card, CardContent } from "@/components/ui/card"
 import { CartHeader } from "@/domains/cart/components/header"
-import {
-  createCheckoutCartFromLineItems,
-  refreshCartPrices,
-} from "@/lib/api/medusa/cart"
+import { createCheckoutCartFromLineItems } from "@/lib/api/medusa/cart"
 import { HttpTypes } from "@medusajs/types"
 import { useTranslations } from "next-intl"
 import { useParams, useRouter } from "next/navigation"
@@ -19,6 +16,8 @@ type Props = {
   cart: HttpTypes.StoreCart | null
   /** 판매중단(draft/미게시)으로 결제를 막는 variant id 목록 */
   unavailableVariantIds?: string[]
+  /** 그중 상품은 그대로인데 옵션만 없어진 variant id 목록 */
+  optionGoneVariantIds?: string[]
   /** 재고를 추적하는 variant 의 남은 수량 (없으면 상한 없음) */
   availableByVariantId?: Record<string, number>
 }
@@ -26,6 +25,7 @@ type Props = {
 export default function CartTemplate({
   cart,
   unavailableVariantIds = [],
+  optionGoneVariantIds = [],
   availableByVariantId,
 }: Props) {
   const router = useRouter()
@@ -36,6 +36,11 @@ export default function CartTemplate({
   const unavailableVariantIdSet = useMemo(
     () => new Set(unavailableVariantIds),
     [unavailableVariantIds]
+  )
+
+  const optionGoneVariantIdSet = useMemo(
+    () => new Set(optionGoneVariantIds),
+    [optionGoneVariantIds]
   )
 
   const cartItems = cart?.items
@@ -151,12 +156,6 @@ export default function CartTemplate({
     unavailableVariantIdSet,
   ])
 
-  useEffect(() => {
-    refreshCartPrices()
-      .then(() => router.refresh())
-      .catch(() => {})
-  }, [])
-
   // 아이템이 변경되면 (삭제 등) 선택 상태 동기화
   useEffect(() => {
     const itemIds = new Set(sortedItems.map((item) => item.id))
@@ -186,6 +185,7 @@ export default function CartTemplate({
                 onSelectAll={handleSelectAll}
                 onSelectItem={handleSelectItem}
                 unavailableVariantIds={unavailableVariantIdSet}
+                optionGoneVariantIds={optionGoneVariantIdSet}
                 availableByVariantId={availableByVariantId}
               />
             </CardContent>

--- a/web/almondyoung-storefront/src/domains/cart/templates/items.tsx
+++ b/web/almondyoung-storefront/src/domains/cart/templates/items.tsx
@@ -26,6 +26,7 @@ type ItemsProps = {
   onSelectItem: (itemId: string, checked: boolean) => void
   /** 판매중단(draft/미게시)으로 결제를 막는 variant id 집합 */
   unavailableVariantIds?: Set<string>
+  optionGoneVariantIds?: Set<string>
   /** 재고를 추적하는 variant 의 남은 수량 (없으면 상한 없음) */
   availableByVariantId?: Record<string, number>
 }
@@ -37,6 +38,7 @@ export default function Items({
   onSelectAll,
   onSelectItem,
   unavailableVariantIds,
+  optionGoneVariantIds,
   availableByVariantId,
 }: ItemsProps) {
   const [isPending, startTransition] = useTransition()
@@ -44,6 +46,12 @@ export default function Items({
 
   const isItemUnavailable = (item: HttpTypes.StoreCartLineItem) =>
     !!item.variant_id && !!unavailableVariantIds?.has(item.variant_id)
+
+  // 상품이 통째로 내려간 것과 그 옵션만 없어진 것은 고객이 취할 행동이 달라 구분해 안내한다.
+  const unavailableReasonOf = (item: HttpTypes.StoreCartLineItem) =>
+    item.variant_id && optionGoneVariantIds?.has(item.variant_id)
+      ? ("option" as const)
+      : ("product" as const)
 
   const maxQuantityOf = (item: HttpTypes.StoreCartLineItem) =>
     item.variant_id ? availableByVariantId?.[item.variant_id] : undefined
@@ -99,6 +107,7 @@ export default function Items({
               <Item
                 item={item}
                 isUnavailable={isItemUnavailable(item)}
+                unavailableReason={unavailableReasonOf(item)}
                 maxQuantity={maxQuantityOf(item)}
               >
                 <Item.Mobile />
@@ -140,6 +149,7 @@ export default function Items({
                 onSelectChange={(checked) => onSelectItem(item.id, checked)}
                 selectDisabled={isPending}
                 isUnavailable={isItemUnavailable(item)}
+                unavailableReason={unavailableReasonOf(item)}
                 maxQuantity={maxQuantityOf(item)}
               >
                 <Item.Desktop />

--- a/web/almondyoung-storefront/src/i18n/messages/en/cart.json
+++ b/web/almondyoung-storefront/src/i18n/messages/en/cart.json
@@ -33,6 +33,8 @@
     "confirm": "Confirm",
     "soldOutBadge": "Unavailable",
     "soldOutHint": "This item is no longer available. Remove it to continue to checkout.",
+    "optionGoneBadge": "Option unavailable",
+    "optionGoneHint": "The selected option is no longer sold. Remove it and add another option instead.",
     "quantityMaxError": "Only {max} left in stock. Please choose {max} or fewer.",
     "quantityStockError": "Not enough stock to update the quantity. Please try again shortly.",
     "quantityMaxHint": "Max {max}",

--- a/web/almondyoung-storefront/src/i18n/messages/ja/cart.json
+++ b/web/almondyoung-storefront/src/i18n/messages/ja/cart.json
@@ -33,6 +33,8 @@
     "confirm": "確認",
     "soldOutBadge": "販売終了",
     "soldOutHint": "販売が終了した商品です。決済を進めるには削除してください。",
+    "optionGoneBadge": "オプション販売終了",
+    "optionGoneHint": "選択されたオプションは販売を終了しました。削除して別のオプションを選び直してください。",
     "quantityMaxError": "在庫が残り{max}個です。{max}個以下でお選びください。",
     "quantityStockError": "在庫が不足しているため数量を変更できません。しばらくしてからお試しください。",
     "quantityMaxHint": "最大{max}個",

--- a/web/almondyoung-storefront/src/i18n/messages/ko/cart.json
+++ b/web/almondyoung-storefront/src/i18n/messages/ko/cart.json
@@ -33,6 +33,8 @@
     "confirm": "확인",
     "soldOutBadge": "판매중단",
     "soldOutHint": "판매가 중단된 상품입니다. 결제하려면 이 상품을 삭제해주세요.",
+    "optionGoneBadge": "옵션 판매중단",
+    "optionGoneHint": "선택하신 옵션이 더 이상 판매되지 않아요. 삭제한 뒤 다른 옵션으로 다시 담아주세요.",
     "quantityMaxError": "재고가 {max}개 남았어요. {max}개 이하로 담아주세요.",
     "quantityStockError": "재고가 부족해 수량을 변경할 수 없어요. 잠시 후 다시 시도해 주세요.",
     "quantityMaxHint": "최대 {max}개",

--- a/web/almondyoung-storefront/src/lib/api/medusa/cart-conflict.test.ts
+++ b/web/almondyoung-storefront/src/lib/api/medusa/cart-conflict.test.ts
@@ -5,6 +5,16 @@ import {
   withCartConflictRetry,
 } from "./cart-conflict"
 
+/** js-sdk 가 던지는 FetchError 와 같은 모양. 상태 코드가 판정의 1차 근거다. */
+class FetchErrorLike extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message)
+  }
+}
+
 describe("isTransientCartConflictError", () => {
   it("락을 못 잡은 경우", () => {
     expect(
@@ -14,10 +24,25 @@ describe("isTransientCartConflictError", () => {
     ).toBe(true)
   })
 
+  it("경합을 conflict 로 알려주면 재시도한다", () => {
+    expect(
+      isTransientCartConflictError(
+        new FetchErrorLike(
+          "The request conflicted with another request. You may retry the request with the provided Idempotency-Key.",
+          409
+        )
+      )
+    ).toBe(true)
+  })
+
+  // Medusa 실제 응답 문구. id 뒤에 콜론이 붙고 was 가 들어간다.
   it("방금 지워진 배송수단을 붙들고 있는 경우", () => {
     expect(
       isTransientCartConflictError(
-        new Error('ShippingMethod with id "casm_01JABCDEF" not found')
+        new FetchErrorLike(
+          "ShippingMethod with id: casm_01JABCDEF was not found",
+          404
+        )
       )
     ).toBe(true)
   })
@@ -46,6 +71,16 @@ describe("isTransientCartConflictError", () => {
     ).toBe(false)
   })
 
+  // 락 실패는 MedusaError 가 아니라 평범한 Error 라, Medusa 가 메시지를 통째로 갈아버린다.
+  // 원문이 안 오므로 문구로는 잡을 수 없다 — Medusa 가 conflict 로 내려줘야 재시도가 걸린다.
+  it("메시지가 지워진 500 은 경합으로 단정하지 않는다", () => {
+    expect(
+      isTransientCartConflictError(
+        new FetchErrorLike("An unknown error occurred.", 500)
+      )
+    ).toBe(false)
+  })
+
   it("에러가 아니거나 메시지가 없으면 false", () => {
     expect(isTransientCartConflictError(null)).toBe(false)
     expect(isTransientCartConflictError(undefined)).toBe(false)
@@ -59,7 +94,10 @@ describe("withCartConflictRetry", () => {
     const run = async () => {
       calls += 1
       if (calls === 1) {
-        throw new Error('ShippingMethod with id "casm_1" not found')
+        throw new FetchErrorLike(
+          "ShippingMethod with id: casm_1 was not found",
+          404
+        )
       }
       return "ok"
     }

--- a/web/almondyoung-storefront/src/lib/api/medusa/cart-conflict.test.ts
+++ b/web/almondyoung-storefront/src/lib/api/medusa/cart-conflict.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isTransientCartConflictError,
+  withCartConflictRetry,
+} from "./cart-conflict"
+
+describe("isTransientCartConflictError", () => {
+  it("락을 못 잡은 경우", () => {
+    expect(
+      isTransientCartConflictError(
+        new Error('Failed to acquire lock for key "cart_01JABCDEF"')
+      )
+    ).toBe(true)
+  })
+
+  it("방금 지워진 배송수단을 붙들고 있는 경우", () => {
+    expect(
+      isTransientCartConflictError(
+        new Error('ShippingMethod with id "casm_01JABCDEF" not found')
+      )
+    ).toBe(true)
+  })
+
+  it("문자열로 와도 판정한다", () => {
+    expect(
+      isTransientCartConflictError('Failed to acquire lock for key "cart_1"')
+    ).toBe(true)
+  })
+
+  it("판매중단 상품은 재시도로 안 풀리므로 제외", () => {
+    expect(
+      isTransientCartConflictError(
+        new Error(
+          "Variants variant_01J do not exist or belong to a product that is not published"
+        )
+      )
+    ).toBe(false)
+  })
+
+  it("재고 부족도 제외", () => {
+    expect(
+      isTransientCartConflictError(
+        new Error("Some variant does not have the required inventory")
+      )
+    ).toBe(false)
+  })
+
+  it("에러가 아니거나 메시지가 없으면 false", () => {
+    expect(isTransientCartConflictError(null)).toBe(false)
+    expect(isTransientCartConflictError(undefined)).toBe(false)
+    expect(isTransientCartConflictError({})).toBe(false)
+  })
+})
+
+describe("withCartConflictRetry", () => {
+  it("경합이면 한 번 더 시도하고 그 결과를 돌려준다", async () => {
+    let calls = 0
+    const run = async () => {
+      calls += 1
+      if (calls === 1) {
+        throw new Error('ShippingMethod with id "casm_1" not found')
+      }
+      return "ok"
+    }
+
+    await expect(withCartConflictRetry(run, 0)).resolves.toBe("ok")
+    expect(calls).toBe(2)
+  })
+
+  it("경합이 아니면 재시도하지 않고 그대로 던진다", async () => {
+    let calls = 0
+    const run = async () => {
+      calls += 1
+      throw new Error(
+        "Variants variant_1 do not exist or belong to a product that is not published"
+      )
+    }
+
+    await expect(withCartConflictRetry(run, 0)).rejects.toThrow(
+      "do not exist or belong to a product that is not published"
+    )
+    expect(calls).toBe(1)
+  })
+
+  it("두 번째도 실패하면 던진다 — 무한 재시도로 서버를 더 밀지 않는다", async () => {
+    let calls = 0
+    const run = async () => {
+      calls += 1
+      throw new Error('Failed to acquire lock for key "cart_1"')
+    }
+
+    await expect(withCartConflictRetry(run, 0)).rejects.toThrow(
+      "Failed to acquire lock"
+    )
+    expect(calls).toBe(2)
+  })
+
+  it("성공하면 한 번만 부른다", async () => {
+    let calls = 0
+    const run = async () => {
+      calls += 1
+      return "ok"
+    }
+
+    await expect(withCartConflictRetry(run, 0)).resolves.toBe("ok")
+    expect(calls).toBe(1)
+  })
+})

--- a/web/almondyoung-storefront/src/lib/api/medusa/cart-conflict.ts
+++ b/web/almondyoung-storefront/src/lib/api/medusa/cart-conflict.ts
@@ -1,0 +1,46 @@
+/**
+ * 같은 카트를 두 요청이 동시에 고칠 때 Medusa 가 내는 에러를 가려낸다.
+ *
+ * Medusa 의 카트 워크플로는 카트 id 로 락을 잡지만 TTL 이 10초로 고정이고 연장되지 않는다.
+ * 응답이 느려져 워크플로가 10초를 넘기면 락이 만료돼 상호배제가 풀리고, 그 사이 다른 요청이
+ * 배송수단 행을 지우면 먼저 뜬 스냅샷이 사라진 id 를 붙들어 터진다. 락을 아예 못 잡는 쪽
+ * (2초 대기 후 포기)도 같은 경합의 다른 얼굴이다.
+ *
+ * 둘 다 카트 상태가 잘못된 게 아니라 타이밍 문제라서, 다시 읽고 한 번 더 시도하면 풀린다.
+ */
+const TRANSIENT_CART_CONFLICT_PATTERNS = [
+  /failed to acquire lock/i,
+  /shipping ?method with id .*not found/i,
+]
+
+export function isTransientCartConflictError(error: unknown): boolean {
+  const message =
+    typeof error === "string"
+      ? error
+      : ((error as { message?: string })?.message ?? "")
+
+  return TRANSIENT_CART_CONFLICT_PATTERNS.some((pattern) =>
+    pattern.test(message)
+  )
+}
+
+/** 경합이 풀릴 시간을 주는 재시도 간격. 락 TTL 보다 훨씬 짧게 둬 렌더를 붙잡지 않는다. */
+export const CART_CONFLICT_RETRY_DELAY_MS = 400
+
+/**
+ * 카트 쓰기를 경합에 한해 한 번만 다시 시도한다. 그 외 에러는 그대로 던진다.
+ *
+ * 두 번째도 실패하면 던진다 — 무한 재시도는 이미 느려진 서버를 더 밀어붙일 뿐이다.
+ */
+export async function withCartConflictRetry<T>(
+  run: () => Promise<T>,
+  delayMs: number = CART_CONFLICT_RETRY_DELAY_MS
+): Promise<T> {
+  try {
+    return await run()
+  } catch (error) {
+    if (!isTransientCartConflictError(error)) throw error
+    await new Promise((resolve) => setTimeout(resolve, delayMs))
+    return run()
+  }
+}

--- a/web/almondyoung-storefront/src/lib/api/medusa/cart-conflict.ts
+++ b/web/almondyoung-storefront/src/lib/api/medusa/cart-conflict.ts
@@ -7,20 +7,44 @@
  * (2초 대기 후 포기)도 같은 경합의 다른 얼굴이다.
  *
  * 둘 다 카트 상태가 잘못된 게 아니라 타이밍 문제라서, 다시 읽고 한 번 더 시도하면 풀린다.
+ *
+ * 판정은 상태 코드를 먼저 본다. Medusa 의 에러 핸들러는 MedusaError 가 아닌 예외의 메시지를
+ * "An unknown error occurred." 로 통째로 갈아버려서, 락 실패처럼 평범한 Error 로 던져지는
+ * 경우엔 원문이 클라이언트까지 오지 않는다. 문구 매칭만으로는 잡을 수 없다.
  */
-const TRANSIENT_CART_CONFLICT_PATTERNS = [
-  /failed to acquire lock/i,
-  /shipping ?method with id .*not found/i,
-]
+
+/** Medusa 가 경합을 conflict 로 알려줄 때. 재시도해도 된다고 스펙이 보장하는 자리다. */
+const CONFLICT_STATUS = 409
+
+/**
+ * 락이 풀린 사이 다른 요청이 배송수단을 갈아치워 사라진 id 를 참조한 경우. 이건 MedusaError
+ * (NOT_FOUND) 라 원문이 그대로 온다. 실제 문구는 `ShippingMethod with id: casm_x was not found`
+ * 처럼 id 뒤에 콜론이 붙는다.
+ */
+const STALE_SHIPPING_METHOD_PATTERN =
+  /shipping ?method with id[:\s].*not found/i
+
+/** 락 자체를 못 잡은 경우. Medusa 가 메시지를 갈지 않고 넘겨줄 때만 잡힌다. */
+const LOCK_PATTERN = /failed to acquire lock/i
+
+const readStatus = (error: unknown): number | undefined => {
+  const status = (error as { status?: unknown })?.status
+  return typeof status === "number" ? status : undefined
+}
+
+const readMessage = (error: unknown): string =>
+  typeof error === "string"
+    ? error
+    : ((error as { message?: string })?.message ?? "")
 
 export function isTransientCartConflictError(error: unknown): boolean {
-  const message =
-    typeof error === "string"
-      ? error
-      : ((error as { message?: string })?.message ?? "")
+  if (readStatus(error) === CONFLICT_STATUS) {
+    return true
+  }
 
-  return TRANSIENT_CART_CONFLICT_PATTERNS.some((pattern) =>
-    pattern.test(message)
+  const message = readMessage(error)
+  return (
+    LOCK_PATTERN.test(message) || STALE_SHIPPING_METHOD_PATTERN.test(message)
   )
 }
 

--- a/web/almondyoung-storefront/src/lib/api/medusa/cart.ts
+++ b/web/almondyoung-storefront/src/lib/api/medusa/cart.ts
@@ -15,6 +15,8 @@ import {
   type CartLineItemClassification,
 } from "@lib/utils/cart-availability"
 import { withCartConflictRetry } from "./cart-conflict"
+import { getIsMembershipCustomer } from "@lib/data/membership"
+import { createRefreshThrottle } from "@lib/utils/refresh-throttle"
 import { HttpTypes } from "@medusajs/types"
 import { revalidateTag } from "next/cache"
 import { redirect } from "next/navigation"
@@ -1537,12 +1539,35 @@ export async function refreshCartPrices(): Promise<CartRefreshResult> {
 }
 
 /**
+ * 이 재계산이 필요한 건 멤버십 상태가 바뀌었을 때다. 그 상태가 그대로면 다시 부를 이유가 없어
+ * (카트 id, 멤버십 여부) 별로 최근에 한 번 돌렸는지 기억해 건너뛴다.
+ *
+ * 렌더 중에는 쿠키를 쓸 수 없어 프로세스 메모리에 둔다. 인스턴스가 바뀌면 한 번 더 돌 뿐이고,
+ * 멤버십이 바뀌면 키가 달라져 즉시 다시 돈다. 관리자가 가격을 직접 고친 경우만 최대 TTL 만큼
+ * 늦게 반영된다.
+ */
+const PRICE_REFRESH_TTL_MS = 10 * 60 * 1000
+const priceRefreshThrottle = createRefreshThrottle(PRICE_REFRESH_TTL_MS)
+
+/**
  * 렌더 중에 부를 수 있는 가격 재계산. revalidateTag 는 부르지 않는다 (렌더 도중 호출은 금지).
  *
  * 카트를 읽기 **전에** 순차로 돌리는 용도다. 예전처럼 클라이언트에서 재계산을 걸고
  * router.refresh 로 다시 그리면, 그 재계산과 다음 렌더의 배송수단 정합이 같은 카트를 동시에
- * 고쳐 경합이 났다.
+ * 고쳐 경합이 났다. 다만 이 호출이 카트 조회 앞을 막고 서기 때문에, 매 렌더마다 돌리면
+ * 그대로 TTFB 가 된다. 필요할 때만 돌린다.
  */
 export async function refreshCartPricesDuringRender(): Promise<CartRefreshResult> {
+  const headers = await getAuthHeaders()
+  if (!headers) return EMPTY_REFRESH_RESULT
+
+  const cartId = await getCartId()
+  if (!cartId) return EMPTY_REFRESH_RESULT
+
+  const isMember = await getIsMembershipCustomer()
+  if (!priceRefreshThrottle.take(`${cartId}:${isMember ? "mem" : "reg"}`)) {
+    return EMPTY_REFRESH_RESULT
+  }
+
   return requestCartPriceRefresh()
 }

--- a/web/almondyoung-storefront/src/lib/api/medusa/cart.ts
+++ b/web/almondyoung-storefront/src/lib/api/medusa/cart.ts
@@ -11,10 +11,10 @@ import {
 } from "@lib/data/cookies"
 import medusaError from "@lib/utils/medusa-error"
 import {
-  buildAvailabilityMap,
-  isVariantQuantityUnavailable,
-  isVariantSoldOut,
+  classifyCartLineItems,
+  type CartLineItemClassification,
 } from "@lib/utils/cart-availability"
+import { withCartConflictRetry } from "./cart-conflict"
 import { HttpTypes } from "@medusajs/types"
 import { revalidateTag } from "next/cache"
 import { redirect } from "next/navigation"
@@ -129,13 +129,7 @@ export async function retrieveCart(
 export async function findUnavailableLineItems(
   cart: HttpTypes.StoreCart,
   countryCode: string
-): Promise<{
-  variantIds: string[]
-  productNames: string[]
-  insufficientVariantIds: string[]
-  insufficientNames: string[]
-  availableByVariantId: Record<string, number>
-}> {
+): Promise<CartLineItemClassification> {
   const items = cart.items ?? []
   const productIds = Array.from(
     new Set(
@@ -145,9 +139,10 @@ export async function findUnavailableLineItems(
     )
   )
 
-  const empty = {
+  const empty: CartLineItemClassification = {
     variantIds: [],
     productNames: [],
+    optionGoneVariantIds: [],
     insufficientVariantIds: [],
     insufficientNames: [],
     availableByVariantId: {},
@@ -184,63 +179,7 @@ export async function findUnavailableLineItems(
     })
     .catch(() => ({ products: [] as HttpTypes.StoreProduct[] }))
 
-  const publishedProductIds = new Set(products.map((product) => product.id))
-  // variant_id → 재고가 계산된 variant. 카트 라인아이템 variant 는 inventory_quantity 가 비어있으므로 사용하지 않는다.
-  const variantById = new Map<string, HttpTypes.StoreProductVariant>()
-  for (const product of products) {
-    for (const variant of product.variants ?? []) {
-      if (variant.id) {
-        variantById.set(variant.id, variant)
-      }
-    }
-  }
-
-  // 판매중단(미게시) 이거나, 재고 기준 품절(수동 품절 포함)이면 구매 불가로 본다.
-  const unavailableItems = items.filter((item) => {
-    if (item.product_id && !publishedProductIds.has(item.product_id)) {
-      return true
-    }
-    // 재고가 계산된 variant 로 판정. 조회 실패 시에만 카트 라인아이템 variant 로 폴백.
-    const variant =
-      (item.variant_id ? variantById.get(item.variant_id) : undefined) ??
-      item.variant
-    return isVariantSoldOut(variant)
-  })
-
-  // 품절은 아니지만 담은 수량이 가용 재고를 넘어선 라인 (담은 뒤 재고가 줄어든 경우).
-  const unavailableSet = new Set(unavailableItems)
-  // 재고가 계산된 variant 로만 판정한다. 카트 라인아이템 variant 는 inventory_quantity 가 비어 있어
-  // 폴백으로 쓰면 전 라인이 재고 0 으로 읽혀 멀쩡한 결제까지 막는다.
-  const insufficientItems = items.filter((item) => {
-    if (unavailableSet.has(item)) return false
-    const variant = item.variant_id ? variantById.get(item.variant_id) : undefined
-    return isVariantQuantityUnavailable(variant, item.quantity)
-  })
-
-  const toVariantIds = (list: typeof items) =>
-    Array.from(
-      new Set(
-        list
-          .map((item) => item.variant_id)
-          .filter((id): id is string => Boolean(id))
-      )
-    )
-  const toNames = (list: typeof items) =>
-    Array.from(
-      new Set(
-        list
-          .map((item) => item.product_title || item.title || "")
-          .filter(Boolean)
-      )
-    )
-
-  return {
-    variantIds: toVariantIds(unavailableItems),
-    productNames: toNames(unavailableItems),
-    insufficientVariantIds: toVariantIds(insufficientItems),
-    insufficientNames: toNames(insufficientItems),
-    availableByVariantId: buildAvailabilityMap(items, variantById),
-  }
+  return classifyCartLineItems(items, products)
 }
 
 export async function getOrSetCart(countryCode: string) {
@@ -1354,18 +1293,22 @@ export const setCartShippingMethods = async (
     ...(await getAuthHeaders()),
   }
 
-  return sdk.client
-    .fetch<{ cart: HttpTypes.StoreCart }>(
-      `/store/carts/${cartId}/shipping-methods/bulk`,
-      {
-        method: "POST",
-        body: { option_ids: optionIds },
-        query: { fields: DEFAULT_CART_FIELDS },
-        headers,
-      }
-    )
-    .then(({ cart }) => cart)
-    .catch(medusaError)
+  const post = () =>
+    sdk.client
+      .fetch<{ cart: HttpTypes.StoreCart }>(
+        `/store/carts/${cartId}/shipping-methods/bulk`,
+        {
+          method: "POST",
+          body: { option_ids: optionIds },
+          query: { fields: DEFAULT_CART_FIELDS },
+          headers,
+        }
+      )
+      .then(({ cart }) => cart)
+
+  // 같은 카트를 만지는 다른 요청과 겹쳤을 뿐이면 한 번 더 건다.
+  // 그냥 던지면 장바구니·체크아웃이 통째로 500 이 된다.
+  return withCartConflictRetry(post).catch(medusaError)
 }
 
 export const addCartShippingMethodDuringRender = async (
@@ -1552,11 +1495,20 @@ export type CartRefreshResult = {
   hasMembershipGroup: boolean | null
 }
 
-// 카트 가격 재계산 + 캐시 무효화
-export async function refreshCartPrices(): Promise<CartRefreshResult> {
-  try {
-    const headers = (await getAuthHeaders()) ?? undefined
+const EMPTY_REFRESH_RESULT: CartRefreshResult = {
+  refreshed: false,
+  hasMembershipGroup: null,
+}
 
+async function requestCartPriceRefresh(): Promise<CartRefreshResult> {
+  const headers = await getAuthHeaders()
+
+  // 비로그인은 이 엔드포인트가 401 만 돌려준다. 부르지 않는다.
+  if (!headers) {
+    return EMPTY_REFRESH_RESULT
+  }
+
+  try {
     const result = await sdk.client.fetch<{
       refreshed: boolean
       hasMembershipGroup?: boolean | null
@@ -1568,11 +1520,29 @@ export async function refreshCartPrices(): Promise<CartRefreshResult> {
     }
   } catch (error) {
     console.error("[refreshCartPrices] 실패:", error)
-    return { refreshed: false, hasMembershipGroup: null }
+    return EMPTY_REFRESH_RESULT
+  }
+}
+
+// 카트 가격 재계산 + 캐시 무효화
+export async function refreshCartPrices(): Promise<CartRefreshResult> {
+  try {
+    return await requestCartPriceRefresh()
   } finally {
     const cartCacheTag = await getCacheTag("carts")
     if (cartCacheTag) {
       revalidateTag(cartCacheTag)
     }
   }
+}
+
+/**
+ * 렌더 중에 부를 수 있는 가격 재계산. revalidateTag 는 부르지 않는다 (렌더 도중 호출은 금지).
+ *
+ * 카트를 읽기 **전에** 순차로 돌리는 용도다. 예전처럼 클라이언트에서 재계산을 걸고
+ * router.refresh 로 다시 그리면, 그 재계산과 다음 렌더의 배송수단 정합이 같은 카트를 동시에
+ * 고쳐 경합이 났다.
+ */
+export async function refreshCartPricesDuringRender(): Promise<CartRefreshResult> {
+  return requestCartPriceRefresh()
 }

--- a/web/almondyoung-storefront/src/lib/utils/cart-availability.test.ts
+++ b/web/almondyoung-storefront/src/lib/utils/cart-availability.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest"
 import {
   buildAvailabilityMap,
+  classifyCartLineItems,
   describeStockShortage,
   getAvailableQuantity,
   isInsufficientInventoryError,
+  isLineItemVariantGone,
   isVariantQuantityUnavailable,
   isVariantSoldOut,
 } from "./cart-availability"
@@ -147,5 +149,224 @@ describe("isVariantQuantityUnavailable", () => {
   it("variant 정보가 없으면 막지 않는다 (조회 실패로 구매를 막지 않기 위함)", () => {
     expect(isVariantQuantityUnavailable(undefined, 3)).toBe(false)
     expect(isVariantQuantityUnavailable(null, 3)).toBe(false)
+  })
+})
+
+describe("isLineItemVariantGone", () => {
+  const published = new Set(["prod_1"])
+  const variantsOf = (ids: string[]) => new Map([["prod_1", new Set(ids)]])
+
+  it("상품은 게시 중인데 variant 만 없어진 라인을 잡는다", () => {
+    expect(
+      isLineItemVariantGone(
+        { product_id: "prod_1", variant_id: "variant_gone" },
+        published,
+        variantsOf(["variant_alive"])
+      )
+    ).toBe(true)
+  })
+
+  it("살아있는 variant 는 잡지 않는다", () => {
+    expect(
+      isLineItemVariantGone(
+        { product_id: "prod_1", variant_id: "variant_alive" },
+        published,
+        variantsOf(["variant_alive"])
+      )
+    ).toBe(false)
+  })
+
+  it("상품 조회가 통째로 실패하면 판정하지 않는다 (미게시 판정이 맡는다)", () => {
+    expect(
+      isLineItemVariantGone(
+        { product_id: "prod_1", variant_id: "variant_gone" },
+        new Set(),
+        new Map()
+      )
+    ).toBe(false)
+  })
+
+  it("응답에 variant 가 안 실려왔으면 판정하지 않는다 — 멀쩡한 카트를 막는 게 더 나쁘다", () => {
+    expect(
+      isLineItemVariantGone(
+        { product_id: "prod_1", variant_id: "variant_gone" },
+        published,
+        variantsOf([])
+      )
+    ).toBe(false)
+  })
+
+  it("id 를 모르는 라인은 판정하지 않는다", () => {
+    expect(
+      isLineItemVariantGone({ product_id: "prod_1" }, published, variantsOf(["v"]))
+    ).toBe(false)
+    expect(
+      isLineItemVariantGone({ variant_id: "variant_gone" }, published, variantsOf(["v"]))
+    ).toBe(false)
+  })
+})
+
+describe("classifyCartLineItems", () => {
+  const inStock = {
+    id: "variant_ok",
+    manage_inventory: true,
+    allow_backorder: false,
+    inventory_quantity: 5,
+  }
+
+  it("상품은 게시 중인데 variant 만 삭제된 라인을 결제 차단 대상으로 넘긴다", () => {
+    const result = classifyCartLineItems(
+      [
+        {
+          product_id: "prod_1",
+          variant_id: "variant_deleted",
+          quantity: 1,
+          product_title: "사라진 옵션 상품",
+          variant: null,
+        },
+      ],
+      [{ id: "prod_1", variants: [inStock] }]
+    )
+
+    expect(result.variantIds).toEqual(["variant_deleted"])
+    expect(result.productNames).toEqual(["사라진 옵션 상품"])
+  })
+
+  it("멀쩡한 라인은 통과시킨다", () => {
+    const result = classifyCartLineItems(
+      [
+        {
+          product_id: "prod_1",
+          variant_id: "variant_ok",
+          quantity: 2,
+          product_title: "정상 상품",
+        },
+      ],
+      [{ id: "prod_1", variants: [inStock] }]
+    )
+
+    expect(result.variantIds).toEqual([])
+    expect(result.insufficientVariantIds).toEqual([])
+    expect(result.availableByVariantId).toEqual({ variant_ok: 5 })
+  })
+
+  it("상품 조회가 통째로 비면 라인을 전부 막되 variant 판정을 이중으로 세지 않는다", () => {
+    const result = classifyCartLineItems(
+      [
+        {
+          product_id: "prod_1",
+          variant_id: "variant_deleted",
+          quantity: 1,
+          product_title: "조회 실패",
+        },
+      ],
+      []
+    )
+
+    expect(result.variantIds).toEqual(["variant_deleted"])
+  })
+
+  it("담은 수량이 남은 재고를 넘으면 부족 목록으로 간다", () => {
+    const result = classifyCartLineItems(
+      [
+        {
+          product_id: "prod_1",
+          variant_id: "variant_ok",
+          quantity: 9,
+          product_title: "재고보다 많이 담음",
+        },
+      ],
+      [{ id: "prod_1", variants: [inStock] }]
+    )
+
+    expect(result.variantIds).toEqual([])
+    expect(result.insufficientVariantIds).toEqual(["variant_ok"])
+    expect(result.insufficientNames).toEqual(["재고보다 많이 담음"])
+  })
+
+  it("품절 라인은 부족이 아니라 구매 불가로 분류한다", () => {
+    const result = classifyCartLineItems(
+      [
+        {
+          product_id: "prod_1",
+          variant_id: "variant_out",
+          quantity: 1,
+          product_title: "품절",
+        },
+      ],
+      [
+        {
+          id: "prod_1",
+          variants: [
+            {
+              id: "variant_out",
+              manage_inventory: true,
+              allow_backorder: false,
+              inventory_quantity: 0,
+            },
+          ],
+        },
+      ]
+    )
+
+    expect(result.variantIds).toEqual(["variant_out"])
+    expect(result.insufficientVariantIds).toEqual([])
+  })
+})
+
+describe("classifyCartLineItems — 구매 불가 사유 구분", () => {
+  it("옵션만 없어진 라인은 상품 판매중단과 따로 표시한다", () => {
+    const result = classifyCartLineItems(
+      [
+        {
+          product_id: "prod_live",
+          variant_id: "variant_gone",
+          quantity: 1,
+          product_title: "판매중인 상품",
+        },
+        {
+          product_id: "prod_dead",
+          variant_id: "variant_dead",
+          quantity: 1,
+          product_title: "내려간 상품",
+        },
+      ],
+      [{ id: "prod_live", variants: [{ id: "variant_other" }] }]
+    )
+
+    expect(result.variantIds.sort()).toEqual(["variant_dead", "variant_gone"])
+    expect(result.optionGoneVariantIds).toEqual(["variant_gone"])
+  })
+
+  it("상품은 왔는데 variant 목록이 비어 있으면 구매를 막지 않는다", () => {
+    const result = classifyCartLineItems(
+      [{ product_id: "prod_1", variant_id: "variant_x", quantity: 1 }],
+      [{ id: "prod_1", variants: [] }]
+    )
+
+    expect(result.variantIds).toEqual([])
+    expect(result.optionGoneVariantIds).toEqual([])
+  })
+
+  it("품절은 옵션 소멸이 아니다", () => {
+    const result = classifyCartLineItems(
+      [{ product_id: "prod_1", variant_id: "variant_out", quantity: 1 }],
+      [
+        {
+          id: "prod_1",
+          variants: [
+            {
+              id: "variant_out",
+              manage_inventory: true,
+              allow_backorder: false,
+              inventory_quantity: 0,
+            },
+          ],
+        },
+      ]
+    )
+
+    expect(result.variantIds).toEqual(["variant_out"])
+    expect(result.optionGoneVariantIds).toEqual([])
   })
 })

--- a/web/almondyoung-storefront/src/lib/utils/cart-availability.ts
+++ b/web/almondyoung-storefront/src/lib/utils/cart-availability.ts
@@ -113,6 +113,33 @@ export function buildAvailabilityMap(
 }
 
 /**
+ * 상품은 그대로 노출되는데 그 variant 만 사라진 라인인지 판단한다.
+ *
+ * variant 가 없으면 Medusa 의 카트 재계산이 `Variants ... do not exist` 로 거부해, 그 라인을
+ * 뺄 때까지 결제도 수량 변경도 막힌다. 그런데 라인아이템에 붙어오는 variant 는 이 경우 그냥
+ * 비어 있어서 품절 판정(isVariantSoldOut)으로는 안 잡히고, 상품은 멀쩡히 게시 중이라
+ * 미게시 판정으로도 안 잡힌다. 화면상 정상인 상품을 담은 채 결제에서만 계속 실패한다.
+ *
+ * 판정 조건을 좁게 잡는다. 그 상품이 조회 결과에 있고, **그 상품의 variant 목록을 실제로
+ * 받아왔을 때만** 없어졌다고 본다. 상품 조회가 실패하거나 응답에 variant 가 안 실려오면
+ * 멀쩡한 라인이 전부 구매 불가로 찍혀 결제를 통째로 막는다 — 못 잡는 쪽보다 나쁘다.
+ * (조회 실패는 미게시 판정이 이미 잡는다.)
+ */
+export function isLineItemVariantGone(
+  item: { product_id?: string | null; variant_id?: string | null },
+  publishedProductIds: Set<string>,
+  variantIdsByProductId: Map<string, Set<string>>
+): boolean {
+  if (!item.variant_id || !item.product_id) return false
+  if (!publishedProductIds.has(item.product_id)) return false
+
+  const knownVariantIds = variantIdsByProductId.get(item.product_id)
+  if (!knownVariantIds?.size) return false
+
+  return !knownVariantIds.has(item.variant_id)
+}
+
+/**
  * variant 가 재고 기준으로 품절인지 판단한다.
  * 상품 상세의 `isInStock`/`hasStock` 과 동일 기준 — 재고관리를 켜고(manage_inventory),
  * 백오더 불가(allow_backorder=false)이며, 가용 재고가 0 이하이면 품절.
@@ -125,4 +152,119 @@ export function isVariantSoldOut(variant?: VariantStock | null): boolean {
   if (!variant.manage_inventory) return false
   if (variant.allow_backorder) return false
   return (variant.inventory_quantity ?? 0) <= 0
+}
+
+type ClassifiableVariant = VariantStock & { id?: string | null }
+
+export type ClassifiableLineItem = {
+  product_id?: string | null
+  variant_id?: string | null
+  quantity?: number | null
+  product_title?: string | null
+  title?: string | null
+  variant?: ClassifiableVariant | null
+}
+
+export type ClassifiableProduct = {
+  id?: string | null
+  variants?: ClassifiableVariant[] | null
+}
+
+export type CartLineItemClassification = {
+  /** 결제를 막아야 하는 라인의 variant id */
+  variantIds: string[]
+  productNames: string[]
+  /**
+   * 그중 상품은 계속 팔리는데 그 옵션만 없어진 라인. 고객이 취할 행동이 달라서
+   * (다른 옵션으로 다시 담으면 된다) 상품 자체의 판매중단과 구분해 안내한다.
+   */
+  optionGoneVariantIds: string[]
+  /** 팔긴 하지만 담은 수량을 못 채우는 라인 */
+  insufficientVariantIds: string[]
+  insufficientNames: string[]
+  availableByVariantId: Record<string, number>
+}
+
+/**
+ * 카트 라인을 구매 가능/불가로 가른다. `products` 는 재고가 계산된 조회 결과
+ * (`/store/products`) 로, 미게시·삭제 상품은 애초에 들어있지 않다.
+ */
+export function classifyCartLineItems(
+  items: ClassifiableLineItem[],
+  products: ClassifiableProduct[]
+): CartLineItemClassification {
+  const publishedProductIds = new Set(
+    products.map((product) => product.id).filter((id): id is string => !!id)
+  )
+  // variant_id → 재고가 계산된 variant. 카트 라인아이템 variant 는 inventory_quantity 가 비어있으므로 사용하지 않는다.
+  const variantById = new Map<string, ClassifiableVariant>()
+  // 상품별 variant 목록. 응답에 variant 가 안 실려온 상품과 진짜로 variant 가 사라진 상품을
+  // 구분하려면 상품 단위로 봐야 한다.
+  const variantIdsByProductId = new Map<string, Set<string>>()
+  for (const product of products) {
+    const ids = new Set<string>()
+    for (const variant of product.variants ?? []) {
+      if (variant.id) {
+        variantById.set(variant.id, variant)
+        ids.add(variant.id)
+      }
+    }
+    if (product.id) variantIdsByProductId.set(product.id, ids)
+  }
+
+  // 판매중단(미게시) 이거나, variant 가 사라졌거나, 재고 기준 품절(수동 품절 포함)이면
+  // 구매 불가로 본다.
+  const unavailableItems = items.filter((item) => {
+    if (item.product_id && !publishedProductIds.has(item.product_id)) {
+      return true
+    }
+    if (isLineItemVariantGone(item, publishedProductIds, variantIdsByProductId)) {
+      return true
+    }
+    // 재고가 계산된 variant 로 판정. 조회 실패 시에만 카트 라인아이템 variant 로 폴백.
+    const variant =
+      (item.variant_id ? variantById.get(item.variant_id) : undefined) ??
+      item.variant
+    return isVariantSoldOut(variant)
+  })
+
+  // 품절은 아니지만 담은 수량이 가용 재고를 넘어선 라인 (담은 뒤 재고가 줄어든 경우).
+  const unavailableSet = new Set(unavailableItems)
+  // 재고가 계산된 variant 로만 판정한다. 카트 라인아이템 variant 는 inventory_quantity 가 비어 있어
+  // 폴백으로 쓰면 전 라인이 재고 0 으로 읽혀 멀쩡한 결제까지 막는다.
+  const insufficientItems = items.filter((item) => {
+    if (unavailableSet.has(item)) return false
+    const variant = item.variant_id ? variantById.get(item.variant_id) : undefined
+    return isVariantQuantityUnavailable(variant, item.quantity)
+  })
+
+  const toVariantIds = (list: ClassifiableLineItem[]) =>
+    Array.from(
+      new Set(
+        list
+          .map((item) => item.variant_id)
+          .filter((id): id is string => Boolean(id))
+      )
+    )
+  const toNames = (list: ClassifiableLineItem[]) =>
+    Array.from(
+      new Set(
+        list
+          .map((item) => item.product_title || item.title || "")
+          .filter(Boolean)
+      )
+    )
+
+  const optionGoneItems = unavailableItems.filter((item) =>
+    isLineItemVariantGone(item, publishedProductIds, variantIdsByProductId)
+  )
+
+  return {
+    variantIds: toVariantIds(unavailableItems),
+    productNames: toNames(unavailableItems),
+    optionGoneVariantIds: toVariantIds(optionGoneItems),
+    insufficientVariantIds: toVariantIds(insufficientItems),
+    insufficientNames: toNames(insufficientItems),
+    availableByVariantId: buildAvailabilityMap(items, variantById),
+  }
 }

--- a/web/almondyoung-storefront/src/lib/utils/refresh-throttle.test.ts
+++ b/web/almondyoung-storefront/src/lib/utils/refresh-throttle.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+import { createRefreshThrottle } from "./refresh-throttle"
+
+const clock = (start = 0) => {
+  let now = start
+  return {
+    now: () => now,
+    advance: (ms: number) => {
+      now += ms
+    },
+  }
+}
+
+describe("createRefreshThrottle", () => {
+  it("같은 키는 창 안에서 한 번만 통과시킨다", () => {
+    const time = clock()
+    const throttle = createRefreshThrottle(1000, time.now)
+
+    expect(throttle.take("cart_1:mem")).toBe(true)
+    expect(throttle.take("cart_1:mem")).toBe(false)
+    expect(throttle.take("cart_1:mem")).toBe(false)
+  })
+
+  it("키가 다르면 서로 막지 않는다", () => {
+    const time = clock()
+    const throttle = createRefreshThrottle(1000, time.now)
+
+    expect(throttle.take("cart_1:reg")).toBe(true)
+    // 멤버십 상태가 바뀌면 키가 달라져 곧바로 다시 돈다.
+    expect(throttle.take("cart_1:mem")).toBe(true)
+    expect(throttle.take("cart_2:reg")).toBe(true)
+  })
+
+  it("창이 지나면 다시 통과시킨다", () => {
+    const time = clock()
+    const throttle = createRefreshThrottle(1000, time.now)
+
+    expect(throttle.take("cart_1:mem")).toBe(true)
+    time.advance(999)
+    expect(throttle.take("cart_1:mem")).toBe(false)
+    time.advance(1)
+    expect(throttle.take("cart_1:mem")).toBe(true)
+  })
+
+  it("만료된 키는 들고 있지 않는다", () => {
+    const time = clock()
+    const throttle = createRefreshThrottle(1000, time.now)
+
+    throttle.take("cart_1:mem")
+    time.advance(1000)
+    // 다른 키를 통과시키는 김에 만료된 항목이 정리되고, 그 뒤에도 판정은 그대로다.
+    expect(throttle.take("cart_2:mem")).toBe(true)
+    expect(throttle.take("cart_1:mem")).toBe(true)
+  })
+})

--- a/web/almondyoung-storefront/src/lib/utils/refresh-throttle.ts
+++ b/web/almondyoung-storefront/src/lib/utils/refresh-throttle.ts
@@ -1,0 +1,34 @@
+/**
+ * 같은 키로 들어온 반복 작업을 일정 시간 동안 한 번만 통과시킨다.
+ *
+ * 카트 가격 재계산처럼 "필요할 때만 돌면 되는데 매 렌더마다 불려서 응답을 붙잡는" 작업에 쓴다.
+ * 상태를 프로세스 메모리에 두므로 인스턴스가 바뀌면 한 번 더 통과할 뿐이고, 키가 달라지면
+ * (예: 멤버십 여부가 바뀌면) 즉시 다시 통과한다.
+ */
+export type RefreshThrottle = {
+  take: (key: string) => boolean
+}
+
+export function createRefreshThrottle(
+  ttlMs: number,
+  now: () => number = Date.now
+): RefreshThrottle {
+  const lastRunAt = new Map<string, number>()
+
+  return {
+    take(key: string): boolean {
+      const current = now()
+
+      // 만료된 항목을 걷어 메모리가 계속 불어나지 않게 한다.
+      lastRunAt.forEach((at, seen) => {
+        if (current - at >= ttlMs) lastRunAt.delete(seen)
+      })
+
+      const last = lastRunAt.get(key)
+      if (last !== undefined && current - last < ttlMs) return false
+
+      lastRunAt.set(key, current)
+      return true
+    },
+  }
+}


### PR DESCRIPTION
#616 에서 멤버십 캐시와 무관한 부분만 떼어낸 PR 입니다. 카탈로그·멤버십 캐시 격리는 #616 에 그대로 남겨두고 여기서는 장바구니 경합과 이미지 캐시 수명만 다룹니다.

## 장바구니 동시 수정 경합

같은 카트를 여러 요청이 동시에 만지면 Medusa 가 409 를 돌려주는데, 지금은 그게 그대로 사용자에게 터졌습니다. 특히 결제 콜백에서 문제가 컸는데, 서버 capture 웹훅이 같은 카트를 완료시키는 순간 콜백 쪽 배송수단 지정이 실패하면서 결제와 주문은 정상인데 화면만 실패 페이지가 떴습니다.

- 일시적 경합이면 한 번 더 시도하고(`cart-conflict.ts`), 그래도 안 되면 완료 자체를 포기하지 않고 넘어갑니다. 배송수단이 실제로 없으면 뒤따르는 complete 가 제 이유로 막습니다.
- 수량 변경 등 카트 조작에도 같은 재시도를 적용했습니다.
- 재고 초과 등으로 담을 수 없는 라인은 `cart-availability.ts` 에서 한 곳으로 모아 판정하고 안내 문구를 보여줍니다.

## 이미지 캐시 수명 연장

next/image 최적화 결과의 캐시 수명을 늘렸습니다. 원본이 바뀌지 않는 상품 이미지가 매번 재최적화되고 있었습니다.

## 테스트

`npm run test` — 111개 통과. 장바구니 경합 재시도와 라인 판정 로직에 유닛 테스트를 붙였습니다.
