### PR TITLE
fix(storefront): 품절 라인에서 수량을 줄일 때 늘리기 문구가 뜨던 것

### DIFF
--- a/web/almondyoung-storefront/src/domains/cart/components/item/index.tsx
+++ b/web/almondyoung-storefront/src/domains/cart/components/item/index.tsx
@@ -117,10 +117,14 @@ function Item({
     if (change.type === "reject") {
       if (change.reason === "belowMin") return false
 
-      // 재고 0 은 "0개 이하로 담아주세요" 가 되어버리므로 품절 문구를 쓴다.
+      // 재고 0 은 "0개 이하로 담아주세요" 가 되어버리므로 품절 문구를 쓴다. 품절 라인은
+      // 줄이는 것도 서버가 거절하므로, 줄이려던 고객에게는 "늘릴 수 없다" 가 아니라
+      // 빼달라고 말해야 한다.
       const message =
         change.reason === "soldOut"
-          ? t("quantitySoldOut")
+          ? change.isIncrease
+            ? t("quantitySoldOut")
+            : t("outOfStockHint")
           : t("quantityMaxError", { max: change.max })
       toast.error(message)
       setError(message)

--- a/web/almondyoung-storefront/src/lib/utils/cart-quantity.test.ts
+++ b/web/almondyoung-storefront/src/lib/utils/cart-quantity.test.ts
@@ -41,7 +41,14 @@ describe("resolveQuantityChange", () => {
   it("품절이면 줄이는 요청도 보내지 않는다", () => {
     expect(
       resolveQuantityChange({ requested: 4, current: 5, maxQuantity: 0 })
-    ).toEqual({ type: "reject", reason: "soldOut" })
+    ).toEqual({ type: "reject", reason: "soldOut", isIncrease: false })
+  })
+
+  // 품절 라인에서 "-" 를 눌렀는데 "늘릴 수 없어요" 가 뜨면 고객이 뭘 해야 할지 알 수 없다.
+  it("품절 거절은 늘리려던 것인지 줄이려던 것인지 구분해 돌려준다", () => {
+    expect(
+      resolveQuantityChange({ requested: 6, current: 5, maxQuantity: 0 })
+    ).toEqual({ type: "reject", reason: "soldOut", isIncrease: true })
   })
 
   it("1개 미만은 보내지 않는다", () => {

--- a/web/almondyoung-storefront/src/lib/utils/cart-quantity.ts
+++ b/web/almondyoung-storefront/src/lib/utils/cart-quantity.ts
@@ -10,7 +10,11 @@
 export type QuantityChange =
   | { type: "apply"; quantity: number; clampedToMax: boolean }
   | { type: "reject"; reason: "belowMin" }
-  | { type: "reject"; reason: "soldOut" }
+  /**
+   * 품절이면 줄이는 요청도 서버가 거절한다. 다만 고객이 방금 무엇을 눌렀는지에 따라 할 말이
+   * 달라서(늘리려 했나 / 줄이려 했나) 방향을 같이 돌려준다.
+   */
+  | { type: "reject"; reason: "soldOut"; isIncrease: boolean }
   /** 안내 문구에 남은 수량을 넣어야 하므로 상한을 같이 돌려준다. */
   | { type: "reject"; reason: "exceedsMax"; max: number }
 
@@ -37,7 +41,7 @@ export function resolveQuantityChange({
   }
 
   if (maxQuantity <= 0) {
-    return { type: "reject", reason: "soldOut" }
+    return { type: "reject", reason: "soldOut", isIncrease: requested > current }
   }
 
   if (requested <= maxQuantity) {


### PR DESCRIPTION
품절된 라인은 줄이는 요청도 Medusa 가 거절한다(로컬 확인: 재고 0 이면 같은 수량으로 보내도 400). 그래서 보내기 전에 막는 건 맞는데, "품절된 상품이라 수량을 늘릴 수 없어요" 가 떴다. 고객은 "-" 를 눌렀는데 늘릴 수 없다는 말을 듣고, 정작 무엇을 해야 하는지는 못 듣는다.

판정이 방향을 같이 돌려주게 해서, 줄이려던 경우에는 라인에 이미 붙어 있는 안내와 같은
"빼달라" 문구를 쓴다.