### PR TITLE
perf(channel-adapter): 대량등록이 Medusa 에 거는 부하를 줄인다

### DIFF
--- a/apps/channel-adapter/scripts/backfill-v2.ts
+++ b/apps/channel-adapter/scripts/backfill-v2.ts
@@ -33,6 +33,7 @@ import { MigrationSessionService } from './lib/migration-session.service';
 import { syncWithRetry, classifyError } from './lib/error-classifier';
 import { PimMedusaSyncService } from '../src/adapters/medusa/pim-medusa-sync.service';
 import { StorefrontRevalidateService } from '../src/adapters/medusa/storefront-revalidate.service';
+import { DeferredRevalidateService } from '../src/adapters/medusa/deferred-revalidate.service';
 import { MedusaClient } from '../src/adapters/medusa/medusa.client';
 import { PimMedusaMappingRepository } from '../src/adapters/medusa/pim-medusa-mapping.repository';
 
@@ -189,10 +190,14 @@ async function main() {
   const mappingRepo = new PimMedusaMappingRepository({ db: channelDb } as any);
   // StorefrontRevalidateService 는 무인자 생성(환경변수 없으면 no-op). 생성자 3번째 인자 누락으로
   // backfill-v2 가 깨져 있던 것을 함께 보정한다.
+  // 4번째 인자 DeferredRevalidateService 도 마찬가지로 무인자에 가까운 구성으로 채운다 —
+  // 이 스크립트는 isBulk 를 세팅하지 않으므로 실제로 dereference 되지 않는다.
+  const revalidateSvc = new StorefrontRevalidateService();
   const syncService = new PimMedusaSyncService(
     medusaClient,
     mappingRepo,
-    new StorefrontRevalidateService(),
+    revalidateSvc,
+    new DeferredRevalidateService(revalidateSvc, new ConfigService()),
   );
 
   // 카테고리/태그/타입/세일즈채널 캐시를 미리 채워 product 당 list/verify HTTP 호출을

--- a/apps/channel-adapter/src/adapter.module.ts
+++ b/apps/channel-adapter/src/adapter.module.ts
@@ -76,6 +76,7 @@ import { ShipmentDispatchInboxWorker } from './services/shipment-dispatch-inbox.
 import { MedusaClient } from './adapters/medusa/medusa.client';
 import { PimMedusaSyncService } from './adapters/medusa/pim-medusa-sync.service';
 import { StorefrontRevalidateService } from './adapters/medusa/storefront-revalidate.service';
+import { DeferredRevalidateService } from './adapters/medusa/deferred-revalidate.service';
 import { MembershipMedusaSyncService } from './adapters/medusa/membership-medusa-sync.service';
 import { PimProductEventConsumer } from './consumers/pim-product-event.consumer';
 import { PimCategoryConsumer } from './consumers/pim-category.consumer';
@@ -270,6 +271,7 @@ const NO_KAFKA_PUBLISHER_STREAMS: StreamConfig[] = [
     ProductSellableQuantityConsumer,
     MembershipEventConsumer,
     PimMedusaMappingRepository,
+    DeferredRevalidateService,
     InboxWorkerService,
 
     // 주문 수집 (Provider 패턴)

--- a/apps/channel-adapter/src/adapters/medusa/deferred-revalidate.service.spec.ts
+++ b/apps/channel-adapter/src/adapters/medusa/deferred-revalidate.service.spec.ts
@@ -55,4 +55,31 @@ describe('DeferredRevalidateService', () => {
 
     expect(revalidate.revalidateProducts).not.toHaveBeenCalled();
   });
+
+  describe('onModuleInit 타이머', () => {
+    let timerService: DeferredRevalidateService;
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      timerService = new DeferredRevalidateService(revalidate as unknown as StorefrontRevalidateService, {
+        get: () => 5000,
+      } as never);
+    });
+
+    afterEach(async () => {
+      // pending 이 이미 비었으므로 onModuleDestroy 의 flush() 는 no-op — 타이머만 정리한다.
+      await timerService.onModuleDestroy();
+      jest.useRealTimers();
+    });
+
+    it('설정된 주기마다 자동으로 flush 한다 — config 파싱된 숫자값을 그대로 쓴다', async () => {
+      timerService.onModuleInit();
+      timerService.enqueue('m1');
+
+      jest.advanceTimersByTime(5000);
+      await Promise.resolve();
+
+      expect(revalidate.revalidateProducts).toHaveBeenCalledWith(['m1']);
+    });
+  });
 });

--- a/apps/channel-adapter/src/adapters/medusa/deferred-revalidate.service.spec.ts
+++ b/apps/channel-adapter/src/adapters/medusa/deferred-revalidate.service.spec.ts
@@ -1,0 +1,58 @@
+import { DeferredRevalidateService } from './deferred-revalidate.service';
+import { StorefrontRevalidateService } from './storefront-revalidate.service';
+
+describe('DeferredRevalidateService', () => {
+  let revalidate: jest.Mocked<Pick<StorefrontRevalidateService, 'revalidateProducts'>>;
+  let service: DeferredRevalidateService;
+
+  beforeEach(() => {
+    revalidate = { revalidateProducts: jest.fn().mockResolvedValue(undefined) };
+    service = new DeferredRevalidateService(
+      revalidate as unknown as StorefrontRevalidateService,
+      { get: () => undefined } as never,
+    );
+  });
+
+  it('누적한 handle 을 flush 에서 한 번에 보낸다', async () => {
+    service.enqueue('m1');
+    service.enqueue('m2');
+
+    await service.flush();
+
+    expect(revalidate.revalidateProducts).toHaveBeenCalledTimes(1);
+    expect(revalidate.revalidateProducts).toHaveBeenCalledWith(['m1', 'm2']);
+  });
+
+  it('같은 handle 이 여러 번 들어와도 한 번만 보낸다', async () => {
+    service.enqueue('m1');
+    service.enqueue('m1');
+
+    await service.flush();
+
+    expect(revalidate.revalidateProducts).toHaveBeenCalledWith(['m1']);
+  });
+
+  it('버퍼가 비면 호출하지 않는다', async () => {
+    await service.flush();
+
+    expect(revalidate.revalidateProducts).not.toHaveBeenCalled();
+  });
+
+  it('flush 가 실패해도 예외를 밖으로 내지 않는다 — 캐시 지연은 동기화를 막을 이유가 아니다', async () => {
+    revalidate.revalidateProducts.mockRejectedValue(new Error('boom'));
+    service.enqueue('m1');
+
+    await expect(service.flush()).resolves.toBeUndefined();
+  });
+
+  it('flush 실패분은 버려진다 — 다음 flush 를 무한히 오염시키지 않는다', async () => {
+    revalidate.revalidateProducts.mockRejectedValueOnce(new Error('boom'));
+    service.enqueue('m1');
+    await service.flush();
+
+    revalidate.revalidateProducts.mockClear();
+    await service.flush();
+
+    expect(revalidate.revalidateProducts).not.toHaveBeenCalled();
+  });
+});

--- a/apps/channel-adapter/src/adapters/medusa/deferred-revalidate.service.ts
+++ b/apps/channel-adapter/src/adapters/medusa/deferred-revalidate.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { StorefrontRevalidateService } from './storefront-revalidate.service';
+
+const DEFAULT_FLUSH_INTERVAL_MS = 60_000;
+
+/**
+ * 대량등록 중의 storefront 캐시 무효화를 모아서 한 번에 친다.
+ *
+ * 단건 경로는 상품마다 즉시 무효화하는데, 그 라우트는 호출마다 전역 목록 태그와
+ * 모든 카테고리 페이지를 지운다. 대량등록이 그걸 상품 수만큼 부르면 캐시가 데워질
+ * 틈이 없다 (실측: 5시간에 770회). 여기 모았다가 주기마다 1회만 친다.
+ *
+ * 버퍼는 인메모리다. 프로세스가 죽으면 그 주기분은 유실되고, 해당 상품은 캐시 TTL
+ * (1시간) 까지 낡은 채로 남는다. 가격·재고가 아니라 캐시라 이 정도는 허용한다.
+ */
+@Injectable()
+export class DeferredRevalidateService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(DeferredRevalidateService.name);
+  private readonly pending = new Set<string>();
+  private readonly flushIntervalMs: number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private readonly storefrontRevalidate: StorefrontRevalidateService,
+    private readonly configService: ConfigService,
+  ) {
+    const raw = this.configService.get<string | number | undefined>('DEFERRED_REVALIDATE_FLUSH_MS');
+    const parsed = Number(raw);
+    this.flushIntervalMs =
+      raw === undefined || raw === null || raw === '' || !Number.isInteger(parsed) || parsed < 1000
+        ? DEFAULT_FLUSH_INTERVAL_MS
+        : parsed;
+  }
+
+  onModuleInit(): void {
+    this.timer = setInterval(() => void this.flush(), this.flushIntervalMs);
+    this.logger.log(`Deferred revalidate started (flushIntervalMs=${this.flushIntervalMs}ms)`);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    // 정상 종료(배포 등)에서는 남은 버퍼를 흘려보낸다.
+    await this.flush();
+  }
+
+  enqueue(handle: string): void {
+    this.pending.add(handle);
+  }
+
+  async flush(): Promise<void> {
+    if (this.pending.size === 0) return;
+
+    // 먼저 비운다 — 실패해도 다음 주기를 오염시키지 않는다. 최악은 캐시가 TTL 까지 낡는 것.
+    const handles = [...this.pending];
+    this.pending.clear();
+
+    try {
+      await this.storefrontRevalidate.revalidateProducts(handles);
+      this.logger.log(`Deferred revalidate flushed: ${handles.length} handles`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`Deferred revalidate flush failed (${handles.length} handles): ${message}`);
+    }
+  }
+}

--- a/apps/channel-adapter/src/adapters/medusa/deferred-revalidate.service.ts
+++ b/apps/channel-adapter/src/adapters/medusa/deferred-revalidate.service.ts
@@ -43,7 +43,11 @@ export class DeferredRevalidateService implements OnModuleInit, OnModuleDestroy 
       clearInterval(this.timer);
       this.timer = null;
     }
-    // 정상 종료(배포 등)에서는 남은 버퍼를 흘려보낸다.
+    // 이 앱은 app.enableShutdownHooks() 를 호출하지 않는다 (main.ts) — 즉 onModuleDestroy 는
+    // app.close() 가 실제로 불릴 때만 실행된다 (지금은 테스트뿐). ECS 배포로 인한 task
+    // replacement 는 SIGTERM 을 프로세스에 보낼 뿐 app.close() 를 거치지 않으므로, 그 경로에서는
+    // 여기 도달하지 못하고 버퍼가 유실된다. 최악의 경우도 flush 주기 1회분의
+    // pim-detail-{handle} 무효화가 늦어지는 것뿐이며, 1시간 캐시 TTL 로 자연 치유된다.
     await this.flush();
   }
 
@@ -59,8 +63,11 @@ export class DeferredRevalidateService implements OnModuleInit, OnModuleDestroy 
     this.pending.clear();
 
     try {
+      // revalidateProducts()(→ StorefrontRevalidateService.post())는 모든 에러를 삼킨다.
+      // 즉 이 catch 는 프로덕션에서 사실상 도달하지 않고, 아래 로그는 "성공"이 아니라
+      // "시도했다"만 의미한다 — 배포 후 재측정은 이 로그를 그렇게 읽어야 한다.
       await this.storefrontRevalidate.revalidateProducts(handles);
-      this.logger.log(`Deferred revalidate flushed: ${handles.length} handles`);
+      this.logger.log(`Deferred revalidate dispatched: ${handles.length} handles`);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       this.logger.warn(`Deferred revalidate flush failed (${handles.length} handles): ${message}`);

--- a/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts
+++ b/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts
@@ -1,5 +1,6 @@
 import { PimMedusaSyncService } from './pim-medusa-sync.service';
 import type { ProductSellableQuantityChangedPayload } from '@packages/event-contracts/streams/inventory.stream';
+import type { PimProductSnapshot } from '../../types';
 
 describe('PimMedusaSyncService.handleProductSellableQuantityChanged', () => {
   const payload: ProductSellableQuantityChangedPayload = {
@@ -93,6 +94,68 @@ describe('PimMedusaSyncService.handleProductSellableQuantityChanged', () => {
       }),
     ).rejects.toThrow('ProductSellableQuantityChanged missing masterId for variant pim-var-1');
     expect(medusaClient.applyProductSellableQuantityProjection).not.toHaveBeenCalled();
+  });
+});
+
+describe('PimMedusaSyncService.syncFromSnapshot 의 revalidate 분기', () => {
+  const snapshot: PimProductSnapshot = {
+    masterId: 'master-1',
+    versionId: 'version-1',
+    version: 1,
+    name: 'Test Product',
+    variants: [
+      {
+        id: 'pim-var-1',
+        isDefault: true,
+        status: 'active',
+        basePrice: 10000,
+      },
+    ],
+    status: 'active',
+  };
+
+  function createService() {
+    const medusaClient = {
+      ensureProductType: jest.fn().mockResolvedValue('ptype_1'),
+      getDefaultSalesChannel: jest.fn().mockResolvedValue('sc_1'),
+      getShippingProfileIdForGroup: jest.fn().mockResolvedValue('ship_1'),
+      upsertProduct: jest.fn().mockResolvedValue({
+        product: { id: 'prod_1', variants: [] },
+        action: 'created',
+      }),
+    };
+    const mappingRepo = {
+      findByPimMasterId: jest.fn().mockResolvedValue(null),
+      recordSuccess: jest.fn().mockResolvedValue(undefined),
+    };
+    const storefrontRevalidate = { revalidateProduct: jest.fn().mockResolvedValue(undefined) };
+    const deferredRevalidate = { enqueue: jest.fn() };
+    const service = new PimMedusaSyncService(
+      medusaClient as any,
+      mappingRepo as any,
+      storefrontRevalidate as any,
+      deferredRevalidate as any,
+    );
+
+    return { service, storefrontRevalidate, deferredRevalidate };
+  }
+
+  it('대량등록(isBulk=true)이면 buffer 에 쌓고 즉시 revalidate 하지 않는다', async () => {
+    const { service, storefrontRevalidate, deferredRevalidate } = createService();
+
+    await service.syncFromSnapshot(snapshot, { skipCategorySync: true, isBulk: true });
+
+    expect(deferredRevalidate.enqueue).toHaveBeenCalledWith('master-1');
+    expect(storefrontRevalidate.revalidateProduct).not.toHaveBeenCalled();
+  });
+
+  it('단건 동기화(isBulk 없음)면 즉시 revalidate 하고 buffer 에 쌓지 않는다', async () => {
+    const { service, storefrontRevalidate, deferredRevalidate } = createService();
+
+    await service.syncFromSnapshot(snapshot, { skipCategorySync: true });
+
+    expect(storefrontRevalidate.revalidateProduct).toHaveBeenCalledWith('master-1');
+    expect(deferredRevalidate.enqueue).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts
+++ b/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts
@@ -220,6 +220,33 @@ describe('PimMedusaSyncService.syncPriceLists (replace semantics)', () => {
     ]);
     expect(calls).toEqual(['remove', 'add']);
   });
+
+  it('신규 생성 상품이면 remove 를 건너뛰고 add 만 한다', async () => {
+    const { service, medusaClient, calls } = createService();
+    const snapshot = {
+      variants: [{ id: 'pim-var-1', membershipPrice: 34000, tieredPrices: [] }],
+    };
+    const medusaVariants = [{ id: 'variant_m1', metadata: { pimVariantId: 'pim-var-1' } }];
+
+    await (service as any).syncPriceLists(snapshot, 'prod_1', medusaVariants, { skipRemove: true });
+
+    expect(medusaClient.removeProductFromPriceList).not.toHaveBeenCalled();
+    expect(medusaClient.addPricesToPriceList).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(['add']);
+  });
+
+  it('기존 상품이면 지금까지대로 remove 후 add 한다', async () => {
+    const { service, medusaClient, calls } = createService();
+    const snapshot = {
+      variants: [{ id: 'pim-var-1', membershipPrice: 34000, tieredPrices: [] }],
+    };
+    const medusaVariants = [{ id: 'variant_m1', metadata: { pimVariantId: 'pim-var-1' } }];
+
+    await (service as any).syncPriceLists(snapshot, 'prod_1', medusaVariants, { skipRemove: false });
+
+    expect(medusaClient.removeProductFromPriceList).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(['remove', 'add']);
+  });
 });
 
 describe('PimMedusaSyncService 카테고리 조상 처리', () => {

--- a/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts
+++ b/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts
@@ -305,3 +305,20 @@ describe('PimMedusaSyncService 카테고리 조상 처리', () => {
     ]);
   });
 });
+
+import { isBulkOrigin } from './pim-medusa-sync.service';
+
+describe('isBulkOrigin', () => {
+  it('bulk_import 를 대량으로 판정한다', () => {
+    expect(isBulkOrigin('bulk_import')).toBe(true);
+  });
+
+  it('출처가 없으면 단건으로 판정한다', () => {
+    expect(isBulkOrigin(undefined)).toBe(false);
+    expect(isBulkOrigin('')).toBe(false);
+  });
+
+  it('모르는 출처는 단건으로 판정한다 — 안전한 쪽이 즉시 반영이다', () => {
+    expect(isBulkOrigin('admin_ui')).toBe(false);
+  });
+});

--- a/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts
+++ b/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts
@@ -30,10 +30,12 @@ describe('PimMedusaSyncService.handleProductSellableQuantityChanged', () => {
     const storefrontRevalidate = {
       revalidateProduct: jest.fn().mockResolvedValue(undefined),
     };
+    const deferredRevalidate = { enqueue: jest.fn() };
     const service = new PimMedusaSyncService(
       medusaClient as any,
       mappingRepo as any,
       storefrontRevalidate as any,
+      deferredRevalidate as any,
     );
 
     return { service, medusaClient, mappingRepo, storefrontRevalidate };
@@ -106,10 +108,12 @@ describe('PimMedusaSyncService.handleProductMasterDeleted', () => {
     const storefrontRevalidate = {
       revalidateProduct: jest.fn().mockResolvedValue(undefined),
     };
+    const deferredRevalidate = { enqueue: jest.fn() };
     const service = new PimMedusaSyncService(
       medusaClient as any,
       mappingRepo as any,
       storefrontRevalidate as any,
+      deferredRevalidate as any,
     );
 
     return { service, medusaClient, mappingRepo, storefrontRevalidate };
@@ -174,10 +178,12 @@ describe('PimMedusaSyncService.syncPriceLists (replace semantics)', () => {
     };
     const mappingRepo = { findByPimMasterId: jest.fn(), update: jest.fn() };
     const storefrontRevalidate = { revalidateProduct: jest.fn() };
+    const deferredRevalidate = { enqueue: jest.fn() };
     const service = new PimMedusaSyncService(
       medusaClient as any,
       mappingRepo as any,
       storefrontRevalidate as any,
+      deferredRevalidate as any,
     );
     return { service, medusaClient, calls };
   }

--- a/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts
+++ b/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts
@@ -400,7 +400,11 @@ export class PimMedusaSyncService {
 
       this.logger.log(`Sync completed: ${masterId} → Medusa ${product.id} (${action})`);
 
-      await this.syncPriceLists(snapshot, product.id, product.variants);
+      await this.syncPriceLists(snapshot, product.id, product.variants, {
+        // 신규 생성 상품은 price list 에 항목이 있을 수 없다. remove 는 상품당 3.30초로
+        // 상품 생성(2.86초)보다 비싼 호출이라 건너뛰는 값어치가 크다.
+        skipRemove: action === 'created',
+      });
 
       await this.mappingRepo.recordSuccess(masterId, {
         pimVersionId: versionId,
@@ -583,7 +587,8 @@ export class PimMedusaSyncService {
   private async syncPriceLists(
     snapshot: PimProductSnapshot,
     medusaProductId: string,
-    medusaVariants?: MedusaProduct['variants'],
+    medusaVariants: MedusaProduct['variants'] | undefined,
+    opts: { skipRemove?: boolean } = {},
   ): Promise<void> {
     if (!medusaVariants || medusaVariants.length === 0) return;
 
@@ -633,7 +638,10 @@ export class PimMedusaSyncService {
       // otherwise re-sync accumulates duplicate rows and a stale-lower price wins (Medusa applies
       // the lowest). Remove→add briefly leaves the product without a membership price; that only
       // ever falls back to the higher base price, so it never undercharges.
-      await this.medusaClient.removeProductFromPriceList(listId, medusaProductId);
+      // 신규 생성 상품은 지울 항목이 없으므로 skipRemove 로 건너뛴다.
+      if (!opts.skipRemove) {
+        await this.medusaClient.removeProductFromPriceList(listId, medusaProductId);
+      }
       await this.medusaClient.addPricesToPriceList(listId, membershipPrices);
     }
 
@@ -646,7 +654,9 @@ export class PimMedusaSyncService {
         status: 'active',
       });
       // Replace, not append (same rationale as the membership list above).
-      await this.medusaClient.removeProductFromPriceList(listId, medusaProductId);
+      if (!opts.skipRemove) {
+        await this.medusaClient.removeProductFromPriceList(listId, medusaProductId);
+      }
       await this.medusaClient.addPricesToPriceList(listId, prices);
     }
   }

--- a/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts
+++ b/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts
@@ -448,6 +448,10 @@ export class PimMedusaSyncService {
         this.logger.error('Failed to record failure', recordError);
       }
 
+      // 성공 경로의 'Sync finished'(:430)와 짝을 이루는 실패 경로 표지. 재측정 로그가
+      // 실패 건을 빠뜨리면 느린 실패가 평균에서 빠져 낙관적으로 왜곡된다.
+      this.logger.log(`Sync finished (failed): ${masterId} (${Date.now() - startedAt}ms)`);
+
       throw error;
     }
   }

--- a/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts
+++ b/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts
@@ -14,6 +14,17 @@ import type {
 } from '@packages/event-contracts/streams/product.stream';
 import type { ProductSellableQuantityChangedPayload } from '@packages/event-contracts/streams/inventory.stream';
 
+/**
+ * 대량 출처 목록. inbox-worker 의 BULK_ORIGINS 와 같은 값이지만, 그쪽은 metadata 를 읽는
+ * SQL 레인 판정이고 이쪽은 payload 를 읽는 핸들러 분기라 의도적으로 따로 둔다.
+ * 모르는 값은 단건으로 본다 — 즉시 반영이 안전한 기본값이다.
+ */
+const BULK_SYNC_ORIGINS: readonly string[] = ['bulk_import'];
+
+export function isBulkOrigin(origin?: string): boolean {
+  return !!origin && BULK_SYNC_ORIGINS.includes(origin);
+}
+
 export interface SyncResult {
   success: boolean;
   masterId: string;
@@ -296,7 +307,10 @@ export class PimMedusaSyncService {
   // }
 
   // 스냅샷 기반 동기화 (Phase 2 - PIM API 호출 없음)
-  async syncFromSnapshot(snapshot: PimProductSnapshot, options?: { skipCategorySync?: boolean }): Promise<SyncResult> {
+  async syncFromSnapshot(
+    snapshot: PimProductSnapshot,
+    options?: { skipCategorySync?: boolean; isBulk?: boolean },
+  ): Promise<SyncResult> {
     const { masterId, versionId } = snapshot;
 
     this.logger.log(`Syncing from event snapshot: ${masterId} (v${snapshot.version})`);
@@ -452,6 +466,8 @@ export class PimMedusaSyncService {
 
     this.logger.log(`📨 PIM Event: ${masterId} (${changeReason}) - versionId: ${versionId ?? 'none'}`);
 
+    const isBulk = isBulkOrigin(event.origin);
+
     switch (changeReason) {
       case 'published':
       case 'rollback':
@@ -464,7 +480,7 @@ export class PimMedusaSyncService {
           this.logger.error(error.message);
           throw error;
         }
-        await this.syncFromSnapshot(snapshot);
+        await this.syncFromSnapshot(snapshot, { isBulk });
         break;
 
       case 'unpublished':

--- a/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts
+++ b/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts
@@ -4,6 +4,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { MedusaClient } from './medusa.client';
 import { PimMedusaMappingRepository } from './pim-medusa-mapping.repository';
 import { StorefrontRevalidateService } from './storefront-revalidate.service';
+import { DeferredRevalidateService } from './deferred-revalidate.service';
 import { transformPimToMedusa, validatePimSnapshot } from './transformers/pim-to-medusa.transformer';
 import type { PimActiveVersionChangedEvent, PimProductSnapshot, MedusaProduct } from '../../types';
 // PIMCLIENT: Type import removed
@@ -43,6 +44,7 @@ export class PimMedusaSyncService {
     private readonly medusaClient: MedusaClient,
     private readonly mappingRepo: PimMedusaMappingRepository,
     private readonly storefrontRevalidate: StorefrontRevalidateService,
+    private readonly deferredRevalidate: DeferredRevalidateService,
   ) {}
 
   // PIMCLIENT: This method is disabled because it calls PIM API (this.pimClient.getCategory)
@@ -312,6 +314,7 @@ export class PimMedusaSyncService {
     options?: { skipCategorySync?: boolean; isBulk?: boolean },
   ): Promise<SyncResult> {
     const { masterId, versionId } = snapshot;
+    const startedAt = Date.now();
 
     this.logger.log(`Syncing from event snapshot: ${masterId} (v${snapshot.version})`);
 
@@ -414,8 +417,17 @@ export class PimMedusaSyncService {
         action,
       });
 
-      // 상품 변경을 스토어프론트 캐시에 즉시 반영 (best-effort)
-      await this.storefrontRevalidate.revalidateProduct(medusaPayload.handle);
+      // 대량등록은 상품마다 무효화하면 전역 목록 태그를 상품 수만큼 지우게 된다.
+      // 버퍼에 모았다가 주기마다 한 번만 친다. 단건은 지금까지대로 즉시 반영.
+      if (options?.isBulk) {
+        this.deferredRevalidate.enqueue(medusaPayload.handle);
+      } else {
+        await this.storefrontRevalidate.revalidateProduct(medusaPayload.handle);
+      }
+
+      // 핸들러 종료 표지. 'Sync completed'(:387) 는 price list 와 revalidate 앞이라
+      // 종료 시점이 아니다 — 전후 성능 비교가 이 로그에 걸린다.
+      this.logger.log(`Sync finished: ${masterId} (${Date.now() - startedAt}ms)`);
 
       return {
         success: true,

--- a/apps/channel-adapter/src/adapters/medusa/storefront-revalidate.service.spec.ts
+++ b/apps/channel-adapter/src/adapters/medusa/storefront-revalidate.service.spec.ts
@@ -34,4 +34,21 @@ describe('StorefrontRevalidateService', () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it('첫 handle 만 handle 로 보내고 나머지는 태그로 보낸다', async () => {
+    await new StorefrontRevalidateService().revalidateProducts(['m1', 'm2', 'm3']);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({
+      handle: 'm1',
+      tags: ['pim-detail-m1', 'product-m2', 'pim-detail-m2', 'product-m3', 'pim-detail-m3'],
+    });
+  });
+
+  it('handle 이 없으면 호출하지 않는다', async () => {
+    await new StorefrontRevalidateService().revalidateProducts([]);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/channel-adapter/src/adapters/medusa/storefront-revalidate.service.ts
+++ b/apps/channel-adapter/src/adapters/medusa/storefront-revalidate.service.ts
@@ -26,6 +26,28 @@ export class StorefrontRevalidateService {
   }
 
   /**
+   * 여러 상품을 한 번에 무효화한다. 대량등록처럼 상품이 연달아 바뀔 때 쓴다.
+   *
+   * 첫 handle 만 `handle` 로 싣는다. 라우트는 `handle` 이 있을 때만 전역 목록 태그
+   * (PRODUCT_LIST_TAG)와 국가별 경로를 도는데, 그건 배치당 1회면 족하고 상품마다
+   * 반복하면 캐시가 데워질 틈이 없어진다 — 그게 지금 고치려는 문제다.
+   * 반대로 아예 안 실으면 목록 캐시가 영영 안 지워져 새 상품이 목록에 안 뜬다.
+   *
+   * 나머지 상품은 `product-{handle}` 태그로 정확히 지운다.
+   */
+  async revalidateProducts(handles: string[]): Promise<void> {
+    if (handles.length === 0) return;
+
+    const [first, ...rest] = handles;
+    const tags = [
+      // product-{first} 는 라우트가 handle 로부터 직접 친다. pim-detail 은 안 친다.
+      `pim-detail-${first}`,
+      ...rest.flatMap((h) => [`product-${h}`, `pim-detail-${h}`]),
+    ];
+    await this.post({ handle: first, tags }, `batch=${handles.length}`);
+  }
+
+  /**
    * 카테고리 변경(이미지·이름·정렬) 후 호출한다.
    *
    * 카테고리 트리 자체는 스토어프론트가 `cache: "no-store"` 로 읽으므로 무효화가 필요 없지만,

--- a/apps/channel-adapter/src/config/env.validation.ts
+++ b/apps/channel-adapter/src/config/env.validation.ts
@@ -55,6 +55,7 @@ export const channelAdapterEnvSchema = z.object({
   INBOX_PROCESSING_LEASE_MS: z.coerce.number().int().positive().optional(),
   INBOX_SHUTDOWN_DRAIN_MS: z.coerce.number().int().nonnegative().optional(),
   INBOX_MAX_RETRIES: z.coerce.number().int().positive().optional(),
+  DEFERRED_REVALIDATE_FLUSH_MS: z.coerce.number().int().positive().optional(),
 
   // Firebase Membership Sync
   ALMOND_AUTH_URL: z.string().url().optional(),

--- a/apps/channel-adapter/src/config/env.validation.ts
+++ b/apps/channel-adapter/src/config/env.validation.ts
@@ -55,7 +55,7 @@ export const channelAdapterEnvSchema = z.object({
   INBOX_PROCESSING_LEASE_MS: z.coerce.number().int().positive().optional(),
   INBOX_SHUTDOWN_DRAIN_MS: z.coerce.number().int().nonnegative().optional(),
   INBOX_MAX_RETRIES: z.coerce.number().int().positive().optional(),
-  DEFERRED_REVALIDATE_FLUSH_MS: z.coerce.number().int().positive().optional(),
+  DEFERRED_REVALIDATE_FLUSH_MS: z.coerce.number().int().min(1000).optional(),
 
   // Firebase Membership Sync
   ALMOND_AUTH_URL: z.string().url().optional(),

--- a/apps/channel-adapter/src/types.ts
+++ b/apps/channel-adapter/src/types.ts
@@ -770,4 +770,8 @@ export interface PimActiveVersionChangedEvent {
   changeReason: 'published' | 'rollback' | 'unpublished';
   changedAt: string;
   snapshot?: PimProductSnapshot | null;
+  // core 가 발행 시 실어 보내는 출처. 단건 게시에는 키 자체가 없다
+  // (apps/core/.../product-versions.service.ts:1043).
+  origin?: string;
+  importSessionId?: string;
 }

--- a/deployments/lcnine/services/infra/services.ts
+++ b/deployments/lcnine/services/infra/services.ts
@@ -243,6 +243,7 @@ export function setup(infra: SharedInfra) {
     INBOX_HANDLER_START_INTERVAL_MS: '3000',
     INBOX_PROCESSING_LEASE_MS: '900000',
     INBOX_SHUTDOWN_DRAIN_MS: '25000',
+    DEFERRED_REVALIDATE_FLUSH_MS: '60000',
   });
   const membershipEnv = withPrefix('MEMBERSHIP', {
     DATABASE_URL: dbUrl('membership'),

--- a/docs/superpowers/plans/2026-08-13-bulk-import-medusa-load.md
+++ b/docs/superpowers/plans/2026-08-13-bulk-import-medusa-load.md
@@ -326,14 +326,14 @@ EOF
 `storefront-revalidate.service.spec.ts` 에 추가:
 
 ```typescript
-  it('여러 handle 을 한 번의 요청으로 보낸다', async () => {
+  it('첫 handle 만 handle 로 보내고 나머지는 태그로 보낸다', async () => {
     await new StorefrontRevalidateService().revalidateProducts(['m1', 'm2', 'm3']);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, init] = fetchMock.mock.calls[0];
     expect(JSON.parse(init.body)).toEqual({
-      tags: ['product-m1', 'pim-detail-m1', 'product-m2', 'pim-detail-m2', 'product-m3', 'pim-detail-m3'],
-      paths: [],
+      handle: 'm1',
+      tags: ['pim-detail-m1', 'product-m2', 'pim-detail-m2', 'product-m3', 'pim-detail-m3'],
     });
   });
 
@@ -344,7 +344,14 @@ EOF
   });
 ```
 
-**설계 근거:** 다건 경로는 `handle` 필드를 쓰지 않고 `tags` 만 쓴다. 라우트(`route.ts:73-86`)는 `handle` 이 있을 때만 `PRODUCT_LIST_TAG` 전역 무효화와 국가별 `revalidatePath` 를 도는데, 그건 호출 1회당 1번이면 충분하고 handle 마다 반복할 필요가 없다. 대신 `product-{handle}` 태그를 직접 실어 개별 상품 캐시를 정확히 지운다. 전역 목록 태그는 아래 Step 4 에서 flush 당 1회만 친다.
+**설계 근거 — `handle` 을 하나만 싣는다.** 라우트(`route.ts:73-86`)는 `body.handle` 이 있을 때만 `revalidateTag(PRODUCT_LIST_TAG)` 를 친다. 목록 캐시 태그는 방문자별(`${tag}-${_medusa_cache_id}`)이라 백엔드가 개별 지목을 못 하고 이 전역 태그가 유일한 경로다.
+
+- `handle` 을 **아예 안 보내면** 전역 목록 태그가 영영 안 지워져 **새 상품이 목록에 최대 1시간 안 뜬다.** 이건 회귀다
+- `handle` 을 **상품마다 보내면** 전역 무효화가 상품 수만큼 일어나 지금 문제를 그대로 재현한다
+
+그래서 배치의 첫 handle 하나만 `handle` 로 싣는다 — 전역 목록 태그와 카테고리 경로가 **배치당 정확히 1회** 돌고, 나머지 상품은 `product-{handle}` 태그로 정확히 지운다. `product-m1` 은 라우트가 `handle` 로부터 직접 치므로 태그 배열에서 뺀다. `pim-detail-m1` 은 라우트가 자동으로 안 치므로 넣는다.
+
+`PRODUCT_LIST_TAG` 의 값(`"products"`)을 channel-adapter 에 복사해 오지 않는 이유도 이것이다 — storefront 가 상수를 바꾸면 조용히 깨진다.
 
 - [ ] **Step 2: 실패를 확인한다**
 
@@ -359,15 +366,23 @@ Expected: FAIL — `revalidateProducts is not a function`
   /**
    * 여러 상품을 한 번에 무효화한다. 대량등록처럼 상품이 연달아 바뀔 때 쓴다.
    *
-   * 단건 `revalidateProduct` 와 달리 `handle` 필드를 쓰지 않는다 — 라우트는 handle 이
-   * 있으면 전역 목록 태그와 국가별 경로를 도는데, 그건 배치당 1회면 족하다.
-   * 개별 상품 캐시는 `product-{handle}` 태그로 정확히 지운다.
+   * 첫 handle 만 `handle` 로 싣는다. 라우트는 `handle` 이 있을 때만 전역 목록 태그
+   * (PRODUCT_LIST_TAG)와 국가별 경로를 도는데, 그건 배치당 1회면 족하고 상품마다
+   * 반복하면 캐시가 데워질 틈이 없어진다 — 그게 지금 고치려는 문제다.
+   * 반대로 아예 안 실으면 목록 캐시가 영영 안 지워져 새 상품이 목록에 안 뜬다.
+   *
+   * 나머지 상품은 `product-{handle}` 태그로 정확히 지운다.
    */
   async revalidateProducts(handles: string[]): Promise<void> {
     if (handles.length === 0) return;
 
-    const tags = handles.flatMap((h) => [`product-${h}`, `pim-detail-${h}`]);
-    await this.post({ tags, paths: [] }, `batch=${handles.length}`);
+    const [first, ...rest] = handles;
+    const tags = [
+      // product-{first} 는 라우트가 handle 로부터 직접 친다. pim-detail 은 안 친다.
+      `pim-detail-${first}`,
+      ...rest.flatMap((h) => [`product-${h}`, `pim-detail-${h}`]),
+    ];
+    await this.post({ handle: first, tags }, `batch=${handles.length}`);
   }
 ```
 

--- a/docs/superpowers/plans/2026-08-13-bulk-import-medusa-load.md
+++ b/docs/superpowers/plans/2026-08-13-bulk-import-medusa-load.md
@@ -1,0 +1,1285 @@
+# 대량등록 Medusa 부하·처리량 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 대량등록이 Medusa 에 거는 부하를 62% 줄이고, 상품당 처리 시간을 26.6초에서 12.3초로 낮춘 뒤, 인박스 클레임 유휴를 걷어내 2,553건 소요를 17시간에서 5시간대로 내린다.
+
+**Architecture:** 세 갈래다. (A) channel-adapter 가 상품마다 두 번 부르던 Medusa price list 호출을, 신규 상품은 한 번으로 줄이고(A1) 나아가 여러 상품을 모아 한 번으로 합친다(A2). (B) 상품마다 await 하던 storefront 캐시 무효화를 버퍼에 모아 주기적으로 한 번만 호출한다. (C) 인박스 클레임 쿼리를 측정한 뒤 인덱스 또는 lane 컬럼 승격으로 슬롯 유휴를 없앤다.
+
+**Tech Stack:** NestJS, TypeScript, Drizzle ORM, Jest, Medusa v2 Admin API, Next.js(storefront `/api/revalidate`)
+
+**설계서:** `docs/superpowers/specs/2026-08-13-bulk-import-medusa-load-design.md`
+
+## 계획 단계에서의 스펙 수정
+
+스펙의 **A(price list 배치화)를 A1·A2 로 쪼갠다.** 코드를 읽고 나니 위험도와 효과가 크게 다르다.
+
+- **A1 — 신규 상품의 `remove` 호출 제거.** 버퍼가 필요 없고 durability 위험이 0이며, 상품당 3.3초를 즉시 회수한다. 측정 구간의 766건이 전부 신규였으므로 대량등록 시나리오에서는 이것만으로 price list 비용의 절반이 사라진다.
+- **A2 — 여러 상품의 `create` 를 한 배치로 합치기.** 나머지 3.28초를 회수하지만 인메모리 버퍼를 쓰므로 **프로세스가 비정상 종료하면 그 주기분의 가격이 유실**된다. 유실을 감지하는 장치가 없다(§리스크 참조).
+
+A1 을 먼저 넣고 A2 는 뒤로 뺀다. A2 없이 A1+B+C 만 해도 상품당 15.6초, 소요 ~6.5시간이다.
+
+## Global Constraints
+
+- 레이어 규칙: Controller → Service → Reader/Manager → Repository. Service 는 `HttpException`·drizzle·Express 타입을 import 하지 않는다. 도메인 예외는 `@app/shared` 의 `NotFoundError`/`BadRequestError`/`ConflictError` 를 던진다
+- `any` / `as` 캐스팅 금지 (문서화된 정당화와 팀 승인 없이는)
+- Nullable 정규화: `string ?? ''`, `number ?? 0`, `date ?? undefined`
+- 트랜잭션은 `dbService.run(fn, tx)` 단일 러너를 쓴다. 클래스별 `inTx` 헬퍼를 새로 만들지 않는다
+- **테스트 실행은 반드시 `npx jest --runTestsByPath <파일경로>` 로 한다.** 이 워크트리 경로에 `+` 가 들어 있어(`.claude/worktrees/feat+bulk-import-medusa-load`) 일반 `jest <path>` 의 정규식 매칭이 오염된다
+- 커밋 메시지 끝에 다음 줄을 붙인다: `Claude-Session: https://claude.ai/code/session_01RxLvaYzJJXi76zMB1J5RCL`
+- 마이그레이션이 생기는 것은 Task 6 뿐이다. 인덱스 추가는 additive expand 이므로 배포 순서는 **`migrate → deploy`** 다 (contract 의 `deploy → migrate` 와 반대 — 헷갈리지 말 것)
+- 새 환경변수는 `deployments/lcnine/services/infra/services.ts` 의 `withPrefix('CHANNEL_ADAPTER', {...})` 블록(현재 `INBOX_*` 가 있는 자리, 약 242행)에 함께 추가한다
+
+---
+
+## File Structure
+
+| 파일 | 책임 | 태스크 |
+|---|---|---|
+| `apps/channel-adapter/src/types.ts` | `PimActiveVersionChangedEvent` 에 `origin` 선언 추가 | 1 |
+| `apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts` | 대량 여부 판정, price list 호출 축소, revalidate 위임 | 1·2·4 |
+| `apps/channel-adapter/src/adapters/medusa/medusa.client.ts` | price list 배치 delete+create 단일 호출 | 4 |
+| `apps/channel-adapter/src/adapters/medusa/deferred-revalidate.service.ts` (신규) | revalidate handle 버퍼 + 주기 flush | 2 |
+| `apps/channel-adapter/src/adapters/medusa/deferred-price-list.service.ts` (신규) | price list 항목 버퍼 + 주기 flush | 4 |
+| `apps/channel-adapter/src/adapters/medusa/storefront-revalidate.service.ts` | 다건 handle 무효화 지원 | 2 |
+| `apps/channel-adapter/src/adapter.module.ts` | 신규 서비스 provider 등록 | 2·4 |
+| `apps/channel-adapter/src/adapters/medusa/inbox-worker.service.ts` | 클레임 쿼리 정렬 개선 | 6 |
+| `apps/channel-adapter/drizzle/*` | 클레임용 인덱스 | 6 |
+| `deployments/lcnine/services/infra/services.ts` | flush 주기 환경변수 | 2·4 |
+
+---
+
+## Task 1: 대량 출처 판정
+
+`syncFromSnapshot` 이 "이 이벤트가 대량등록에서 왔는가"를 알아야 이후 태스크가 분기할 수 있다. 지금 `origin` 은 런타임 payload 에는 있지만 TS 타입에 선언돼 있지 않다.
+
+**Files:**
+- Modify: `apps/channel-adapter/src/types.ts:763-773`
+- Modify: `apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts` (`handleActiveVersionChanged` 450행, `syncFromSnapshot` 299행)
+- Test: `apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts`
+
+**Interfaces:**
+- Produces: `SyncFromSnapshotOptions.isBulk?: boolean` — Task 2·4 가 이 플래그로 지연 경로를 켠다
+- Produces: `isBulkOrigin(origin?: string): boolean` — 순수 함수, 같은 파일에서 export
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다**
+
+`apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts` 끝에 추가:
+
+```typescript
+import { isBulkOrigin } from './pim-medusa-sync.service';
+
+describe('isBulkOrigin', () => {
+  it('bulk_import 를 대량으로 판정한다', () => {
+    expect(isBulkOrigin('bulk_import')).toBe(true);
+  });
+
+  it('출처가 없으면 단건으로 판정한다', () => {
+    expect(isBulkOrigin(undefined)).toBe(false);
+    expect(isBulkOrigin('')).toBe(false);
+  });
+
+  it('모르는 출처는 단건으로 판정한다 — 안전한 쪽이 즉시 반영이다', () => {
+    expect(isBulkOrigin('admin_ui')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: 실패를 확인한다**
+
+Run: `npx jest --runTestsByPath apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts`
+Expected: FAIL — `isBulkOrigin is not a function` 또는 import 해석 실패
+
+- [ ] **Step 3: 타입에 origin 을 선언한다**
+
+`apps/channel-adapter/src/types.ts:763` 의 인터페이스에 두 줄 추가:
+
+```typescript
+export interface PimActiveVersionChangedEvent {
+  masterId: string;
+  versionId: string | null;
+  name: string | null;
+  previousActiveVersionId: string | null;
+  categoryIds?: string[];
+  primaryCategoryId?: string | null;
+  changeReason: 'published' | 'rollback' | 'unpublished';
+  changedAt: string;
+  snapshot?: PimProductSnapshot | null;
+  // core 가 발행 시 실어 보내는 출처. 단건 게시에는 키 자체가 없다
+  // (apps/core/.../product-versions.service.ts:1043).
+  origin?: string;
+  importSessionId?: string;
+}
+```
+
+- [ ] **Step 4: 판정 함수를 구현한다**
+
+`pim-medusa-sync.service.ts` 상단 import 아래에 추가:
+
+```typescript
+/**
+ * 대량 출처 목록. inbox-worker 의 BULK_ORIGINS 와 같은 값이지만, 그쪽은 metadata 를 읽는
+ * SQL 레인 판정이고 이쪽은 payload 를 읽는 핸들러 분기라 의도적으로 따로 둔다.
+ * 모르는 값은 단건으로 본다 — 즉시 반영이 안전한 기본값이다.
+ */
+const BULK_SYNC_ORIGINS: readonly string[] = ['bulk_import'];
+
+export function isBulkOrigin(origin?: string): boolean {
+  return !!origin && BULK_SYNC_ORIGINS.includes(origin);
+}
+```
+
+- [ ] **Step 5: 테스트 통과를 확인한다**
+
+Run: `npx jest --runTestsByPath apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts`
+Expected: PASS
+
+- [ ] **Step 6: 플래그를 syncFromSnapshot 까지 배선한다**
+
+`syncFromSnapshot` 시그니처(299행)를 바꾼다:
+
+```typescript
+  async syncFromSnapshot(
+    snapshot: PimProductSnapshot,
+    options?: { skipCategorySync?: boolean; isBulk?: boolean },
+  ): Promise<SyncResult> {
+```
+
+`handleActiveVersionChanged`(450행)에서 넘긴다. 현재 `syncFromSnapshot` 을 부르는 자리에 `isBulk` 를 더한다:
+
+```typescript
+    const isBulk = isBulkOrigin(event.origin);
+```
+
+그리고 그 함수 안의 `syncFromSnapshot(...)` 호출마다 `isBulk` 를 옵션에 실어 보낸다. 이 단계에서는 플래그를 아직 아무도 읽지 않는다 — 배선만 한다.
+
+- [ ] **Step 7: 타입체크와 기존 테스트를 돌린다**
+
+Run: `npx tsc --noEmit -p tsconfig.json`
+Expected: 기준선 대비 신규 에러 0 (기준선은 162건, 메모리 `lint-scope-caveat` 참조)
+
+Run: `npx jest --runTestsByPath apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts`
+Expected: PASS
+
+- [ ] **Step 8: 커밋**
+
+```bash
+git add apps/channel-adapter/src/types.ts apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts
+git commit -m "$(cat <<'EOF'
+feat(channel-adapter): 동기화에 대량 출처 판정을 들인다
+
+core 가 payload 에 싣는 origin 이 TS 타입엔 없어 핸들러가 대량 여부를 몰랐다.
+타입에 선언하고 isBulkOrigin 으로 판정해 syncFromSnapshot 까지 배선한다.
+모르는 출처는 단건으로 본다 — 즉시 반영이 안전한 기본값이다.
+
+Claude-Session: https://claude.ai/code/session_01RxLvaYzJJXi76zMB1J5RCL
+EOF
+)"
+```
+
+---
+
+## Task 2: 신규 상품의 price list `remove` 제거 (A1)
+
+`syncPriceLists` 는 가격을 넣기 전에 항상 먼저 지운다. 신규 생성 상품에는 지울 것이 없는데도 그렇다. 측정값으로 이 호출은 상품당 3.30초, 대량등록 Medusa 비용의 31%다.
+
+`upsertProduct` 가 이미 `action: 'created' | 'updated'` 를 돌려주는데(`medusa.client.ts:1674`) 호출부(`:378`)가 받아놓고 `syncPriceLists`(`:389`)에는 넘기지 않는다.
+
+**Files:**
+- Modify: `apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts:378-389`, `:567-636`
+- Test: `apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts`
+
+**Interfaces:**
+- Consumes: `upsertProduct` 의 `action: 'created' | 'updated'` (기존)
+- Produces: `syncPriceLists(snapshot, productId, variants, opts: { skipRemove: boolean })` — Task 4 가 같은 진입점을 버퍼로 바꾼다
+
+- [ ] **Step 1: 사전 확인 — `action='created'` 를 믿어도 되는지 읽는다**
+
+`medusa.client.ts:1674-1714` 를 읽고 `action: 'created'` 가 반환되는 경로가 **정말로 상품이 새로 만들어진 경우뿐인지** 확인한다. `:1683` 과 `:1706` 은 `'updated'`, `:1714` 가 `'created'` 다.
+
+확인할 것: 매핑 기록이 실패한 뒤 재시도돼서, 상품은 이미 Medusa 에 있는데 `medusaProductId` 인자가 `undefined` 로 들어오는 경로가 있는가. 있다면 그 경로에서 handle 로 기존 상품을 찾아 `'updated'` 로 빠지는지.
+
+**`'created'` 인데 상품이 이미 존재할 수 있다면 이 태스크를 중단하고 사람에게 보고한다.** 그 경우 remove 를 건너뛰면 가격이 중복 누적된다.
+
+- [ ] **Step 2: 실패하는 테스트를 쓴다**
+
+기존 `describe('PimMedusaSyncService.syncPriceLists (replace semantics)')` 블록(`:151-223`)이 이미 `createService()` 헬퍼를 갖고 있고, `syncPriceLists` 를 `(service as any).syncPriceLists(snapshot, 'prod_1', medusaVariants)` 로 직접 부른다. **그 블록 안에 그 스타일로 추가한다.** 새 헬퍼를 만들지 않는다.
+
+```typescript
+  it('신규 생성 상품이면 remove 를 건너뛰고 add 만 한다', async () => {
+    const { service, medusaClient, calls } = createService();
+    const snapshot = {
+      variants: [{ id: 'pim-var-1', membershipPrice: 34000, tieredPrices: [] }],
+    };
+    const medusaVariants = [{ id: 'variant_m1', metadata: { pimVariantId: 'pim-var-1' } }];
+
+    await (service as any).syncPriceLists(snapshot, 'prod_1', medusaVariants, { skipRemove: true });
+
+    expect(medusaClient.removeProductFromPriceList).not.toHaveBeenCalled();
+    expect(medusaClient.addPricesToPriceList).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(['add']);
+  });
+
+  it('기존 상품이면 지금까지대로 remove 후 add 한다', async () => {
+    const { service, medusaClient, calls } = createService();
+    const snapshot = {
+      variants: [{ id: 'pim-var-1', membershipPrice: 34000, tieredPrices: [] }],
+    };
+    const medusaVariants = [{ id: 'variant_m1', metadata: { pimVariantId: 'pim-var-1' } }];
+
+    await (service as any).syncPriceLists(snapshot, 'prod_1', medusaVariants, { skipRemove: false });
+
+    expect(medusaClient.removeProductFromPriceList).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(['remove', 'add']);
+  });
+```
+
+- [ ] **Step 3: 실패를 확인한다**
+
+Run: `npx jest --runTestsByPath apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts`
+Expected: FAIL — "신규 생성 상품이면" 케이스에서 `removeProductFromPriceList` 가 1회 호출됨. 기존 2건은 계속 PASS 여야 한다
+
+- [ ] **Step 4: 구현한다**
+
+`:389` 의 호출을 바꾼다:
+
+```typescript
+      await this.syncPriceLists(snapshot, product.id, product.variants, {
+        // 신규 생성 상품은 price list 에 항목이 있을 수 없다. remove 는 상품당 3.30초로
+        // 상품 생성(2.86초)보다 비싼 호출이라 건너뛰는 값어치가 크다.
+        skipRemove: action === 'created',
+      });
+```
+
+`syncPriceLists` 시그니처와 두 remove 호출을 바꾼다 (`:567`, `:620`, `:633`). **`opts` 는 기본값이 있는 선택 인자여야 한다** — 기존 테스트 2건이 3개 인자로 호출하고 있고, 그 둘은 "remove 후 add" 를 계속 검증해야 하는 유효한 스펙이다:
+
+```typescript
+  private async syncPriceLists(
+    snapshot: PimProductSnapshot,
+    medusaProductId: string,
+    medusaVariants: MedusaProduct['variants'] | undefined,
+    opts: { skipRemove?: boolean } = {},
+  ): Promise<void> {
+```
+
+`:620`·`:633` 에서는 `if (!opts.skipRemove)` 로 감싼다 — 기본값 `{}` 면 `undefined` 라 지금까지대로 remove 를 탄다.
+
+`:620` 과 `:633` 의 remove 를 각각 감싼다:
+
+```typescript
+      if (!opts.skipRemove) {
+        await this.medusaClient.removeProductFromPriceList(listId, medusaProductId);
+      }
+      await this.medusaClient.addPricesToPriceList(listId, membershipPrices);
+```
+
+기존 주석(`:616-619`)은 그대로 둔다 — `updated` 경로에서는 여전히 유효한 설명이다. 그 아래에 한 줄만 덧붙인다:
+
+```typescript
+      // 신규 생성 상품은 지울 항목이 없으므로 skipRemove 로 건너뛴다.
+```
+
+- [ ] **Step 5: 테스트 통과를 확인한다**
+
+Run: `npx jest --runTestsByPath apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts`
+Expected: PASS (신규 2건 포함 전부)
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts
+git commit -m "$(cat <<'EOF'
+fix(channel-adapter): 신규 상품의 price list remove 호출을 걷어낸다
+
+remove 는 상품당 3.30초로 상품 생성(2.86초)보다 비싸다. 신규 생성 상품은
+price list 에 지울 항목이 없는데도 매번 불렀다. upsertProduct 가 이미
+돌려주던 action 을 syncPriceLists 로 넘겨 분기한다.
+
+대량등록 Medusa 비용의 31% 에 해당한다.
+
+Claude-Session: https://claude.ai/code/session_01RxLvaYzJJXi76zMB1J5RCL
+EOF
+)"
+```
+
+---
+
+## Task 3: storefront revalidate 배치화 (B)
+
+상품마다 `revalidateProduct` 를 await 하는데, 측정 구간 771건 중 762건이 5초 타임아웃이었다. storefront 쪽은 770/770 완료하므로 **기다림 자체가 무의미**하다. 더 큰 문제는 라우트가 호출 한 번마다 `PRODUCT_LIST_TAG` 전역과 모든 카테고리 페이지를 무효화한다는 것 — 17시간 동안 2,553번이면 캐시가 데워질 틈이 없다.
+
+**Files:**
+- Create: `apps/channel-adapter/src/adapters/medusa/deferred-revalidate.service.ts`
+- Create: `apps/channel-adapter/src/adapters/medusa/deferred-revalidate.service.spec.ts`
+- Modify: `apps/channel-adapter/src/adapters/medusa/storefront-revalidate.service.ts`
+- Modify: `apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts:400`
+- Modify: `apps/channel-adapter/src/adapter.module.ts:273` 부근 providers
+- Modify: `deployments/lcnine/services/infra/services.ts:242` 부근
+
+**Interfaces:**
+- Consumes: `SyncFromSnapshotOptions.isBulk` (Task 1)
+- Produces: `StorefrontRevalidateService.revalidateProducts(handles: string[]): Promise<void>`
+- Produces: `DeferredRevalidateService.enqueue(handle: string): void` / `flush(): Promise<void>`
+
+- [ ] **Step 1: 다건 무효화의 실패하는 테스트를 쓴다**
+
+`storefront-revalidate.service.spec.ts` 에 추가:
+
+```typescript
+  it('여러 handle 을 한 번의 요청으로 보낸다', async () => {
+    await new StorefrontRevalidateService().revalidateProducts(['m1', 'm2', 'm3']);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({
+      tags: ['product-m1', 'pim-detail-m1', 'product-m2', 'pim-detail-m2', 'product-m3', 'pim-detail-m3'],
+      paths: [],
+    });
+  });
+
+  it('handle 이 없으면 호출하지 않는다', async () => {
+    await new StorefrontRevalidateService().revalidateProducts([]);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+```
+
+**설계 근거:** 다건 경로는 `handle` 필드를 쓰지 않고 `tags` 만 쓴다. 라우트(`route.ts:73-86`)는 `handle` 이 있을 때만 `PRODUCT_LIST_TAG` 전역 무효화와 국가별 `revalidatePath` 를 도는데, 그건 호출 1회당 1번이면 충분하고 handle 마다 반복할 필요가 없다. 대신 `product-{handle}` 태그를 직접 실어 개별 상품 캐시를 정확히 지운다. 전역 목록 태그는 아래 Step 4 에서 flush 당 1회만 친다.
+
+- [ ] **Step 2: 실패를 확인한다**
+
+Run: `npx jest --runTestsByPath apps/channel-adapter/src/adapters/medusa/storefront-revalidate.service.spec.ts`
+Expected: FAIL — `revalidateProducts is not a function`
+
+- [ ] **Step 3: 다건 메서드를 구현한다**
+
+`storefront-revalidate.service.ts` 에 추가:
+
+```typescript
+  /**
+   * 여러 상품을 한 번에 무효화한다. 대량등록처럼 상품이 연달아 바뀔 때 쓴다.
+   *
+   * 단건 `revalidateProduct` 와 달리 `handle` 필드를 쓰지 않는다 — 라우트는 handle 이
+   * 있으면 전역 목록 태그와 국가별 경로를 도는데, 그건 배치당 1회면 족하다.
+   * 개별 상품 캐시는 `product-{handle}` 태그로 정확히 지운다.
+   */
+  async revalidateProducts(handles: string[]): Promise<void> {
+    if (handles.length === 0) return;
+
+    const tags = handles.flatMap((h) => [`product-${h}`, `pim-detail-${h}`]);
+    await this.post({ tags, paths: [] }, `batch=${handles.length}`);
+  }
+```
+
+- [ ] **Step 4: 테스트 통과를 확인한다**
+
+Run: `npx jest --runTestsByPath apps/channel-adapter/src/adapters/medusa/storefront-revalidate.service.spec.ts`
+Expected: PASS
+
+- [ ] **Step 5: 버퍼 서비스의 실패하는 테스트를 쓴다**
+
+`deferred-revalidate.service.spec.ts` 생성:
+
+```typescript
+import { DeferredRevalidateService } from './deferred-revalidate.service';
+import { StorefrontRevalidateService } from './storefront-revalidate.service';
+
+describe('DeferredRevalidateService', () => {
+  let revalidate: jest.Mocked<Pick<StorefrontRevalidateService, 'revalidateProducts'>>;
+  let service: DeferredRevalidateService;
+
+  beforeEach(() => {
+    revalidate = { revalidateProducts: jest.fn().mockResolvedValue(undefined) };
+    service = new DeferredRevalidateService(
+      revalidate as unknown as StorefrontRevalidateService,
+      { get: () => undefined } as never,
+    );
+  });
+
+  it('누적한 handle 을 flush 에서 한 번에 보낸다', async () => {
+    service.enqueue('m1');
+    service.enqueue('m2');
+
+    await service.flush();
+
+    expect(revalidate.revalidateProducts).toHaveBeenCalledTimes(1);
+    expect(revalidate.revalidateProducts).toHaveBeenCalledWith(['m1', 'm2']);
+  });
+
+  it('같은 handle 이 여러 번 들어와도 한 번만 보낸다', async () => {
+    service.enqueue('m1');
+    service.enqueue('m1');
+
+    await service.flush();
+
+    expect(revalidate.revalidateProducts).toHaveBeenCalledWith(['m1']);
+  });
+
+  it('버퍼가 비면 호출하지 않는다', async () => {
+    await service.flush();
+
+    expect(revalidate.revalidateProducts).not.toHaveBeenCalled();
+  });
+
+  it('flush 가 실패해도 예외를 밖으로 내지 않는다 — 캐시 지연은 동기화를 막을 이유가 아니다', async () => {
+    revalidate.revalidateProducts.mockRejectedValue(new Error('boom'));
+    service.enqueue('m1');
+
+    await expect(service.flush()).resolves.toBeUndefined();
+  });
+
+  it('flush 실패분은 버려진다 — 다음 flush 를 무한히 오염시키지 않는다', async () => {
+    revalidate.revalidateProducts.mockRejectedValueOnce(new Error('boom'));
+    service.enqueue('m1');
+    await service.flush();
+
+    revalidate.revalidateProducts.mockClear();
+    await service.flush();
+
+    expect(revalidate.revalidateProducts).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 6: 실패를 확인한다**
+
+Run: `npx jest --runTestsByPath apps/channel-adapter/src/adapters/medusa/deferred-revalidate.service.spec.ts`
+Expected: FAIL — 모듈을 찾을 수 없음
+
+- [ ] **Step 7: 버퍼 서비스를 구현한다**
+
+`deferred-revalidate.service.ts` 생성:
+
+```typescript
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { StorefrontRevalidateService } from './storefront-revalidate.service';
+
+const DEFAULT_FLUSH_INTERVAL_MS = 60_000;
+
+/**
+ * 대량등록 중의 storefront 캐시 무효화를 모아서 한 번에 친다.
+ *
+ * 단건 경로는 상품마다 즉시 무효화하는데, 그 라우트는 호출마다 전역 목록 태그와
+ * 모든 카테고리 페이지를 지운다. 대량등록이 그걸 상품 수만큼 부르면 캐시가 데워질
+ * 틈이 없다 (실측: 5시간에 770회). 여기 모았다가 주기마다 1회만 친다.
+ *
+ * 버퍼는 인메모리다. 프로세스가 죽으면 그 주기분은 유실되고, 해당 상품은 캐시 TTL
+ * (1시간) 까지 낡은 채로 남는다. 가격·재고가 아니라 캐시라 이 정도는 허용한다.
+ */
+@Injectable()
+export class DeferredRevalidateService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(DeferredRevalidateService.name);
+  private readonly pending = new Set<string>();
+  private readonly flushIntervalMs: number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private readonly storefrontRevalidate: StorefrontRevalidateService,
+    private readonly configService: ConfigService,
+  ) {
+    const raw = this.configService.get<string | number | undefined>('DEFERRED_REVALIDATE_FLUSH_MS');
+    const parsed = Number(raw);
+    this.flushIntervalMs =
+      raw === undefined || raw === null || raw === '' || !Number.isInteger(parsed) || parsed < 1000
+        ? DEFAULT_FLUSH_INTERVAL_MS
+        : parsed;
+  }
+
+  onModuleInit(): void {
+    this.timer = setInterval(() => void this.flush(), this.flushIntervalMs);
+    this.logger.log(`Deferred revalidate started (flushIntervalMs=${this.flushIntervalMs}ms)`);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    // 정상 종료(배포 등)에서는 남은 버퍼를 흘려보낸다.
+    await this.flush();
+  }
+
+  enqueue(handle: string): void {
+    this.pending.add(handle);
+  }
+
+  async flush(): Promise<void> {
+    if (this.pending.size === 0) return;
+
+    // 먼저 비운다 — 실패해도 다음 주기를 오염시키지 않는다. 최악은 캐시가 TTL 까지 낡는 것.
+    const handles = [...this.pending];
+    this.pending.clear();
+
+    try {
+      await this.storefrontRevalidate.revalidateProducts(handles);
+      this.logger.log(`Deferred revalidate flushed: ${handles.length} handles`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`Deferred revalidate flush failed (${handles.length} handles): ${message}`);
+    }
+  }
+}
+```
+
+- [ ] **Step 8: 테스트 통과를 확인한다**
+
+Run: `npx jest --runTestsByPath apps/channel-adapter/src/adapters/medusa/deferred-revalidate.service.spec.ts`
+Expected: PASS (5건)
+
+- [ ] **Step 9: 동기화 경로를 분기한다**
+
+`pim-medusa-sync.service.ts` 생성자에 `DeferredRevalidateService` 를 주입하고, `:400` 을 바꾼다:
+
+```typescript
+      // 대량등록은 상품마다 무효화하면 전역 목록 태그를 상품 수만큼 지우게 된다.
+      // 버퍼에 모았다가 주기마다 한 번만 친다. 단건은 지금까지대로 즉시 반영.
+      if (options?.isBulk) {
+        this.deferredRevalidate.enqueue(medusaPayload.handle);
+      } else {
+        await this.storefrontRevalidate.revalidateProduct(medusaPayload.handle);
+      }
+```
+
+**생성자 인자가 늘어나면 기존 스펙이 깨진다.** `pim-medusa-sync.service.spec.ts` 에서 서비스를 직접 `new PimMedusaSyncService(medusaClient as any, mappingRepo as any, storefrontRevalidate as any)` 로 만드는 자리가 최소 `:177` 에 있고, 다른 describe 블록도 `Test.createTestingModule` 스타일로 만든다(`:226` 부근). **두 스타일 전부 새 의존을 추가해야 한다.** `grep -n "new PimMedusaSyncService\|PimMedusaSyncService," apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts` 로 전수한 뒤 고친다.
+
+- [ ] **Step 9b: 핸들러 종료 로그를 남긴다**
+
+이 태스크가 대량 경로의 revalidate 로그를 없애는데, 그게 지금까지 핸들러 종료 표지로 쓰이던 로그다(§재측정 참조). 대체 표지를 만든다. `syncFromSnapshot` 의 반환 직전(`:400` 블록 다음)에 추가:
+
+```typescript
+      // 핸들러 종료 표지. 'Sync completed'(:387) 는 price list 와 revalidate 앞이라
+      // 종료 시점이 아니다 — 전후 성능 비교가 이 로그에 걸린다.
+      this.logger.log(`Sync finished: ${masterId} (${Date.now() - startedAt}ms)`);
+```
+
+함수 진입부(`:300` `const { masterId, versionId } = snapshot;` 아래)에 `const startedAt = Date.now();` 를 더한다.
+
+- [ ] **Step 10: provider 를 등록한다**
+
+`apps/channel-adapter/src/adapter.module.ts` 의 import 목록과 `providers` 배열(273행 부근 `InboxWorkerService` 옆)에 `DeferredRevalidateService` 를 추가한다.
+
+- [ ] **Step 11: 환경변수를 추가한다**
+
+`deployments/lcnine/services/infra/services.ts` 의 channel-adapter env 블록(242행 부근, `INBOX_SHUTDOWN_DRAIN_MS` 아래)에 추가:
+
+```typescript
+    DEFERRED_REVALIDATE_FLUSH_MS: '60000',
+```
+
+- [ ] **Step 12: 전체 테스트와 타입체크**
+
+Run: `npx jest --runTestsByPath apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts apps/channel-adapter/src/adapters/medusa/deferred-revalidate.service.spec.ts apps/channel-adapter/src/adapters/medusa/storefront-revalidate.service.spec.ts`
+Expected: PASS
+
+Run: `npx nest build channel-adapter`
+Expected: 성공
+
+- [ ] **Step 13: 커밋**
+
+```bash
+git add apps/channel-adapter/src/adapters/medusa/ apps/channel-adapter/src/adapter.module.ts deployments/lcnine/services/infra/services.ts
+git commit -m "$(cat <<'EOF'
+perf(channel-adapter): 대량등록의 storefront 무효화를 모아서 한 번에 친다
+
+revalidate 라우트는 호출마다 전역 목록 태그와 모든 카테고리 페이지를 지운다.
+대량등록이 상품마다 부르면 캐시가 데워질 틈이 없다 (실측 5시간 770회).
+버퍼에 모았다가 60초마다 1회만 친다. 단건 경로는 즉시 반영 그대로 둔다.
+
+호출자가 5초 타임아웃으로 기다리던 것도 사라진다 — storefront 쪽은 770/770
+완료하고 있었으므로 그 기다림은 처음부터 무의미했다 (상품당 5.0초).
+
+Claude-Session: https://claude.ai/code/session_01RxLvaYzJJXi76zMB1J5RCL
+EOF
+)"
+```
+
+---
+
+## Task 4: price list 교차 상품 배치화 (A2)
+
+> **이 태스크는 durability 를 거래한다.** 인메모리 버퍼에 가격을 모으므로 프로세스가 비정상 종료하면 그 주기분의 멤버십·티어 가격이 Medusa 에 반영되지 않은 채 사라진다. 유실을 감지하는 장치가 없다. Task 1~3 만으로도 상품당 15.6초·소요 6.5시간에 도달하므로, **여기서 멈추고 재측정한 뒤 진행 여부를 판단해도 된다.**
+
+**Files:**
+- Create: `apps/channel-adapter/src/adapters/medusa/deferred-price-list.service.ts`
+- Create: `apps/channel-adapter/src/adapters/medusa/deferred-price-list.service.spec.ts`
+- Modify: `apps/channel-adapter/src/adapters/medusa/medusa.client.ts` (배치 메서드 추가)
+- Modify: `apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts:567-636`
+- Modify: `apps/channel-adapter/src/adapter.module.ts`, `deployments/lcnine/services/infra/services.ts`
+
+**Interfaces:**
+- Consumes: `SyncFromSnapshotOptions.isBulk` (Task 1), `skipRemove` 판정 (Task 2)
+- Produces: `MedusaClient.batchPriceListPrices(listId, { create, deleteProductIds }): Promise<void>`
+- Produces: `DeferredPriceListService.enqueue(listId, prices, opts): void` / `flush(): Promise<void>`
+
+- [ ] **Step 1: 배치 클라이언트 메서드의 실패하는 테스트를 쓴다**
+
+`medusa.client.spec.ts` 에 추가:
+
+```typescript
+describe('batchPriceListPrices', () => {
+  it('삭제 대상 상품이 없으면 create 만 한 번 보낸다', async () => {
+    const client = makeClient();                 // 기존 스펙 헬퍼
+    await client.batchPriceListPrices('plist_1', {
+      create: [{ amount: 1000, currency_code: 'krw', variant_id: 'var_1' }],
+      deleteProductIds: [],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('/admin/price-lists/plist_1/prices/batch');
+    expect(fetchMock.mock.calls[0][1].body).toEqual({
+      create: [{ amount: 1000, currency_code: 'krw', variant_id: 'var_1' }],
+    });
+  });
+
+  it('삭제 대상이 있으면 remove 를 먼저 한 번 보낸다', async () => {
+    const client = makeClient();
+    await client.batchPriceListPrices('plist_1', {
+      create: [{ amount: 1000, currency_code: 'krw', variant_id: 'var_1' }],
+      deleteProductIds: ['prod_1', 'prod_2'],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe('/admin/price-lists/plist_1/products');
+    expect(fetchMock.mock.calls[0][1].body).toEqual({ remove: ['prod_1', 'prod_2'] });
+    expect(fetchMock.mock.calls[1][0]).toBe('/admin/price-lists/plist_1/prices/batch');
+  });
+
+  it('create 도 삭제 대상도 없으면 아무것도 보내지 않는다', async () => {
+    const client = makeClient();
+    await client.batchPriceListPrices('plist_1', { create: [], deleteProductIds: [] });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: 실패를 확인한다**
+
+Run: `npx jest --runTestsByPath apps/channel-adapter/src/adapters/medusa/medusa.client.spec.ts -t batchPriceListPrices`
+Expected: FAIL — `batchPriceListPrices is not a function`
+
+- [ ] **Step 3: 배치 클라이언트 메서드를 구현한다**
+
+`medusa.client.ts` 의 `addPricesToPriceList`(2168행) 아래에 추가:
+
+```typescript
+  /**
+   * 여러 상품의 price list 가격을 한 번에 정리한다.
+   *
+   * 단건 경로(`removeProductFromPriceList` + `addPricesToPriceList`)는 상품당 3.30초 +
+   * 3.28초다. 비용의 대부분은 가격 데이터가 아니라 호출당 고정비다 — Medusa 의
+   * `batchPriceListPricesWorkflow` 가 create/update/remove 세 중첩 워크플로를 항상
+   * 전부 돌리고, 빈 하위 워크플로도 조기 반환 가드를 통과해 쿼리를 낸다.
+   * 그래서 상품 수만큼 부르는 대신 한 번에 몰아 넣는다.
+   *
+   * `remove` 는 Medusa 가 productId 로 price id 를 서버측에서 찾아주므로 별도 조회가 없다.
+   */
+  async batchPriceListPrices(
+    priceListId: string,
+    input: {
+      create: Array<{
+        amount: number;
+        currency_code: string;
+        variant_id: string;
+        min_quantity?: number;
+        max_quantity?: number;
+      }>;
+      deleteProductIds: string[];
+    },
+  ): Promise<void> {
+    if (input.deleteProductIds.length === 0 && input.create.length === 0) return;
+
+    try {
+      if (input.deleteProductIds.length > 0) {
+        await this.sdk.client.fetch(`/admin/price-lists/${priceListId}/products`, {
+          method: 'post',
+          body: { remove: input.deleteProductIds },
+        });
+      }
+
+      if (input.create.length > 0) {
+        await this.sdk.client.fetch(`/admin/price-lists/${priceListId}/prices/batch`, {
+          method: 'post',
+          body: { create: input.create },
+        });
+      }
+
+      this.logger.log(
+        `Batched price list ${priceListId}: removed ${input.deleteProductIds.length} products, ` +
+          `created ${input.create.length} prices`,
+      );
+    } catch (error) {
+      const fetchError = error as FetchError;
+      this.logger.error(`Failed to batch price list ${priceListId}: ${fetchError.message}`);
+      throw new Error(`Medusa batchPriceListPrices failed: ${fetchError.message}`);
+    }
+  }
+```
+
+- [ ] **Step 4: 테스트 통과를 확인한다**
+
+Run: `npx jest --runTestsByPath apps/channel-adapter/src/adapters/medusa/medusa.client.spec.ts -t batchPriceListPrices`
+Expected: PASS (3건)
+
+- [ ] **Step 5: 버퍼 서비스의 실패하는 테스트를 쓴다**
+
+`deferred-price-list.service.spec.ts` 생성:
+
+```typescript
+import { DeferredPriceListService } from './deferred-price-list.service';
+import { MedusaClient } from './medusa.client';
+
+describe('DeferredPriceListService', () => {
+  let client: jest.Mocked<Pick<MedusaClient, 'batchPriceListPrices'>>;
+  let service: DeferredPriceListService;
+
+  const price = (variantId: string) => ({ amount: 1000, currency_code: 'krw', variant_id: variantId });
+
+  beforeEach(() => {
+    client = { batchPriceListPrices: jest.fn().mockResolvedValue(undefined) };
+    service = new DeferredPriceListService(client as unknown as MedusaClient, { get: () => undefined } as never);
+  });
+
+  it('같은 price list 의 가격을 한 번의 배치로 합친다', async () => {
+    service.enqueue('plist_1', [price('var_1')], { productId: 'prod_1', skipRemove: true });
+    service.enqueue('plist_1', [price('var_2')], { productId: 'prod_2', skipRemove: true });
+
+    await service.flush();
+
+    expect(client.batchPriceListPrices).toHaveBeenCalledTimes(1);
+    expect(client.batchPriceListPrices).toHaveBeenCalledWith('plist_1', {
+      create: [price('var_1'), price('var_2')],
+      deleteProductIds: [],
+    });
+  });
+
+  it('price list 가 다르면 각각 보낸다', async () => {
+    service.enqueue('plist_1', [price('var_1')], { productId: 'prod_1', skipRemove: true });
+    service.enqueue('plist_2', [price('var_2')], { productId: 'prod_2', skipRemove: true });
+
+    await service.flush();
+
+    expect(client.batchPriceListPrices).toHaveBeenCalledTimes(2);
+  });
+
+  it('기존 상품만 삭제 대상에 넣는다', async () => {
+    service.enqueue('plist_1', [price('var_1')], { productId: 'prod_new', skipRemove: true });
+    service.enqueue('plist_1', [price('var_2')], { productId: 'prod_old', skipRemove: false });
+
+    await service.flush();
+
+    expect(client.batchPriceListPrices).toHaveBeenCalledWith('plist_1', {
+      create: [price('var_1'), price('var_2')],
+      deleteProductIds: ['prod_old'],
+    });
+  });
+
+  it('한 price list 가 실패해도 나머지는 보낸다', async () => {
+    client.batchPriceListPrices.mockRejectedValueOnce(new Error('boom'));
+    service.enqueue('plist_1', [price('var_1')], { productId: 'prod_1', skipRemove: true });
+    service.enqueue('plist_2', [price('var_2')], { productId: 'prod_2', skipRemove: true });
+
+    await service.flush();
+
+    expect(client.batchPriceListPrices).toHaveBeenCalledTimes(2);
+  });
+
+  it('실패한 배치의 상품 id 를 error 로 남긴다 — 유실을 사람이 찾을 수 있어야 한다', async () => {
+    const errorSpy = jest.spyOn(service['logger'], 'error').mockImplementation();
+    client.batchPriceListPrices.mockRejectedValueOnce(new Error('boom'));
+    service.enqueue('plist_1', [price('var_1')], { productId: 'prod_1', skipRemove: true });
+
+    await service.flush();
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('prod_1'));
+  });
+
+  it('버퍼가 비면 호출하지 않는다', async () => {
+    await service.flush();
+
+    expect(client.batchPriceListPrices).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 6: 실패를 확인한다**
+
+Run: `npx jest --runTestsByPath apps/channel-adapter/src/adapters/medusa/deferred-price-list.service.spec.ts`
+Expected: FAIL — 모듈을 찾을 수 없음
+
+- [ ] **Step 7: 버퍼 서비스를 구현한다**
+
+`deferred-price-list.service.ts` 생성:
+
+```typescript
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { MedusaClient } from './medusa.client';
+
+const DEFAULT_FLUSH_INTERVAL_MS = 30_000;
+
+type PriceInput = {
+  amount: number;
+  currency_code: string;
+  variant_id: string;
+  min_quantity?: number;
+  max_quantity?: number;
+};
+
+type PendingList = {
+  create: PriceInput[];
+  deleteProductIds: string[];
+  productIds: string[];
+};
+
+/**
+ * 대량등록의 price list 쓰기를 모아서 한 번에 보낸다.
+ *
+ * 단건 경로는 상품당 remove 3.30초 + add 3.28초인데, 비용의 대부분이 호출당 고정비라
+ * 여러 상품을 한 배치로 합치면 거의 사라진다 (실측 근거는 설계서 §5-A).
+ *
+ * 버퍼는 인메모리다. **프로세스가 비정상 종료하면 그 주기분의 가격이 유실되고, 해당
+ * 상품은 기본가로 노출된다** (멤버십·티어 할인이 빠진 더 비싼 가격이라 미수금은 안 생긴다).
+ * 유실 시 상품 id 를 error 로 남기므로 재게시로 복구할 수 있다. flush 주기를 30초로
+ * 짧게 잡은 이유가 이 노출 창을 줄이는 것이다.
+ */
+@Injectable()
+export class DeferredPriceListService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(DeferredPriceListService.name);
+  private readonly pending = new Map<string, PendingList>();
+  private readonly flushIntervalMs: number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private readonly medusaClient: MedusaClient,
+    private readonly configService: ConfigService,
+  ) {
+    const raw = this.configService.get<string | number | undefined>('DEFERRED_PRICE_LIST_FLUSH_MS');
+    const parsed = Number(raw);
+    this.flushIntervalMs =
+      raw === undefined || raw === null || raw === '' || !Number.isInteger(parsed) || parsed < 1000
+        ? DEFAULT_FLUSH_INTERVAL_MS
+        : parsed;
+  }
+
+  onModuleInit(): void {
+    this.timer = setInterval(() => void this.flush(), this.flushIntervalMs);
+    this.logger.log(`Deferred price list started (flushIntervalMs=${this.flushIntervalMs}ms)`);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    await this.flush();
+  }
+
+  enqueue(
+    priceListId: string,
+    prices: PriceInput[],
+    opts: { productId: string; skipRemove: boolean },
+  ): void {
+    const entry = this.pending.get(priceListId) ?? { create: [], deleteProductIds: [], productIds: [] };
+    entry.create.push(...prices);
+    entry.productIds.push(opts.productId);
+    if (!opts.skipRemove) {
+      entry.deleteProductIds.push(opts.productId);
+    }
+    this.pending.set(priceListId, entry);
+  }
+
+  async flush(): Promise<void> {
+    if (this.pending.size === 0) return;
+
+    const batches = [...this.pending.entries()];
+    this.pending.clear();
+
+    for (const [priceListId, entry] of batches) {
+      try {
+        await this.medusaClient.batchPriceListPrices(priceListId, {
+          create: entry.create,
+          deleteProductIds: entry.deleteProductIds,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        // 유실이다. 재게시로만 복구되므로 상품 id 를 남겨 사람이 찾을 수 있게 한다.
+        this.logger.error(
+          `Deferred price list flush failed for ${priceListId} (${message}). ` +
+            `Lost prices for products: ${entry.productIds.join(', ')}`,
+        );
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 8: 테스트 통과를 확인한다**
+
+Run: `npx jest --runTestsByPath apps/channel-adapter/src/adapters/medusa/deferred-price-list.service.spec.ts`
+Expected: PASS (6건)
+
+- [ ] **Step 9: syncPriceLists 를 버퍼로 분기한다**
+
+`pim-medusa-sync.service.ts` 생성자에 `DeferredPriceListService` 를 주입하고, `syncPriceLists` 시그니처에 `isBulk` 를 더한다. `:620` 과 `:633` 의 두 블록을 각각 바꾼다 (멤버십 블록 예시, 티어 블록도 동일하게):
+
+```typescript
+      if (opts.isBulk) {
+        this.deferredPriceList.enqueue(listId, membershipPrices, {
+          productId: medusaProductId,
+          skipRemove: opts.skipRemove,
+        });
+      } else {
+        if (!opts.skipRemove) {
+          await this.medusaClient.removeProductFromPriceList(listId, medusaProductId);
+        }
+        await this.medusaClient.addPricesToPriceList(listId, membershipPrices);
+      }
+```
+
+호출부(`:389`)에 `isBulk` 를 더한다:
+
+```typescript
+      await this.syncPriceLists(snapshot, product.id, product.variants, {
+        skipRemove: action === 'created',
+        isBulk: options?.isBulk ?? false,
+      });
+```
+
+- [ ] **Step 10: 배치 경로의 통합 테스트를 쓴다**
+
+`pim-medusa-sync.service.spec.ts` 에 추가:
+
+```typescript
+  it('대량 경로에서는 price list 를 즉시 호출하지 않고 버퍼에 넣는다', async () => {
+    const { service, medusaClient } = createService();
+    const deferred = { enqueue: jest.fn() };
+    (service as any).deferredPriceList = deferred;
+    const snapshot = { variants: [{ id: 'pim-var-1', membershipPrice: 34000, tieredPrices: [] }] };
+    const medusaVariants = [{ id: 'variant_m1', metadata: { pimVariantId: 'pim-var-1' } }];
+
+    await (service as any).syncPriceLists(snapshot, 'prod_1', medusaVariants, {
+      isBulk: true,
+      skipRemove: true,
+    });
+
+    expect(medusaClient.addPricesToPriceList).not.toHaveBeenCalled();
+    expect(medusaClient.removeProductFromPriceList).not.toHaveBeenCalled();
+    expect(deferred.enqueue).toHaveBeenCalledWith(
+      'plist_membership',
+      [{ amount: 34000, currency_code: 'krw', variant_id: 'variant_m1' }],
+      { productId: 'prod_1', skipRemove: true },
+    );
+  });
+
+  it('단건 경로는 지금까지대로 즉시 호출한다', async () => {
+    const { service, medusaClient, calls } = createService();
+    const snapshot = { variants: [{ id: 'pim-var-1', membershipPrice: 34000, tieredPrices: [] }] };
+    const medusaVariants = [{ id: 'variant_m1', metadata: { pimVariantId: 'pim-var-1' } }];
+
+    await (service as any).syncPriceLists(snapshot, 'prod_1', medusaVariants, { isBulk: false });
+
+    expect(medusaClient.removeProductFromPriceList).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(['remove', 'add']);
+  });
+
+  it('멤버십과 티어가 함께 있으면 price list 별로 각각 버퍼에 넣는다', async () => {
+    const { service } = createService();
+    const deferred = { enqueue: jest.fn() };
+    (service as any).deferredPriceList = deferred;
+    const snapshot = {
+      variants: [
+        {
+          id: 'pim-var-1',
+          membershipPrice: 34000,
+          tieredPrices: [{ minQuantity: 5, price: 9000 }],
+        },
+      ],
+    };
+    const medusaVariants = [{ id: 'variant_m1', metadata: { pimVariantId: 'pim-var-1' } }];
+
+    await (service as any).syncPriceLists(snapshot, 'prod_1', medusaVariants, {
+      isBulk: true,
+      skipRemove: true,
+    });
+
+    expect(deferred.enqueue).toHaveBeenCalledTimes(2);
+    const listIds = deferred.enqueue.mock.calls.map((c: unknown[]) => c[0]);
+    expect(listIds).toEqual(['plist_membership', 'plist_Tiered_Prices_-_Min_5']);
+  });
+```
+
+세 번째 테스트가 설계서 §9 의 "멤버십+티어 혼재" 케이스다. 두 price list 가 서로 섞이지 않는지를 본다.
+
+- [ ] **Step 11: 등록·환경변수·검증**
+
+`adapter.module.ts` providers 에 `DeferredPriceListService` 추가.
+`services.ts` channel-adapter env 에 `DEFERRED_PRICE_LIST_FLUSH_MS: '30000'` 추가.
+
+Run: `npx jest --runTestsByPath apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts apps/channel-adapter/src/adapters/medusa/deferred-price-list.service.spec.ts apps/channel-adapter/src/adapters/medusa/medusa.client.spec.ts`
+Expected: PASS
+
+Run: `npx nest build channel-adapter`
+Expected: 성공
+
+- [ ] **Step 12: 커밋**
+
+```bash
+git add apps/channel-adapter/src/adapters/medusa/ apps/channel-adapter/src/adapter.module.ts deployments/lcnine/services/infra/services.ts
+git commit -m "$(cat <<'EOF'
+perf(channel-adapter): 대량등록의 price list 쓰기를 배치로 합친다
+
+상품당 remove 3.30초 + add 3.28초인데 비용의 대부분이 호출당 고정비였다.
+Medusa 의 batchPriceListPricesWorkflow 가 create/update/remove 세 중첩
+워크플로를 항상 전부 돌리고, 빈 하위 워크플로도 조기 반환 가드를 통과해
+쿼리를 낸다. 상품 수만큼 부르는 대신 30초마다 한 배치로 몰아 넣는다.
+
+버퍼는 인메모리라 비정상 종료 시 그 주기분이 유실된다. 유실 상품 id 를
+error 로 남겨 재게시로 복구할 수 있게 했다. 단건 경로는 즉시 호출 그대로.
+
+Claude-Session: https://claude.ai/code/session_01RxLvaYzJJXi76zMB1J5RCL
+EOF
+)"
+```
+
+---
+
+## Task 5: 인박스 클레임 측정 게이트 (C 선행)
+
+> **이 태스크는 사람이 실행한다.** 프로덕션 DB 접근이 필요하고, 결과가 Task 6 의 두 갈래 중 하나를 고른다. 측정 없이 Task 6 을 시작하지 않는다.
+
+슬롯이 비어도 다음 핸들러가 평균 16.9초 뒤에야 뜬다(3.5초 이내는 21%뿐, 최솟값은 정확히 틱 간격인 3.0초). 가설은 `claimNextInboxEvent`(`inbox-worker.service.ts:214`)의 `ORDER BY (bulk lane), created_at` 이 매 틱 후보 행 전부를 정렬한다는 것이다. 코드 주석 자체가 그렇게 적혀 있다.
+
+- [ ] **Step 1: 터널을 연다**
+
+```bash
+cd deployments/lcnine/services && npx sst tunnel --stage live
+```
+
+- [ ] **Step 2: 적체 규모를 잰다**
+
+```sql
+SELECT status, count(*) FROM inbox_events GROUP BY status;
+```
+
+기록할 것: `pending` 행 수.
+
+- [ ] **Step 3: 클레임 쿼리를 EXPLAIN 한다**
+
+`inbox-worker.service.ts:214` 의 `claimNextInboxEvent` 가 만드는 SQL 을 그대로 옮겨 실행한다. 서비스 로그의 drizzle 쿼리 출력이나 코드에서 재구성한다.
+
+```sql
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT ... FROM inbox_events
+WHERE status = 'pending' AND event_type IN (...)
+ORDER BY (event_type IN (...) OR COALESCE(metadata->>'origin','') = 'bulk_import'), created_at
+LIMIT 1;
+```
+
+기록할 것: 총 실행시간, `Seq Scan` 여부, `Sort` 노드의 행 수와 메모리.
+
+- [ ] **Step 4: 기존 인덱스를 확인한다**
+
+```sql
+SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'inbox_events';
+```
+
+- [ ] **Step 5: 갈래를 고른다**
+
+| 관측 | 다음 태스크 |
+|---|---|
+| `Sort` 가 대부분의 시간을 먹고 정렬 대상 행이 pending 전체 | **Task 6-A (lane 컬럼 승격)** — 표현식 정렬은 인덱스로 못 받는다 |
+| `Seq Scan` 이 지배적이고 정렬 대상은 적음 | **Task 6-B (부분 인덱스)** |
+| 쿼리가 100ms 미만 | 가설 기각. 유휴의 원인이 다른 데 있다 — 재조사 필요, Task 6 중단 |
+
+측정 결과를 설계서 §6 표에 적어 넣고 커밋한다.
+
+---
+
+## Task 6-A: 레인을 컬럼으로 승격 (Task 5 가 이 갈래를 가리킨 경우)
+
+표현식 `ORDER BY` 는 인덱스로 받을 수 없다. 레인을 생성 컬럼으로 만들어 정렬을 인덱스에 태운다.
+
+**Files:**
+- Modify: `apps/channel-adapter/src/schema.ts` (`inbox_events` 테이블 정의가 여기 있다)
+- Create: `apps/channel-adapter/drizzle/<timestamp>_add-inbox-lane-column.sql` (생성됨)
+- Modify: `apps/channel-adapter/src/adapters/medusa/inbox-worker.service.ts:214-260`
+- Test: `apps/channel-adapter/src/adapters/medusa/inbox-claim-order.integration.spec.ts` (기존 파일)
+
+- [ ] **Step 1: 기존 순서 스펙이 초록인지 먼저 확인한다**
+
+Run: `npm run test:inbox-claim-order:integration`
+Expected: PASS. 여기서 실패하면 그건 이 태스크와 무관한 선행 문제다 — 먼저 보고한다.
+
+- [ ] **Step 2: 스키마에 생성 컬럼을 더한다**
+
+`inbox_events` 테이블 정의에 추가:
+
+```typescript
+  // 강등 레인. ORDER BY 표현식을 인덱스로 받으려고 컬럼으로 승격했다.
+  // 0 = 일반(멤버십·배송 등 고객이 즉시 체감), 1 = 대량(재고 재계산·대량등록).
+  lane: smallint('lane')
+    .notNull()
+    .default(0),
+```
+
+- [ ] **Step 3: 마이그레이션을 생성한다**
+
+```bash
+npm run db:generate:channel-adapter -- --name add-inbox-lane-column
+```
+
+생성된 SQL 을 읽는다. 컬럼 추가 + 기본값이어야 한다. 여기에 인덱스와 백필을 손으로 덧붙인다:
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS inbox_events_pending_lane_idx
+  ON inbox_events (lane, created_at)
+  WHERE status = 'pending';
+
+UPDATE inbox_events
+SET lane = 1
+WHERE status = 'pending'
+  AND (event_type IN ('ProductSellableQuantityChanged')
+       OR COALESCE(metadata->>'origin', '') = 'bulk_import');
+```
+
+`CONCURRENTLY` 는 트랜잭션 밖에서만 돈다. drizzle 마이그레이션이 트랜잭션으로 감싸면 `--> statement-breakpoint` 로 분리하거나 인덱스를 별도 수동 단계로 뺀다. 생성된 파일을 읽고 판단한다.
+
+- [ ] **Step 4: 쓰기 경로가 lane 을 채우게 한다**
+
+`pim-product-event.consumer.ts:129` 부근의 inbox 행 생성에 `lane` 을 더한다. 판정은 지금 SQL 이 하던 것과 같은 규칙이다:
+
+```typescript
+        lane: params.origin && BULK_ORIGINS.includes(params.origin) ? 1 : 0,
+```
+
+다른 enqueue 경로(`InboxService.enqueue`)도 같은 규칙으로 채운다 — `grep -rn "inbox_events\|insert(.*inboxEvents" apps/channel-adapter/src --include=*.ts` 로 전수한다.
+
+- [ ] **Step 5: 클레임 쿼리를 바꾼다**
+
+`claimNextInboxEvent` 의 `ORDER BY` 를 표현식에서 컬럼으로 바꾼다:
+
+```typescript
+      .orderBy(inboxEvents.lane, inboxEvents.createdAt)
+```
+
+`bulkEventTypesSql` / `bulkOriginsSql` 구성 코드를 지운다. 주석은 왜 레인이 있는지 설명하는 부분만 남기고 "표현식이 전 행에 계산된다"는 대목은 컬럼으로 바뀌었으니 갱신한다.
+
+- [ ] **Step 6: 순서 스펙이 여전히 초록인지 확인한다**
+
+Run: `npm run test:inbox-claim-order:integration`
+Expected: PASS — 강등 순서가 컬럼으로 바뀌어도 동일해야 한다
+
+- [ ] **Step 7: EXPLAIN 을 다시 떠서 근거를 남긴다**
+
+Task 5 Step 3 과 같은 쿼리를 새 계획으로 실행하고, 전후를 설계서 §6 에 적는다. `Index Scan` 으로 바뀌고 실행시간이 떨어져야 한다.
+
+- [ ] **Step 8: 커밋**
+
+```bash
+git add apps/channel-adapter/database apps/channel-adapter/drizzle apps/channel-adapter/src docs/superpowers/specs
+git commit -m "$(cat <<'EOF'
+perf(channel-adapter): 인박스 강등 레인을 컬럼으로 승격한다
+
+ORDER BY 표현식이 LIMIT 1 이어도 후보 행 전부에 계산돼, 적체가 크면 매 틱
+전수 정렬이 됐다. 슬롯이 비어도 다음 핸들러가 평균 16.9초 뒤에 떴다
+(3.5초 이내 21%). 레인을 컬럼으로 만들어 정렬을 부분 인덱스에 태운다.
+
+강등 규칙 자체는 그대로다 — 대량 이벤트가 멤버십·배송을 밀어내지 않는다.
+
+Claude-Session: https://claude.ai/code/session_01RxLvaYzJJXi76zMB1J5RCL
+EOF
+)"
+```
+
+---
+
+## Task 6-B: 부분 인덱스만 추가 (Task 5 가 이 갈래를 가리킨 경우)
+
+`Seq Scan` 이 지배적이고 정렬 대상 행은 적다면 컬럼 승격 없이 인덱스로 끝난다.
+
+**Files:**
+- Create: `apps/channel-adapter/drizzle/<timestamp>_add-inbox-pending-idx.sql`
+- Modify: inbox_events 스키마 정의 (인덱스 선언)
+
+- [ ] **Step 1: 스키마에 인덱스를 선언한다**
+
+`inbox_events` 테이블 정의의 인덱스 블록에 추가:
+
+```typescript
+  pendingClaimIdx: index('inbox_events_pending_claim_idx')
+    .on(table.eventType, table.createdAt)
+    .where(sql`status = 'pending'`),
+```
+
+- [ ] **Step 2: 마이그레이션을 생성하고 읽는다**
+
+```bash
+npm run db:generate:channel-adapter -- --name add-inbox-pending-idx
+```
+
+생성된 SQL 을 읽고 `CREATE INDEX` 에 `CONCURRENTLY` 를 더한다 (운영 테이블에 락을 오래 잡지 않기 위해).
+
+- [ ] **Step 3: 순서 스펙을 돌린다**
+
+Run: `npm run test:inbox-claim-order:integration`
+Expected: PASS
+
+- [ ] **Step 4: EXPLAIN 전후를 설계서 §6 에 적는다**
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add apps/channel-adapter/database apps/channel-adapter/drizzle docs/superpowers/specs
+git commit -m "$(cat <<'EOF'
+perf(channel-adapter): 인박스 클레임에 부분 인덱스를 붙인다
+
+pending 행 스캔이 클레임 지연의 원인이었다. 슬롯이 비어도 다음 핸들러가
+평균 16.9초 뒤에 떴다. status='pending' 부분 인덱스로 후보 집합을 좁힌다.
+
+Claude-Session: https://claude.ai/code/session_01RxLvaYzJJXi76zMB1J5RCL
+EOF
+)"
+```
+
+---
+
+## 배포 순서
+
+1. **Task 1~3 을 먼저 배포한다** (마이그레이션 0건). channel-adapter 단독 배포.
+2. 대량등록을 한 번 돌리고 재측정한다 — 상품당 소요, Medusa CPU, CloudFront 적중률.
+3. Task 4 는 재측정 결과를 보고 진행 여부를 판단한다 (durability 거래가 값어치 있는지).
+4. Task 5 측정 → Task 6-A 또는 6-B. **마이그레이션이 생기므로 `migrate → deploy` 순서다** (additive expand).
+5. 설계서 §5-D(admin/store 분리)는 여기까지 끝난 뒤 재측정해서 결정한다. 이 계획의 범위 밖이다.
+
+## 설계서 §6 미확정 항목의 처리
+
+| 미확정 | 이 계획에서의 처리 |
+|---|---|
+| `action='created'` 신뢰성 | **Task 2 Step 1 이 게이트.** 확신 없으면 중단 |
+| 클레임 쿼리 비용 | **Task 5 가 측정.** 결과가 Task 6 갈래를 고른다 |
+| price list 지연의 O(n) 성장 원인 (빈 IN 리스트 vs `workflow_execution` 누적) | **조사하지 않는다.** Task 4 가 호출 수를 상품 수에서 배치 수로 줄이면 이 질문이 실용적으로 무의미해진다. Task 4 를 보류하기로 하면 그때 조사 대상으로 되살린다 |
+| revalidate 가 5초를 넘기는 원인 | **조사하지 않는다.** Task 3 이 await 를 없애 무관해진다. 다만 라우트가 여전히 느리다는 사실은 남으므로, 단건 편집 UX 가 문제되면 별도 과제 |
+| `GET /admin/orders` 분당 10회 | 범위 밖. 시간 귀속 상위가 아니다 |
+
+## 재측정 방법
+
+배포 후 다음을 다시 잰다. 명령은 이 세션에서 쓴 것과 같다.
+
+- **상품당 소요**: channel-adapter 로그에서 `Syncing from event snapshot: {masterId}` → `revalidate ... for handle={masterId}` 쌍의 시간차. Task 3 이후에는 대량 경로에서 revalidate 로그가 사라지므로 **종료 표지를 `Sync completed` 뒤에 새로 하나 남기거나**, `pim_medusa_mappings.updatedAt` 으로 대신 잰다
+- **Medusa 시간 귀속**: Medusa 로그의 `[SLOW]` 라인을 엔드포인트별 `sum(ms)` 로 집계 (300ms 초과만 남는 하한선임에 주의)
+- **슬롯 가동률**: 핸들러 소요 합 ÷ (창 × 동시성)
+
+> Task 3 이 대량 경로의 revalidate 로그를 없애면 이 세션이 쓴 측정 방법이 깨진다. **Task 3 Step 9b 가 `Sync finished: {masterId} ({durationMs}ms)` 를 핸들러 끝에 남기는 이유가 이것이다** — 배포 후에는 이 로그의 `durationMs` 를 직접 집계하면 되므로 시작/종료 쌍 맞추기도 필요 없어진다.
+
+## 리스크
+
+| 리스크 | 완화 |
+|---|---|
+| Task 2 의 `action='created'` 가 신뢰할 수 없으면 가격이 중복 누적 | Step 1 의 사전 확인이 게이트. 확신 없으면 중단하고 보고 |
+| Task 4 의 버퍼 유실로 상품이 기본가로 노출 | 기본가는 할인 전 가격이라 미수금은 없다. 유실 상품 id 를 error 로 남긴다. flush 30초로 창을 좁힌다 |
+| Task 4 배포 중 정상 종료가 아니면 유실 | `onModuleDestroy` 에서 flush 한다. ECS 의 graceful shutdown 안에 들어와야 하므로 `INBOX_SHUTDOWN_DRAIN_MS`(25초)보다 짧게 끝나야 한다 |
+| Task 6-A 의 백필 `UPDATE` 가 큰 테이블에서 오래 걸림 | pending 행만 대상이라 규모가 작다. Task 5 Step 2 에서 미리 센다 |
+| 대량등록 중 다른 도메인 이벤트 지연 | 강등 레인은 6-A 에서도 유지된다. 규칙 자체는 안 바꾼다 |
+| storefront 캐시가 최대 60초 늦게 반영 | 단건 경로는 즉시 반영을 유지한다. 대량등록에만 적용 |

--- a/docs/superpowers/plans/2026-08-13-bulk-import-medusa-load.md
+++ b/docs/superpowers/plans/2026-08-13-bulk-import-medusa-load.md
@@ -22,7 +22,7 @@ A1 을 먼저 넣고 A2 는 뒤로 뺀다. A2 없이 A1+B+C 만 해도 상품당
 ## Global Constraints
 
 - 레이어 규칙: Controller → Service → Reader/Manager → Repository. Service 는 `HttpException`·drizzle·Express 타입을 import 하지 않는다. 도메인 예외는 `@app/shared` 의 `NotFoundError`/`BadRequestError`/`ConflictError` 를 던진다
-- `any` / `as` 캐스팅 금지 (문서화된 정당화와 팀 승인 없이는)
+- `any` / `as` 캐스팅 금지 (문서화된 정당화와 팀 승인 없이는). **프로덕션 코드에만 적용된다** — 테스트는 기존 스펙 파일의 관례(`medusaClient as any`, `(service as any).syncPriceLists(...)`, `service['logger']`)를 따른다. 이 판정은 2026-08-13 사람이 내렸다
 - Nullable 정규화: `string ?? ''`, `number ?? 0`, `date ?? undefined`
 - 트랜잭션은 `dbService.run(fn, tx)` 단일 러너를 쓴다. 클래스별 `inTx` 헬퍼를 새로 만들지 않는다
 - **테스트 실행은 반드시 `npx jest --runTestsByPath <파일경로>` 로 한다.** 이 워크트리 경로에 `+` 가 들어 있어(`.claude/worktrees/feat+bulk-import-medusa-load`) 일반 `jest <path>` 의 정규식 매칭이 오염된다

--- a/docs/superpowers/specs/2026-08-13-bulk-import-medusa-load-design.md
+++ b/docs/superpowers/specs/2026-08-13-bulk-import-medusa-load-design.md
@@ -1,0 +1,324 @@
+# 대량등록의 Medusa 부하와 처리량 설계
+
+작성 2026-08-13. 대량등록이 Medusa 를 포화시켜 storefront 를 느리게 만드는 문제와, 상품 2,553건에
+17시간이 걸리는 처리량 문제를 함께 다룬다.
+
+## 1. 배경
+
+2026-08-12 이전 진단은 storefront 체감 지연의 원인을 렌더당 Medusa 호출 증가(1.45 → 2.08)로 지목했고,
+`listShippingGroups()` 캐시 누락을 고쳐(`7c3d5f557`) 08-12 15:22 KST 에 배포했다. **그 수정은 실제로
+먹혔다** — 배포 직후 6시간(15~21시) 렌더당 호출 1.59~1.79, Medusa p95 0.95~1.96s, CPU 24~51%.
+
+그러나 08-12 22시부터 별개의 국면이 시작됐고 이 문서 작성 시점까지 15시간 넘게 진행 중이다.
+CPU 68~86% 지속, 메모리 74~84% 고착. 이 국면의 원인은 storefront 트래픽이 아니다.
+
+## 2. 측정 근거
+
+모든 수치는 라이브 CloudWatch 실측이다. 별도 표기가 없으면 창은 **2026-08-13 04:00~09:00 KST
+(18,000초)**, Medusa 는 `1 vCPU / 2 GB / scaling min 1 max 1 / valkey 사이드카 동거`.
+
+### 2-1. 부하는 트래픽이 아니라 대량등록에서 온다
+
+| 시각 | storefront Lambda 호출 | Medusa CPU |
+|---|---:|---:|
+| 08-12 05시 | 3,658 | 27.9% |
+| 08-13 05시 | 2,588 (더 적음) | **75.8%** |
+
+트래픽이 더 적은데 CPU 는 2.7배. 요청 처리가 아니라 백그라운드 유입이 태우고 있다.
+
+### 2-2. Medusa 요청 시간 귀속
+
+`[SLOW]` 미들웨어(`apps/medusa/src/api/middlewares.ts:27`)가 300ms 초과 요청만 남기므로 아래는 하한선이다.
+
+| 총시간 | 건수 | 평균 | 엔드포인트 |
+|---:|---:|---:|---|
+| 2,548s | 771 | 3.30s | `POST /admin/price-lists/{id}/products` (remove) |
+| 2,523s | 770 | 3.28s | `POST /admin/price-lists/{id}/prices/batch` (add) |
+| 2,193s | 766 | 2.86s | `POST /admin/products` |
+| 387s | 301 | 1.29s | `POST /admin/inventory-items` |
+| 300s | 198 | 1.51s | `POST /admin/price-lists/{id}` |
+| **≈8,130s** | | | **대량등록 소계 = 창의 45%** |
+| 1,110s | 1,605 | 0.69s | `GET /store/product-categories` |
+| 294s | 145 | 2.03s | `GET /store/products` |
+| 250s | 162 | 1.54s | `GET /store/products-sorted` |
+| **≈1,900s** | | | **storefront 소계 = 창의 10.5%** |
+
+대량등록이 storefront 의 4.3배. Medusa 시간 10.6초/상품 중 **price list 가 6.6초(62%)** 로,
+상품 생성(2.86초)보다 2.3배 비싸다.
+
+### 2-3. 처리량 회계
+
+핸들러 실제 소요는 `Syncing from event snapshot: {masterId}` → `revalidate ... for handle={masterId}`
+쌍으로 측정했다(창 08-13 07:00~09:00 KST, 269쌍). `Sync completed` 로그(`:387`)는 price list 동기화와
+revalidate **이전에** 찍히므로 종료 표지로 쓸 수 없다.
+
+- 핸들러 소요 **p50 21.2s / mean 23.9s / p90 35.4s**
+- 처리량 **26.6초/상품**, 슬롯 가동률 **45%** (`INBOX_MAX_CONCURRENT_HANDLERS=2`)
+- 슬롯이 빈 뒤 다음 시작까지 **p50 9.0s / mean 16.9s**, 3.5초 이내는 21%뿐
+  (최솟값이 정확히 3.0초 = `INBOX_HANDLER_START_INTERVAL_MS` 이므로 타이머 자체는 정상)
+
+상품 1건당 가용 슬롯시간 53.2초의 구성:
+
+| 항목 | 초 | 비중 |
+|---|---:|---:|
+| 클레임 유휴 | 29.3 | 55% |
+| channel-adapter 자체 작업 | 8.3 | 16% |
+| price-list remove + add | 6.6 | 12% |
+| storefront revalidate 대기 | 5.0 | 9% |
+| Medusa 상품 생성 | 2.9 | 5% |
+| Medusa 기타 | 1.2 | 2% |
+
+대량등록은 08-12 22시에 시작해 17시간 동안 약 2,553건을 처리했다.
+
+### 2-4. 기각된 가설 (재조사 금지)
+
+- **sort-index subscriber 중복 실행** — 아니다. 5시간에 워크플로 773회, 상품 766건 = **1.01회/상품**.
+  로그 2줄(step 의 `Sort index updated` + subscriber 의 `Price sync completed`)을 중복 실행으로
+  오독했던 것. 디바운스는 1% 남짓만 아낀다.
+- **valkey noeviction 폭탄** — 아직 안 터졌다. Medusa 로그에 OOM/maxmemory 0건.
+- **revalidate 라우트의 `listRegions()` 되먹임** — 아니다. 창 안 `/store/regions` 33건뿐, Next fetch
+  캐시가 먹고 있다.
+- **캐시 무효화가 죽어 있다** — 아니다. storefront 쪽 `storefront.revalidate.completed` **770/770**.
+  `AbortSignal.timeout(5000)` 은 호출자 fetch 만 끊고 Lambda 는 끝까지 실행한다.
+
+## 3. 문제 정의
+
+두 축이고 답이 다르다.
+
+- **축 A — storefront 가 느리다.** 대량등록이 Medusa 1 vCPU 를 포화시킨다. 최대 기여자는 price list(62%).
+- **축 B — 대량등록이 17시간 걸린다.** 최대 기여자는 인박스 클레임 유휴(55%).
+
+price list 는 두 축 상단에 동시에 등장하는 유일한 항목이고, **유일하게 카탈로그 크기에 따라 자란다**
+(같은 대량등록 안에서 평균 2.6초 → 5.4초).
+
+## 4. 범위
+
+**포함**
+
+- A. price list 호출 배치화
+- B. storefront revalidate 배치화
+- C. 인박스 클레임 유휴 (선행 조사 후)
+- D. Medusa admin/store 인스턴스 분리 + 공유 캐시
+
+**제외**
+
+- **in-process 경로 전환** — `apps/medusa/src/scripts/backfill-from-core.ts` 가 `createProductsWorkflow`
+  를 직접 불러 HTTP/auth/ALB 를 통째로 우회하는 경로가 이미 있고 백필로 검증됐다. 처리량을 분 단위로
+  내릴 수 있는 유일한 수단이지만, 현재는 image 에 baking 된 JSON 전용이라 런타임 경로로 쓰려면
+  재설계가 필요하다. **별도 과제로 분리한다.**
+- sort-index subscriber 디바운스 — §2-4 에서 기각.
+- Medusa 수직 확장 — Node 단일 스레드라 1→2 vCPU 효과가 제한적.
+
+## 5. 설계
+
+### A. price list 호출 배치화
+
+**현재.** `syncPriceLists`(`apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts:567`)가
+상품마다 `removeProductFromPriceList` + `addPricesToPriceList` 를 부른다(`:620`, `:633`).
+상품 766건에 price-list 호출 1,541회.
+
+**왜 3.3초인가.** 가격 데이터 처리가 아니라 호출당 고정비다. 두 엔드포인트 모두
+`batchPriceListPricesWorkflow` 로 들어가는데, 이 워크플로는 create / update / remove **세 개의 중첩
+워크플로를 `parallelize` 로 항상 전부 실행한다**. remove 요청이라 `create: []`, `update: []` 인데도
+건너뛰지 않는다 — 조기 반환 가드가 `if (!data.length)` 로 **바깥 배열 길이(=1)** 를 보지 안쪽 `prices`
+를 보지 않기 때문이다(`validate-variant-price-links.js`, `validate-price-lists.js`). 결과적으로 빈
+작업인 하위 워크플로 2개가 매 호출 쿼리를 낸다. 여기에 라우트 자체의 remote query 3회
+(`fetchPriceListPriceIdsForProduct` 2회 + `fetchPriceList` 1회)와 workflow-engine 체크포인트
+(Redis 쓰기 + Postgres `workflow_execution` upsert)가 스텝마다 얹힌다.
+
+방증: 단순 갱신인 `POST /admin/price-lists/{id}` 도 1.51초다. 워크플로 오버헤드 바닥이 1.5초쯤이고,
+price list 조작은 중첩 워크플로가 더 얹혀 3.3초가 된다.
+
+**설계.** 상품 단위 호출을 세션 단위 배치로 바꾼다.
+
+- 핸들러는 price list 항목을 즉시 반영하지 않고 버퍼에 누적한다
+- 주기적으로(§B 와 같은 flush 지점) 누적분을 `POST /admin/price-lists/{id}/prices/batch` **한 번**으로
+  보낸다. 이 엔드포인트는 `create` 에 여러 variant·여러 상품의 가격을 한 번에 받도록 설계돼 있다
+- `remove` 는 배치 안에서 한 번만 수행한다. `upsertProduct` 가 반환하는
+  `action: 'created' | 'updated'`(`medusa.client.ts:1674`)를 버퍼에 같이 담아, 배치의 `delete` 대상은
+  `updated` 인 상품의 기존 price id 로만 구성한다. 신규 생성 상품은 price list 에 항목이 있을 수 없다
+- 기존 주석이 밝힌 remove 의 이유("재동기화 시 중복 누적, 낮은 옛 가격이 이김")는 배치 안에서
+  delete+create 를 한 워크플로로 처리하면 그대로 유지된다
+
+**효과.** 호출 1,541회 → 수십 회. 상품당 6.6초 → 0에 수렴. Medusa CPU 부하의 62% 제거.
+카탈로그 크기에 따른 악화도 멈춘다.
+
+**주의.** `action='created'` 인데 실제로는 상품이 이미 존재하는 경로(매핑 기록 실패 후 재시도 등)가
+있으면 중복 가격이 생긴다. 구현 전에 `upsertProduct` 의 분기(`medusa.client.ts:1683`, `:1706`, `:1714`)
+를 읽고 그 경우가 가능한지 확인할 것.
+
+### B. storefront revalidate 배치화
+
+**현재.** `syncFromSnapshot:400` 이 상품마다 `revalidateProduct(handle)` 를 **await** 한다.
+창 안 771건 중 762건이 5초 타임아웃(`AbortSignal.timeout(5000)`,
+`storefront-revalidate.service.ts:56`). 그런데 storefront 쪽은 770/770 완료 — 호출자만 기다렸다 버린다.
+
+**진짜 문제는 과잉 무효화다.** `web/almondyoung-storefront/src/app/api/revalidate/route.ts` 는
+`handle` 하나를 받으면:
+
+| 작업 | 범위 |
+|---|---|
+| `revalidateTag('product-{handle}')` | 해당 상품 — 적정 |
+| `revalidateTag(PRODUCT_LIST_TAG)` | **전체 상품 목록** |
+| `revalidatePath('/{cc}/products/{handle}')` | 국가별 상세 경로 |
+| `revalidatePath('/[countryCode]/category/[...segments]', 'page')` | **모든 카테고리 페이지** |
+| `revalidateTag(...body.tags)` | `pim-detail-{handle}` |
+
+상품 1건마다 목록 캐시 전체와 카테고리 페이지 전체가 날아간다. 17시간 × 2,553건이면 캐시가 데워질
+틈이 없다. 라우트 설계 자체는 단건 변경에 합리적이다 — 목록 fetch 태그가
+`${tag}-${_medusa_cache_id}` 로 **방문자별**이라 백엔드가 지목할 수 없고, 그래서 공용 태그를 칠 수밖에
+없다(라우트 주석). 문제는 대량 경로가 그 단건 API 를 2,553번 부르는 것이다.
+
+**설계.**
+
+- bulk origin 이면 개별 상품 sync 에서 revalidate 를 호출하지 않는다
+- handle 을 버퍼에 모았다가 **주기적으로 한 번** 호출한다. 그 한 번에 전역 무효화도 1회만 일어난다
+- 라우트는 이미 `tags: []` / `paths: []` 배열을 받으므로 **storefront 변경 없이** 가능하다
+- flush 주기는 60초를 기본값으로 하되 환경변수로 조정 가능하게 둔다
+
+**flush 지점 선택.** `importSessionId` 는 이벤트 **payload** 에 실린다(metadata 에는 없다 — 인박스
+정렬이 payload TOAST 해제를 피하려는 의도적 설계). 핸들러 시점에는 payload 가 이미 로드돼 있어
+세션 단위 그룹핑이 가능하다. 그럼에도 **주기적 flush 를 택한다**:
+
+| 방식 | 평가 |
+|---|---|
+| core 가 "세션 완료" 이벤트 발행 | 가장 정확하나 core 변경 필요 |
+| 세션별 디바운스(N초 무이벤트 시 flush) | core 변경 0. 세션 경계 추적 필요 |
+| **주기적 flush (60초마다 누적분 1회)** | **세션 개념 불필요. 재시작에 강함** |
+
+주기 flush 는 프로세스가 죽어도 최악이 "그 주기분이 캐시 TTL(1시간)까지 늦게 반영"이다.
+
+**효과.** 상품당 5초 회수(처리량 21%)와, 더 중요하게 **대량등록 중에도 storefront 캐시가 살아남는다.**
+이건 Medusa CPU 와 독립된 두 번째 지연 축이다.
+
+**부수 작업.** fire-and-forget 이 되면 5초 타임아웃은 의미가 없어지므로 정리한다. 지금은 762건이
+`error` 로그라 진짜 실패가 묻힌다 — 실패 로그는 실제 실패에만 남긴다.
+
+### C. 인박스 클레임 유휴 — 선행 조사 필요
+
+**현상.** 슬롯이 비어도 다음 핸들러가 평균 16.9초 뒤에야 뜬다. 상품당 가용 슬롯시간의 55%.
+
+**가설.** `claimNextInboxEvent`(`apps/channel-adapter/src/adapters/medusa/inbox-worker.service.ts:214`)
+의 `ORDER BY (bulk lane), created_at`. 코드 주석 자체가 "ORDER BY 표현식은 LIMIT 1 이어도 후보 행
+전부에 대해 계산된다"고 밝힌다. 적체가 클수록 매 틱 전수 정렬이 된다. `tryStartNextHandler` 는
+`isClaiming` 전역 뮤텍스로 감싸여 있어 클레임이 느리면 그동안 틱이 통째로 스킵된다.
+
+**선행 조사.** 구현 전에 확정한다.
+
+1. 프로덕션 `inbox_events` 에서 클레임 쿼리 `EXPLAIN ANALYZE`
+2. `(event_type, created_at)` 및 metadata origin 표현식을 받쳐줄 인덱스 존재 여부
+3. pending 행 수 추이
+
+**조사 결과에 따른 갈래.** 인덱스로 해결되면 인덱스 추가(마이그레이션 1건). 표현식 정렬 자체가
+문제면 레인을 컬럼으로 승격(`lane smallint` 생성 컬럼 + 인덱스)해 정렬을 인덱스에 태운다.
+
+**순서 제약이 있다.** C 를 A·B 보다 먼저 하면 처리량만 2배가 되면서 Medusa 가 100% 에 박혀
+storefront 가 지금보다 나빠진다. **A·B 로 상품당 작업량을 먼저 줄이고 그다음 C 로 큐를 연다.**
+
+### D. Medusa admin/store 인스턴스 분리
+
+**현재.** `scaling: { min: 1, max: 1 }` 고정이고, 사유는 valkey 가 사이드카라 태스크 2개면 세션과
+BullMQ 큐가 갈라지는 것(`deployments/lcnine/services/infra/services.ts:464-472`).
+
+**설계.**
+
+- 공유 캐시 복원: **ElastiCache Serverless (Valkey)**. 이 규모에선 노드형보다 싸고 운영 부담이 0이며,
+  현재 사이드카의 `appendonly no` + `save ''`(재시작 시 인플라이트 큐 유실)도 해소된다
+- Medusa 를 두 서비스로 분리하고 ALB **path 조건**으로 `/admin/*` 을 admin 쪽으로 보낸다.
+  `createService` 가 이미 `transform.listenerRule` 로 host 조건을 덮어쓰므로 같은 자리에 붙는다
+  - **Store 인스턴스**: `MEDUSA_WORKER_MODE=server`. store API 만, 백그라운드 잡·cron 없음
+  - **Admin 인스턴스**: `shared`. admin API + subscriber/워크플로/cron 전부
+- 이로써 cron 중복 실행 문제도 사라진다(`apps/medusa/src/jobs/sync-product-sort-index.ts:8` 주석이
+  지적한 그 문제)
+- locking 은 이미 `locking-redis`(`medusa-config.js:234`)라 공유 캐시만 생기면 멀티 인스턴스 정합성은 확보
+
+**대안 기각.** 단순 `max: 2` + shared 모드는 ALB 라운드로빈이라 storefront 요청이 계속 대량등록과
+같은 이벤트 루프에 큐잉된다. 비용이 같은데 격리가 없다.
+
+**비용.** 두 번째 Fargate 태스크(arm64 1vCPU/2GB) 약 +$33/월 + 캐시 약 +$10/월 = **월 +$43**.
+현재 $392, 목표 $180~220 이므로 목표와는 반대 방향이다. A·B·C 로 "2대면 충분"을 먼저 만들어 두는 것이
+순서상 맞다.
+
+## 6. 미확정 사항
+
+구현 전 또는 구현 중 확정한다. 추정을 사실로 옮기지 않는다.
+
+| 항목 | 확정 방법 |
+|---|---|
+| price list 지연이 카탈로그에 비례해 자라는 원인 — 빈 IN 리스트(`variant_id: []`)의 무필터 퇴화 vs `workflow_execution` 누적 | `EXPLAIN ANALYZE` + `SELECT count(*) FROM workflow_execution`. SST 터널 필요 |
+| revalidate 라우트가 5초를 넘기는 원인 — OpenNext ISR 태그 캐시 팬아웃 추정 | 태그 캐시 DynamoDB 테이블 크기와 revalidation 큐 유입량 |
+| 클레임 쿼리 비용 (§C) | 프로덕션 `EXPLAIN ANALYZE` |
+| `action='created'` 인데 상품이 이미 존재하는 경로 가능 여부 | `medusa.client.ts:1674-1714` 분기 정독 |
+| 조용한 시간대 `GET /admin/orders` 분당 10회의 정체 | 미해결. 시간 귀속 상위는 아니라 우선순위 낮음 |
+
+## 7. 순서와 의존
+
+```
+A (price list 배치) ─┐
+                     ├─ 같은 버퍼·flush 배관 공유 → 한 작업으로 묶는다
+B (revalidate 배치) ─┘
+        ↓
+C 선행 조사 (EXPLAIN) → C 구현
+        ↓
+D (admin/store 분리 + ElastiCache)
+```
+
+A 와 B 는 둘 다 "상품마다 하던 걸 모아서 한 번에"라 누적 버퍼와 flush 지점을 공유한다. 따로 만들면
+같은 배관을 두 번 깐다.
+
+D 는 A·B·C 와 독립적으로 배포 가능하지만, C 로 처리량이 오르면 순간 부하가 커지므로 C 앞이나
+동시에 두는 편이 안전하다.
+
+## 8. 예상 효과
+
+처리량 모형: `동시성 × 상품당소요 = 핸들러소요 + 슬롯유휴`. 현재 `2 × 26.6 = 23.9 + 29.3` 이다.
+핸들러를 줄여도 슬롯유휴 29.3초는 그대로 남는다.
+
+| 단계 | 핸들러 | 상품당 | 2,553건 소요 | 부수 효과 |
+|---|---:|---:|---:|---|
+| 현재 | 23.9s | 26.6s | 17시간 | 전역 캐시 2,553회 무효화 |
+| +A | 17.3s | 23.3s | 16.5시간 | **Medusa CPU 부하 −62%** |
+| +B | 12.3s | 20.8s | 14.7시간 | **CloudFront 적중률 회복** |
+| +C | 12.3s | ~7.7s | **~5.5시간** | |
+| +D | — | — | — | storefront 를 구조적으로 격리 |
+
+**A·B 는 17시간 문제를 거의 못 줄인다** (17 → 14.7시간). 슬롯유휴가 상품당 가용시간의 55%를
+차지하기 때문이다. A·B 의 값어치는 처리량이 아니라 **축 A(storefront 지연) 해소**에 있다 —
+Medusa CPU 부하 −62%, 전역 캐시 폭격 제거. 17시간을 5시간대로 내리는 것은 C 다.
+
+역으로 **C 를 먼저 하면 Medusa 가 포화한다.** C 만 적용하면 464건/시로 올라가는데, A 이전의 Medusa
+비용 10.6초/상품이면 시간당 4,918초가 필요해 1 vCPU(3,600초)를 넘는다. A 를 먼저 적용해 4.0초/상품이
+되면 1,856초 = 52% 로 들어온다. **순서를 지켜야 하는 이유가 이 계산이다.**
+
+## 9. 테스트
+
+- **A**: 배치 delete+create 가 단건 remove+add 와 같은 최종 가격 상태를 만드는지 — 신규 상품 / 기존
+  상품 재동기화 / 멤버십+티어 혼재 세 경우. `apps/core` 통합 테스트 러너는
+  `npm run test:core:integration:local` (워크트리에서는 `COMPOSE_PROJECT_NAME=almondyoung-server` 필수)
+- **A**: 배치 중 일부 상품 실패 시 나머지가 반영되는지 (부분 실패 격리)
+- **B**: flush 주기 안에 같은 handle 이 여러 번 들어와도 태그가 중복 전송되지 않는지
+- **B**: 프로세스 재시작으로 버퍼가 유실돼도 다음 주기 또는 TTL 로 수렴하는지
+- **C**: 인덱스 추가 전후 `EXPLAIN ANALYZE` 비교를 근거로 남긴다
+- **D**: admin path 라우팅이 `/admin/*` 만 정확히 가르는지, store 인스턴스에 cron·subscriber 가 뜨지
+  않는지 부팅 로그로 확인
+
+`web/almondyoung-storefront` 와 `apps/admin-web` 은 컴포넌트 테스트 환경이 없다 — 판정 로직은 순수
+함수로 뽑아야 검증된다.
+
+## 10. 리스크
+
+| 리스크 | 완화 |
+|---|---|
+| A 의 배치 delete 대상 산정이 틀리면 가격 중복 또는 유실 | `action` 신뢰성 확인(§6), 통합 테스트 3케이스 |
+| B 로 신규 상품 노출이 flush 주기만큼 늦어짐 | 기본 60초. 대량등록 총 소요가 4시간대로 줄면 체감 미미 |
+| D 배포 시 ElastiCache 전환 중 인플라이트 BullMQ 잡 유실 | 현재 사이드카도 재시작마다 유실되므로 신뢰도 등급은 동일. 대량등록 비활성 시간대에 전환 |
+| D 가 월 $43 비용 증가 | A·B·C 를 먼저 배포해 실제로 2대가 필요한지 재측정한 뒤 결정 |
+| 대량등록이 도는 동안 다른 도메인 이벤트가 지연 | 후순위 레인이 이미 존재. C 로 클레임이 빨라지면 함께 개선 |
+
+## 11. 참고
+
+- 측정 시 AWS CLI 는 타임스탬프를 이미 KST(+09:00)로 반환한다. Logs Insights 의 `bin()` 결과는 UTC 다.
+  두 축을 섞으면 창이 어긋난다
+- `Sync completed` 로그(`pim-medusa-sync.service.ts:387`)는 핸들러 종료 표지가 아니다. price list
+  동기화와 revalidate 가 그 뒤에 온다
+- `[SLOW]` 미들웨어는 300ms 초과만 남긴다. 시간 귀속은 항상 하한선이다


### PR DESCRIPTION
대량등록이 Medusa 단일 vCPU 를 포화시켜 storefront 를 느리게 만드는 문제를 줄인다.
실측 근거와 설계는 `docs/superpowers/specs/2026-08-13-bulk-import-medusa-load-design.md`,
구현 계획은 `docs/superpowers/plans/2026-08-13-bulk-import-medusa-load.md` 에 있다.

## 무엇이 문제였나 (2026-08-13 라이브 실측)

저트래픽 구간(08-13 04~09시 KST, 5시간)에 Medusa 요청 시간을 엔드포인트에 귀속시킨 결과:

| 총시간 | 건수 | 평균 | 엔드포인트 |
|---:|---:|---:|---|
| 2,548s | 771 | 3.30s | `POST /admin/price-lists/{id}/products` (remove) |
| 2,523s | 770 | 3.28s | `POST /admin/price-lists/{id}/prices/batch` |
| 2,193s | 766 | 2.86s | `POST /admin/products` |
| **≈8,130s** | | | **대량등록 소계 = 창의 45%** |
| ≈1,900s | | | storefront 소계 = 창의 10.5% |

대량등록이 storefront 의 4.3배를 먹고 있었다. 같은 시각 CPU 75.8% 인데 storefront 호출은
전날 같은 시간대(CPU 27.9%)보다 오히려 적었다 — 트래픽이 아니라 백그라운드가 태우고 있었다.

## 무엇을 바꿨나

**1. 대량 출처 판정** — core 가 payload 에 싣던 `origin` 이 channel-adapter TS 타입에 없어
핸들러가 대량 여부를 몰랐다. 타입에 선언하고 `isBulkOrigin` 으로 판정한다.

**2. 신규 상품의 price list `remove` 스킵** — remove(3.30초)는 상품 생성(2.86초)보다 비싼데,
신규 생성 상품에는 지울 항목이 자체가 없다. `upsertProduct` 가 이미 돌려주던 `action` 으로 분기한다.
**대량등록 Medusa 비용의 31%.**

**3. storefront revalidate 배치화** — 상품마다 await 하던 캐시 무효화를 60초 버퍼로 모은다.
측정 구간 771건 중 762건이 5초 타임아웃이었는데 storefront 쪽은 770/770 완료했다 —
그 기다림은 처음부터 무의미했다(상품당 5.0초). 더 중요한 건 그 라우트가 호출마다
**전역 목록 태그와 모든 카테고리 페이지**를 지운다는 것이다. 17시간 × 2,553건이면 캐시가
데워질 틈이 없다. 이제 배치당 1회만 친다. **단건 편집 경로는 즉시 반영 그대로.**

## 배포

- **마이그레이션 0건.** 신규 env `DEFERRED_REVALIDATE_FLUSH_MS` 1개(optional, 기본 60초)
- 배포 순서 제약 없음, 롤백 깔끔
- 동작 변화는 `origin: 'bulk_import'` 이벤트에만 적용

## 알려진 한계

- **버퍼는 인메모리다.** channel-adapter 는 `enableShutdownHooks()` 를 부르지 않으므로
  ECS 태스크 교체 시 `onModuleDestroy` 가 안 돈다. 최대 한 flush 주기분의
  `pim-detail-{handle}` 무효화가 유실되고, 캐시 TTL(1시간)로 자연 복구된다.
  주석에 사실대로 적어뒀다. `enableShutdownHooks()` 도입은 InboxWorker 의 25초 드레인도
  같이 켜므로 별도 검증이 필요한 후속 과제다.
- 기존 실패 4개 suite(`medusa.client.spec` 등)는 `origin/develop` 에서 물려받은 것이다.
  해당 소스를 이 브랜치가 건드리지 않음을 `git diff --stat` 으로 확인했다.
  통과 수는 207 → 210.

## 후속 (이 PR 범위 밖)

계획서의 Task 4~6 은 의도적으로 미실행이다.

- **Task 4 (price list 교차 배치)** — 남은 3.28초를 회수하지만 인메모리 버퍼라 유실 위험을
  거래한다. 이 PR 배포 후 재측정하고 판단할 것
- **Task 5~6 (인박스 클레임 유휴)** — 슬롯 가동률이 45%라 상품당 26.6초 중 절반이
  큐 대기다. **17시간을 5시간대로 내리는 건 이쪽이다.** 프로덕션 `EXPLAIN ANALYZE` 가 선행

이 PR 자체는 처리량(17시간)을 크게 줄이지 않는다 — 목표는 **Medusa CPU 부하와
storefront 캐시 적중률**이다.

## 재측정 방법

배포 후 `Sync finished: {masterId} ({durationMs}ms)` 로그의 `durationMs` 를 집계한다.
성공/실패 양쪽에 남는다.

https://claude.ai/code/session_01RxLvaYzJJXi76zMB1J5RCL