### PR TITLE
fix(medusa): 카트 락 경합을 500 unknown 대신 409 로 알린다

### DIFF
--- a/apps/medusa/src/api/__tests__/cart-lock-conflict.unit.spec.ts
+++ b/apps/medusa/src/api/__tests__/cart-lock-conflict.unit.spec.ts
@@ -1,0 +1,44 @@
+import { MedusaError } from '@medusajs/framework/utils';
+import { toCartLockConflict } from '../cart-lock-conflict';
+
+describe('toCartLockConflict', () => {
+  it('락 실패를 conflict 로 올린다', () => {
+    const converted = toCartLockConflict(new Error('Failed to acquire lock for key "cart_01JABC"'));
+
+    expect(converted).toBeInstanceOf(MedusaError);
+    expect((converted as MedusaError).type).toBe(MedusaError.Types.CONFLICT);
+  });
+
+  it('이미 MedusaError 로 분류된 건 건드리지 않는다', () => {
+    const original = new MedusaError(MedusaError.Types.NOT_FOUND, 'ShippingMethod with id: casm_1 was not found');
+
+    expect(toCartLockConflict(original)).toBe(original);
+  });
+
+  it('다른 에러는 그대로 통과시킨다', () => {
+    const original = new Error('Some variant does not have the required inventory');
+
+    expect(toCartLockConflict(original)).toBe(original);
+  });
+
+  it('에러가 아닌 값도 그대로 통과시킨다', () => {
+    expect(toCartLockConflict('boom')).toBe('boom');
+    expect(toCartLockConflict(undefined)).toBeUndefined();
+  });
+});
+
+describe('realm 을 넘어온 에러', () => {
+  // 워크플로 엔진을 거친 에러는 instanceof Error 가 false 로 나온다 (로컬 실측).
+  // 모양으로 판정하지 않으면 락 실패가 그대로 500 unknown 으로 나간다.
+  it('instanceof 가 깨진 에러도 conflict 로 올린다', () => {
+    const crossRealm = Object.assign(Object.create(null), {
+      name: 'Error',
+      message: 'Failed to acquire lock for key "cart_01JABC"',
+    });
+
+    expect(crossRealm instanceof Error).toBe(false);
+
+    const converted = toCartLockConflict(crossRealm);
+    expect((converted as MedusaError).type).toBe(MedusaError.Types.CONFLICT);
+  });
+});

--- a/apps/medusa/src/api/cart-lock-conflict.ts
+++ b/apps/medusa/src/api/cart-lock-conflict.ts
@@ -1,0 +1,52 @@
+import { errorHandler as buildDefaultErrorHandler } from '@medusajs/framework/http';
+import { MedusaError } from '@medusajs/framework/utils';
+import type { NextFunction, Request, Response } from 'express';
+
+/**
+ * 카트 워크플로는 카트 id 로 락을 잡는데, 못 잡으면 locking provider 가 평범한 `Error` 를 던진다.
+ * 기본 에러 핸들러는 MedusaError 가 아닌 예외를 전부 default 로 떨어뜨려 메시지를
+ * "An unknown error occurred." 로 갈고 500 을 준다. 그래서 클라이언트 입장에서는 잠깐 겹친 것과
+ * 진짜 장애가 똑같아 보이고, 다시 시도하면 풀릴 요청을 그대로 실패로 처리하게 된다.
+ *
+ * 락 실패는 상태가 잘못된 게 아니라 타이밍이라 conflict 로 올려 409 로 내보낸다. 재시도해도
+ * 된다는 신호가 상태 코드에 실려야 클라이언트가 문구를 파싱하지 않고 판단할 수 있다.
+ */
+const LOCK_FAILURE_PATTERN = /failed to acquire lock/i;
+
+/**
+ * `instanceof` 로 판정하지 않는다. 워크플로 엔진을 거쳐 온 에러는 다른 realm 에서 만들어져
+ * `error instanceof Error` 가 false 로 나온다 (로컬에서 실측). 모양으로 판정한다.
+ */
+const readMessage = (error: unknown): string => {
+  const message = (error as { message?: unknown })?.message;
+  return typeof message === 'string' ? message : '';
+};
+
+/** MedusaError 는 type 을 들고 있다. 이미 분류된 에러는 그 판정을 존중한다. */
+const isAlreadyClassified = (error: unknown): boolean =>
+  typeof (error as { type?: unknown })?.type === 'string';
+
+export const toCartLockConflict = (error: unknown): unknown => {
+  if (isAlreadyClassified(error)) return error;
+
+  const message = readMessage(error);
+  if (!LOCK_FAILURE_PATTERN.test(message)) return error;
+
+  return new MedusaError(MedusaError.Types.CONFLICT, message);
+};
+
+/**
+ * 기본 핸들러를 감싼다. 직접 구현하면 나머지 에러 매핑까지 우리가 떠안게 되므로,
+ * 락 실패만 바꿔 끼우고 판단은 그대로 넘긴다.
+ */
+export const createCartLockAwareErrorHandler = () => {
+  const defaultErrorHandler = buildDefaultErrorHandler();
+
+  return (error: unknown, req: Request, res: Response, next: NextFunction) =>
+    defaultErrorHandler(
+      toCartLockConflict(error) as Parameters<typeof defaultErrorHandler>[0],
+      req,
+      res,
+      next,
+    );
+};

--- a/apps/medusa/src/api/middlewares.ts
+++ b/apps/medusa/src/api/middlewares.ts
@@ -1,4 +1,5 @@
 import { authenticate, defineMiddlewares } from '@medusajs/framework/http';
+import { createCartLockAwareErrorHandler } from './cart-lock-conflict';
 import { validateAndTransformQuery } from '@medusajs/framework';
 import { adminRouteMiddlewares } from './admin/middlewares';
 import { listTransformQueryConfig as ordersListQueryConfig } from './store/orders-list/query-config';
@@ -32,6 +33,8 @@ const timingMiddleware = (req: any, res: any, next: any) => {
 };
 
 export default defineMiddlewares({
+  // 카트 락 경합을 500 unknown 대신 409 로 내보낸다. 나머지 에러 처리는 기본 핸들러 그대로.
+  errorHandler: createCartLockAwareErrorHandler(),
   routes: [
     // 모든 요청에 타이밍 미들웨어 적용
     {


### PR DESCRIPTION
#619 리뷰에서 "카트 경합 재시도가 실제로는 안 걸린다"는 지적이 나왔고, 원인을 파보니 Medusa 쪽에서 신호가 사라지고 있었습니다. 그 부분만 떼어낸 PR 입니다.

## 문제

카트 워크플로가 락을 못 잡으면 locking provider 가 평범한 `Error` 를 던집니다. 기본 에러 핸들러는 `MedusaError` 가 아닌 예외를 전부 default 로 떨어뜨려 메시지를 `An unknown error occurred.` 로 갈고 500 을 줍니다.

```
서버 로그   : Error: Failed to acquire lock for key "cart_01KZT..."
실제 응답   : 500 { type: "unknown_error", message: "An unknown error occurred." }
```

클라이언트 입장에서는 잠깐 겹친 것과 진짜 장애가 구분되지 않습니다. 다시 시도하면 풀릴 요청도 실패로 끝납니다.

## 수정

락 실패만 conflict 로 올려 409 로 내보냅니다. 나머지 에러 판단은 기본 핸들러를 감싸서 그대로 맡깁니다.

구현하면서 하나 걸렸는데, `error instanceof Error` 로 판정하면 안 걸립니다. 워크플로 엔진을 거쳐 온 에러는 다른 realm 에서 만들어져 `instanceof` 가 false 로 나옵니다(로컬에서 디버그로 확인). 메시지 모양으로 판정하고, 이 케이스를 테스트로 박아뒀습니다.
