### PR TITLE
fix(security): IDOR evidence 좌표 드리프트 복구 + file-service staff 읽기 경로 기록

### DIFF
--- a/docs/api-authz-audit-2026-08.md
+++ b/docs/api-authz-audit-2026-08.md
@@ -188,7 +188,7 @@ AST 로 판정할 수 없다. **초록불을 "IDOR 없음"으로 읽지 말 것.
   때문에 `iss` 클레임 없는 HS256 토큰은 **issuer/audience 검증을 통째로 건너뛴다**. 레거시 Medusa
   토큰 호환이 의도. IdP·Medusa·core·wallet·file-service 가 `AUTH_SECRET` 하나를 공유하므로 한
   서비스에서 시크릿이 새면 전 서비스 위조가 된다.
-  - **`apps/file-service/src/access/file-access.ts:58-60`** — 같은 신뢰구조의 다른 사례.
+  - **`apps/file-service/src/access/file-access.ts:75-76`** — 같은 신뢰구조의 다른 사례.
     `scopes: ['master']` 만 든 서비스 위임 토큰은 `isMasterOrOwner()` 의 파일 소유권 검사를
     전량 통과한다. IDOR 은 아니다(정상 우회 경로다) — 다만 `master` 역할/스코프를 실을 수 있는
     토큰이 새면 전 사용자 파일이 열린다. 같은 서비스의

--- a/scripts/security/idor-reviewed.spec.ts
+++ b/scripts/security/idor-reviewed.spec.ts
@@ -183,21 +183,21 @@ const IDOR_REVIEWED: Record<string, { verdict: Verdict; evidence: string; predic
   },
   'file-service DELETE /files/:fileId': {
     verdict: 'SAFE',
-    evidence: 'apps/file-service/src/access/file-access.ts:55',
+    evidence: 'apps/file-service/src/access/file-access.ts:68',
     predicate: 'if (file.uploadedBy === user.userId) return true;',
-    note: 'LifecycleController.deleteFile -> FileAccess.delete(fileId, user) (file-access.ts:42) -> isMasterOrOwner(file, user) at file-access.ts:47 gates the softDelete call on the same file.uploadedBy === user.userId check; repo.softDelete(id) itself (file.repository.ts:44-55) only filters by eq(uploads.id, id), so all ownership enforcement lives in this application-layer check.',
+    note: 'LifecycleController.deleteFile -> FileAccess.delete(fileId, user) (file-access.ts:51) -> isMasterOrOwner(file, user) at file-access.ts:56 gates the softDelete call on the same file.uploadedBy === user.userId check; repo.softDelete(id) itself (file.repository.ts:44) only filters by eq(uploads.id, id), so all ownership enforcement lives in this application-layer check. Delete is NOT widened by the STAFF_READABLE_CONTEXT_IDS path added in 235197151 — that path lives in loadReadable only.',
   },
   'file-service GET /files/:fileId/download': {
     verdict: 'SAFE',
-    evidence: 'apps/file-service/src/access/file-access.ts:55',
+    evidence: 'apps/file-service/src/access/file-access.ts:68',
     predicate: 'if (file.uploadedBy === user.userId) return true;',
-    note: "DownloadController.getSignedUrl -> DownloadService.getSignedUrl (apps/file-service/src/download/download.service.ts:21) -> FileAccess.loadReadable(fileId, user) (file-access.ts:20) -> isMasterOrOwner (file-access.ts:54-64) compares file.uploadedBy against caller's own userId before returning the row; non-owner/non-public/non-master throws ForbiddenError.",
+    note: "DownloadController.getSignedUrl -> DownloadService.getSignedUrl (apps/file-service/src/download/download.service.ts:21) -> FileAccess.loadReadable(fileId, user) (file-access.ts:26) -> isMasterOrOwner (file-access.ts:67-77) compares file.uploadedBy against caller's own userId before returning the row. 235197151 added a fourth allow path at file-access.ts:37 — a STAFF_ROLES caller may read any file whose contextId is in STAFF_READABLE_CONTEXT_IDS (digital-asset only). That is an intentional role-based grant for admin review, not an IDOR: it is scoped by context, not by object id, and file-access.spec.ts asserts admin still cannot read a business-license file. Everything else throws ForbiddenError.",
   },
   'file-service GET /files/:fileId/metadata': {
     verdict: 'SAFE',
-    evidence: 'apps/file-service/src/access/file-access.ts:55',
+    evidence: 'apps/file-service/src/access/file-access.ts:68',
     predicate: 'if (file.uploadedBy === user.userId) return true;',
-    note: 'DownloadController.getMetadata -> DownloadService.getMetadata (download.service.ts:50) -> FileAccess.loadReadable(fileId, user) -> same isMasterOrOwner ownership check as the download route.',
+    note: 'DownloadController.getMetadata -> DownloadService.getMetadata (download.service.ts:50) -> FileAccess.loadReadable(fileId, user) -> same isMasterOrOwner ownership check as the download route, and the same STAFF_READABLE_CONTEXT_IDS allow path at file-access.ts:37.',
   },
   'file-service POST /files/batch-upload': {
     verdict: 'N/A',


### PR DESCRIPTION
`develop` 의 `gates` 가 빨갰다 (`scripts/security/idor-reviewed.spec.ts` 좌표 드리프트 감지 테스트, file-service 3개 라우트). 프로덕션 코드 변경 없음 — **감사 기록만 사실에 맞춘다.**

## 근본 원인

`235197151` (file-service 다운로드 기능) 이 `file-access.ts` 에 13줄을 추가해 predicate 를 `:55` → `:68` 로 밀었는데 IDOR evidence 가 갱신되지 않았다.

**단순 좌표 밀림이 아니었다.** 같은 커밋이 `loadReadable` 에 **네 번째 허용 경로**를 추가했다 (`file-access.ts:37`):

```ts
if (this.isStaff(user) && STAFF_READABLE_CONTEXT_IDS.includes(file.contextId)) return file;
```

`GET /files/:fileId/download` 과 `/metadata` 의 evidence note 는 여전히 *"non-owner/non-public/non-master throws ForbiddenError"* 라고 적고 있었다 — 이제 사실이 아니다. **이 테스트가 잡아낸 건 줄 번호가 아니라 접근 모델 변경이다.** 설계 의도대로 작동했다.

## 판정: SAFE 유지

새 경로는 object id 가 아니라 `contextId` 로 좁혀지는 **의도적 role 기반 부여**(어드민의 디지털 상품 파일 검수)이고, `file-access.spec.ts` 가 admin 이 `business-license` 컨텍스트는 못 읽는 음성 케이스를 잠그고 있다. IDOR(타인 객체를 id 조작으로 열람)이 아니다. `delete` 는 `isMasterOrOwner` 만 쓰므로 안 넓어졌다.

verdict 는 건드리지 않고 note 만 고쳤다. 원 감사(`f9e96af9d`)의 SAFE 근거가 부정확해진 첫 사례라 재확인 여지는 이슈로 남긴다.

## 변경 (2파일 7줄)

- `evidence` `:55` → `:68` (3건)
- 두 read 라우트 note 에 `STAFF_READABLE_CONTEXT_IDS` 경로 기록 + delete 는 안 넓어졌음 명시
- note 안의 낡은 좌표 5개 갱신 (`42→51`, `47→56`, `20→26`, `54-64→67-77`, `44-55→44`)
- `docs/api-authz-audit-2026-08.md` P2 항목 좌표 `58-60` → `75-76` (같은 커밋이 민 것)

## 검증

| 게이트 | 결과 |
|---|---|
| `npm run type-check` | 에러 0 |
| `npx jest --maxWorkers=2` | **4,109 중 3,438 통과, 실패 0** (직전 develop 은 1 실패) |

통합 게이트는 이 변경과 무관해 돌리지 않았다.