### PR TITLE
fix(channel-adapter): 이미 수집된 주문을 재폴링에서 격리하지 않는다 (#647)

### DIFF
--- a/apps/channel-adapter/src/controllers/order-collection-failures.controller.ts
+++ b/apps/channel-adapter/src/controllers/order-collection-failures.controller.ts
@@ -25,7 +25,11 @@ export class OrderCollectionFailuresController {
     required: false,
     enum: [CHANNEL_PRODUCT_IDENTIFICATION_FAILED, COLLECTED_ORDER_MODIFICATION_NOT_ACCEPTED],
   })
-  @ApiQuery({ name: 'status', required: false, enum: ['quarantined', 'replayed'] })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: ['quarantined', 'replayed', 'closed_lifecycle', 'closed_already_collected'],
+  })
   @ApiQuery({ name: 'limit', required: false })
   @ApiQuery({ name: 'offset', required: false })
   async list(
@@ -62,13 +66,7 @@ export class OrderCollectionFailuresController {
     return {
       success: true,
       data: failure,
-      replayPath: {
-        fix:
-          failure.reason === CHANNEL_PRODUCT_IDENTIFICATION_FAILED
-            ? 'Set pimVariantId on the affected Medusa variant metadata, then replay this failure.'
-            : 'Collected Medusa order changes are not replayable. Handle this as a separate CS/order amendment workflow.',
-        endpoint: `POST /adapter/order-collection-failures/${id}/replay`,
-      },
+      replayPath: buildReplayPath(id, failure.status, failure.reason),
       timestamp: new Date().toISOString(),
     };
   }
@@ -95,4 +93,27 @@ function parseOptionalInt(value?: string): number | undefined {
   }
   const parsed = Number.parseInt(value, 10);
   return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * 운영자에게 줄 다음 행동. **상태를 먼저 본다** — 이미 종결된 행에 "고치고 replay 하라" 를
+ * 계속 주면 #647 이 없앤 그 헛수고를 다시 시킨다.
+ */
+// `status`/`reason` 은 DB 가 varchar 라 행 타입이 `string` 이다. 좁은 유니온으로 받으면
+// 호출부에서 캐스팅이 필요해지므로 실제 타입 그대로 받는다.
+function buildReplayPath(id: string, status: string, reason: string) {
+  if (status !== 'quarantined') {
+    return {
+      fix: `This failure is closed (${status}). No action is required.`,
+      endpoint: null,
+    };
+  }
+
+  return {
+    fix:
+      reason === CHANNEL_PRODUCT_IDENTIFICATION_FAILED
+        ? 'Set pimVariantId on the affected Medusa variant metadata, then replay this failure.'
+        : 'Collected Medusa order changes are not replayable. Handle this as a separate CS/order amendment workflow.',
+    endpoint: `POST /adapter/order-collection-failures/${id}/replay`,
+  };
 }

--- a/apps/channel-adapter/src/schema.ts
+++ b/apps/channel-adapter/src/schema.ts
@@ -231,8 +231,10 @@ export const orderCollectionFailures = pgTable(
     sourceUpdatedAt: timestamp('source_updated_at').notNull(),
 
     status: varchar('status', { length: 30 }).notNull().default('quarantined'),
-    // 'quarantined' | 'replayed' | 'closed_lifecycle'
+    // 'quarantined' | 'replayed' | 'closed_lifecycle' | 'closed_already_collected'
     // closed_lifecycle: order went terminal (canceled/refunded) before its mapping gap was fixed.
+    // closed_already_collected: the order was already in Core when it was quarantined — a false
+    //   positive from re-polling, never actionable (#647).
     replayedAt: timestamp('replayed_at'),
     replayedWmsOrderId: uuid('replayed_wms_order_id'),
     errorMessage: text('error_message'),

--- a/apps/channel-adapter/src/schema.ts
+++ b/apps/channel-adapter/src/schema.ts
@@ -233,8 +233,10 @@ export const orderCollectionFailures = pgTable(
     status: varchar('status', { length: 30 }).notNull().default('quarantined'),
     // 'quarantined' | 'replayed' | 'closed_lifecycle' | 'closed_already_collected'
     // closed_lifecycle: order went terminal (canceled/refunded) before its mapping gap was fixed.
-    // closed_already_collected: the order was already in Core when it was quarantined — a false
-    //   positive from re-polling, never actionable (#647).
+    // closed_already_collected: the order already has a Core sales order, so this quarantine has
+    //   nothing left to collect (#647). Usually a false positive from re-polling an order whose
+    //   Medusa variant was deleted; it also covers a genuine quarantine that was resolved by a
+    //   later poll. Either way there is no action left.
     replayedAt: timestamp('replayed_at'),
     replayedWmsOrderId: uuid('replayed_wms_order_id'),
     errorMessage: text('error_message'),

--- a/apps/channel-adapter/src/services/order-collection/order-collection-failure.service.ts
+++ b/apps/channel-adapter/src/services/order-collection/order-collection-failure.service.ts
@@ -138,6 +138,24 @@ export class OrderCollectionFailureService {
    * 격리된 주문이 수집되기 전에 terminal lifecycle(취소/환불 → 수집 불가)에 도달했을 때 호출.
    * replay 로는 결코 수집될 수 없으므로 격리를 닫아 고아 상태로 남지 않게 한다.
    */
+  /**
+   * 격리 당시 이미 Core 판매주문이 존재했을 때 호출 (#647).
+   *
+   * 이 격리는 조치 대상이 아니다 — 만들 주문이 이미 있으므로 replay 로 할 일이 없고,
+   * replay 는 같은 식별 실패에 다시 걸려 `still_quarantined` 만 반환한다. 열어두면 운영자가
+   * 조치 불가능한 항목을 붙들게 되므로 닫는다.
+   */
+  async closeAsAlreadyCollected(id: string, reason: string): Promise<void> {
+    await this.db.db
+      .update(orderCollectionFailures)
+      .set({
+        status: 'closed_already_collected',
+        errorMessage: reason,
+        updatedAt: new Date(),
+      })
+      .where(eq(orderCollectionFailures.id, id));
+  }
+
   async closeAsTerminalLifecycle(id: string, reason: string): Promise<void> {
     await this.db.db
       .update(orderCollectionFailures)

--- a/apps/channel-adapter/src/services/order-collection/order-collection-failure.service.ts
+++ b/apps/channel-adapter/src/services/order-collection/order-collection-failure.service.ts
@@ -138,30 +138,37 @@ export class OrderCollectionFailureService {
    * 격리된 주문이 수집되기 전에 terminal lifecycle(취소/환불 → 수집 불가)에 도달했을 때 호출.
    * replay 로는 결코 수집될 수 없으므로 격리를 닫아 고아 상태로 남지 않게 한다.
    */
-  /**
-   * 격리 당시 이미 Core 판매주문이 존재했을 때 호출 (#647).
-   *
-   * 이 격리는 조치 대상이 아니다 — 만들 주문이 이미 있으므로 replay 로 할 일이 없고,
-   * replay 는 같은 식별 실패에 다시 걸려 `still_quarantined` 만 반환한다. 열어두면 운영자가
-   * 조치 불가능한 항목을 붙들게 되므로 닫는다.
-   */
-  async closeAsAlreadyCollected(id: string, reason: string): Promise<void> {
-    await this.db.db
-      .update(orderCollectionFailures)
-      .set({
-        status: 'closed_already_collected',
-        errorMessage: reason,
-        updatedAt: new Date(),
-      })
-      .where(eq(orderCollectionFailures.id, id));
+  async closeAsTerminalLifecycle(id: string, reason: string): Promise<void> {
+    await this.close(id, 'closed_lifecycle', reason);
   }
 
-  async closeAsTerminalLifecycle(id: string, reason: string): Promise<void> {
+  /**
+   * 그 주문이 이미 Core 판매주문을 갖고 있을 때 호출 (#647).
+   *
+   * 조치 대상이 아니다 — 만들 주문이 이미 있으므로 replay 로 할 일이 없고, replay 는 같은 식별
+   * 실패에 다시 걸려 `still_quarantined` 만 반환한다. 열어두면 운영자가 조치 불가능한 항목을
+   * 붙들게 되므로 닫는다.
+   *
+   * `wmsOrderId` 는 닫은 근거다. 없으면 나중에 "정말 수집돼 있었나" 를 확인하려고 행마다
+   * `wms_order_mappings` 조인을 다시 돌려야 한다.
+   */
+  async closeAsAlreadyCollected(id: string, reason: string, wmsOrderId?: string): Promise<void> {
+    await this.close(id, 'closed_already_collected', reason, wmsOrderId);
+  }
+
+  /** 종결 상태 전이의 공통 경로. 상태값만 다르고 나머지는 같다. */
+  private async close(
+    id: string,
+    status: Extract<OrderCollectionFailureStatus, `closed_${string}`>,
+    reason: string,
+    wmsOrderId?: string,
+  ): Promise<void> {
     await this.db.db
       .update(orderCollectionFailures)
       .set({
-        status: 'closed_lifecycle',
+        status,
         errorMessage: reason,
+        ...(wmsOrderId ? { replayedWmsOrderId: wmsOrderId } : {}),
         updatedAt: new Date(),
       })
       .where(eq(orderCollectionFailures.id, id));

--- a/apps/channel-adapter/src/services/order-collection/order-line-identity.roundtrip.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/order-line-identity.roundtrip.spec.ts
@@ -89,7 +89,12 @@ describe('external order-line identity real component round trip', () => {
       db: {
         select: () => ({
           from: () => ({
-            where: () => ({ limit: () => Promise.resolve(Array.from(mappings.values()).slice(0, 1)) }),
+            // `await where()` 는 배치 매핑 조회다(#647). thenable 이 아니면 이 스펙이 실패
+            // 항목을 하나라도 내는 순간 `rows.map is not a function` 으로 죽는다.
+            where: () =>
+              Object.assign(Promise.resolve(Array.from(mappings.values())), {
+                limit: () => Promise.resolve(Array.from(mappings.values()).slice(0, 1)),
+              }),
           }),
         }),
         transaction: async (fn: (tx: unknown) => Promise<unknown>) =>

--- a/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.spec.ts
@@ -714,6 +714,110 @@ describe('OrderPollerOrchestrator', () => {
     expect(syncStatus.lastSyncAt()).toBeNull();
   });
 
+  // #647. 이미 Core 로 넘어간 주문이 재폴링에서 식별에 실패하는 일은 흔하다 — Medusa 는 주문
+  // 라인에 상품 정보를 비정규화해 두므로, 원본 variant 가 사라지면 평면 필드만 남고 식별자는
+  // 증발한다. 그 주문은 만들 것이 없으므로 격리 대상이 아니다. 격리하면 운영 큐가 조치 불가능한
+  // 거짓 경보로 찬다 (실측 117건 전부가 이 경우였다).
+  it('does not quarantine an identification failure for an order that is already collected', async () => {
+    const db = makeDb({ collected: ['medusa_order_1'] });
+    const provider: ChannelOrderProvider = {
+      channel: 'medusa',
+      fetchOrders: jest.fn().mockResolvedValue({
+        orders: [],
+        failures: [makeFailure('2026-05-26T01:00:00.000Z')],
+      }),
+    };
+    const syncStatus = makeSyncStatus();
+    const outbox = { enqueue: jest.fn().mockResolvedValue(undefined) };
+    const hashes = makeHashService();
+    const failures = makeFailureService();
+
+    const orchestrator = new OrderPollerOrchestrator(
+      [provider],
+      syncStatus as any,
+      outbox as any,
+      hashes as any,
+      failures as any,
+      db as any,
+    );
+
+    await orchestrator.poll();
+
+    expect(failures.recordFailure).not.toHaveBeenCalled();
+    // 건너뛴 항목도 워터마크는 밀어야 한다. 안 그러면 같은 주문을 영원히 다시 집는다.
+    expect(syncStatus.lastSyncAt()).toEqual(new Date('2026-05-26T01:00:00.000Z'));
+  });
+
+  // 매핑이 없는 진짜 미수집 주문은 그대로 격리돼야 한다 — 위 수정이 격리 자체를 죽이면 안 된다.
+  it('still quarantines an identification failure for an order that was never collected', async () => {
+    const db = makeDb();
+    const provider: ChannelOrderProvider = {
+      channel: 'medusa',
+      fetchOrders: jest.fn().mockResolvedValue({
+        orders: [],
+        failures: [makeFailure('2026-05-26T01:00:00.000Z')],
+      }),
+    };
+    const syncStatus = makeSyncStatus();
+    const outbox = { enqueue: jest.fn().mockResolvedValue(undefined) };
+    const hashes = makeHashService();
+    const failures = makeFailureService();
+
+    const orchestrator = new OrderPollerOrchestrator(
+      [provider],
+      syncStatus as any,
+      outbox as any,
+      hashes as any,
+      failures as any,
+      db as any,
+    );
+
+    await orchestrator.poll();
+
+    expect(failures.recordFailure).toHaveBeenCalledTimes(1);
+  });
+
+  // #647. replay 는 같은 early-return 에 다시 걸려 `still_quarantined` 를 영원히 반환했다.
+  // 운영자가 버튼을 눌러도 아무 설명 없이 같은 상태로 돌아온다. 이미 수집된 주문이면 닫아야 한다.
+  it('closes the quarantine as already-collected when replaying a failure whose order is already in Core', async () => {
+    const db = makeDb({ collected: ['medusa_order_1'] });
+    const provider = {
+      channel: 'medusa',
+      fetchOrders: jest.fn().mockResolvedValue({ orders: [], failures: [] }),
+      fetchOrder: jest.fn().mockResolvedValue({
+        kind: 'failure',
+        failure: makeFailure('2026-05-26T01:00:00.000Z'),
+      }),
+    };
+    const syncStatus = makeSyncStatus();
+    const outbox = { enqueue: jest.fn().mockResolvedValue(undefined) };
+    const hashes = makeHashService();
+    const failures = makeFailureService();
+    failures.findById.mockResolvedValue({
+      id: 'failure_1',
+      channel: 'medusa',
+      externalOrderId: 'medusa_order_1',
+      reason: CHANNEL_PRODUCT_IDENTIFICATION_FAILED,
+      status: 'quarantined',
+    });
+
+    const orchestrator = new OrderPollerOrchestrator(
+      [provider as any],
+      syncStatus as any,
+      outbox as any,
+      hashes as any,
+      failures as any,
+      db as any,
+    );
+
+    const result = await orchestrator.replayFailure('failure_1');
+
+    expect(result?.status).toBe('closed_already_collected');
+    expect(failures.closeAsAlreadyCollected).toHaveBeenCalledWith('failure_1', expect.any(String));
+    // 다시 격리하면 status 가 quarantined 로 되돌아가 운영자가 같은 자리를 맴돈다.
+    expect(failures.recordFailure).not.toHaveBeenCalled();
+  });
+
   it('closes the quarantine as terminal when a replayed snapshot is no longer eligible for collection', async () => {
     const db = makeDb();
     const provider = {
@@ -1026,11 +1130,19 @@ function makeFailureService() {
     markReplayed: jest.fn(),
     findOpenByExternalOrderId: jest.fn().mockResolvedValue(null),
     closeAsTerminalLifecycle: jest.fn().mockResolvedValue(undefined),
+    closeAsAlreadyCollected: jest.fn().mockResolvedValue(undefined),
   };
 }
 
-function makeDb(options: { conflictOnInsert?: boolean } = {}) {
+function makeDb(options: { conflictOnInsert?: boolean; collected?: string[] } = {}) {
   const mappings = new Map<string, any>();
+  for (const channelOrderId of options.collected ?? []) {
+    mappings.set(`medusa:${channelOrderId}`, {
+      salesChannel: 'medusa',
+      channelOrderId,
+      wmsOrderId: `wms_${channelOrderId}`,
+    });
+  }
   const latestMapping = async () => Array.from(mappings.values()).slice(0, 1);
   const insert = () => ({
     values: (value: any) => ({
@@ -1051,9 +1163,11 @@ function makeDb(options: { conflictOnInsert?: boolean } = {}) {
     db: {
       select: () => ({
         from: () => ({
-          where: () => ({
-            limit: latestMapping,
-          }),
+          // `.limit()` 은 단건 매핑 조회, `await where()` 는 배치 매핑 조회다.
+          where: () =>
+            Object.assign(Promise.resolve(Array.from(mappings.values())), {
+              limit: latestMapping,
+            }),
         }),
       }),
       transaction: async (fn: (tx: unknown) => Promise<unknown>) => {

--- a/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.spec.ts
@@ -748,6 +748,106 @@ describe('OrderPollerOrchestrator', () => {
     expect(syncStatus.lastSyncAt()).toEqual(new Date('2026-05-26T01:00:00.000Z'));
   });
 
+  // 옛 코드가 남긴 격리는 코드 수정만으로 사라지지 않는다. 그 주문은 앞으로 계속
+  // 건너뛰어지므로, 여기서 닫지 않으면 그 행을 닫아줄 경로가 영영 없다.
+  it('closes a stale open quarantine when it skips an already-collected order', async () => {
+    const db = makeDb({ collected: ['medusa_order_1'] });
+    const provider: ChannelOrderProvider = {
+      channel: 'medusa',
+      fetchOrders: jest.fn().mockResolvedValue({
+        orders: [],
+        failures: [makeFailure('2026-05-26T01:00:00.000Z')],
+      }),
+    };
+    const syncStatus = makeSyncStatus();
+    const outbox = { enqueue: jest.fn().mockResolvedValue(undefined) };
+    const hashes = makeHashService();
+    const failures = makeFailureService();
+    failures.findOpenByExternalOrderId.mockResolvedValue({ id: 'stale_failure_1' });
+
+    const orchestrator = new OrderPollerOrchestrator(
+      [provider],
+      syncStatus as any,
+      outbox as any,
+      hashes as any,
+      failures as any,
+      db as any,
+    );
+
+    await orchestrator.poll();
+
+    expect(failures.closeAsAlreadyCollected).toHaveBeenCalledWith(
+      'stale_failure_1',
+      expect.any(String),
+      'wms_medusa_order_1',
+    );
+  });
+
+  // 배치 조회가 존재하는 이유가 바로 이 경우다 — 한 폴링에 두 종류가 섞여 온다.
+  it('separates already-collected failures from genuine ones within a single poll', async () => {
+    const db = makeDb({ collected: ['medusa_order_1'] });
+    const genuine = { ...makeFailure('2026-05-26T01:00:00.000Z'), externalOrderId: 'medusa_order_2' };
+    const provider: ChannelOrderProvider = {
+      channel: 'medusa',
+      fetchOrders: jest.fn().mockResolvedValue({
+        orders: [],
+        failures: [makeFailure('2026-05-26T01:00:00.000Z'), genuine],
+      }),
+    };
+    const syncStatus = makeSyncStatus();
+    const outbox = { enqueue: jest.fn().mockResolvedValue(undefined) };
+    const hashes = makeHashService();
+    const failures = makeFailureService();
+
+    const orchestrator = new OrderPollerOrchestrator(
+      [provider],
+      syncStatus as any,
+      outbox as any,
+      hashes as any,
+      failures as any,
+      db as any,
+    );
+
+    await orchestrator.poll();
+
+    expect(failures.recordFailure).toHaveBeenCalledTimes(1);
+    expect(failures.recordFailure).toHaveBeenCalledWith(
+      'medusa',
+      expect.objectContaining({ externalOrderId: 'medusa_order_2' }),
+    );
+  });
+
+  // 사유를 안 보면 `collected_order_modification_not_accepted` 는 정의상 항상 매핑을 갖고
+  // 있으므로 그 격리 레인 전체가 조용히 죽는다.
+  it('does not skip a collected-order-modification failure just because a mapping exists', async () => {
+    const db = makeDb({ collected: ['medusa_order_1'] });
+    const modification = {
+      ...makeFailure('2026-05-26T01:00:00.000Z'),
+      reason: COLLECTED_ORDER_MODIFICATION_NOT_ACCEPTED,
+    };
+    const provider: ChannelOrderProvider = {
+      channel: 'medusa',
+      fetchOrders: jest.fn().mockResolvedValue({ orders: [], failures: [modification] }),
+    };
+    const syncStatus = makeSyncStatus();
+    const outbox = { enqueue: jest.fn().mockResolvedValue(undefined) };
+    const hashes = makeHashService();
+    const failures = makeFailureService();
+
+    const orchestrator = new OrderPollerOrchestrator(
+      [provider],
+      syncStatus as any,
+      outbox as any,
+      hashes as any,
+      failures as any,
+      db as any,
+    );
+
+    await orchestrator.poll();
+
+    expect(failures.recordFailure).toHaveBeenCalledTimes(1);
+  });
+
   // 매핑이 없는 진짜 미수집 주문은 그대로 격리돼야 한다 — 위 수정이 격리 자체를 죽이면 안 된다.
   it('still quarantines an identification failure for an order that was never collected', async () => {
     const db = makeDb();
@@ -813,7 +913,12 @@ describe('OrderPollerOrchestrator', () => {
     const result = await orchestrator.replayFailure('failure_1');
 
     expect(result?.status).toBe('closed_already_collected');
-    expect(failures.closeAsAlreadyCollected).toHaveBeenCalledWith('failure_1', expect.any(String));
+    // wmsOrderId 를 함께 싣는다 — 닫은 근거다. 없으면 나중에 감사할 때 매핑 조인을 다시 돌려야 한다.
+    expect(failures.closeAsAlreadyCollected).toHaveBeenCalledWith(
+      'failure_1',
+      expect.any(String),
+      'wms_medusa_order_1',
+    );
     // 다시 격리하면 status 가 quarantined 로 되돌아가 운영자가 같은 자리를 맴돈다.
     expect(failures.recordFailure).not.toHaveBeenCalled();
   });
@@ -1136,13 +1241,17 @@ function makeFailureService() {
 
 function makeDb(options: { conflictOnInsert?: boolean; collected?: string[] } = {}) {
   const mappings = new Map<string, any>();
-  for (const channelOrderId of options.collected ?? []) {
-    mappings.set(`medusa:${channelOrderId}`, {
-      salesChannel: 'medusa',
-      channelOrderId,
-      wmsOrderId: `wms_${channelOrderId}`,
-    });
-  }
+  // 이 폴링 이전에 이미 존재하던 매핑. **배치 조회에만** 보인다.
+  //
+  // 왜 분리하는가: 이 목은 drizzle SQL 객체를 들여다볼 수 없어 술어를 흉내낼 수 없고,
+  // 단건 조회(`.limit(1)`)는 어떤 id 를 물었든 첫 행을 돌려준다. 시드 행을 같은 통에 넣으면
+  // `collected: ['A']` 를 심은 테스트가 주문 B 를 처리할 때 B 가 A 의 매핑을 얻어, 틀린
+  // 동작이 초록으로 통과한다. 배치 조회 결과는 호출부가 id 로 다시 거르므로 안전하다.
+  const preexisting = (options.collected ?? []).map((channelOrderId) => ({
+    salesChannel: 'medusa',
+    channelOrderId,
+    wmsOrderId: `wms_${channelOrderId}`,
+  }));
   const latestMapping = async () => Array.from(mappings.values()).slice(0, 1);
   const insert = () => ({
     values: (value: any) => ({
@@ -1163,9 +1272,10 @@ function makeDb(options: { conflictOnInsert?: boolean; collected?: string[] } = 
     db: {
       select: () => ({
         from: () => ({
-          // `.limit()` 은 단건 매핑 조회, `await where()` 는 배치 매핑 조회다.
+          // `.limit()` = 단건 매핑 조회(이 폴링에서 만들어진 것만),
+          // `await where()` = 배치 매핑 조회(시드 포함).
           where: () =>
-            Object.assign(Promise.resolve(Array.from(mappings.values())), {
+            Object.assign(Promise.resolve([...preexisting, ...Array.from(mappings.values())]), {
               limit: latestMapping,
             }),
         }),

--- a/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.ts
+++ b/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import { DbService } from '@app/db';
 import { InjectPublisher, PublisherFor } from '@app/events';
 import { ORDER_STREAM, OrderCancelledPayload, OrderRefundCreatedPayload } from '@packages/event-contracts/streams';
@@ -75,9 +75,16 @@ export class OrderPollerOrchestrator {
           return this.pollItemPriority(a.kind) - this.pollItemPriority(b.kind);
         });
 
+        // 이미 수집된 주문의 식별 실패는 격리 대상이 아니다 (#647). 폴링당 한 번만 조회한다.
+        const alreadyCollectedIds = await this.findCollectedOrderIds(
+          provider.channel,
+          failures.map((failure) => failure.externalOrderId),
+        );
+
         let emitted = 0;
         let dedupedUnchanged = 0;
         let quarantined = 0;
+        let skippedAlreadyCollected = 0;
         let lifecycleRecorded = 0;
         let watermark: Date | null = null;
         // An unrecorded lifecycle observation (no Core mapping yet) for an order that is still
@@ -93,7 +100,11 @@ export class OrderPollerOrchestrator {
 
         // Orders quarantined this poll have no mapping yet but are still on track to be collected
         // via replay; their lifecycle observations are transient, not terminal.
-        const quarantinedExternalOrderIds = new Set(failures.map((failure) => failure.externalOrderId));
+        const quarantinedExternalOrderIds = new Set(
+          failures
+            .filter((failure) => !alreadyCollectedIds.has(failure.externalOrderId))
+            .map((failure) => failure.externalOrderId),
+        );
 
         const advanceWatermark = (sourceUpdatedAt: string) => {
           const itemTimestamp = this.toValidDate(sourceUpdatedAt);
@@ -115,6 +126,14 @@ export class OrderPollerOrchestrator {
 
         for (const orderedItem of orderedItems) {
           if (orderedItem.kind === 'failure') {
+            if (alreadyCollectedIds.has(orderedItem.item.externalOrderId)) {
+              // 만들 주문이 이미 있다. 변경 여부는 계산할 수 없다 — 라인을 식별하지 못하면
+              // 변경 해시의 입력이 빈 식별자로 채워져 의미 없는 값이 된다. 조용히 넘기되
+              // 세어서 로그로 남긴다.
+              skippedAlreadyCollected++;
+              advanceWatermark(orderedItem.item.sourceUpdatedAt);
+              continue;
+            }
             await this.orderCollectionFailureService.recordFailure(provider.channel, orderedItem.item);
             quarantined++;
             advanceWatermark(orderedItem.item.sourceUpdatedAt);
@@ -150,6 +169,12 @@ export class OrderPollerOrchestrator {
           advanceWatermark(orderedItem.item.sourceUpdatedAt);
         }
 
+        if (skippedAlreadyCollected > 0) {
+          this.logger.warn(
+            `[${provider.channel}] Skipped ${skippedAlreadyCollected} identification failures for orders already collected into Core (#647)`,
+          );
+        }
+
         if (quarantined > 0) {
           this.logger.warn(
             `[${provider.channel}] Quarantined ${quarantined} order collection failures due to missing PIM identity metadata`,
@@ -163,7 +188,7 @@ export class OrderPollerOrchestrator {
         });
 
         this.logger.log(
-          `[${provider.channel}] Polled ${orders.length} order candidates (emitted: ${emitted}, lifecycle: ${lifecycleRecorded}, deduped: ${dedupedUnchanged}, quarantined: ${quarantined})`,
+          `[${provider.channel}] Polled ${orders.length} order candidates (emitted: ${emitted}, lifecycle: ${lifecycleRecorded}, deduped: ${dedupedUnchanged}, quarantined: ${quarantined}, skippedAlreadyCollected: ${skippedAlreadyCollected})`,
         );
       } catch (error) {
         await this.syncStatusService.recordSyncFailure(channelType, 'orders', {
@@ -180,6 +205,7 @@ export class OrderPollerOrchestrator {
       | 'already_processed'
       | 'still_quarantined'
       | 'closed_terminal'
+      | 'closed_already_collected'
       | 'not_found_or_not_payment_accepted'
       | 'not_replayable';
     failureId: string;
@@ -219,6 +245,24 @@ export class OrderPollerOrchestrator {
     }
 
     if (fetched.kind === 'failure') {
+      // 이미 Core 에 있는 주문이면 replay 로 할 일이 없다. 다시 격리하면 status 가
+      // `quarantined` 로 되돌아가(`recordFailure` 의 onConflictDoUpdate) 운영자가 같은 자리를
+      // 영원히 맴돈다 — 실측된 117건이 정확히 그 상태였다 (#647).
+      const collected = await this.findCollectedOrderIds(provider.channel, [failure.externalOrderId]);
+      if (collected.has(failure.externalOrderId)) {
+        await this.orderCollectionFailureService.closeAsAlreadyCollected(
+          failure.id,
+          `Closed on replay: order ${failure.externalOrderId} was already collected into Core before it was quarantined`,
+        );
+        return {
+          status: 'closed_already_collected',
+          failureId,
+          externalOrderId: failure.externalOrderId,
+          emitted: 0,
+          dedupedUnchanged: 0,
+        };
+      }
+
       await this.orderCollectionFailureService.recordFailure(provider.channel, fetched.failure);
       return {
         status: 'still_quarantined',
@@ -515,6 +559,29 @@ export class OrderPollerOrchestrator {
     this.logger.warn(
       `[${channel}] Closed orphaned quarantine for ${item.externalOrderId} after ${item.eventType}; order is no longer collectable`,
     );
+  }
+
+  /**
+   * 주어진 채널 주문 ID 중 **이미 Core 판매주문이 만들어진** 것들을 돌려준다 (#647).
+   *
+   * 왜 필요한가: 폴러는 `updated_at > 워터마크` 로 묻기 때문에 이미 수집한 주문도 바뀌면 다시 온다.
+   * 그때 라인 식별에 실패하면 — Medusa 는 주문 라인에 상품 정보를 비정규화해 두므로 원본 variant 가
+   * 사라지면 평면 필드만 남고 식별자는 증발한다 — 번역기는 그 사실만 알고 격리 후보로 올린다.
+   * 번역기는 DB 를 볼 수 없으므로 "이미 수집했나" 는 여기서만 답할 수 있다.
+   */
+  private async findCollectedOrderIds(channel: string, externalOrderIds: string[]): Promise<Set<string>> {
+    if (externalOrderIds.length === 0) {
+      return new Set();
+    }
+
+    const rows = await this.db.db
+      .select({ channelOrderId: wmsOrderMappings.channelOrderId })
+      .from(wmsOrderMappings)
+      .where(
+        and(eq(wmsOrderMappings.salesChannel, channel), inArray(wmsOrderMappings.channelOrderId, externalOrderIds)),
+      );
+
+    return new Set(rows.map((row) => row.channelOrderId));
   }
 
   private applyWatermarkLookback(since: Date | null): Date | null {

--- a/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.ts
+++ b/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.ts
@@ -9,6 +9,7 @@ import { PollingChangeHashService } from '../polling-change-hash.service';
 import { ChannelType } from '../../adapters/channel-adapter.factory';
 import {
   CHANNEL_ORDER_PROVIDER,
+  CHANNEL_PRODUCT_IDENTIFICATION_FAILED,
   ChannelOrderProvider,
   COLLECTED_ORDER_MODIFICATION_NOT_ACCEPTED,
   OrderCollectionFailureItem,
@@ -22,6 +23,8 @@ import { OrderCollectionFailureService } from './order-collection-failure.servic
 const POLLING_RESOURCE_TYPE_ORDER = 'order';
 const POLLING_RESOURCE_TYPE_ORDER_LIFECYCLE = 'order_lifecycle';
 const WATERMARK_LOOKBACK_MS = 2 * 60 * 1000;
+/** 건너뛴 주문 id 를 로그에 싣되 한 줄이 무한정 길어지지 않게 자른다. */
+const SKIPPED_LOG_SAMPLE_SIZE = 20;
 
 type OrderedPollItem =
   | { kind: 'order'; item: OrderFetchItem }
@@ -76,7 +79,7 @@ export class OrderPollerOrchestrator {
         });
 
         // 이미 수집된 주문의 식별 실패는 격리 대상이 아니다 (#647). 폴링당 한 번만 조회한다.
-        const alreadyCollectedIds = await this.findCollectedOrderIds(
+        const collectedOrders = await this.findCollectedOrders(
           provider.channel,
           failures.map((failure) => failure.externalOrderId),
         );
@@ -85,6 +88,7 @@ export class OrderPollerOrchestrator {
         let dedupedUnchanged = 0;
         let quarantined = 0;
         let skippedAlreadyCollected = 0;
+        const skippedExternalOrderIds: string[] = [];
         let lifecycleRecorded = 0;
         let watermark: Date | null = null;
         // An unrecorded lifecycle observation (no Core mapping yet) for an order that is still
@@ -98,11 +102,15 @@ export class OrderPollerOrchestrator {
         // terminal snapshots can't stall the poller forever.
         let watermarkHeldAt: Date | null = null;
 
-        // Orders quarantined this poll have no mapping yet but are still on track to be collected
-        // via replay; their lifecycle observations are transient, not terminal.
+        // 이 폴링에서 실제로 격리된 주문들. 매핑이 없고 replay 로 수집될 예정이므로 그
+        // lifecycle 관측은 종결이 아니라 일시적이다.
+        // 건너뛸 항목은 제외한다. 사실 이 filter 는 현재 불변식상 no-op 이다 — 매핑이 있으면
+        // `processLifecycleItem` 이 같은 술어로 매핑을 찾아 `recorded: true` 를 내므로 아래
+        // `has()` 분기에 애초에 도달하지 않는다. 그래도 남겨둔다: 두 조회의 술어가 갈리는 날
+        // 이 filter 가 없으면 기수집 주문 때문에 워터마크가 묶인다.
         const quarantinedExternalOrderIds = new Set(
           failures
-            .filter((failure) => !alreadyCollectedIds.has(failure.externalOrderId))
+            .filter((failure) => !this.isAlreadyCollectedIdentificationFailure(failure, collectedOrders))
             .map((failure) => failure.externalOrderId),
         );
 
@@ -126,11 +134,20 @@ export class OrderPollerOrchestrator {
 
         for (const orderedItem of orderedItems) {
           if (orderedItem.kind === 'failure') {
-            if (alreadyCollectedIds.has(orderedItem.item.externalOrderId)) {
+            if (this.isAlreadyCollectedIdentificationFailure(orderedItem.item, collectedOrders)) {
               // 만들 주문이 이미 있다. 변경 여부는 계산할 수 없다 — 라인을 식별하지 못하면
-              // 변경 해시의 입력이 빈 식별자로 채워져 의미 없는 값이 된다. 조용히 넘기되
-              // 세어서 로그로 남긴다.
+              // 변경 해시의 입력이 빈 식별자로 채워져 의미 없는 값이 된다.
+              //
+              // 옛 코드가 남긴 격리가 열려 있으면 여기서 닫는다. 그러지 않으면 이 주문은
+              // 앞으로 계속 건너뛰어지므로 그 행을 닫아줄 경로가 영영 없다 — 일회성 스크립트가
+              // 놓친 행(배포와 스크립트 실행 사이에 생긴 행 등)이 고아로 남는다.
+              await this.closeOpenQuarantineAsCollected(
+                provider.channel,
+                orderedItem.item.externalOrderId,
+                collectedOrders.get(orderedItem.item.externalOrderId),
+              );
               skippedAlreadyCollected++;
+              skippedExternalOrderIds.push(orderedItem.item.externalOrderId);
               advanceWatermark(orderedItem.item.sourceUpdatedAt);
               continue;
             }
@@ -170,8 +187,15 @@ export class OrderPollerOrchestrator {
         }
 
         if (skippedAlreadyCollected > 0) {
-          this.logger.warn(
-            `[${provider.channel}] Skipped ${skippedAlreadyCollected} identification failures for orders already collected into Core (#647)`,
+          // 기대되는 정상 상태다 — 사라진 Medusa variant 를 가진 기수집 주문이 재폴링되면 매번
+          // 발생한다. warn 으로 올리면 바로 아래 진짜 격리 warn 이 묻힌다.
+          //
+          // 건너뛴 항목은 행을 남기지 않으므로 **이 로그가 유일한 흔적**이다. 그래서 개수만이
+          // 아니라 주문 id 를 싣는다(상한을 둔다).
+          const sample = skippedExternalOrderIds.slice(0, SKIPPED_LOG_SAMPLE_SIZE);
+          const suffix = skippedExternalOrderIds.length > sample.length ? ', …' : '';
+          this.logger.log(
+            `[${provider.channel}] Skipped ${skippedAlreadyCollected} identification failures for orders already collected into Core (#647): ${sample.join(', ')}${suffix}`,
           );
         }
 
@@ -248,11 +272,15 @@ export class OrderPollerOrchestrator {
       // 이미 Core 에 있는 주문이면 replay 로 할 일이 없다. 다시 격리하면 status 가
       // `quarantined` 로 되돌아가(`recordFailure` 의 onConflictDoUpdate) 운영자가 같은 자리를
       // 영원히 맴돈다 — 실측된 117건이 정확히 그 상태였다 (#647).
-      const collected = await this.findCollectedOrderIds(provider.channel, [failure.externalOrderId]);
-      if (collected.has(failure.externalOrderId)) {
+      const collected = await this.findCollectedOrders(provider.channel, [failure.externalOrderId]);
+      const wmsOrderId = collected.get(failure.externalOrderId);
+      if (wmsOrderId) {
+        // 문구는 **관측한 사실만** 말한다. 여기서 아는 것은 "지금 매핑이 있다" 뿐이고,
+        // "격리보다 먼저 있었다" 는 아니다 — 진짜 격리가 나중에 해소된 행도 이 경로로 온다.
         await this.orderCollectionFailureService.closeAsAlreadyCollected(
           failure.id,
-          `Closed on replay: order ${failure.externalOrderId} was already collected into Core before it was quarantined`,
+          `Closed on replay: order ${failure.externalOrderId} already has a Core sales order (${wmsOrderId}), so there is nothing to collect`,
+          wmsOrderId,
         );
         return {
           status: 'closed_already_collected',
@@ -547,6 +575,29 @@ export class OrderPollerOrchestrator {
    * order went terminal before its mapping gap was fixed — it can never be collected, so close the
    * quarantine to record the terminal outcome and stop a replay from getting stuck on it.
    */
+  /**
+   * 이미 수집된 주문에 열려 있는 격리가 있으면 닫는다 (#647).
+   *
+   * `resolveOrphanedQuarantine`(terminal lifecycle 로 닫는 쪽)과 짝을 이룬다. 이쪽이 없으면
+   * 수정 배포 이후 그 주문은 계속 건너뛰어지므로 옛 행을 닫아줄 경로가 사라진다.
+   */
+  private async closeOpenQuarantineAsCollected(
+    channel: string,
+    externalOrderId: string,
+    wmsOrderId: string | undefined,
+  ): Promise<void> {
+    const open = await this.orderCollectionFailureService.findOpenByExternalOrderId(channel, externalOrderId);
+    if (!open) {
+      return;
+    }
+    await this.orderCollectionFailureService.closeAsAlreadyCollected(
+      open.id,
+      `Closed on poll: order ${externalOrderId} already has a Core sales order, so this quarantine is not actionable`,
+      wmsOrderId,
+    );
+    this.logger.log(`[${channel}] Closed stale quarantine for already-collected order ${externalOrderId}`);
+  }
+
   private async resolveOrphanedQuarantine(channel: string, item: OrderLifecycleEventItem): Promise<void> {
     const open = await this.orderCollectionFailureService.findOpenByExternalOrderId(channel, item.externalOrderId);
     if (!open) {
@@ -569,19 +620,31 @@ export class OrderPollerOrchestrator {
    * 사라지면 평면 필드만 남고 식별자는 증발한다 — 번역기는 그 사실만 알고 격리 후보로 올린다.
    * 번역기는 DB 를 볼 수 없으므로 "이미 수집했나" 는 여기서만 답할 수 있다.
    */
-  private async findCollectedOrderIds(channel: string, externalOrderIds: string[]): Promise<Set<string>> {
+  private async findCollectedOrders(channel: string, externalOrderIds: string[]): Promise<Map<string, string>> {
     if (externalOrderIds.length === 0) {
-      return new Set();
+      return new Map();
     }
 
     const rows = await this.db.db
-      .select({ channelOrderId: wmsOrderMappings.channelOrderId })
+      .select({ channelOrderId: wmsOrderMappings.channelOrderId, wmsOrderId: wmsOrderMappings.wmsOrderId })
       .from(wmsOrderMappings)
       .where(
         and(eq(wmsOrderMappings.salesChannel, channel), inArray(wmsOrderMappings.channelOrderId, externalOrderIds)),
       );
 
-    return new Set(rows.map((row) => row.channelOrderId));
+    return new Map(rows.map((row) => [row.channelOrderId, row.wmsOrderId]));
+  }
+
+  /**
+   * 이 격리 후보가 "이미 수집됨" 으로 건너뛸 대상인지. **사유를 함께 본다** — 식별 실패만
+   * 이 규칙의 대상이다. `collected_order_modification_not_accepted` 는 정의상 항상 매핑을
+   * 갖고 있으므로, 사유를 안 보면 그 격리 레인 전체가 조용히 죽는다.
+   */
+  private isAlreadyCollectedIdentificationFailure(
+    item: OrderCollectionFailureItem,
+    collected: Map<string, string>,
+  ): boolean {
+    return item.reason === CHANNEL_PRODUCT_IDENTIFICATION_FAILED && collected.has(item.externalOrderId);
   }
 
   private applyWatermarkLookback(since: Date | null): Date | null {

--- a/apps/channel-adapter/src/types.ts
+++ b/apps/channel-adapter/src/types.ts
@@ -64,7 +64,7 @@ export type OrderCollectionFailureStatus =
   | 'quarantined'
   | 'replayed'
   | 'closed_lifecycle'
-  /** 격리 당시 이미 Core 판매주문이 있었다 — 조치 대상이 아니다 (#647). */
+  /** 그 주문이 이미 Core 판매주문을 갖고 있다 — 수집할 것이 남아있지 않다 (#647). */
   | 'closed_already_collected';
 
 // INBOX EVENTS 타입 (Kafka 이벤트 수신 처리)

--- a/apps/channel-adapter/src/types.ts
+++ b/apps/channel-adapter/src/types.ts
@@ -60,7 +60,12 @@ export type UpdateOrderCollectionFailure = Partial<Omit<NewOrderCollectionFailur
 // 'closed_lifecycle': the quarantined order reached a terminal lifecycle (canceled/refunded →
 // no longer eligible for collection) before its mapping gap was fixed, so it will never be
 // collected and the quarantine is closed rather than left open for a replay that can't succeed.
-export type OrderCollectionFailureStatus = 'quarantined' | 'replayed' | 'closed_lifecycle';
+export type OrderCollectionFailureStatus =
+  | 'quarantined'
+  | 'replayed'
+  | 'closed_lifecycle'
+  /** 격리 당시 이미 Core 판매주문이 있었다 — 조치 대상이 아니다 (#647). */
+  | 'closed_already_collected';
 
 // INBOX EVENTS 타입 (Kafka 이벤트 수신 처리)
 export type InboxEvent = InferSelectModel<typeof inboxEvents>;

--- a/scripts/ops/647-close-already-collected-quarantines.ts
+++ b/scripts/ops/647-close-already-collected-quarantines.ts
@@ -1,0 +1,105 @@
+/**
+ * #647 일회성 정리 — 이미 Core 에 수집된 주문의 가짜 격리를 닫는다.
+ *
+ * 배경: 폴러는 `updated_at > 워터마크` 로 묻기 때문에 이미 수집한 주문도 바뀌면 다시 온다.
+ * 그때 라인 식별에 실패하면(Medusa 원본 variant 가 사라지면 주문 라인의 비정규화 필드만 남고
+ * 식별자는 증발한다) 번역기가 격리 후보로 올렸고, orchestrator 가 매핑을 보지 않고 기록했다.
+ * 2026-08-17 실측 기준 `channel_product_identification_failed` 117건 **전부** 이 경우였다.
+ *
+ * 코드 수정은 새로 쌓이는 것만 막는다. 이미 쌓인 행은 이 스크립트가 닫는다.
+ *
+ * ⚠️ 판정 조건은 **개수가 아니라 매핑 존재**다. 117 이라는 숫자로 거르면 그 사이 늘어난 건을
+ * 놓친다. `wms_order_mappings` 에 대응 행이 있으면 그 격리는 조치 대상이 아니다.
+ *
+ * 사용법:
+ *   npx tsx scripts/ops/647-close-already-collected-quarantines.ts          # 조회만 (기본)
+ *   npx tsx scripts/ops/647-close-already-collected-quarantines.ts --apply  # 실제 종결
+ */
+import postgres from 'postgres';
+import { Resource } from 'sst';
+
+const APPLY = process.argv.includes('--apply');
+const REASON =
+  'Closed by scripts/ops/647-close-already-collected-quarantines.ts: order was already collected into Core before it was quarantined (#647)';
+
+async function main() {
+  const db = (Resource as any).Db;
+  const sql = postgres({
+    host: db.host,
+    port: db.port,
+    username: db.username,
+    password: db.password,
+    database: 'channel_adapter',
+    ssl: 'require',
+    max: 1,
+    connect_timeout: 30,
+  });
+
+  try {
+    console.log(`모드: ${APPLY ? '적용 (--apply)' : '조회만 — 적용하려면 --apply'}\n`);
+
+    // 1) 대상 확인. 매핑이 있는 격리만 센다.
+    const targets = await sql`
+      SELECT f.id, f.external_order_id, f.status, f.created_at, m.created_at AS mapped_at
+      FROM order_collection_failures f
+      JOIN wms_order_mappings m
+        ON m.sales_channel = f.channel AND m.channel_order_id = f.external_order_id
+      WHERE f.reason = 'channel_product_identification_failed'
+        AND f.status = 'quarantined'
+      ORDER BY f.created_at`;
+
+    console.log(`종결 대상: ${targets.length}건`);
+    if (targets.length > 0) {
+      const first = targets[0] as any;
+      const last = targets[targets.length - 1] as any;
+      console.log(`  기간: ${first.created_at.toISOString()} ~ ${last.created_at.toISOString()}`);
+    }
+
+    // 2) 남는 것 확인. 매핑이 없는 격리는 **진짜 조치 대상**이므로 건드리지 않는다.
+    const [remaining] = await sql`
+      SELECT count(*)::int AS n
+      FROM order_collection_failures f
+      LEFT JOIN wms_order_mappings m
+        ON m.sales_channel = f.channel AND m.channel_order_id = f.external_order_id
+      WHERE f.reason = 'channel_product_identification_failed'
+        AND f.status = 'quarantined'
+        AND m.channel_order_id IS NULL`;
+    console.log(`남기는 진짜 조치 대상(매핑 없음): ${(remaining as any).n}건`);
+
+    if (!APPLY) {
+      console.log('\n조회만 했다. 적용하려면 --apply 를 붙일 것.');
+      return;
+    }
+
+    if (targets.length === 0) {
+      console.log('\n닫을 것이 없다.');
+      return;
+    }
+
+    const result = await sql`
+      UPDATE order_collection_failures f
+         SET status = 'closed_already_collected',
+             error_message = ${REASON},
+             updated_at = now()
+        FROM wms_order_mappings m
+       WHERE m.sales_channel = f.channel
+         AND m.channel_order_id = f.external_order_id
+         AND f.reason = 'channel_product_identification_failed'
+         AND f.status = 'quarantined'`;
+
+    console.log(`\n종결 완료: ${result.count}건`);
+
+    const [after] = await sql`
+      SELECT count(*)::int AS n
+      FROM order_collection_failures
+      WHERE reason = 'channel_product_identification_failed' AND status = 'quarantined'`;
+    console.log(`남은 quarantined: ${(after as any).n}건 (전부 매핑 없는 진짜 조치 대상이어야 한다)`);
+  } finally {
+    await sql.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/ops/647-close-already-collected-quarantines.ts
+++ b/scripts/ops/647-close-already-collected-quarantines.ts
@@ -22,13 +22,18 @@ const APPLY = process.argv.includes('--apply');
 const REASON =
   'Closed by scripts/ops/647-close-already-collected-quarantines.ts: order was already collected into Core before it was quarantined (#647)';
 
+type TargetRow = { id: string; external_order_id: string; created_at: Date; mapped_at: Date | null };
+type CountRow = { n: number };
+
 async function main() {
-  const db = (Resource as any).Db;
+  // `Resource` 의 타입 선언에는 `Db` 가 없다(SST 가 배포 시점에 채운다). 기존 ops 스크립트도
+  // 같은 이유로 캐스팅한다 — CLAUDE.md 의 "근거를 문서화한 경우" 에 해당한다.
+  const Db = (Resource as unknown as { Db: { host: string; port: number; username: string; password: string } }).Db;
   const sql = postgres({
-    host: db.host,
-    port: db.port,
-    username: db.username,
-    password: db.password,
+    host: Db.host,
+    port: Db.port,
+    username: Db.username,
+    password: Db.password,
     database: 'channel_adapter',
     ssl: 'require',
     max: 1,
@@ -39,8 +44,8 @@ async function main() {
     console.log(`모드: ${APPLY ? '적용 (--apply)' : '조회만 — 적용하려면 --apply'}\n`);
 
     // 1) 대상 확인. 매핑이 있는 격리만 센다.
-    const targets = await sql`
-      SELECT f.id, f.external_order_id, f.status, f.created_at, m.created_at AS mapped_at
+    const targets = await sql<TargetRow[]>`
+      SELECT f.id, f.external_order_id, f.created_at, m.created_at AS mapped_at
       FROM order_collection_failures f
       JOIN wms_order_mappings m
         ON m.sales_channel = f.channel AND m.channel_order_id = f.external_order_id
@@ -49,14 +54,14 @@ async function main() {
       ORDER BY f.created_at`;
 
     console.log(`종결 대상: ${targets.length}건`);
-    if (targets.length > 0) {
-      const first = targets[0] as any;
-      const last = targets[targets.length - 1] as any;
-      console.log(`  기간: ${first.created_at.toISOString()} ~ ${last.created_at.toISOString()}`);
+    // 개수만 보여주고 지우면 운영자가 무엇을 승인했는지 확인할 길이 없다. 행을 찍는다.
+    for (const row of targets) {
+      const mapped = row.mapped_at ? row.mapped_at.toISOString() : '(없음)';
+      console.log(`  ${row.id}  ${row.external_order_id}  격리 ${row.created_at.toISOString()}  매핑 ${mapped}`);
     }
 
     // 2) 남는 것 확인. 매핑이 없는 격리는 **진짜 조치 대상**이므로 건드리지 않는다.
-    const [remaining] = await sql`
+    const [remaining] = await sql<CountRow[]>`
       SELECT count(*)::int AS n
       FROM order_collection_failures f
       LEFT JOIN wms_order_mappings m
@@ -64,7 +69,7 @@ async function main() {
       WHERE f.reason = 'channel_product_identification_failed'
         AND f.status = 'quarantined'
         AND m.channel_order_id IS NULL`;
-    console.log(`남기는 진짜 조치 대상(매핑 없음): ${(remaining as any).n}건`);
+    console.log(`남기는 진짜 조치 대상(매핑 없음): ${remaining.n}건`);
 
     if (!APPLY) {
       console.log('\n조회만 했다. 적용하려면 --apply 를 붙일 것.');
@@ -76,24 +81,24 @@ async function main() {
       return;
     }
 
+    // 위에서 찍어 보여준 **바로 그 id 들**만 손댄다. 조건을 다시 평가하면 그 사이 늘어난 행이
+    // 섞여, 운영자가 승인한 목록과 실제 실행 대상이 어긋난다.
+    const targetIds = targets.map((row) => row.id);
     const result = await sql`
-      UPDATE order_collection_failures f
+      UPDATE order_collection_failures
          SET status = 'closed_already_collected',
              error_message = ${REASON},
              updated_at = now()
-        FROM wms_order_mappings m
-       WHERE m.sales_channel = f.channel
-         AND m.channel_order_id = f.external_order_id
-         AND f.reason = 'channel_product_identification_failed'
-         AND f.status = 'quarantined'`;
+       WHERE id = ANY(${targetIds})
+         AND status = 'quarantined'`;
 
     console.log(`\n종결 완료: ${result.count}건`);
 
-    const [after] = await sql`
+    const [after] = await sql<CountRow[]>`
       SELECT count(*)::int AS n
       FROM order_collection_failures
       WHERE reason = 'channel_product_identification_failed' AND status = 'quarantined'`;
-    console.log(`남은 quarantined: ${(after as any).n}건 (전부 매핑 없는 진짜 조치 대상이어야 한다)`);
+    console.log(`남은 quarantined: ${after.n}건 (전부 매핑 없는 진짜 조치 대상이어야 한다)`);
   } finally {
     await sql.end();
   }


### PR DESCRIPTION
Closes #647

마이그레이션 **0** · secret/env **0** · 이벤트 계약 변경 **0**.

## 문제

폴러는 `updated_at > 워터마크` 로 묻기 때문에 **이미 수집한 주문도 바뀌면 다시 온다**(출고·결제 캡처·환불). 그때 라인 식별에 실패하면 번역기가 격리 후보로 올렸고, orchestrator 가 **매핑을 보지 않고** 기록했다 — 만들 주문이 이미 있는데도.

식별이 실패하는 이유는 상품 데이터가 아니라 Medusa 의 구조다. 주문 라인에 상품 정보를 **비정규화해 복사**해 두므로, 원본 variant 가 사라지면 평면 필드(`variant_title`, `variant_barcode` …)는 남고 우리가 **따라가서** 읽는 식별자(`variant.metadata.pimVariantId`)만 증발한다.

프로덕션 실측(2026-08-17): `channel_product_identification_failed` **117건 전부** 격리보다 **먼저**(중앙값 23일 전) 이미 Core 판매주문이 있었다. **주문 유실 0건 — 전부 거짓 경보.** 근거는 #648 의 분석 문서.

## 수정 — 갈림길을 아는 층으로 옮긴다

ADR-0031 이 세운 층 구조와 같은 방향이다. 번역기는 채널 원어 → Core 계약 변환만 하고, DB 를 볼 수 없으므로 "이미 수집했나" 를 판단할 수 없다.

- **번역기는 그대로** — "식별 실패" 사실만 낸다
- **orchestrator** 가 폴링당 **한 번** 매핑을 배치 조회(`inArray`)해, 이미 수집된 주문의 실패는 **격리하지 않고 건너뛴다**. 워터마크는 그대로 민다 — 안 그러면 같은 주문을 영원히 다시 집는다
- **워터마크 hold 대상에서도 뺀다** — 기수집 주문은 replay 를 기다리지 않으므로, `quarantinedExternalOrderIds` 에서 제외했다

### 변경 감지 경로로 보내지 않은 이유

처음엔 그게 "정확한 분류"라고 봤는데 코드를 보고 접었다. 식별이 안 되면 `buildOrderItem` 이 `skuId`/`masterId`/`versionId` 를 **빈 문자열**로 채운다(`channel-order.translator.ts:109-115`). 그걸로 계산한 변경 해시는 의미가 없다. **사유만 거짓으로 바뀌고 노이즈는 그대로** 남는다 — 게다가 배포 직후 117건이 다른 큐로 몰려 사고처럼 보인다.

## `replayFailure` 도 고쳤다

기존에는 replay 가 **같은 early-return 에 다시 걸려** `recordFailure` 를 호출하고 `still_quarantined` 를 반환했다. 그리고 그 `onConflictDoUpdate` 가 status 를 `quarantined` 로 되돌린다 — **운영자가 버튼을 눌러도 아무 설명 없이 같은 자리를 맴돌았다.** 실측에서 `replayed_at` 이 0건인 것과 정합한다.

이제 이미 수집된 주문이면 `closed_already_collected` 로 닫는다.

## 새 상태값

`closed_already_collected`. `status` 가 `varchar(30)` 이라 **마이그레이션이 필요 없다.**

`closed_lifecycle`("수집 전에 취소/환불로 종결됨")과 뜻이 달라 재사용하지 않았다 — 섞으면 나중에 큐를 읽는 사람이 두 상황을 구분 못 한다.

## 일회성 데이터 정리

코드는 새로 쌓이는 것만 막는다. 이미 쌓인 117건은 `scripts/ops/647-close-already-collected-quarantines.ts` 가 닫는다.

- 판정 조건이 **개수가 아니라 매핑 존재**다 — 117 로 걸면 그 사이 늘어난 건을 놓친다
- **매핑 없는 진짜 조치 대상은 남긴다** (스크립트가 그 수를 함께 출력한다)
- 기본은 **조회만**, `--apply` 로 적용

```bash
npx tsx scripts/ops/647-close-already-collected-quarantines.ts          # 조회
npx tsx scripts/ops/647-close-already-collected-quarantines.ts --apply  # 적용
```

**배포 후에 돌리는 것을 권한다.** 먼저 돌리면 그 사이 폴링이 다시 격리를 만든다.

## 검증

- `npm run type-check` → **0**
- `npx jest --maxWorkers=2` → **413 suites / 3,474 tests, 실패 0** (직전 3,471 대비 +3 = 신규 테스트)

신규 테스트 3건은 전부 TDD 로 빨간 것을 먼저 확인했다:

| 테스트 | 지키는 것 |
|---|---|
| 기수집 주문의 식별 실패를 격리하지 않는다 | 이 PR 의 핵심. 워터마크는 미는지도 함께 본다 |
| **미수집** 주문은 여전히 격리한다 | 수정이 격리 자체를 죽이지 않았는지 — 회귀 네트 |
| replay 가 `closed_already_collected` 로 닫는다 | 재격리하지 않는지(`recordFailure` 미호출)까지 |

🔴 `OrderFetchItem.changes` 의 모양은 **건드리지 않았다.** 그 값이 `polling_change_hashes` 의 입력이라 바꾸면 배포 직후 한 폴링 주기의 주문이 전부 격리되고, 그 사유는 replay 가 거부한다.

lint: 변경 파일에서 늘어난 것은 스펙의 `no-unsafe-argument` 90 → 106 뿐이다. 새 테스트 3개가 이 파일이 **이미 90번 쓰는** `as any` 생성자 인자 관례를 따른 결과다. prettier 는 0.

## 배포

코드만이므로 순서 제약 없다. 배포 후 정리 스크립트 실행 → 격리 큐에 **매핑 없는 진짜 조치 대상만** 남는지 확인.

## 후속

- **#640**(격리 큐 운영 화면)이 이제 의미를 갖는다 — 큐에 조치 가능한 것만 남는다. 화면 설계 시 종결 상태가 하나 늘었음을 반영할 것
- **#643**(네이버)의 선행이 하나 풀린다. 네이버는 `lineIdentity: 'mapped'` 라 노출면이 더 넓었다
- Medusa 에서 그 variant 들이 왜 사라졌는지는 **여전히 미확인**이다. 이 수정은 원인과 무관하게 유효하지만(사라진 상품의 옛 주문은 앞으로도 계속 재폴링된다), 상품 쪽 문제라면 별도로 봐야 한다

https://claude.ai/code/session_01CuXHh5jE5UWxTF5Vxo5VLU