### PR TITLE
fix(storefront): 재고를 넘긴 장바구니 라인의 수량을 줄일 수 있게

### DIFF
--- a/web/almondyoung-storefront/src/domains/cart/components/item/index.tsx
+++ b/web/almondyoung-storefront/src/domains/cart/components/item/index.tsx
@@ -15,6 +15,7 @@ import { TableCell, TableRow } from "@/components/ui/table"
 import { deleteLineItem, updateLineItem } from "@/lib/api/medusa/cart"
 import { cn } from "@/lib/utils"
 import { isInsufficientInventoryError } from "@/lib/utils/cart-availability"
+import { resolveQuantityChange } from "@/lib/utils/cart-quantity"
 import { getThumbnailUrl } from "@/lib/utils/get-thumbnail-url"
 import { formatPrice } from "@/lib/utils/price-utils"
 import { HttpTypes } from "@medusajs/types"
@@ -46,7 +47,7 @@ type ItemChildProps = {
   totalPrice: number
   discountPercentage: number
   compareAtTotalPrice: number
-  changeQuantity: (quantity: number) => void
+  changeQuantity: (quantity: number) => boolean
   handleDelete: () => Promise<void>
   selected?: boolean
   onSelectChange?: (checked: boolean) => void
@@ -75,32 +76,41 @@ function Item({
   const [deleting, setDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const changeQuantity = (quantity: number) => {
-    if (quantity < 1) return
-
+  /** 요청을 서버로 보냈으면 true. 상한/품절로 막았으면 false (다이얼로그를 닫지 않기 위해). */
+  const changeQuantity = (quantity: number): boolean => {
     // 남은 재고를 넘기면 서버에 보내기 전에 남은 수량을 알려준다. 그대로 보내면 Medusa 가
     // 영문 재고부족 에러(`Some variant does not have the required inventory`)를 던지고,
     // 그게 그대로 토스트에 떠서 고객이 무슨 상황인지 알 수 없었다.
-    //
-    // 단 '줄이는' 방향은 막지 않는다. 담은 뒤 재고가 줄어 이미 상한을 넘긴 라인(예: 담긴 5개,
-    // 재고 3개)에서 4개로 낮추는 것까지 막으면 고객이 수량을 조정할 방법이 없어진다.
-    const isIncrease = quantity > item.quantity
-    if (maxQuantity !== undefined && quantity > maxQuantity && isIncrease) {
+    const change = resolveQuantityChange({
+      requested: quantity,
+      current: item.quantity,
+      maxQuantity,
+    })
+
+    if (change.type === "reject") {
+      if (change.reason === "belowMin") return false
+
       // 재고 0 은 "0개 이하로 담아주세요" 가 되어버리므로 품절 문구를 쓴다.
       const message =
-        maxQuantity <= 0
+        change.reason === "soldOut"
           ? t("quantitySoldOut")
-          : t("quantityMaxError", { max: maxQuantity })
+          : t("quantityMaxError", { max: change.max })
       toast.error(message)
       setError(message)
-      return
+      return false
     }
 
     setError(null)
 
+    // 상한을 넘긴 라인에서 줄이는 요청은 상한까지 내려간다. 바뀐 수량을 알려주지 않으면
+    // "-" 를 눌렀는데 숫자가 여러 칸 떨어진 것처럼 보인다.
+    if (change.clampedToMax) {
+      toast.info(t("quantityAdjustedToMax", { max: change.quantity }))
+    }
+
     startTransition(async () => {
       try {
-        await updateLineItem({ lineId: item.id, quantity })
+        await updateLineItem({ lineId: item.id, quantity: change.quantity })
       } catch (err) {
         const raw = err instanceof Error ? err.message : ""
         // 재고 정보가 방금 바뀌어 상한 검사를 통과했는데도 실패한 경우. 백엔드가 한글로 던진
@@ -117,6 +127,8 @@ function Item({
         setError(message)
       }
     })
+
+    return true
   }
 
   const handleDelete = async () => {
@@ -201,22 +213,11 @@ function DesktopItem({
       return toast.error(t("quantityMinError"))
     }
 
-    // 상한을 넘기면 다이얼로그를 닫지 않고 남은 수량을 알려준다(고객이 바로 고쳐 넣을 수 있게).
-    // changeQuantity 와 같은 규칙으로 '줄이는' 방향은 통과시킨다.
-    if (
-      maxQuantity !== undefined &&
-      num > maxQuantity &&
-      num > (item?.quantity ?? 0)
-    ) {
-      return toast.error(
-        maxQuantity <= 0
-          ? t("quantitySoldOut")
-          : t("quantityMaxError", { max: maxQuantity })
-      )
+    // 상한 판정과 안내는 changeQuantity 가 한다. 막힌 경우엔 다이얼로그를 닫지 않아
+    // 고객이 바로 고쳐 넣을 수 있게 한다.
+    if (changeQuantity?.(num)) {
+      setIsModalOpen(false)
     }
-
-    await changeQuantity?.(num)
-    setIsModalOpen(false)
   }
 
   // 재고 0(품절)은 이미 품절 배지가 알려주므로 "최대 0개" 힌트는 띄우지 않는다.
@@ -471,20 +472,11 @@ function MobileItem({
       return toast.error(t("quantityMinError"))
     }
 
-    if (
-      maxQuantity !== undefined &&
-      num > maxQuantity &&
-      num > (item?.quantity ?? 0)
-    ) {
-      return toast.error(
-        maxQuantity <= 0
-          ? t("quantitySoldOut")
-          : t("quantityMaxError", { max: maxQuantity })
-      )
+    // 상한 판정과 안내는 changeQuantity 가 한다. 막힌 경우엔 다이얼로그를 닫지 않아
+    // 고객이 바로 고쳐 넣을 수 있게 한다.
+    if (changeQuantity?.(num)) {
+      setIsModalOpen(false)
     }
-
-    await changeQuantity?.(num)
-    setIsModalOpen(false)
   }
 
   // 재고 0(품절)은 이미 품절 배지가 알려주므로 "최대 0개" 힌트는 띄우지 않는다.

--- a/web/almondyoung-storefront/src/i18n/messages/en/cart.json
+++ b/web/almondyoung-storefront/src/i18n/messages/en/cart.json
@@ -36,7 +36,8 @@
     "quantityMaxError": "Only {max} left in stock. Please choose {max} or fewer.",
     "quantityStockError": "Not enough stock to update the quantity. Please try again shortly.",
     "quantityMaxHint": "Max {max}",
-    "quantitySoldOut": "This item is sold out, so the quantity cannot be increased."
+    "quantitySoldOut": "This item is sold out, so the quantity cannot be increased.",
+    "quantityAdjustedToMax": "Only {max} left in stock, so the quantity was set to {max}."
   },
   "summary": {
     "title": "Order summary",

--- a/web/almondyoung-storefront/src/i18n/messages/ja/cart.json
+++ b/web/almondyoung-storefront/src/i18n/messages/ja/cart.json
@@ -36,7 +36,8 @@
     "quantityMaxError": "在庫が残り{max}個です。{max}個以下でお選びください。",
     "quantityStockError": "在庫が不足しているため数量を変更できません。しばらくしてからお試しください。",
     "quantityMaxHint": "最大{max}個",
-    "quantitySoldOut": "品切れのため数量を増やせません。"
+    "quantitySoldOut": "品切れのため数量を増やせません。",
+    "quantityAdjustedToMax": "在庫が{max}個のため、{max}個に調整しました。"
   },
   "summary": {
     "title": "ご注文金額",

--- a/web/almondyoung-storefront/src/i18n/messages/ko/cart.json
+++ b/web/almondyoung-storefront/src/i18n/messages/ko/cart.json
@@ -36,7 +36,8 @@
     "quantityMaxError": "재고가 {max}개 남았어요. {max}개 이하로 담아주세요.",
     "quantityStockError": "재고가 부족해 수량을 변경할 수 없어요. 잠시 후 다시 시도해 주세요.",
     "quantityMaxHint": "최대 {max}개",
-    "quantitySoldOut": "품절된 상품이라 수량을 늘릴 수 없어요."
+    "quantitySoldOut": "품절된 상품이라 수량을 늘릴 수 없어요.",
+    "quantityAdjustedToMax": "재고가 {max}개라 {max}개로 맞췄어요."
   },
   "summary": {
     "title": "주문 예상 금액",

--- a/web/almondyoung-storefront/src/lib/utils/cart-quantity.test.ts
+++ b/web/almondyoung-storefront/src/lib/utils/cart-quantity.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+import { resolveQuantityChange } from "./cart-quantity"
+
+describe("resolveQuantityChange", () => {
+  it("상한이 없으면 요청한 수량을 그대로 쓴다", () => {
+    expect(
+      resolveQuantityChange({ requested: 30, current: 1, maxQuantity: undefined })
+    ).toEqual({ type: "apply", quantity: 30, clampedToMax: false })
+  })
+
+  it("상한 안쪽이면 요청한 수량을 그대로 쓴다", () => {
+    expect(
+      resolveQuantityChange({ requested: 3, current: 2, maxQuantity: 5 })
+    ).toEqual({ type: "apply", quantity: 3, clampedToMax: false })
+  })
+
+  it("상한을 넘겨 늘리려 하면 남은 수량과 함께 막는다", () => {
+    expect(
+      resolveQuantityChange({ requested: 6, current: 5, maxQuantity: 5 })
+    ).toEqual({ type: "reject", reason: "exceedsMax", max: 5 })
+  })
+
+  it("이미 상한을 넘긴 라인에서 한 칸 줄이면 상한까지 내려간다", () => {
+    expect(
+      resolveQuantityChange({ requested: 9, current: 10, maxQuantity: 5 })
+    ).toEqual({ type: "apply", quantity: 5, clampedToMax: true })
+  })
+
+  it("이미 상한을 넘긴 라인에서 상한보다 큰 수량을 입력해도 상한까지 내려간다", () => {
+    expect(
+      resolveQuantityChange({ requested: 7, current: 10, maxQuantity: 5 })
+    ).toEqual({ type: "apply", quantity: 5, clampedToMax: true })
+  })
+
+  it("상한을 넘긴 라인에서 상한 이하로 줄이는 건 그대로 통과시킨다", () => {
+    expect(
+      resolveQuantityChange({ requested: 2, current: 10, maxQuantity: 5 })
+    ).toEqual({ type: "apply", quantity: 2, clampedToMax: false })
+  })
+
+  it("품절이면 줄이는 요청도 보내지 않는다", () => {
+    expect(
+      resolveQuantityChange({ requested: 4, current: 5, maxQuantity: 0 })
+    ).toEqual({ type: "reject", reason: "soldOut" })
+  })
+
+  it("1개 미만은 보내지 않는다", () => {
+    expect(
+      resolveQuantityChange({ requested: 0, current: 1, maxQuantity: 5 })
+    ).toEqual({ type: "reject", reason: "belowMin" })
+    expect(
+      resolveQuantityChange({ requested: NaN, current: 1, maxQuantity: 5 })
+    ).toEqual({ type: "reject", reason: "belowMin" })
+  })
+})

--- a/web/almondyoung-storefront/src/lib/utils/cart-quantity.ts
+++ b/web/almondyoung-storefront/src/lib/utils/cart-quantity.ts
@@ -1,0 +1,54 @@
+/**
+ * 장바구니 수량 변경 요청을 서버에 보내기 전에 판정한다.
+ *
+ * 담은 뒤 재고가 줄어 이미 상한을 넘긴 라인(담긴 10개, 남은 재고 5개)에서 "-" 를 누르면
+ * 9개가 되는데, 9개도 여전히 재고를 넘어 Medusa 가 거절한다. 8·7·6 도 마찬가지라
+ * 한 칸씩 내리는 경로가 전부 막힌다. 이때 고객이 원하는 건 "하나 줄이기" 가 아니라
+ * "살 수 있는 상태로 만들기" 이므로 상한까지 한 번에 내린다.
+ */
+
+export type QuantityChange =
+  | { type: "apply"; quantity: number; clampedToMax: boolean }
+  | { type: "reject"; reason: "belowMin" }
+  | { type: "reject"; reason: "soldOut" }
+  /** 안내 문구에 남은 수량을 넣어야 하므로 상한을 같이 돌려준다. */
+  | { type: "reject"; reason: "exceedsMax"; max: number }
+
+type ResolveInput = {
+  /** 고객이 요청한 수량 */
+  requested: number
+  /** 현재 담겨 있는 수량 */
+  current: number
+  /** 남은 구매 가능 수량. undefined 면 상한이 없다(재고 미추적/백오더) */
+  maxQuantity?: number
+}
+
+export function resolveQuantityChange({
+  requested,
+  current,
+  maxQuantity,
+}: ResolveInput): QuantityChange {
+  if (!Number.isFinite(requested) || requested < 1) {
+    return { type: "reject", reason: "belowMin" }
+  }
+
+  if (maxQuantity === undefined) {
+    return { type: "apply", quantity: requested, clampedToMax: false }
+  }
+
+  if (maxQuantity <= 0) {
+    return { type: "reject", reason: "soldOut" }
+  }
+
+  if (requested <= maxQuantity) {
+    return { type: "apply", quantity: requested, clampedToMax: false }
+  }
+
+  // 늘리려는 요청은 그대로 막고 남은 수량을 알려준다.
+  if (requested > current) {
+    return { type: "reject", reason: "exceedsMax", max: maxQuantity }
+  }
+
+  // 줄이려는 요청인데 목표치가 아직 상한을 넘는다. 상한까지 내려 한 번에 유효 상태로 만든다.
+  return { type: "apply", quantity: maxQuantity, clampedToMax: true }
+}


### PR DESCRIPTION
장바구니에서 "-" 버튼으로 수량을 줄일 수 없는 증상 cs

담은 뒤 재고가 줄어 이미 상한을 넘긴 라인에서만 발생합니다. 담긴 10개 / 남은 재고 5개라고 하면,

- "-" 버튼 → 9개를 요청 → 9개도 재고를 넘어 Medusa 가 거절 → 실패 토스트
- 8, 7, 6 도 마찬가지라 한 칸씩 내려가는 경로가 전부 막힙니다
- 수량을 직접 타이핑해 5를 넣으면 한 번에 통과 (제보 내용과 일치)

상한 가드가 늘리는 방향에만 걸려 있어 감소 요청은 그대로 서버로 나갔습니다. `updateLineItemInCartWorkflow` 는 `confirmVariantInventoryWorkflow` 를 실행하므로 가용 재고를 넘는 값은 감소든 증가든 거절됩니다.

## 수정

줄이는 요청의 목표치가 상한을 넘으면 상한까지 내립니다. "-" 한 번에 5개가 되고 그 뒤부터는 평범하게 한 칸씩 움직입니다.

"감소는 항상 허용" 대신 이 방향을 택한 이유는, 이 상황에서 고객이 하려는 게 "하나 줄이기" 가 아니라 "살 수 있는 상태로 만들기" 이기 때문입니다. 9·8·7·6 은 서버가 전부 거절하는 도달 불가능한 값이라 UI 가 거기로 갈 이유가 없습니다. 다만 숫자가 여러 칸 떨어지면 오작동처럼 보이므로 맞춘 수량을 안내합니다 (ko/en/ja 추가).

같이 고친 것:

- 수량 입력 다이얼로그도 같은 구멍이 있었습니다. 상한과 담긴 수량 사이 값(위 예에서 7)이 "감소" 라 통과해 서버가 거절했습니다.
- 상한에 막혀도 다이얼로그가 닫혀서 다시 열어야 했습니다. 이제 열어둡니다.
- 품절(가용 0) 라인은 줄이기도 서버가 거절하므로 아예 보내지 않고 품절 안내를 띄웁니다.

판정은 `cart-quantity.ts` 의 순수 함수로 빼서 스테퍼와 다이얼로그가 같이 씁니다.