### PR TITLE
fix(storefront): 재고로 결제가 막힐 때 사유 안내 + 장바구니 품절/판매중단 구분

### DIFF
--- a/web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/fail/page.tsx
+++ b/web/almondyoung-storefront/src/app/[countryCode]/(checkout)/checkout/fail/page.tsx
@@ -3,13 +3,23 @@ import { useSearchParams, useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
 import { useTranslations } from "next-intl"
 import CheckoutHeader from "@/app/[countryCode]/(checkout)/checkout/checkout-header"
+import LocalizedClientLink from "@/components/shared/localized-client-link"
 import { CHECKOUT_ERROR_CODES } from "@/lib/api/medusa/checkout-error-code"
 
 // 코드가 잡히는 에러는 Medusa 영문 원문 대신 안내 문구를 보여준다.
 const MESSAGE_KEY_BY_CODE: Record<string, string> = {
   [CHECKOUT_ERROR_CODES.shippingMethodMissing]: "shippingMethodMissing",
   [CHECKOUT_ERROR_CODES.shippingMethodNone]: "shippingMethodNone",
+  [CHECKOUT_ERROR_CODES.insufficientInventory]: "insufficientInventory",
+  [CHECKOUT_ERROR_CODES.variantUnavailable]: "variantUnavailable",
 }
+
+// 재고 때문에 막힌 경우엔 결제도 주문도 성립하지 않았다는 사실과, 장바구니에서
+// 무엇을 고쳐야 하는지를 같이 알려준다. 카드 한도 같은 일반 원인 목록은 이때 방해만 된다.
+const STOCK_ERROR_CODES: string[] = [
+  CHECKOUT_ERROR_CODES.insufficientInventory,
+  CHECKOUT_ERROR_CODES.variantUnavailable,
+]
 
 export default function CheckoutFailPage() {
   const t = useTranslations("checkout.fail")
@@ -39,6 +49,8 @@ export default function CheckoutFailPage() {
     router.back()
   }
 
+  const isStockError = STOCK_ERROR_CODES.includes(errorInfo?.code ?? "")
+
   if (!errorInfo) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-[#f8f8f8]">
@@ -66,28 +78,51 @@ export default function CheckoutFailPage() {
           </span>
         </p>
 
-        <div className="mb-8 space-y-4">
-          <div className="bg-gray-10 rounded-lg p-4">
-            <h3 className="mb-2 text-sm font-medium text-gray-900">
-              {t("commonCausesTitle")}
-            </h3>
-            <ul className="list-inside list-disc space-y-1 text-sm text-gray-600">
-              <li>{t("causes.limitExceeded")}</li>
-              <li>{t("causes.cardError")}</li>
-              <li>{t("causes.lowBalance")}</li>
-              <li>{t("causes.userCancel")}</li>
-              <li>{t("causes.networkError")}</li>
-            </ul>
+        {isStockError ? (
+          <div className="mb-8 rounded-lg bg-gray-50 p-4">
+            <p className="text-sm text-gray-700">{t("stock.notCharged")}</p>
+            <p className="mt-2 text-sm text-gray-700">
+              {t(
+                errorInfo.code === CHECKOUT_ERROR_CODES.variantUnavailable
+                  ? "stock.whatToDoUnavailable"
+                  : "stock.whatToDoQuantity"
+              )}
+            </p>
           </div>
-        </div>
+        ) : (
+          <div className="mb-8 space-y-4">
+            <div className="bg-gray-10 rounded-lg p-4">
+              <h3 className="mb-2 text-sm font-medium text-gray-900">
+                {t("commonCausesTitle")}
+              </h3>
+              <ul className="list-inside list-disc space-y-1 text-sm text-gray-600">
+                <li>{t("causes.limitExceeded")}</li>
+                <li>{t("causes.cardError")}</li>
+                <li>{t("causes.lowBalance")}</li>
+                <li>{t("causes.userCancel")}</li>
+                <li>{t("causes.networkError")}</li>
+              </ul>
+            </div>
+          </div>
+        )}
 
         <div className="space-y-3">
-          <button
-            onClick={handleRetry}
-            className="w-full rounded-lg bg-[#ff6600] py-3 font-medium text-white transition-colors hover:bg-[#e14d00]"
-          >
-            {t("retry")}
-          </button>
+          {isStockError && (
+            <LocalizedClientLink
+              href="/cart"
+              className="block w-full rounded-lg bg-[#ff6600] py-3 text-center font-medium text-white transition-colors hover:bg-[#e14d00]"
+            >
+              {t("stock.goToCart")}
+            </LocalizedClientLink>
+          )}
+          {!isStockError && (
+            <button
+              onClick={handleRetry}
+              className="w-full rounded-lg bg-[#ff6600] py-3 font-medium text-white transition-colors hover:bg-[#e14d00]"
+            >
+              {t("retry")}
+            </button>
+          )}
           <button
             onClick={handleGoBack}
             className="w-full rounded-lg bg-gray-200 py-3 font-medium text-gray-700 transition-colors hover:bg-gray-300"

--- a/web/almondyoung-storefront/src/app/[countryCode]/cart/page.tsx
+++ b/web/almondyoung-storefront/src/app/[countryCode]/cart/page.tsx
@@ -55,6 +55,7 @@ export default async function Cart({
   const {
     variantIds: unavailableVariantIds,
     optionGoneVariantIds,
+    soldOutVariantIds,
     availableByVariantId,
   } = await findUnavailableLineItems(cart, countryCode)
 
@@ -75,6 +76,7 @@ export default async function Cart({
       cart={cart}
       unavailableVariantIds={unavailableVariantIds}
       optionGoneVariantIds={optionGoneVariantIds}
+      soldOutVariantIds={soldOutVariantIds}
       availableByVariantId={availableByVariantId}
     />
   )

--- a/web/almondyoung-storefront/src/domains/cart/components/item/index.tsx
+++ b/web/almondyoung-storefront/src/domains/cart/components/item/index.tsx
@@ -14,7 +14,10 @@ import { Input } from "@/components/ui/input"
 import { TableCell, TableRow } from "@/components/ui/table"
 import { deleteLineItem, updateLineItem } from "@/lib/api/medusa/cart"
 import { cn } from "@/lib/utils"
-import { isInsufficientInventoryError } from "@/lib/utils/cart-availability"
+import {
+  isInsufficientInventoryError,
+  resolveStockNotice,
+} from "@/lib/utils/cart-availability"
 import { getThumbnailUrl } from "@/lib/utils/get-thumbnail-url"
 import { formatPrice } from "@/lib/utils/price-utils"
 import { HttpTypes } from "@medusajs/types"
@@ -28,13 +31,21 @@ import { toast } from "sonner"
  * 구매 불가 사유. 상품이 통째로 내려간 것(`product`)과 그 옵션만 없어진 것(`option`)은
  * 고객이 할 수 있는 일이 다르다 — 후자는 다른 옵션으로 다시 담으면 된다.
  */
-type UnavailableReason = "product" | "option"
+type UnavailableReason = "product" | "option" | "soldOut"
 
 const unavailableBadgeKey = (reason?: UnavailableReason) =>
-  reason === "option" ? "optionGoneBadge" : "soldOutBadge"
+  reason === "option"
+    ? "optionGoneBadge"
+    : reason === "soldOut"
+      ? "outOfStockBadge"
+      : "soldOutBadge"
 
 const unavailableHintKey = (reason?: UnavailableReason) =>
-  reason === "option" ? "optionGoneHint" : "soldOutHint"
+  reason === "option"
+    ? "optionGoneHint"
+    : reason === "soldOut"
+      ? "outOfStockHint"
+      : "soldOutHint"
 
 type ItemProps = {
   item: HttpTypes.StoreCartLineItem
@@ -237,11 +248,10 @@ function DesktopItem({
     setIsModalOpen(false)
   }
 
-  // 재고 0(품절)은 이미 품절 배지가 알려주므로 "최대 0개" 힌트는 띄우지 않는다.
-  const atStockLimit =
-    maxQuantity !== undefined &&
-    maxQuantity > 0 &&
-    (item?.quantity ?? 0) >= maxQuantity
+  // 판매중단 라인은 이미 별도 배지가 있으므로 재고 안내를 겹쳐 띄우지 않는다.
+  const stockNotice = isUnavailable
+    ? null
+    : resolveStockNotice(item?.quantity ?? 0, maxQuantity)
 
   return (
     <TableRow className="w-full" data-testid="product-row">
@@ -274,7 +284,9 @@ function DesktopItem({
             />
           ) : (
             <div className="bg-muted flex aspect-square w-full items-center justify-center rounded-md">
-              <span className="text-muted-foreground text-xs">{t("noImage")}</span>
+              <span className="text-muted-foreground text-xs">
+                {t("noImage")}
+              </span>
             </div>
           )}
         </LocalizedClientLink>
@@ -285,6 +297,11 @@ function DesktopItem({
         {isUnavailable && (
           <p className="mb-1 text-xs font-semibold text-red-600">
             {t(unavailableBadgeKey(unavailableReason))}
+          </p>
+        )}
+        {stockNotice?.kind === "overStock" && (
+          <p className="mb-1 text-xs font-semibold text-red-600">
+            {t("overStockBadge")}
           </p>
         )}
         <p className="text-sm font-medium" data-testid="product-title">
@@ -300,6 +317,11 @@ function DesktopItem({
         {isUnavailable && (
           <p className="mt-1 text-xs text-red-600">
             {t(unavailableHintKey(unavailableReason))}
+          </p>
+        )}
+        {stockNotice?.kind === "overStock" && (
+          <p className="mt-1 text-xs text-red-600">
+            {t("overStockHint", { max: stockNotice.max })}
           </p>
         )}
       </TableCell>
@@ -342,9 +364,9 @@ function DesktopItem({
               <Plus className="h-4 w-4" />
             </Button>
           </div>
-          {atStockLimit && (
+          {stockNotice?.kind === "atLimit" && (
             <p className="text-muted-foreground mt-1 text-xs">
-              {t("quantityMaxHint", { max: maxQuantity })}
+              {t("quantityMaxHint", { max: stockNotice.max })}
             </p>
           )}
 
@@ -395,14 +417,18 @@ function DesktopItem({
             {(discountPercentage ?? 0) > 0 && (
               <div className="flex items-center gap-1">
                 <span className="text-muted-foreground text-xs line-through">
-                  {formatPrice(compareAtUnitPrice!)}{tCart("won")}
+                  {formatPrice(compareAtUnitPrice!)}
+                  {tCart("won")}
                 </span>
                 <span className="text-destructive text-xs font-medium">
                   {discountPercentage}%
                 </span>
               </div>
             )}
-            <span className="text-sm">{formatPrice(unitPrice ?? 0)}{tCart("won")}</span>
+            <span className="text-sm">
+              {formatPrice(unitPrice ?? 0)}
+              {tCart("won")}
+            </span>
           </div>
         </TableCell>
       )}
@@ -418,14 +444,16 @@ function DesktopItem({
             <span className="flex gap-x-1">
               <span className="text-muted-foreground">{item.quantity}x</span>
               <span className="text-sm">
-                {formatPrice(unitPrice ?? 0)}{tCart("won")}
+                {formatPrice(unitPrice ?? 0)}
+                {tCart("won")}
               </span>
             </span>
           )}
           {(discountPercentage ?? 0) > 0 && (
             <div className="flex items-center gap-1">
               <span className="text-muted-foreground text-xs line-through">
-                {formatPrice(compareAtTotalPrice ?? 0)}{tCart("won")}
+                {formatPrice(compareAtTotalPrice ?? 0)}
+                {tCart("won")}
               </span>
               <span className="text-destructive text-xs font-medium">
                 {discountPercentage}%
@@ -433,7 +461,8 @@ function DesktopItem({
             </div>
           )}
           <span className="text-sm font-medium">
-            {formatPrice(totalPrice ?? 0)}{tCart("won")}
+            {formatPrice(totalPrice ?? 0)}
+            {tCart("won")}
           </span>
         </div>
       </TableCell>
@@ -508,11 +537,10 @@ function MobileItem({
     setIsModalOpen(false)
   }
 
-  // 재고 0(품절)은 이미 품절 배지가 알려주므로 "최대 0개" 힌트는 띄우지 않는다.
-  const atStockLimit =
-    maxQuantity !== undefined &&
-    maxQuantity > 0 &&
-    (item?.quantity ?? 0) >= maxQuantity
+  // 판매중단 라인은 이미 별도 배지가 있으므로 재고 안내를 겹쳐 띄우지 않는다.
+  const stockNotice = isUnavailable
+    ? null
+    : resolveStockNotice(item?.quantity ?? 0, maxQuantity)
 
   return (
     <div className="flex gap-3 border-b py-4">
@@ -531,7 +559,9 @@ function MobileItem({
           />
         ) : (
           <div className="bg-muted flex h-[72px] w-[72px] items-center justify-center rounded-md">
-            <span className="text-muted-foreground text-xs">{t("noImage")}</span>
+            <span className="text-muted-foreground text-xs">
+              {t("noImage")}
+            </span>
           </div>
         )}
       </LocalizedClientLink>
@@ -544,6 +574,11 @@ function MobileItem({
             {isUnavailable && (
               <p className="mb-0.5 text-xs font-semibold text-red-600">
                 {t(unavailableBadgeKey(unavailableReason))}
+              </p>
+            )}
+            {stockNotice?.kind === "overStock" && (
+              <p className="mb-0.5 text-xs font-semibold text-red-600">
+                {t("overStockBadge")}
               </p>
             )}
             <p className="line-clamp-2 text-sm leading-snug font-medium">
@@ -559,6 +594,11 @@ function MobileItem({
             {isUnavailable && (
               <p className="mt-0.5 text-xs text-red-600">
                 {t(unavailableHintKey(unavailableReason))}
+              </p>
+            )}
+            {stockNotice?.kind === "overStock" && (
+              <p className="mt-0.5 text-xs text-red-600">
+                {t("overStockHint", { max: stockNotice.max })}
               </p>
             )}
           </div>
@@ -612,9 +652,9 @@ function MobileItem({
             >
               <Plus className="h-4 w-4" />
             </Button>
-            {atStockLimit && (
+            {stockNotice?.kind === "atLimit" && (
               <span className="text-muted-foreground ml-2 text-xs">
-                {t("quantityMaxHint", { max: maxQuantity })}
+                {t("quantityMaxHint", { max: stockNotice.max })}
               </span>
             )}
           </div>
@@ -656,7 +696,8 @@ function MobileItem({
               </span>
             )}
             <span className="text-sm font-semibold">
-              {formatPrice(totalPrice ?? 0)}{tCart("won")}
+              {formatPrice(totalPrice ?? 0)}
+              {tCart("won")}
             </span>
           </div>
         </div>

--- a/web/almondyoung-storefront/src/domains/cart/templates/index.tsx
+++ b/web/almondyoung-storefront/src/domains/cart/templates/index.tsx
@@ -18,6 +18,7 @@ type Props = {
   unavailableVariantIds?: string[]
   /** 그중 상품은 그대로인데 옵션만 없어진 variant id 목록 */
   optionGoneVariantIds?: string[]
+  soldOutVariantIds?: string[]
   /** 재고를 추적하는 variant 의 남은 수량 (없으면 상한 없음) */
   availableByVariantId?: Record<string, number>
 }
@@ -26,6 +27,7 @@ export default function CartTemplate({
   cart,
   unavailableVariantIds = [],
   optionGoneVariantIds = [],
+  soldOutVariantIds = [],
   availableByVariantId,
 }: Props) {
   const router = useRouter()
@@ -41,6 +43,11 @@ export default function CartTemplate({
   const optionGoneVariantIdSet = useMemo(
     () => new Set(optionGoneVariantIds),
     [optionGoneVariantIds]
+  )
+
+  const soldOutVariantIdSet = useMemo(
+    () => new Set(soldOutVariantIds),
+    [soldOutVariantIds]
   )
 
   const cartItems = cart?.items
@@ -186,6 +193,7 @@ export default function CartTemplate({
                 onSelectItem={handleSelectItem}
                 unavailableVariantIds={unavailableVariantIdSet}
                 optionGoneVariantIds={optionGoneVariantIdSet}
+                soldOutVariantIds={soldOutVariantIdSet}
                 availableByVariantId={availableByVariantId}
               />
             </CardContent>

--- a/web/almondyoung-storefront/src/domains/cart/templates/items.tsx
+++ b/web/almondyoung-storefront/src/domains/cart/templates/items.tsx
@@ -27,6 +27,7 @@ type ItemsProps = {
   /** 판매중단(draft/미게시)으로 결제를 막는 variant id 집합 */
   unavailableVariantIds?: Set<string>
   optionGoneVariantIds?: Set<string>
+  soldOutVariantIds?: Set<string>
   /** 재고를 추적하는 variant 의 남은 수량 (없으면 상한 없음) */
   availableByVariantId?: Record<string, number>
 }
@@ -39,6 +40,7 @@ export default function Items({
   onSelectItem,
   unavailableVariantIds,
   optionGoneVariantIds,
+  soldOutVariantIds,
   availableByVariantId,
 }: ItemsProps) {
   const [isPending, startTransition] = useTransition()
@@ -47,11 +49,13 @@ export default function Items({
   const isItemUnavailable = (item: HttpTypes.StoreCartLineItem) =>
     !!item.variant_id && !!unavailableVariantIds?.has(item.variant_id)
 
-  // 상품이 통째로 내려간 것과 그 옵션만 없어진 것은 고객이 취할 행동이 달라 구분해 안내한다.
-  const unavailableReasonOf = (item: HttpTypes.StoreCartLineItem) =>
-    item.variant_id && optionGoneVariantIds?.has(item.variant_id)
-      ? ("option" as const)
-      : ("product" as const)
+  // 판매중단 · 옵션 삭제 · 품절은 고객이 취할 행동과 문구가 달라 구분해 안내한다.
+  const unavailableReasonOf = (item: HttpTypes.StoreCartLineItem) => {
+    if (!item.variant_id) return "product" as const
+    if (optionGoneVariantIds?.has(item.variant_id)) return "option" as const
+    if (soldOutVariantIds?.has(item.variant_id)) return "soldOut" as const
+    return "product" as const
+  }
 
   const maxQuantityOf = (item: HttpTypes.StoreCartLineItem) =>
     item.variant_id ? availableByVariantId?.[item.variant_id] : undefined
@@ -135,7 +139,9 @@ export default function Items({
               <TableHead className="hidden w-20 xl:table-cell">
                 {t("tableUnitPrice")}
               </TableHead>
-              <TableHead className="w-20 text-right">{t("tableTotal")}</TableHead>
+              <TableHead className="w-20 text-right">
+                {t("tableTotal")}
+              </TableHead>
               <TableHead className="w-10 pr-0"></TableHead>
             </TableRow>
           </TableHeader>

--- a/web/almondyoung-storefront/src/i18n/messages/en/cart.json
+++ b/web/almondyoung-storefront/src/i18n/messages/en/cart.json
@@ -38,7 +38,11 @@
     "quantityMaxError": "Only {max} left in stock. Please choose {max} or fewer.",
     "quantityStockError": "Not enough stock to update the quantity. Please try again shortly.",
     "quantityMaxHint": "Max {max}",
-    "quantitySoldOut": "This item is sold out, so the quantity cannot be increased."
+    "quantitySoldOut": "This item is sold out, so the quantity cannot be increased.",
+    "outOfStockBadge": "Sold out",
+    "outOfStockHint": "This item is sold out. Remove it to continue to checkout.",
+    "overStockBadge": "Not enough stock",
+    "overStockHint": "Only {max} left in stock. Please lower the quantity to {max} or fewer."
   },
   "summary": {
     "title": "Order summary",

--- a/web/almondyoung-storefront/src/i18n/messages/en/checkout.json
+++ b/web/almondyoung-storefront/src/i18n/messages/en/checkout.json
@@ -351,7 +351,15 @@
     "retry": "Try again",
     "goBack": "Back to previous page",
     "shippingMethodMissing": "Shipping details changed, so the order could not be completed. Please return to your cart and try again.",
-    "shippingMethodNone": "No shipping method was set. Please return to your cart and try again."
+    "shippingMethodNone": "No shipping method was set. Please return to your cart and try again.",
+    "insufficientInventory": "The item ran out of stock during payment, so the payment did not go through.",
+    "variantUnavailable": "An item in your cart is no longer sold, so the payment did not go through.",
+    "stock": {
+      "notCharged": "You were not charged and no order was created.",
+      "goToCart": "Go to cart",
+      "whatToDoQuantity": "In your cart, lower the quantity of the item that is short on stock and try again.",
+      "whatToDoUnavailable": "Remove the item from your cart and try again."
+    }
   },
   "callback": {
     "paymentFailed": "Payment failed.",

--- a/web/almondyoung-storefront/src/i18n/messages/ja/cart.json
+++ b/web/almondyoung-storefront/src/i18n/messages/ja/cart.json
@@ -38,7 +38,11 @@
     "quantityMaxError": "在庫が残り{max}個です。{max}個以下でお選びください。",
     "quantityStockError": "在庫が不足しているため数量を変更できません。しばらくしてからお試しください。",
     "quantityMaxHint": "最大{max}個",
-    "quantitySoldOut": "品切れのため数量を増やせません。"
+    "quantitySoldOut": "品切れのため数量を増やせません。",
+    "outOfStockBadge": "品切れ",
+    "outOfStockHint": "品切れの商品です。決済を進めるには削除してください。",
+    "overStockBadge": "在庫不足",
+    "overStockHint": "在庫が残り{max}個です。{max}個以下に調整してください。"
   },
   "summary": {
     "title": "ご注文金額",

--- a/web/almondyoung-storefront/src/i18n/messages/ja/checkout.json
+++ b/web/almondyoung-storefront/src/i18n/messages/ja/checkout.json
@@ -351,7 +351,15 @@
     "retry": "再試行する",
     "goBack": "前のページに戻る",
     "shippingMethodMissing": "配送料の情報が変更されたため、注文を完了できませんでした。カートに戻ってもう一度お試しください。",
-    "shippingMethodNone": "配送方法が設定されていません。カートに戻ってもう一度お試しください。"
+    "shippingMethodNone": "配送方法が設定されていません。カートに戻ってもう一度お試しください。",
+    "insufficientInventory": "決済中に在庫が不足したため、決済は行われませんでした。",
+    "variantUnavailable": "カートの商品が販売終了となったため、決済は行われませんでした。",
+    "stock": {
+      "notCharged": "料金は請求されておらず、注文も作成されていません。",
+      "goToCart": "カートを確認する",
+      "whatToDoQuantity": "カートで在庫が不足している商品の数量を減らしてから、再度お試しください。",
+      "whatToDoUnavailable": "カートから該当商品を削除してから、再度お試しください。"
+    }
   },
   "callback": {
     "paymentFailed": "決済に失敗しました。",

--- a/web/almondyoung-storefront/src/i18n/messages/ko/cart.json
+++ b/web/almondyoung-storefront/src/i18n/messages/ko/cart.json
@@ -38,7 +38,11 @@
     "quantityMaxError": "재고가 {max}개 남았어요. {max}개 이하로 담아주세요.",
     "quantityStockError": "재고가 부족해 수량을 변경할 수 없어요. 잠시 후 다시 시도해 주세요.",
     "quantityMaxHint": "최대 {max}개",
-    "quantitySoldOut": "품절된 상품이라 수량을 늘릴 수 없어요."
+    "quantitySoldOut": "품절된 상품이라 수량을 늘릴 수 없어요.",
+    "outOfStockBadge": "품절",
+    "outOfStockHint": "품절된 상품이에요. 결제하려면 빼주세요.",
+    "overStockBadge": "재고 부족",
+    "overStockHint": "재고가 {max}개 남았어요. {max}개 이하로 조정해주세요."
   },
   "summary": {
     "title": "주문 예상 금액",

--- a/web/almondyoung-storefront/src/i18n/messages/ko/checkout.json
+++ b/web/almondyoung-storefront/src/i18n/messages/ko/checkout.json
@@ -351,7 +351,15 @@
     "retry": "다시 시도하기",
     "goBack": "이전 페이지로 돌아가기",
     "shippingMethodMissing": "배송비 정보가 바뀌어 주문을 마치지 못했어요. 장바구니로 돌아가 다시 시도해 주세요.",
-    "shippingMethodNone": "배송 방법이 설정되지 않았어요. 장바구니로 돌아가 다시 시도해 주세요."
+    "shippingMethodNone": "배송 방법이 설정되지 않았어요. 장바구니로 돌아가 다시 시도해 주세요.",
+    "insufficientInventory": "결제 중에 재고가 부족해져 결제가 진행되지 않았어요.",
+    "variantUnavailable": "담아두신 상품이 판매 중단되어 결제가 진행되지 않았어요.",
+    "stock": {
+      "notCharged": "결제 금액이 청구되지 않았고 주문도 만들어지지 않았어요.",
+      "goToCart": "장바구니에서 확인하기",
+      "whatToDoQuantity": "장바구니에서 재고가 부족한 상품의 수량을 줄이고 다시 결제해 주세요.",
+      "whatToDoUnavailable": "장바구니에서 해당 상품을 빼고 다시 결제해 주세요."
+    }
   },
   "callback": {
     "paymentFailed": "결제에 실패했습니다.",

--- a/web/almondyoung-storefront/src/lib/api/medusa/cart.ts
+++ b/web/almondyoung-storefront/src/lib/api/medusa/cart.ts
@@ -20,11 +20,7 @@ import { revalidateTag } from "next/cache"
 import { redirect } from "next/navigation"
 import { HttpApiError } from "../api-error"
 import { getRegion } from "./regions"
-import {
-  recoverCustomerCart,
-  retrieveCustomer,
-  transferCart,
-} from "./customer"
+import { recoverCustomerCart, retrieveCustomer, transferCart } from "./customer"
 import {
   cartRequiresShipping,
   selectShippingOptionsForCart,
@@ -107,8 +103,7 @@ export async function retrieveCart(
       if (error?.response?.status === 404) {
         try {
           await removeCartId()
-        } catch {
-        }
+        } catch {}
       }
       return null
     })
@@ -143,6 +138,7 @@ export async function findUnavailableLineItems(
     variantIds: [],
     productNames: [],
     optionGoneVariantIds: [],
+    soldOutVariantIds: [],
     insufficientVariantIds: [],
     insufficientNames: [],
     availableByVariantId: {},
@@ -1427,7 +1423,10 @@ export async function ensureCorrectShippingMethod(
     shippingMethods
   )
 
-  if (shippingMethods.length > 0 && (!alreadyCorrect || options?.refreshAmounts)) {
+  if (
+    shippingMethods.length > 0 &&
+    (!alreadyCorrect || options?.refreshAmounts)
+  ) {
     const updatedCart = await setCartShippingMethods(
       cart.id,
       shippingMethods.map((option) => option.id)

--- a/web/almondyoung-storefront/src/lib/api/medusa/checkout-error-code.test.ts
+++ b/web/almondyoung-storefront/src/lib/api/medusa/checkout-error-code.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { CHECKOUT_ERROR_CODES, toCheckoutErrorCode } from "./checkout-error-code"
+import {
+  CHECKOUT_ERROR_CODES,
+  toCheckoutErrorCode,
+} from "./checkout-error-code"
 
 describe("toCheckoutErrorCode", () => {
   it("배송비 그룹이 덜 붙은 에러를 잡는다", () => {
@@ -9,7 +12,9 @@ describe("toCheckoutErrorCode", () => {
     expect(toCheckoutErrorCode(new Error(raw))).toBe(
       CHECKOUT_ERROR_CODES.shippingMethodMissing
     )
-    expect(toCheckoutErrorCode(raw)).toBe(CHECKOUT_ERROR_CODES.shippingMethodMissing)
+    expect(toCheckoutErrorCode(raw)).toBe(
+      CHECKOUT_ERROR_CODES.shippingMethodMissing
+    )
   })
 
   it("배송수단이 아예 없는 에러를 잡는다", () => {
@@ -27,5 +32,27 @@ describe("toCheckoutErrorCode", () => {
     expect(toCheckoutErrorCode(new Error("Insufficient inventory"))).toBeNull()
     expect(toCheckoutErrorCode(null)).toBeNull()
     expect(toCheckoutErrorCode("")).toBeNull()
+  })
+})
+
+describe("재고 관련 실패", () => {
+  it("재고 부족은 코드로 잡는다", () => {
+    expect(
+      toCheckoutErrorCode(
+        new Error("Some variant does not have the required inventory")
+      )
+    ).toBe(CHECKOUT_ERROR_CODES.insufficientInventory)
+  })
+
+  it("판매중단된 variant 는 코드로 잡는다", () => {
+    expect(
+      toCheckoutErrorCode(
+        "Variants with IDs variant_01 do not exist or belong to a product that is not published"
+      )
+    ).toBe(CHECKOUT_ERROR_CODES.variantUnavailable)
+  })
+
+  it("모르는 에러는 그대로 null 을 돌려준다", () => {
+    expect(toCheckoutErrorCode(new Error("payment declined"))).toBeNull()
   })
 })

--- a/web/almondyoung-storefront/src/lib/api/medusa/checkout-error-code.ts
+++ b/web/almondyoung-storefront/src/lib/api/medusa/checkout-error-code.ts
@@ -10,6 +10,10 @@ export const CHECKOUT_ERROR_CODES = {
   shippingMethodMissing: "SHIPPING_METHOD_MISSING",
   /** 배송이 필요한 상품인데 배송수단이 하나도 없다. */
   shippingMethodNone: "SHIPPING_METHOD_NONE",
+  /** 결제 도중 재고가 모자라졌다. 주문 생성 전에 막히므로 결제도 성립하지 않는다. */
+  insufficientInventory: "INSUFFICIENT_INVENTORY",
+  /** 담아둔 상품(또는 옵션)이 판매중단됐다. */
+  variantUnavailable: "VARIANT_UNAVAILABLE",
 } as const
 
 export type CheckoutErrorCode =
@@ -24,12 +28,18 @@ const PATTERNS: Array<{ test: RegExp; code: CheckoutErrorCode }> = [
     test: /No shipping method selected but the cart contains items that require shipping/i,
     code: CHECKOUT_ERROR_CODES.shippingMethodNone,
   },
+  {
+    test: /does not have the required inventory/i,
+    code: CHECKOUT_ERROR_CODES.insufficientInventory,
+  },
+  {
+    test: /do not exist or belong to a product that is not published/i,
+    code: CHECKOUT_ERROR_CODES.variantUnavailable,
+  },
 ]
 
 /** 아는 에러면 코드를, 모르면 null 을 돌려준다. */
-export function toCheckoutErrorCode(
-  error: unknown
-): CheckoutErrorCode | null {
+export function toCheckoutErrorCode(error: unknown): CheckoutErrorCode | null {
   const message =
     error instanceof Error
       ? error.message

--- a/web/almondyoung-storefront/src/lib/utils/cart-availability.test.ts
+++ b/web/almondyoung-storefront/src/lib/utils/cart-availability.test.ts
@@ -8,6 +8,7 @@ import {
   isLineItemVariantGone,
   isVariantQuantityUnavailable,
   isVariantSoldOut,
+  resolveStockNotice,
 } from "./cart-availability"
 
 const tracked = { manage_inventory: true, allow_backorder: false }
@@ -26,7 +27,11 @@ describe("getAvailableQuantity", () => {
       getAvailableQuantity({ manage_inventory: false, inventory_quantity: 0 })
     ).toBeNull()
     expect(
-      getAvailableQuantity({ ...tracked, allow_backorder: true, inventory_quantity: 0 })
+      getAvailableQuantity({
+        ...tracked,
+        allow_backorder: true,
+        inventory_quantity: 0,
+      })
     ).toBeNull()
   })
 
@@ -40,27 +45,41 @@ describe("getAvailableQuantity", () => {
 // 장바구니에 담긴 수량까지 합쳐 넘긴 경우는 고객이 취할 행동이 달라 구분해서 안내해야 한다.
 describe("describeStockShortage", () => {
   it("요청 수량이 남은 재고보다 많으면 수량을 알려줄 수 있다", () => {
-    expect(describeStockShortage({ available: 2, quantity: 5 })).toBe("exceeds-stock")
+    expect(describeStockShortage({ available: 2, quantity: 5 })).toBe(
+      "exceeds-stock"
+    )
   })
 
   it("재고 안에서 요청했는데도 실패하면 장바구니 합산 초과로 본다", () => {
-    expect(describeStockShortage({ available: 5, quantity: 2 })).toBe("cart-sum")
-    expect(describeStockShortage({ available: 5, quantity: 5 })).toBe("cart-sum")
+    expect(describeStockShortage({ available: 5, quantity: 2 })).toBe(
+      "cart-sum"
+    )
+    expect(describeStockShortage({ available: 5, quantity: 5 })).toBe(
+      "cart-sum"
+    )
   })
 
   it("재고 0 은 품절로 구분한다 — 수량 안내로 가면 '0개 이하로 담아주세요' 가 된다", () => {
-    expect(describeStockShortage({ available: 0, quantity: 1 })).toBe("sold-out")
-    expect(describeStockShortage({ available: 0, quantity: 9 })).toBe("sold-out")
+    expect(describeStockShortage({ available: 0, quantity: 1 })).toBe(
+      "sold-out"
+    )
+    expect(describeStockShortage({ available: 0, quantity: 9 })).toBe(
+      "sold-out"
+    )
   })
 
   it("남은 재고를 모르는 화면은 수량 없는 일반 안내로 떨어진다", () => {
     expect(describeStockShortage({})).toBe("unknown")
-    expect(describeStockShortage({ available: null, quantity: 3 })).toBe("unknown")
+    expect(describeStockShortage({ available: null, quantity: 3 })).toBe(
+      "unknown"
+    )
   })
 
   it("수량을 안 넘기면 1개 담기로 본다", () => {
     expect(describeStockShortage({ available: 1 })).toBe("cart-sum")
-    expect(describeStockShortage({ available: 1, quantity: 2 })).toBe("exceeds-stock")
+    expect(describeStockShortage({ available: 1, quantity: 2 })).toBe(
+      "exceeds-stock"
+    )
   })
 })
 
@@ -71,13 +90,17 @@ describe("isInsufficientInventoryError", () => {
         new Error("Some variant does not have the required inventory")
       )
     ).toBe(true)
-    expect(isInsufficientInventoryError("Variant does not have the required inventory")).toBe(
-      true
-    )
+    expect(
+      isInsufficientInventoryError(
+        "Variant does not have the required inventory"
+      )
+    ).toBe(true)
   })
 
   it("다른 에러는 재고부족으로 오인하지 않는다", () => {
-    expect(isInsufficientInventoryError(new Error("Cart not found"))).toBe(false)
+    expect(isInsufficientInventoryError(new Error("Cart not found"))).toBe(
+      false
+    )
     expect(isInsufficientInventoryError(undefined)).toBe(false)
   })
 })
@@ -99,7 +122,10 @@ describe("buildAvailabilityMap", () => {
   })
 
   it("상품 조회에 없던 variant 는 상한을 두지 않는다 (조회 실패로 구매를 막지 않는다)", () => {
-    const map = buildAvailabilityMap([{ variant_id: "variant_missing" }], fetched)
+    const map = buildAvailabilityMap(
+      [{ variant_id: "variant_missing" }],
+      fetched
+    )
     expect(map).toEqual({})
     expect(map.variant_missing).toBeUndefined()
   })
@@ -113,7 +139,9 @@ describe("buildAvailabilityMap", () => {
   })
 
   it("variant_id 가 없는 라인은 건너뛴다", () => {
-    expect(buildAvailabilityMap([{ variant_id: null }, {}], fetched)).toEqual({})
+    expect(buildAvailabilityMap([{ variant_id: null }, {}], fetched)).toEqual(
+      {}
+    )
   })
 })
 
@@ -121,11 +149,15 @@ describe("buildAvailabilityMap", () => {
 // "담은 수량 > 가용재고" 를 통과시켰고, 그대로 결제로 가면 cart.complete 의 재고예약이 실패했다.
 describe("isVariantQuantityUnavailable", () => {
   it("담은 수량이 가용재고를 넘으면 불가로 본다", () => {
-    expect(isVariantQuantityUnavailable({ ...tracked, inventory_quantity: 1 }, 2)).toBe(true)
+    expect(
+      isVariantQuantityUnavailable({ ...tracked, inventory_quantity: 1 }, 2)
+    ).toBe(true)
   })
 
   it("가용재고와 같은 수량은 구매 가능하다", () => {
-    expect(isVariantQuantityUnavailable({ ...tracked, inventory_quantity: 2 }, 2)).toBe(false)
+    expect(
+      isVariantQuantityUnavailable({ ...tracked, inventory_quantity: 2 }, 2)
+    ).toBe(false)
   })
 
   it("품절(재고 0)은 기존 판정과 겹친다", () => {
@@ -136,11 +168,18 @@ describe("isVariantQuantityUnavailable", () => {
 
   it("재고관리를 안 하거나 백오더 허용이면 수량 제한이 없다", () => {
     expect(
-      isVariantQuantityUnavailable({ manage_inventory: false, inventory_quantity: 0 }, 10)
+      isVariantQuantityUnavailable(
+        { manage_inventory: false, inventory_quantity: 0 },
+        10
+      )
     ).toBe(false)
     expect(
       isVariantQuantityUnavailable(
-        { manage_inventory: true, allow_backorder: true, inventory_quantity: 0 },
+        {
+          manage_inventory: true,
+          allow_backorder: true,
+          inventory_quantity: 0,
+        },
         10
       )
     ).toBe(false)
@@ -198,10 +237,18 @@ describe("isLineItemVariantGone", () => {
 
   it("id 를 모르는 라인은 판정하지 않는다", () => {
     expect(
-      isLineItemVariantGone({ product_id: "prod_1" }, published, variantsOf(["v"]))
+      isLineItemVariantGone(
+        { product_id: "prod_1" },
+        published,
+        variantsOf(["v"])
+      )
     ).toBe(false)
     expect(
-      isLineItemVariantGone({ variant_id: "variant_gone" }, published, variantsOf(["v"]))
+      isLineItemVariantGone(
+        { variant_id: "variant_gone" },
+        published,
+        variantsOf(["v"])
+      )
     ).toBe(false)
   })
 })
@@ -368,5 +415,62 @@ describe("classifyCartLineItems — 구매 불가 사유 구분", () => {
 
     expect(result.variantIds).toEqual(["variant_out"])
     expect(result.optionGoneVariantIds).toEqual([])
+  })
+})
+
+describe("resolveStockNotice", () => {
+  it("상한을 모르면 아무 안내도 하지 않는다", () => {
+    expect(resolveStockNotice(3, undefined)).toBeNull()
+  })
+
+  it("품절 라인은 구매 불가로 따로 잡히므로 여기서는 안내하지 않는다", () => {
+    expect(resolveStockNotice(2, 0)).toBeNull()
+  })
+
+  it("담긴 수량이 재고를 넘으면 남은 수량과 함께 안내한다", () => {
+    expect(resolveStockNotice(10, 5)).toEqual({ kind: "overStock", max: 5 })
+  })
+
+  it("담긴 수량이 재고와 같으면 상한에 닿았다고만 알린다", () => {
+    expect(resolveStockNotice(5, 5)).toEqual({ kind: "atLimit", max: 5 })
+  })
+
+  it("여유가 있으면 아무 안내도 하지 않는다", () => {
+    expect(resolveStockNotice(2, 5)).toBeNull()
+  })
+})
+
+describe("classifyCartLineItems — 품절과 판매중단 구분", () => {
+  it("재고 0 인 라인은 품절로 따로 표시된다", () => {
+    const result = classifyCartLineItems(
+      [{ product_id: "prod_1", variant_id: "var_1", quantity: 1 }],
+      [
+        {
+          id: "prod_1",
+          variants: [
+            {
+              id: "var_1",
+              manage_inventory: true,
+              allow_backorder: false,
+              inventory_quantity: 0,
+            },
+          ],
+        },
+      ]
+    )
+
+    expect(result.variantIds).toContain("var_1")
+    expect(result.soldOutVariantIds).toEqual(["var_1"])
+    expect(result.optionGoneVariantIds).toEqual([])
+  })
+
+  it("미게시 상품은 품절이 아니라 판매중단으로 남는다", () => {
+    const result = classifyCartLineItems(
+      [{ product_id: "prod_gone", variant_id: "var_2", quantity: 1 }],
+      []
+    )
+
+    expect(result.variantIds).toContain("var_2")
+    expect(result.soldOutVariantIds).toEqual([])
   })
 })

--- a/web/almondyoung-storefront/src/lib/utils/cart-availability.ts
+++ b/web/almondyoung-storefront/src/lib/utils/cart-availability.ts
@@ -179,6 +179,8 @@ export type CartLineItemClassification = {
    * (다른 옵션으로 다시 담으면 된다) 상품 자체의 판매중단과 구분해 안내한다.
    */
   optionGoneVariantIds: string[]
+  /** 그중 재고가 0 이라 품절인 라인. 판매중단과 문구가 달라야 한다. */
+  soldOutVariantIds: string[]
   /** 팔긴 하지만 담은 수량을 못 채우는 라인 */
   insufficientVariantIds: string[]
   insufficientNames: string[]
@@ -218,7 +220,9 @@ export function classifyCartLineItems(
     if (item.product_id && !publishedProductIds.has(item.product_id)) {
       return true
     }
-    if (isLineItemVariantGone(item, publishedProductIds, variantIdsByProductId)) {
+    if (
+      isLineItemVariantGone(item, publishedProductIds, variantIdsByProductId)
+    ) {
       return true
     }
     // 재고가 계산된 variant 로 판정. 조회 실패 시에만 카트 라인아이템 variant 로 폴백.
@@ -234,7 +238,9 @@ export function classifyCartLineItems(
   // 폴백으로 쓰면 전 라인이 재고 0 으로 읽혀 멀쩡한 결제까지 막는다.
   const insufficientItems = items.filter((item) => {
     if (unavailableSet.has(item)) return false
-    const variant = item.variant_id ? variantById.get(item.variant_id) : undefined
+    const variant = item.variant_id
+      ? variantById.get(item.variant_id)
+      : undefined
     return isVariantQuantityUnavailable(variant, item.quantity)
   })
 
@@ -255,6 +261,13 @@ export function classifyCartLineItems(
       )
     )
 
+  const soldOutItems = unavailableItems.filter((item) => {
+    const variant =
+      (item.variant_id ? variantById.get(item.variant_id) : undefined) ??
+      item.variant
+    return isVariantSoldOut(variant)
+  })
+
   const optionGoneItems = unavailableItems.filter((item) =>
     isLineItemVariantGone(item, publishedProductIds, variantIdsByProductId)
   )
@@ -263,8 +276,44 @@ export function classifyCartLineItems(
     variantIds: toVariantIds(unavailableItems),
     productNames: toNames(unavailableItems),
     optionGoneVariantIds: toVariantIds(optionGoneItems),
+    soldOutVariantIds: toVariantIds(soldOutItems),
     insufficientVariantIds: toVariantIds(insufficientItems),
     insufficientNames: toNames(insufficientItems),
     availableByVariantId: buildAvailabilityMap(items, variantById),
+  }
+}
+
+/**
+ * 장바구니 한 줄에 띄울 재고 안내. 판매중단·품절처럼 라인을 빼야 하는 상태는
+ * classifyCartLineItems 가 구매 불가로 잡아 별도 배지가 맡는다. 여기서는 "팔리긴 하는데
+ * 지금 담긴 수량으로는 결제가 안 되는" 상태만 구분한다.
+ *
+ * 결제 직전에 재고가 확인되므로(주문 생성 전 차단), 고객이 장바구니에서 미리 알고
+ * 수량을 줄일 수 있어야 한다.
+ */
+export type StockNotice =
+  | { kind: "overStock"; max: number }
+  | { kind: "atLimit"; max: number }
+  | null
+
+export function resolveStockNotice(
+  quantity: number,
+  maxQuantity?: number
+): StockNotice {
+  if (maxQuantity === undefined) return null
+
+  switch (describeStockShortage({ available: maxQuantity, quantity })) {
+    case "unknown":
+      return null
+    case "sold-out":
+      // 품절 라인은 classifyCartLineItems 가 구매 불가로 따로 잡아 안내한다.
+      return null
+    case "exceeds-stock":
+      return { kind: "overStock", max: maxQuantity }
+    case "cart-sum":
+      // 아직 결제는 되지만 더 담을 수는 없는 상태.
+      return quantity >= maxQuantity
+        ? { kind: "atLimit", max: maxQuantity }
+        : null
   }
 }


### PR DESCRIPTION
결제 중 재고가 부족해지면 주문 생성 전에 막히도록 바뀐 뒤(#560), 고객이 왜 막혔는지 알 수 있는지 확인해보니 두 군데가 비어 있었음

## 결제 실패 페이지

재고 부족과 판매중단이 코드로 매핑되지 않아 Medusa 영문 원문(`Some variant does not have the required inventory`)이 그대로 화면에 찍혔습니다. 그 아래 "일반적인 오류 원인" 목록은 카드 한도·잔액 부족·네트워크라 재고 문제인데 결제수단 문제처럼 읽혔습니다.

- 두 사유를 코드로 잡아 한국어로 안내합니다.
- **결제 금액이 청구되지 않았고 주문도 만들어지지 않았다**는 사실을 같이 알립니다.
- 이때는 카드 원인 목록 대신 장바구니 버튼을 띄우고, 재시도 버튼은 감춥니다. 재고가 그대로면 같은 실패를 반복합니다.
- 수량을 줄이면 되는 경우와 상품을 빼야 하는 경우는 문구를 나눴습니다.
- 매핑되지 않는 에러는 이전과 동일하게 원인 목록·재시도 버튼·원문을 그대로 씁니다.

## 장바구니

재고가 0 인 라인이 **"판매중단"** 배지와 "판매가 중단된 상품입니다" 문구로 표시되고 있었습니다. 구매 불가 판정이 미게시·옵션 삭제·품절을 한 덩어리로 묶어서, 재고가 떨어진 것과 판매를 접은 것이 같은 문구를 썼습니다. 고객이 재입고를 기다릴지 대체품을 찾을지 판단할 수 없습니다.

- 품절 라인을 분류에서 따로 돌려주고 사유를 판매중단·옵션 삭제·품절 셋으로 나눴습니다.
- 담긴 수량이 남은 재고를 넘긴 라인도 안내합니다. 이전에는 회색 "최대 N개" 힌트뿐이라 결제가 막힌다는 사실도, 무엇을 해야 하는지도 알 수 없었습니다.
- 판정은 담기 화면이 쓰던 `describeStockShortage` 위에 얹어 어휘를 맞췄습니다.
