### PR TITLE
fix(channel-adapter): 폴링 해시 확인을 트랜잭션 안 조건부 갱신으로 바꾼다 (#599)

### DIFF
--- a/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.spec.ts
@@ -600,6 +600,89 @@ describe('OrderPollerOrchestrator', () => {
     expect(provider.fetchOrders).toHaveBeenCalledWith(new Date('2026-05-26T01:08:00.000Z'));
   });
 
+  // #599: 이중 크론(또는 5분보다 오래 걸린 폴)이 겹치면 두 폴이 같은 옛 해시를 읽고 **둘 다**
+  // 트랜잭션에 진입해 같은 사실을 두 번 발행했다. 두 이벤트는 messageId 가 달라 core 의
+  // `checkAndRecordEvent` 멱등 가드가 잡지 못한다. 라이브에서 08-10 이후 8건 실측됐다.
+  it('emits a lifecycle event once when two concurrent polls observe the same stale hash', async () => {
+    const db = makeDb();
+    db.mappings.set('medusa:medusa_order_1', {
+      salesChannel: 'medusa',
+      channelOrderId: 'medusa_order_1',
+      wmsOrderId: '11111111-1111-4111-8111-111111111111',
+    });
+    const provider: ChannelOrderProvider = {
+      channel: 'medusa',
+      fetchOrders: jest.fn().mockResolvedValue({
+        orders: [],
+        failures: [],
+        lifecycleEvents: [makeLifecycleEvent('OrderCancelled', 'cancelled', '2026-05-26T01:00:00.000Z')],
+      }),
+    };
+    const syncStatus = makeSyncStatus();
+    const outbox = { enqueue: jest.fn().mockResolvedValue(undefined) };
+    const hashes = makeHashService();
+    const failures = makeFailureService();
+
+    const orchestrator = new OrderPollerOrchestrator(
+      [provider],
+      syncStatus as any,
+      outbox as any,
+      hashes as any,
+      failures as any,
+      db as any,
+    );
+
+    await Promise.all([orchestrator.poll(), orchestrator.poll()]);
+
+    const cancellations = outbox.enqueue.mock.calls.filter(
+      ([event]: [{ eventType: string }, unknown]) => event.eventType === 'OrderCancelled',
+    );
+    expect(cancellations).toHaveLength(1);
+  });
+
+  // #599: 변경 격리 경로도 해시 확인이 트랜잭션 밖이라 같은 레이스를 갖는다.
+  it('quarantines a collected-order modification once when two concurrent polls observe the same stale hash', async () => {
+    const db = makeDb();
+    db.mappings.set('medusa:medusa_order_1', {
+      salesChannel: 'medusa',
+      channelOrderId: 'medusa_order_1',
+      wmsOrderId: '11111111-1111-4111-8111-111111111111',
+    });
+    const provider: ChannelOrderProvider = {
+      channel: 'medusa',
+      fetchOrders: jest.fn().mockResolvedValue({
+        orders: [
+          makeOrder('2026-05-26T01:10:00.000Z', {
+            totalAmount: 12000,
+            eligibleForOrderCreation: false,
+          }),
+        ],
+        failures: [],
+      }),
+    };
+    const syncStatus = makeSyncStatus();
+    const outbox = { enqueue: jest.fn().mockResolvedValue(undefined) };
+    const hashes = makeHashService();
+    const failures = makeFailureService();
+
+    const orchestrator = new OrderPollerOrchestrator(
+      [provider],
+      syncStatus as any,
+      outbox as any,
+      hashes as any,
+      failures as any,
+      db as any,
+    );
+
+    await Promise.all([orchestrator.poll(), orchestrator.poll()]);
+
+    const quarantines = failures.recordFailure.mock.calls.filter(
+      ([, failure]: [string, OrderCollectionFailureItem]) =>
+        failure.reason === COLLECTED_ORDER_MODIFICATION_NOT_ACCEPTED,
+    );
+    expect(quarantines).toHaveLength(1);
+  });
+
   it('uses the mapping insert as the OrderCreated idempotency gate', async () => {
     const db = makeDb({ conflictOnInsert: true });
     const provider: ChannelOrderProvider = {
@@ -1209,6 +1292,15 @@ function makeHashService() {
     }),
     upsert: jest.fn(async (source: string, resourceType: string, resourceId: string, hash: string) => {
       hashes.set(key(source, resourceType, resourceId), hash);
+    }),
+    // 조건부 갱신(CAS) 의 목. **검사와 기록 사이에 await 가 없다** — 그것이 요점이다.
+    // JS 는 단일 스레드라 await 없는 구간은 원자적이고, 이것이 Postgres 의
+    // `INSERT … ON CONFLICT DO UPDATE … WHERE hash <> excluded.hash RETURNING` 과 같은 성질이다.
+    claimChanged: jest.fn(async (source: string, resourceType: string, resourceId: string, hash: string) => {
+      const k = key(source, resourceType, resourceId);
+      if (hashes.get(k) === hash) return false;
+      hashes.set(k, hash);
+      return true;
     }),
   };
 }

--- a/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.ts
+++ b/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.ts
@@ -429,20 +429,22 @@ export class OrderPollerOrchestrator {
     // 이미 Core로 넘긴 Medusa 주문 변경은 자동 반영하지 않는다.
     // 무의미한 updated_at bump는 hash로 거르고, 실제 변경은 운영 예외로 격리한다.
     const newHash = this.pollingHashService.computeHash(item.changes);
-    const storedHash = await this.pollingHashService.getStoredHash(
-      provider.channel,
-      POLLING_RESOURCE_TYPE_ORDER,
-      item.externalOrderId,
-    );
-    if (storedHash === newHash) {
-      return {
-        emitted: 0,
-        dedupedUnchanged: 1,
-        wmsOrderId: mapping[0].wmsOrderId,
-      };
-    }
 
-    await this.db.db.transaction(async (tx) => {
+    // lifecycle 경로와 같은 이유로 확인과 기록이 한 트랜잭션·한 문장이다 (#599).
+    const claimed = await this.db.db.transaction(async (tx) => {
+      // 격리 저장보다 **먼저** 선점한다. 같은 트랜잭션이므로 격리가 실패하면 선점도 함께
+      // 롤백되고, 다음 폴링이 다시 시도한다 — 옛 코드의 "성공 후에만 갱신" 성질이 그대로다.
+      const won = await this.pollingHashService.claimChanged(
+        provider.channel,
+        POLLING_RESOURCE_TYPE_ORDER,
+        item.externalOrderId,
+        newHash,
+        tx,
+      );
+      if (!won) {
+        return false;
+      }
+
       await this.orderCollectionFailureService.recordFailure(
         provider.channel,
         {
@@ -461,19 +463,13 @@ export class OrderPollerOrchestrator {
         tx,
       );
 
-      // 격리 저장 성공 후에만 갱신 — 도중 실패 시 다음 폴링에서 재시도되도록
-      await this.pollingHashService.upsert(
-        provider.channel,
-        POLLING_RESOURCE_TYPE_ORDER,
-        item.externalOrderId,
-        newHash,
-        tx,
-      );
+      // 해시 기록은 `claimChanged` 가 이미 같은 트랜잭션에서 끝냈다.
+      return true;
     });
 
     return {
       emitted: 0,
-      dedupedUnchanged: 0,
+      dedupedUnchanged: claimed ? 0 : 1,
       wmsOrderId: mapping[0].wmsOrderId,
     };
   }
@@ -513,24 +509,22 @@ export class OrderPollerOrchestrator {
       payload,
       rawEvent: item.rawEvent,
     });
-    const storedHash = await this.pollingHashService.getStoredHash(
-      provider.channel,
-      POLLING_RESOURCE_TYPE_ORDER_LIFECYCLE,
-      lifecycleResourceId,
-    );
-
-    if (storedHash === newHash) {
-      return {
-        emitted: 0,
-        dedupedUnchanged: 1,
-        recorded: true,
-        wmsOrderId: mapping[0].wmsOrderId,
-      };
-    }
-
     const wmsOrderId = mapping[0].wmsOrderId;
 
-    await this.db.db.transaction(async (tx) => {
+    // 해시 확인이 **트랜잭션 안**이고, 검사와 기록이 한 문장이다 (#599). 밖에서 읽고 안에서
+    // 쓰면 겹쳐 도는 두 폴이 같은 옛 해시를 보고 둘 다 발행한다 — 라이브에서 실제로 발생했다.
+    const claimed = await this.db.db.transaction(async (tx) => {
+      const won = await this.pollingHashService.claimChanged(
+        provider.channel,
+        POLLING_RESOURCE_TYPE_ORDER_LIFECYCLE,
+        lifecycleResourceId,
+        newHash,
+        tx,
+      );
+      if (!won) {
+        return false;
+      }
+
       // 이벤트 키마다 payload 타입이 다르므로 **분기해서** 적재한다. `OrderLifecycleEventItem`
       // 이 판별 유니온이라 각 가지에서 `item.payload` 가 알아서 좁혀진다 — 캐스팅이 없다.
       // metadata 를 `{ partitionKey }` 로 두는 근거는 `enqueueOrderCreated` 와 같다.
@@ -548,20 +542,24 @@ export class OrderPollerOrchestrator {
         await this.ordersPublisher.enqueue({ eventType: 'OrderRefundCreated', payload: refunded, ...common }, tx);
       }
 
-      await this.pollingHashService.upsert(
-        provider.channel,
-        POLLING_RESOURCE_TYPE_ORDER_LIFECYCLE,
-        lifecycleResourceId,
-        newHash,
-        tx,
-      );
+      // 해시 기록은 `claimChanged` 가 이미 같은 트랜잭션에서 끝냈다 — 여기서 또 쓰지 않는다.
+      return true;
     });
+
+    if (!claimed) {
+      return {
+        emitted: 0,
+        dedupedUnchanged: 1,
+        recorded: true,
+        wmsOrderId,
+      };
+    }
 
     return {
       emitted: 1,
       dedupedUnchanged: 0,
       recorded: true,
-      wmsOrderId: mapping[0].wmsOrderId,
+      wmsOrderId,
     };
   }
 

--- a/apps/channel-adapter/src/services/polling-change-hash-claim.integration.spec.ts
+++ b/apps/channel-adapter/src/services/polling-change-hash-claim.integration.spec.ts
@@ -1,0 +1,113 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- postgres publishes `export =`; Jest compiles CJS.
+import postgres = require('postgres');
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { PollingChangeHashService } from './polling-change-hash.service';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+
+const SOURCE = 'medusa';
+const RESOURCE_TYPE = 'order_lifecycle';
+
+/**
+ * `claimChanged` 의 유닛 테스트는 목이 CAS 를 흉내낸다 — 그 목이 **실제 Postgres 와 같은지**는
+ * 여기서만 증명된다 (#599). 특히 두 가지가 여기서 검증된다:
+ *
+ * 1. drizzle 의 `setWhere` 가 `ON CONFLICT DO UPDATE … WHERE` 로 제대로 렌더링되는가
+ * 2. 겹친 두 트랜잭션에서 **정확히 한 쪽만** 선점하는가 (행 잠금 뒤 술어 재평가)
+ */
+describeIfDb('PollingChangeHashService.claimChanged (PostgreSQL integration)', () => {
+  // `describe.skip` 도 콜백 본문은 실행된다 — 연결 객체를 여기서 만들면 DB 없는 기본 실행에서도
+  // 쓸모없이 생성된다. `beforeAll` 은 skip 시 아예 돌지 않으므로 그쪽에서 만든다.
+  let client: ReturnType<typeof postgres>;
+  let service: PollingChangeHashService;
+  let db: ReturnType<typeof drizzle>;
+  const created: string[] = [];
+
+  const newResourceId = () => {
+    const id = `claim-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    created.push(id);
+    return id;
+  };
+
+  beforeAll(() => {
+    client = postgres(DATABASE_URL as string, { max: 4, prepare: false });
+    db = drizzle(client);
+    service = new PollingChangeHashService({ db } as never);
+  });
+
+  afterAll(async () => {
+    if (created.length > 0) {
+      await client`delete from polling_change_hashes where resource_id = any(${client.array(created)})`;
+    }
+    await client.end({ timeout: 5 });
+  });
+
+  it('claims a resource it has never seen', async () => {
+    const resourceId = newResourceId();
+
+    await expect(service.claimChanged(SOURCE, RESOURCE_TYPE, resourceId, 'hash-1')).resolves.toBe(true);
+  });
+
+  it('refuses to re-claim an unchanged hash', async () => {
+    const resourceId = newResourceId();
+
+    await service.claimChanged(SOURCE, RESOURCE_TYPE, resourceId, 'hash-1');
+
+    await expect(service.claimChanged(SOURCE, RESOURCE_TYPE, resourceId, 'hash-1')).resolves.toBe(false);
+  });
+
+  it('claims again once the hash actually changes', async () => {
+    const resourceId = newResourceId();
+
+    await service.claimChanged(SOURCE, RESOURCE_TYPE, resourceId, 'hash-1');
+
+    await expect(service.claimChanged(SOURCE, RESOURCE_TYPE, resourceId, 'hash-2')).resolves.toBe(true);
+    await expect(service.getStoredHash(SOURCE, RESOURCE_TYPE, resourceId)).resolves.toBe('hash-2');
+  });
+
+  // 이것이 #599 의 본체다 — 겹쳐 도는 두 폴이 같은 사실을 두 번 발행하던 레이스.
+  it('lets exactly one of two concurrent transactions claim the same changed hash', async () => {
+    const resourceId = newResourceId();
+
+    let releaseFirst!: () => void;
+    const firstMayCommit = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let firstClaimed!: (won: boolean) => void;
+    const firstDidClaim = new Promise<boolean>((resolve) => {
+      firstClaimed = resolve;
+    });
+
+    try {
+      const txA = db.transaction(async (tx) => {
+        const won = await service.claimChanged(SOURCE, RESOURCE_TYPE, resourceId, 'hash-1', tx as never);
+        firstClaimed(won);
+        await firstMayCommit;
+        return won;
+      });
+
+      // A 가 선점한 뒤 아직 커밋하지 않은 상태에서 B 를 띄운다 — 프로덕션의 겹친 폴과 같은 모양.
+      await expect(firstDidClaim).resolves.toBe(true);
+
+      let secondSettled = false;
+      const txB = db
+        .transaction(async (tx) => service.claimChanged(SOURCE, RESOURCE_TYPE, resourceId, 'hash-1', tx as never))
+        .then((won) => {
+          secondSettled = true;
+          return won;
+        });
+
+      // B 는 A 가 잡은 행 잠금에서 대기해야 한다.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(secondSettled).toBe(false);
+
+      releaseFirst();
+
+      await expect(txA).resolves.toBe(true);
+      await expect(txB).resolves.toBe(false);
+    } finally {
+      releaseFirst();
+    }
+  });
+});

--- a/apps/channel-adapter/src/services/polling-change-hash.service.ts
+++ b/apps/channel-adapter/src/services/polling-change-hash.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { createHash } from 'crypto';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, ne } from 'drizzle-orm';
 import { DbService } from '@app/db';
 import { channelAdapterSchema, pollingChangeHashes } from '../schema';
 
@@ -23,12 +23,7 @@ export class PollingChangeHashService {
     return createHash('sha256').update(stableStringify(content)).digest('hex');
   }
 
-  async getStoredHash(
-    source: string,
-    resourceType: string,
-    resourceId: string,
-    tx?: DbTx,
-  ): Promise<string | null> {
+  async getStoredHash(source: string, resourceType: string, resourceId: string, tx?: DbTx): Promise<string | null> {
     const exec = (trx: DbTx | DbService<typeof channelAdapterSchema>['db']) =>
       trx
         .select({ hash: pollingChangeHashes.hash })
@@ -45,24 +40,62 @@ export class PollingChangeHashService {
     return rows[0]?.hash ?? null;
   }
 
-  async upsert(
+  /**
+   * 해시가 바뀐 경우에만 기록을 선점하고, 선점에 성공했는지를 돌려준다 (#599).
+   *
+   * `getStoredHash` → 비교 → `upsert` 로 나눠 쓰면 **읽기와 쓰기 사이에 틈이 생긴다.** 겹쳐 도는
+   * 두 폴이 같은 옛 해시를 읽고 둘 다 "바뀌었다" 고 판단해 같은 사실을 두 번 발행한다. 두
+   * 이벤트는 messageId 가 달라 소비자의 멱등 가드가 잡지 못한다 — 라이브에서 실제로 8건 발생했다.
+   *
+   * 여기서는 검사와 기록이 **한 문장**이다:
+   *
+   * ```sql
+   * INSERT … ON CONFLICT (source, resource_type, resource_id)
+   * DO UPDATE SET hash = …, last_seen_at = …
+   * WHERE polling_change_hashes.hash <> <새 해시>
+   * RETURNING resource_id
+   * ```
+   *
+   * - 행이 없으면 INSERT 성공 → 반환 행 있음 → 선점
+   * - 행이 있고 해시가 다르면 DO UPDATE 발동 → 반환 행 있음 → 선점
+   * - 행이 있고 해시가 같으면 `setWhere` 가 거짓 → 반환 행 없음 → 이미 처리된 사실
+   *
+   * 동시 실행에서 뒤늦은 쪽은 `ON CONFLICT DO UPDATE` 가 잡는 행 잠금에서 대기하다가, 앞선
+   * 트랜잭션이 커밋된 **뒤의** 행으로 술어를 다시 평가한다. 그래서 정확히 한 쪽만 선점한다.
+   *
+   * 호출자는 **반드시 발행과 같은 트랜잭션**에서 부를 것 — 선점만 커밋되고 발행이 사라지면
+   * 그 사실은 영영 재발행되지 않는다.
+   */
+  async claimChanged(
     source: string,
     resourceType: string,
     resourceId: string,
     hash: string,
     tx?: DbTx,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const now = new Date();
     const exec = (trx: DbTx | DbService<typeof channelAdapterSchema>['db']) =>
       trx
         .insert(pollingChangeHashes)
         .values({ source, resourceType, resourceId, hash, lastSeenAt: now })
         .onConflictDoUpdate({
-          target: [
-            pollingChangeHashes.source,
-            pollingChangeHashes.resourceType,
-            pollingChangeHashes.resourceId,
-          ],
+          target: [pollingChangeHashes.source, pollingChangeHashes.resourceType, pollingChangeHashes.resourceId],
+          set: { hash, lastSeenAt: now },
+          setWhere: ne(pollingChangeHashes.hash, hash),
+        })
+        .returning({ resourceId: pollingChangeHashes.resourceId });
+    const rows = await exec(tx ?? this.db.db);
+    return rows.length > 0;
+  }
+
+  async upsert(source: string, resourceType: string, resourceId: string, hash: string, tx?: DbTx): Promise<void> {
+    const now = new Date();
+    const exec = (trx: DbTx | DbService<typeof channelAdapterSchema>['db']) =>
+      trx
+        .insert(pollingChangeHashes)
+        .values({ source, resourceType, resourceId, hash, lastSeenAt: now })
+        .onConflictDoUpdate({
+          target: [pollingChangeHashes.source, pollingChangeHashes.resourceType, pollingChangeHashes.resourceId],
           set: { hash, lastSeenAt: now },
         });
     await exec(tx ?? this.db.db);


### PR DESCRIPTION
## 무엇을 고치나

겹쳐 도는 두 폴이 **같은 옛 해시를 읽고 둘 다 트랜잭션에 진입**해 같은 사실을 두 번 발행했다.
두 이벤트는 `messageId` 가 달라 core `OrderEventsConsumer` 의 `checkAndRecordEvent` 멱등 가드가
잡지 못한다.

`#599` 의 "해야 할 일" 3개 중 **항목 1만** 떼어냈다. 항목 2(이중 크론 원인 규명)·3(core·membership·
wallet 영향 확인)은 성격이 달라 범위 밖이다.

## 이론이 아니라 실제로 일어났다

라이브 로그 실측 (2026-08-10 이후, 로그그룹 `…/Core`):

| 항목 | 건수 |
|---|---|
| lifecycle 이벤트 수신 | 26 |
| 고유 사실 | 18 |
| **중복** | **8** |

```
08-17 11:00:05.064  [OrderCancelled] Received: orderId=472cc359-…
08-17 11:00:05.150  [OrderCancelled] Received: orderId=472cc359-…   ← 중복
```

아웃박스의 `uq_event_outbox_topic_event_idempotency` 도 막지 못한다 — 이 경로가 `idempotencyKey`
를 넘기지 않아 NULL 이고, PG 는 `NULLS DISTINCT` 로 서로 다르게 취급한다.

## 어떻게 고쳤나

`getStoredHash` → 비교 → `upsert` 로 나뉘어 있던 것을 **CAS 한 문장**으로 합쳤다:

```sql
INSERT … ON CONFLICT (source, resource_type, resource_id)
DO UPDATE SET hash = …, last_seen_at = …
WHERE polling_change_hashes.hash <> <새 해시>
RETURNING resource_id
```

- 반환 행 있음 → 선점 → 발행
- 반환 행 없음 → 이미 처리된 사실 → skip

겹친 트랜잭션에서 뒤늦은 쪽은 `ON CONFLICT DO UPDATE` 의 행 잠금에서 대기하다가 **앞선 커밋 뒤의
행으로 술어를 재평가**하므로 정확히 한 쪽만 선점한다. 선점과 발행이 같은 트랜잭션이라 발행이
실패하면 선점도 함께 롤백된다 — 옛 코드의 "격리 저장 성공 후에만 갱신" 성질이 그대로 유지된다.

`processLifecycleItem` 과 `processOrderModification` 둘 다 같은 모양이었어서 함께 고쳤다.

`OrderCreated` 경로는 `wms_order_mappings` 의 `onConflictDoNothing` 이 이미 막고 있어 건드리지
않았다 (실측에서도 중복 0건).

## 테스트

**유닛** — 두 폴을 실제로 동시에 돌린다. 수정 전 2건, 수정 후 1건:

- `emits a lifecycle event once when two concurrent polls observe the same stale hash`
- `quarantines a collected-order modification once when two concurrent polls observe the same stale hash`

**통합** (`polling-change-hash-claim.integration.spec.ts`, `DATABASE_URL` 가드) — 유닛의 목이 CAS 를
흉내내므로, 그 목이 **실제 Postgres 와 같은지**는 여기서만 증명된다. `setWhere` 렌더링과 동시성
의미론(한 트랜잭션이 선점을 쥔 채 커밋하지 않으면 다른 쪽이 대기 → 커밋 후 `false`)을 검증한다.

이 통합 스펙이 결함을 실제로 잡는지 변이 검사로 확인했다 — `setWhere` 를 빼면 4건 중 2건이 빨개진다.

## 게이트

- `npm run type-check` → **0**
- `npx jest --maxWorkers=2` → **417 suite 통과, 실패 0** (worker 경고는 이 브랜치 이전부터 있던 것)
- 통합 스펙 → 실 Postgres 4/4 통과, `DATABASE_URL` 없으면 4건 skip

## 배포

- **마이그레이션 없음**
- 시크릿·env·이벤트 계약 변경 없음
- channel-adapter 단독 배포로 충분

## 🔴 함께 봐야 할 것 — #656

지금 이 중복이 무해해 보이는 유일한 이유는 **원본도 함께 버려지고 있어서**다. 같은 기간 26건이
전부 `NotFoundException: Sales order … not found` 로 DLQ 행이었다(성공 0건). 원인은 별개 결함이라
#656 으로 분리했다 — channel-adapter 의 `wms_order_mappings.wmsOrderId` 와 core 의
`sales_orders.id` 가 서로 다른 id 공간이다.

**#656 을 고치는 순간 이 PR 이 없으면 중복 8건이 그대로 실피해가 된다.** 두 이슈는 함께 나가야 한다.

Closes #599 항목 1 (이슈 자체는 항목 2·3 이 남아 열어 둔다)

https://claude.ai/code/session_01D3NdaFakWfg3XLUomHsYzi