### PR TITLE
refactor(fulfillment)!: 피킹 계획 층 곁다리 정리 — requestedStrategy·이중 창고 검사 제거 (ADR-0030 PR 2)

### DIFF
--- a/apps/core/src/modules/fulfillment/controllers/picking-v2.controller.spec.ts
+++ b/apps/core/src/modules/fulfillment/controllers/picking-v2.controller.spec.ts
@@ -172,11 +172,7 @@ describe('PickingCommandV2Controller generic strategy contract', () => {
       completePick: jest.fn(),
     };
     const controller = new PickingCommandV2Controller(picking as never);
-    await controller.plan(
-      { strategy: 'discrete', batchId: ids.batchId, shipmentIds: [ids.shipmentId] },
-      'plan-key',
-      actor,
-    );
+    await controller.plan({ batchId: ids.batchId, shipmentIds: [ids.shipmentId] }, 'plan-key', actor);
     await controller.start({ batchId: ids.batchId, planId: ids.planId }, 'start-key', actor);
     await controller.scan({ ...ids, quantity: 2, expectedLeaseVersion: 1 }, 'scan-key', actor);
     await controller.handoff(
@@ -211,7 +207,6 @@ describe('PickingCommandV2Controller generic strategy contract', () => {
       shipmentIds: [ids.shipmentId],
       actorId: 'worker-1',
       idempotencyKey: 'plan-key',
-      requestedStrategy: 'discrete',
     });
     expect(picking.scan).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/core/src/modules/fulfillment/controllers/picking-v2.controller.ts
+++ b/apps/core/src/modules/fulfillment/controllers/picking-v2.controller.ts
@@ -105,7 +105,6 @@ export class PickingCommandV2Controller {
       shipmentIds: dto.shipmentIds,
       actorId: this.actor(user).id,
       idempotencyKey: this.idempotencyKey(idempotencyKey),
-      requestedStrategy: dto.strategy,
     });
   }
 

--- a/apps/core/src/modules/fulfillment/dto/picking-v2.dto.ts
+++ b/apps/core/src/modules/fulfillment/dto/picking-v2.dto.ts
@@ -5,7 +5,6 @@ import {
   IsIn,
   IsInt,
   IsNotEmpty,
-  IsOptional,
   IsString,
   IsUUID,
   Matches,
@@ -16,11 +15,6 @@ import {
 const PHYSICAL_CART_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 
 export class PlanPickingV2Dto {
-  /** @deprecated 배치의 pickingMethod 에서 파생된다. 보내면 일치 검증만 한다. */
-  @IsOptional()
-  @IsIn(['discrete', 'aggregate_then_sort', 'pick_to_tote'])
-  strategy?: 'discrete' | 'aggregate_then_sort' | 'pick_to_tote';
-
   @IsUUID()
   batchId: string;
 

--- a/apps/core/src/modules/fulfillment/picking/aggregate-then-sort.strategy.spec.ts
+++ b/apps/core/src/modules/fulfillment/picking/aggregate-then-sort.strategy.spec.ts
@@ -18,7 +18,6 @@ import {
 import { planPicking, startPicking } from './plan/picking-plan';
 import {
   assertPlanningEligibility,
-  assertWarehouseConfiguration,
   lockAggregate,
   lockSourceCapacities,
   planStalenessReason,
@@ -50,7 +49,6 @@ jest.mock('./plan/picking-plan.queries', () => ({
 
 const PLAN_LAYER_MOCKS = [
   assertPlanningEligibility,
-  assertWarehouseConfiguration,
   lockAggregate,
   lockSourceCapacities,
   planStalenessReason,
@@ -497,7 +495,6 @@ function createHarness(): AggregateHarness {
     workItems: Object.values(state.workItems),
   };
   jest.mocked(lockAggregate).mockResolvedValue(aggregate as never);
-  jest.mocked(assertWarehouseConfiguration).mockResolvedValue(undefined);
   jest.mocked(assertPlanningEligibility).mockResolvedValue(undefined);
   jest
     .mocked(lockSourceCapacities)

--- a/apps/core/src/modules/fulfillment/picking/pick-to-tote.strategy.spec.ts
+++ b/apps/core/src/modules/fulfillment/picking/pick-to-tote.strategy.spec.ts
@@ -20,7 +20,6 @@ import {
 import { planPicking, startPicking } from './plan/picking-plan';
 import {
   assertPlanningEligibility,
-  assertWarehouseConfiguration,
   lockAggregate,
   lockSourceCapacities,
   planStalenessReason,
@@ -1101,7 +1100,6 @@ function createPickToToteContractFixture(): PickingStrategyContractFixture {
     workItems: Object.values(state.workItems),
   };
   jest.mocked(lockAggregate).mockResolvedValue(aggregate as never);
-  jest.mocked(assertWarehouseConfiguration).mockResolvedValue(undefined);
   jest.mocked(assertPlanningEligibility).mockResolvedValue(undefined);
   jest.mocked(lockSourceCapacities).mockResolvedValue([
     {

--- a/apps/core/src/modules/fulfillment/picking/picking-strategy.contract.spec.ts
+++ b/apps/core/src/modules/fulfillment/picking/picking-strategy.contract.spec.ts
@@ -12,7 +12,6 @@ import { DiscretePickingStrategy } from './discrete-picking.strategy';
 import { planPicking, startPicking } from './plan/picking-plan';
 import {
   assertPlanningEligibility,
-  assertWarehouseConfiguration,
   lockAggregate,
   lockSourceCapacities,
   planStalenessReason,
@@ -42,7 +41,6 @@ jest.mock('./plan/picking-plan.queries', () => ({
 
 const PLAN_LAYER_MOCKS = [
   assertPlanningEligibility,
-  assertWarehouseConfiguration,
   lockAggregate,
   lockSourceCapacities,
   planStalenessReason,
@@ -644,7 +642,6 @@ function createProductionDiscreteFixture(): PickingStrategyContractFixture {
     workItems: Object.values(state.workItems),
   };
   jest.mocked(lockAggregate).mockResolvedValue(aggregate as never);
-  jest.mocked(assertWarehouseConfiguration).mockResolvedValue(undefined);
   jest.mocked(assertPlanningEligibility).mockResolvedValue(undefined);
   jest.mocked(lockSourceCapacities).mockResolvedValue([
     {

--- a/apps/core/src/modules/fulfillment/picking/picking-strategy.interface.ts
+++ b/apps/core/src/modules/fulfillment/picking/picking-strategy.interface.ts
@@ -20,12 +20,6 @@ export interface PlanPickingInput {
   shipmentIds: string[];
   actorId: string;
   idempotencyKey: string;
-  /**
-   * 호출자가 보낸 전략(선택). 실제 전략은 배치의 pickingMethod 에서 파생되며,
-   * 이 값이 있으면 파생값과 일치하는지만 검증한다. 외부 호출자 완충용이고
-   * 후속 정리에서 제거 대상이다.
-   */
-  requestedStrategy?: PickingStrategyName;
 }
 
 export interface StartPickingInput {

--- a/apps/core/src/modules/fulfillment/picking/plan/picking-plan.locks.ts
+++ b/apps/core/src/modules/fulfillment/picking/plan/picking-plan.locks.ts
@@ -398,27 +398,3 @@ export async function planStalenessReason(
   }
   return null;
 }
-
-/**
- * Second warehouse check, reached only after `PickingStrategyRegistry.resolveForWarehouse` has
- * already made the same assertion with a different error code. ADR-0030 §3.5 retires this in a
- * separate, independently revertable commit because it is a behaviour change, not a pure move.
- */
-export async function assertWarehouseConfiguration(
-  trx: DbTx,
-  warehouseId: string,
-  strategyName: PickingStrategyName,
-): Promise<void> {
-  const [warehouse] = await trx
-    .select({ supportedPickingStrategies: wmsTables.warehouses.supportedPickingStrategies })
-    .from(wmsTables.warehouses)
-    .where(eq(wmsTables.warehouses.id, warehouseId))
-    .limit(1);
-  if (!warehouse) throw new NotFoundException(`Warehouse ${warehouseId} not found`);
-  if (!warehouse.supportedPickingStrategies?.includes(strategyName)) {
-    throw conflict(
-      'PICKING_STRATEGY_NOT_CONFIGURED',
-      `Warehouse ${warehouseId} does not explicitly enable ${strategyName}`,
-    );
-  }
-}

--- a/apps/core/src/modules/fulfillment/picking/plan/picking-plan.spec.ts
+++ b/apps/core/src/modules/fulfillment/picking/plan/picking-plan.spec.ts
@@ -5,7 +5,6 @@ import { planPicking } from './picking-plan';
 import { conflict, errorMessage, isPlanValidationError } from './picking-plan.errors';
 import {
   assertPlanningEligibility,
-  assertWarehouseConfiguration,
   lockAggregate,
   lockSourceCapacities,
   planStalenessReason,
@@ -332,7 +331,6 @@ describe('picking plan layer — layer 1 pure functions', () => {
 describe('planPicking', () => {
   beforeEach(() => {
     jest.mocked(lockAggregate).mockResolvedValue(LOCKED_AGGREGATE as never);
-    jest.mocked(assertWarehouseConfiguration).mockResolvedValue(undefined);
     jest.mocked(assertPlanningEligibility).mockResolvedValue(undefined);
     jest.mocked(planStalenessReason).mockResolvedValue(null);
     jest

--- a/apps/core/src/modules/fulfillment/picking/plan/picking-plan.ts
+++ b/apps/core/src/modules/fulfillment/picking/plan/picking-plan.ts
@@ -11,7 +11,6 @@ import {
 import { conflict, errorMessage, isPlanValidationError } from './picking-plan.errors';
 import {
   assertPlanningEligibility,
-  assertWarehouseConfiguration,
   lockAggregate,
   lockSourceCapacities,
   planStalenessReason,
@@ -141,7 +140,6 @@ export async function planPicking(
         }
         let staleReason: string | null = null;
         try {
-          await assertWarehouseConfiguration(trx, aggregate.batch.warehouseId, strategyName);
           await assertPlanningEligibility(trx, deps.waybills, aggregate, storedShipmentIds);
           staleReason = await planStalenessReason(trx, deps.controlledStock, openPlan.id, aggregate, strategyName);
         } catch (error) {
@@ -180,7 +178,6 @@ export async function planPicking(
         return { response, resourceType: 'picking_plan', resourceId: openPlan.id };
       }
 
-      await assertWarehouseConfiguration(trx, aggregate.batch.warehouseId, strategyName);
       await assertPlanningEligibility(trx, deps.waybills, aggregate, shipmentIds);
 
       const capacities = await lockSourceCapacities(trx, deps.controlledStock, aggregate);
@@ -317,7 +314,6 @@ export async function startPicking(
       let invalidationReason: string | null = null;
       try {
         const aggregate = await lockAggregate(trx, deps.invariant, input.batchId, shipmentIds);
-        await assertWarehouseConfiguration(trx, aggregate.batch.warehouseId, strategyName);
         await assertPlanningEligibility(trx, deps.waybills, aggregate, shipmentIds);
         invalidationReason = await planStalenessReason(
           trx,

--- a/apps/core/src/modules/fulfillment/services/outbound-v2-warehouse-scenarios.integration.spec.ts
+++ b/apps/core/src/modules/fulfillment/services/outbound-v2-warehouse-scenarios.integration.spec.ts
@@ -653,7 +653,6 @@ describeIfDb('Outbound V2 warehouse release scenarios 06-10', () => {
       batchId,
       shipmentIds: [member.shipment.id],
       actorId: worker.id,
-      requestedStrategy: 'discrete',
       idempotencyKey: `discrete-plan-${randomUUID()}`,
     });
     expect(plan.state).toBe('planned');
@@ -1271,30 +1270,6 @@ describeIfDb('Outbound V2 warehouse release scenarios 06-10', () => {
     });
   });
 
-  it('refuses a strategy that contradicts the batch picking method', async () => {
-    await inRollbackTx(db, async (tx) => {
-      // 창고는 두 전략을 모두 지원하지만 배치는 individual 이다.
-      const world = await seedWorld(tx, [2], ['discrete', 'aggregate_then_sort']);
-      await seedRegisteredWaybills(tx, world);
-      const services = makeServices(tx);
-      const manager = { id: randomUUID(), roles: ['master'] };
-      const worker = { id: randomUUID(), roles: ['warehouse_worker'] };
-      const { batch } = await createBatchWithShipments(services, world, manager);
-
-      await expect(
-        services.picking.plan({
-          batchId: batch.batchId,
-          shipmentIds: [world.shipments[0].shipment.id],
-          actorId: worker.id,
-          idempotencyKey: `mismatch-plan-${randomUUID()}`,
-          requestedStrategy: 'aggregate_then_sort',
-        }),
-      ).rejects.toMatchObject({
-        response: { error: 'PICKING_STRATEGY_BATCH_METHOD_MISMATCH' },
-      });
-    });
-  });
-
   // ADR-0030 §3.5: 창고가 해당 전략을 켰는지 확인하는 검사의 소유자는
   // `PickingStrategyRegistry.resolveForWarehouse` 다 — plan 도 start 도 계획 층에 들어가기 전에
   // 이걸 먼저 통과해야 한다. 아래 세 케이스는 그 한 벌만으로 plan/replan/start 세 지점이 모두
@@ -1474,25 +1449,24 @@ describeIfDb('Outbound V2 warehouse release scenarios 06-10', () => {
       const { batch } = await createBatchWithShipments(services, world, manager);
       const shipmentIds = [world.shipments[0].shipment.id];
 
-      await services.picking.plan({
+      const first = await services.picking.plan({
         batchId: batch.batchId,
         shipmentIds,
         actorId: worker.id,
         idempotencyKey: `replan-first-${randomUUID()}`,
       });
+      expect(first.state).toBe('planned');
 
-      // 재plan 도 같은 경로를 타므로 배치 방식과 어긋나는 전략은 여전히 막힌다.
-      await expect(
-        services.picking.plan({
-          batchId: batch.batchId,
-          shipmentIds,
-          actorId: worker.id,
-          idempotencyKey: `replan-second-${randomUUID()}`,
-          requestedStrategy: 'aggregate_then_sort',
-        }),
-      ).rejects.toMatchObject({
-        response: { error: 'PICKING_STRATEGY_BATCH_METHOD_MISMATCH' },
+      // 창고가 aggregate_then_sort 도 지원하지만 배치는 individual 이므로 재plan 도 discrete 로 파생된다.
+      const second = await services.picking.plan({
+        batchId: batch.batchId,
+        shipmentIds,
+        actorId: worker.id,
+        idempotencyKey: `replan-second-${randomUUID()}`,
       });
+      expect(second.state).toBe('planned');
+      if (second.state !== 'planned') throw new Error(second.reason);
+      expect(second.strategy).toBe('discrete');
     });
   });
 });

--- a/apps/core/src/modules/fulfillment/services/outbound-v2-warehouse-scenarios.integration.spec.ts
+++ b/apps/core/src/modules/fulfillment/services/outbound-v2-warehouse-scenarios.integration.spec.ts
@@ -7,6 +7,7 @@ import {
   SHIPMENT_STREAM,
 } from '@packages/event-contracts/streams';
 import { randomUUID } from 'crypto';
+import { ConflictException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { and, eq, inArray, ne, sql } from 'drizzle-orm';
 import * as postgres from 'postgres';
@@ -25,6 +26,7 @@ import { AggregateThenSortPickingStrategy } from '../picking/aggregate-then-sort
 import { DiscretePickingStrategy } from '../picking/discrete-picking.strategy';
 import { PickToTotePickingStrategy } from '../picking/pick-to-tote.strategy';
 import { PickingStrategyRegistry } from '../picking/picking-strategy.registry';
+import type { PickingStrategyName } from '../picking/picking-strategy.interface';
 import { inRollbackTx, makeDb, seedHolder, seedSku, seedWarehouseWithZone } from './__support__';
 import { BatchInventorySessionService } from './batch-inventory-session.service';
 import { canonicalFulfillmentRequestHash, FulfillmentCommandService } from './fulfillment-command.service';
@@ -1290,6 +1292,149 @@ describeIfDb('Outbound V2 warehouse release scenarios 06-10', () => {
       ).rejects.toMatchObject({
         response: { error: 'PICKING_STRATEGY_BATCH_METHOD_MISMATCH' },
       });
+    });
+  });
+
+  // ADR-0030 §3.5: 창고가 해당 전략을 켰는지 확인하는 검사의 소유자는
+  // `PickingStrategyRegistry.resolveForWarehouse` 다 — plan 도 start 도 계획 층에 들어가기 전에
+  // 이걸 먼저 통과해야 한다. 아래 세 케이스는 그 한 벌만으로 plan/replan/start 세 지점이 모두
+  // 막히는지를 실 DB 로 고정한다. 단언을 registry 쪽 메시지에 맞춘 것은 의도적이다 — 검사가
+  // registry 밖으로 새어 나가거나 사라지면 여기서 깨진다.
+  //
+  // 배치 생성 자체가 창고 지원 여부를 게이트하므로(`OUTBOUND_BATCH_METHOD_NOT_SUPPORTED`), 미설정 창고는
+  // 배치를 만든 뒤 설정을 회수해서 만든다 — 운영에서 창고 설정이 바뀌면 실제로 이 상태가 된다.
+  async function revokeWarehouseStrategies(tx: DbTx, warehouseId: string, remaining: PickingStrategyName[]) {
+    await tx
+      .update(wmsTables.warehouses)
+      .set({ supportedPickingStrategies: remaining })
+      .where(eq(wmsTables.warehouses.id, warehouseId));
+  }
+
+  // `expect.stringContaining` 은 any 를 돌려줘 toMatchObject 안에 넣으면 lint 가 막는다. 잡아서
+  // 좁히면 클래스와 메시지를 둘 다 타입 안전하게 고정할 수 있다.
+  async function expectConflict(promise: Promise<unknown>, messagePart: string) {
+    let caught: unknown;
+    try {
+      await promise;
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(ConflictException);
+    if (!(caught instanceof ConflictException)) throw new Error('expected a ConflictException');
+    expect(caught.message).toContain(messagePart);
+  }
+
+  it('refuses to plan on a warehouse whose picking strategy configuration was emptied', async () => {
+    await inRollbackTx(db, async (tx) => {
+      const world = await seedWorld(tx, [2], ['discrete']);
+      await seedRegisteredWaybills(tx, world);
+      const services = makeServices(tx);
+      const manager = { id: randomUUID(), roles: ['master'] };
+      const worker = { id: randomUUID(), roles: ['warehouse_worker'] };
+      const { batch } = await createBatchWithShipments(services, world, manager);
+      await revokeWarehouseStrategies(tx, world.warehouseId, []);
+
+      await expectConflict(
+        services.picking.plan({
+          batchId: batch.batchId,
+          shipmentIds: [world.shipments[0].shipment.id],
+          actorId: worker.id,
+          idempotencyKey: `unconfigured-plan-${randomUUID()}`,
+        }),
+        'has no picking strategy configuration',
+      );
+
+      // 거부는 어떤 계획 행도 남기지 않는다.
+      const plans = await tx
+        .select({ id: wmsTables.pickingPlans.id })
+        .from(wmsTables.pickingPlans)
+        .where(eq(wmsTables.pickingPlans.batchId, batch.batchId));
+      expect(plans).toHaveLength(0);
+    });
+  });
+
+  it('refuses to replan an existing draft after the batch strategy is disabled for the warehouse', async () => {
+    await inRollbackTx(db, async (tx) => {
+      const world = await seedWorld(tx, [2], ['discrete']);
+      await seedRegisteredWaybills(tx, world);
+      const services = makeServices(tx);
+      const manager = { id: randomUUID(), roles: ['master'] };
+      const worker = { id: randomUUID(), roles: ['warehouse_worker'] };
+      const { batch } = await createBatchWithShipments(services, world, manager);
+      const shipmentIds = [world.shipments[0].shipment.id];
+
+      const first = await services.picking.plan({
+        batchId: batch.batchId,
+        shipmentIds,
+        actorId: worker.id,
+        idempotencyKey: `revoked-replan-first-${randomUUID()}`,
+      });
+      expect(first.state).toBe('planned');
+
+      // 창고는 여전히 설정돼 있지만 배치가 요구하는 discrete 만 빠졌다.
+      await revokeWarehouseStrategies(tx, world.warehouseId, ['pick_to_tote']);
+
+      await expectConflict(
+        services.picking.plan({
+          batchId: batch.batchId,
+          shipmentIds,
+          actorId: worker.id,
+          idempotencyKey: `revoked-replan-second-${randomUUID()}`,
+        }),
+        'is not enabled for warehouse',
+      );
+
+      // 기존 draft 는 무효화되지 않고 그대로 남는다 — 거부는 draft 경로에 닿기 전에 일어난다.
+      if (first.state !== 'planned') throw new Error(first.reason);
+      const [stored] = await tx
+        .select({ status: wmsTables.pickingPlans.status })
+        .from(wmsTables.pickingPlans)
+        .where(eq(wmsTables.pickingPlans.id, first.planId));
+      expect(stored.status).toBe('draft');
+    });
+  });
+
+  it('refuses to start a planned batch after the strategy is disabled for the warehouse', async () => {
+    await inRollbackTx(db, async (tx) => {
+      const world = await seedWorld(tx, [2], ['discrete']);
+      await seedRegisteredWaybills(tx, world);
+      const services = makeServices(tx);
+      const manager = { id: randomUUID(), roles: ['master'] };
+      const worker = { id: randomUUID(), roles: ['warehouse_worker'] };
+      const { batch } = await createBatchWithShipments(services, world, manager);
+
+      const planned = await services.picking.plan({
+        batchId: batch.batchId,
+        shipmentIds: [world.shipments[0].shipment.id],
+        actorId: worker.id,
+        idempotencyKey: `revoked-start-plan-${randomUUID()}`,
+      });
+      expect(planned.state).toBe('planned');
+      if (planned.state !== 'planned') throw new Error(planned.reason);
+
+      await revokeWarehouseStrategies(tx, world.warehouseId, ['pick_to_tote']);
+
+      await expectConflict(
+        services.picking.start({
+          batchId: batch.batchId,
+          planId: planned.planId,
+          actorId: worker.id,
+          idempotencyKey: `revoked-start-${randomUUID()}`,
+        }),
+        'is not enabled for warehouse',
+      );
+
+      // 세션도 만들어지지 않고 계획은 draft 로 남는다.
+      const sessions = await tx
+        .select({ id: wmsTables.batchInventorySessions.id })
+        .from(wmsTables.batchInventorySessions)
+        .where(eq(wmsTables.batchInventorySessions.batchId, batch.batchId));
+      expect(sessions).toHaveLength(0);
+      const [stored] = await tx
+        .select({ status: wmsTables.pickingPlans.status })
+        .from(wmsTables.pickingPlans)
+        .where(eq(wmsTables.pickingPlans.id, planned.planId));
+      expect(stored.status).toBe('draft');
     });
   });
 

--- a/apps/core/src/modules/fulfillment/services/picking-process.service.ts
+++ b/apps/core/src/modules/fulfillment/services/picking-process.service.ts
@@ -107,13 +107,6 @@ export class PickingProcessService {
         .limit(1);
       if (!batch) throw new NotFoundException(`Outbound batch ${input.batchId} not found`);
       const derived = STRATEGY_BY_PICKING_METHOD[batch.pickingMethod];
-      if (input.requestedStrategy && input.requestedStrategy !== derived) {
-        throw new ConflictException({
-          code: 'PICKING_STRATEGY_BATCH_METHOD_MISMATCH',
-          error: 'PICKING_STRATEGY_BATCH_METHOD_MISMATCH',
-          message: `Batch ${input.batchId} is ${batch.pickingMethod}; strategy ${input.requestedStrategy} is not allowed`,
-        });
-      }
       // 창고 허용 검사는 유지한다. 반환된 전략 객체는 버린다 — 계획 층은 전략에 의존하지 않는다.
       await this.requiredRegistry().resolveForWarehouse(derived, batch.warehouseId, trx);
       return planPicking(this.planDeps, derived, input, trx);


### PR DESCRIPTION
ADR-0030 §6 의 **PR 2 — 행동 변경**. PR 1(#633) 이 만든 `plan/` 모듈 안의 두 대상을
정리한다. 커밋 3개는 각각 독립 revert 가능하다.

설계 근거: `docs/adr/0030-picking-plan-layer-extraction.md` §3.5 ·
`docs/superpowers/specs/2026-08-15-picking-plan-layer-design.md` §6

## 커밋

| # | 커밋 | 성격 |
|---|---|---|
| 0 | `6c764c3ef` 「전략 미설정 창고에서 plan·replan·start 거부」통합 케이스 3건 추가 | 테스트 추가 — 커밋 2 의 안전망 |
| 1 | `0f720c99b` `requestedStrategy` 제거 | **API 계약 변경** |
| 2 | `99516d26b` `assertWarehouseConfiguration` 삭제 | **행동 변경** |

## 커밋 0 — 스펙이 비워 둔 실행 확인을 채운다

스펙 §3.5 는 이중 창고 검사 제거를 **"코드 읽기로만 판단했고 실행으로 확인하지 않았다"**
고 명시하면서, 착수 전에 「전략 미설정 창고에서 plan 거부」케이스가 있는지 확인하고
없으면 추가하라고 했다. 실측 결과 **없었다** — 기존 통합 스펙은 전부
`supportedPickingStrategies` 를 *설정해서 켜는* 쪽이고,
`outbound-batch-orchestrator.integration.spec.ts:337,352` 는 배치 생성 단계지 plan 단계가
아니다.

그래서 `assertWarehouseConfiguration` 의 도달 지점 3곳에 **1:1 대응**하는 케이스를
`outbound-v2-warehouse-scenarios.integration.spec.ts` 에 추가했다:

- 신규 plan (`picking-plan.ts:183`) — 창고 설정을 비운 경우
- draft replan (`picking-plan.ts:144`) — 배치가 쓰는 전략만 회수한 경우
- start (`picking-plan.ts:320`) — 계획 후 전략을 회수한 경우

**단언을 registry 쪽 메시지에 고정한 것이 핵심이다** (`has no picking strategy
configuration` / `is not enabled for warehouse`). 계획 층 벌의 메시지
(`does not explicitly enable`) 가 아니므로, 커밋 2 로 계획 층 벌이 사라져도 registry
한 벌이 살아 있는 한 그대로 통과한다. **실제로 커밋 2 전후 모두 통과함을 확인했다** —
스펙이 비워 둔 실행 확인이 이걸로 채워졌다.

미설정 창고는 배치 생성 자체가 게이트하므로(`OUTBOUND_BATCH_METHOD_NOT_SUPPORTED`)
**배치를 만든 뒤 설정을 회수해서** 만든다. 운영에서 창고 설정이 바뀌면 실제로 이 상태가
된다.

## 커밋 1 — `requestedStrategy` 제거 ⚠️ BREAKING

`POST /picking/plans` 의 `strategy` 필드가 사라진다. **보내면 이제 DTO whitelist 검증에
걸린다.**

전략은 배치의 `pickingMethod` 에서 파생되고(`STRATEGY_BY_PICKING_METHOD`),
`requestedStrategy` 는 그 파생값과 일치하는지만 확인하는 완충 장치였다. 필드 주석
스스로 "후속 정리에서 제거 대상" 이라 적고 있었다. 실호출자 측정:

- admin-web `picking.client.ts` — 이 필드를 보내지 않는다
- warehouse-app — `simple-outbound` 경로만 쓰고 이 DTO 를 안 탄다
- core 내부 `simple-outbound.service.ts` — 필드 없이 부른다

측정상 0이지만 **미지의 외부 호출자 가능성은 남는다.** 문제가 되면 이 커밋만 revert 하면
된다(충돌 없음 확인).

통합 스펙 2건 처리:

- `refuses a strategy that contradicts the batch picking method` — **삭제**. 테스트
  전체가 `PICKING_STRATEGY_BATCH_METHOD_MISMATCH` 만 검증하는데, 필드가 없으면 그 경로에
  도달할 방법 자체가 없다. 커버리지가 줄어서가 아니라 **표현할 수 없는 상태**가 됐기
  때문이다.
- `applies the same derivation to a replanned batch` — **축소**. 불일치 단언만 걷어내고,
  재plan 이 배치에서 `discrete` 를 파생하는지 확인하는 쪽으로 바꿨다. 창고가
  `aggregate_then_sort` 도 지원하는 세계라 파생 자체는 제거된 필드와 무관하게 여전히
  유의미하다.

## 커밋 2 — 이중 창고 허용 검사 제거

창고가 해당 전략을 켰는지 확인하는 검사가 두 벌이었다:

1. `PickingStrategyRegistry.resolveForWarehouse` — plan · registerTote · 그 외 모든
   연산(`withPlanStrategy`)에 걸린다
2. 계획 층 `assertWarehouseConfiguration` — 같은 행을 다시 읽어 같은 검사를
   `PICKING_STRATEGY_NOT_CONFIGURED` 라는 다른 코드로 한 번 더 한다

둘째를 지운다. `PickingProcessService.plan` / `.start` 는 `planPicking` / `startPicking`
을 부르기 전에 이미 registry 검사를 통과시키므로, 계획 층 벌은 도달 지점 3곳 모두에서
실행될 일이 없었다. 에러코드 `PICKING_STRATEGY_NOT_CONFIGURED` 는 admin-web ·
warehouse-app · 테스트 어디에도 참조자가 없어 그대로 사라진다.

단위 스펙 4곳의 mock 도 대상이 사라져 함께 제거했다.

## 검증

전부 최종 히스토리에서 실행한 결과다.

| 게이트 | 결과 |
|---|---|
| `npm run type-check` | **0** (`dist/tsconfig.tsbuildinfo` 삭제 후 재실행 — 캐시가 에러를 가리지 않게) |
| `npx jest --maxWorkers=2 --workerIdleMemoryLimit=512MB` | **1 failed / 3437 passed** |
| `npm run test:core:integration:local -- 'fulfillment/services/outbound-v2'` | **6 suite / 41 test** |
| 변경파일 `eslint` | **0** |

jest 실패 1건은 `scripts/security/idor-reviewed.spec.ts` 로, **base `4cb592f52` 부터 이미
빨갛다**(작업 시작 전 실측). 이 PR 은 `apps/file-service` · `scripts/security` 를 한 줄도
건드리지 않았다 — `git diff 4cb592f52..HEAD -- apps/file-service scripts/security` 가 비어
있음으로 확인.

통합 41 test = base 39 + 커밋 0 의 3건 − 커밋 1 이 삭제한 1건.

**가드레일 확인**: 세 전략 어댑터(`discrete-picking` · `pick-to-tote` ·
`aggregate-then-sort`)는 **diff 0 바이트**다. `scan` / `handoff` / `completePick` /
`unpickShipment` 는 손대지 않았다.

**revert 독립성**: 커밋 1·2 각각 `git revert` 충돌 없음을 확인했다. 커밋 0 단독 revert 는
충돌하지만(커밋 1 이 인접한 테스트를 지운다), 지키려는 변경 없이 안전망만 되돌리는 건
의미 있는 연산이 아니다.

## 배포

**마이그레이션 0건 · 이벤트 계약 변경 0건 · SST secret/env 0건.** 배포 순서 제약 없다.

## 리뷰 포인트

- 커밋 1 의 BREAKING 판정에 동의하는지 — 측정은 실호출자 0이지만 외부 호출자를 전수로
  증명한 건 아니다
- `applies the same derivation to a replanned batch` 를 삭제 대신 축소한 판단

https://claude.ai/code/session_01X5Qm2UNHH5nz254i2s7Kaw
