### PR TITLE
fix(core,channel-adapter): lifecycle 이벤트를 채널 키로 판매주문에 잇는다 (#656)

### DIFF
--- a/apps/channel-adapter/src/services/order-collection/channel-order-provider.interface.ts
+++ b/apps/channel-adapter/src/services/order-collection/channel-order-provider.interface.ts
@@ -3,6 +3,7 @@ import {
   OrderCreatedPayload,
   OrderRefundCreatedPayload,
   OrderItem,
+  SalesChannel,
   ShippingAddress,
 } from '@packages/event-contracts/streams';
 
@@ -79,6 +80,8 @@ export interface ReplayableChannelOrderProvider extends ChannelOrderProvider {
 }
 
 export interface ChannelOrderProvider {
-  readonly channel: string;
+  // 유일한 구현(`TranslatingOrderProvider`)과 `ChannelOrderSource` 가 이미 `SalesChannel` 이다.
+  // 여기만 `string` 이라 호출부가 캐스팅을 강요당했다 (#656).
+  readonly channel: SalesChannel;
   fetchOrders(since: Date | null): Promise<FetchOrdersResult>;
 }

--- a/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.spec.ts
@@ -640,6 +640,56 @@ describe('OrderPollerOrchestrator', () => {
     expect(cancellations).toHaveLength(1);
   });
 
+  // #656: `payload.orderId` 는 여기서 만든 id 라 core 의 `sales_orders.id` 가 아니다. core 가 SO 를
+  // 찾을 수 있게 `OrderCreated` 와 같은 채널 키를 lifecycle 이벤트에도 실어야 한다.
+  it('carries the channel key on lifecycle events so Core can resolve the sales order', async () => {
+    const db = makeDb();
+    db.mappings.set('medusa:medusa_order_1', {
+      salesChannel: 'medusa',
+      channelOrderId: 'medusa_order_1',
+      wmsOrderId: '11111111-1111-4111-8111-111111111111',
+    });
+    const provider: ChannelOrderProvider = {
+      channel: 'medusa',
+      fetchOrders: jest.fn().mockResolvedValue({
+        orders: [],
+        failures: [],
+        lifecycleEvents: [
+          makeLifecycleEvent('OrderCancelled', 'cancelled', '2026-05-26T01:00:00.000Z'),
+          makeLifecycleEvent('OrderRefundCreated', 'refund:ref_1', '2026-05-26T01:05:00.000Z'),
+        ],
+      }),
+    };
+    const syncStatus = makeSyncStatus();
+    const outbox = { enqueue: jest.fn().mockResolvedValue(undefined) };
+    const hashes = makeHashService();
+    const failures = makeFailureService();
+
+    const orchestrator = new OrderPollerOrchestrator(
+      [provider],
+      syncStatus as any,
+      outbox as any,
+      hashes as any,
+      failures as any,
+      db as any,
+    );
+
+    await orchestrator.poll();
+
+    for (const eventType of ['OrderCancelled', 'OrderRefundCreated']) {
+      expect(outbox.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType,
+          payload: expect.objectContaining({
+            salesChannel: 'medusa',
+            externalOrderId: 'medusa_order_1',
+          }),
+        }),
+        expect.anything(),
+      );
+    }
+  });
+
   // #599: 변경 격리 경로도 해시 확인이 트랜잭션 밖이라 같은 레이스를 갖는다.
   it('quarantines a collected-order modification once when two concurrent polls observe the same stale hash', async () => {
     const db = makeDb();
@@ -965,7 +1015,7 @@ describe('OrderPollerOrchestrator', () => {
   it('closes the quarantine as already-collected when replaying a failure whose order is already in Core', async () => {
     const db = makeDb({ collected: ['medusa_order_1'] });
     const provider = {
-      channel: 'medusa',
+      channel: 'medusa' as const,
       fetchOrders: jest.fn().mockResolvedValue({ orders: [], failures: [] }),
       fetchOrder: jest.fn().mockResolvedValue({
         kind: 'failure',
@@ -1009,7 +1059,7 @@ describe('OrderPollerOrchestrator', () => {
   it('closes the quarantine as terminal when a replayed snapshot is no longer eligible for collection', async () => {
     const db = makeDb();
     const provider = {
-      channel: 'medusa',
+      channel: 'medusa' as const,
       fetchOrders: jest.fn(),
       fetchOrder: jest.fn().mockResolvedValue({
         kind: 'order',

--- a/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.ts
+++ b/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.ts
@@ -3,7 +3,11 @@ import { Cron } from '@nestjs/schedule';
 import { eq, and, inArray } from 'drizzle-orm';
 import { DbService } from '@app/db';
 import { InjectPublisher, PublisherFor } from '@app/events';
-import { ORDER_STREAM, OrderCancelledPayload, OrderRefundCreatedPayload } from '@packages/event-contracts/streams';
+import {
+  ORDER_STREAM,
+  OrderCancelledPayload,
+  OrderRefundCreatedPayload,
+} from '@packages/event-contracts/streams';
 import { SyncStatusService } from '../sync-status.service';
 import { PollingChangeHashService } from '../polling-change-hash.service';
 import { ChannelType } from '../../adapters/channel-adapter.factory';
@@ -534,11 +538,19 @@ export class OrderPollerOrchestrator {
         metadata: { partitionKey: provider.channel },
       };
 
+      // 채널 키 (#656). `wmsOrderId` 는 여기서 만든 id 라 **core 의 `sales_orders.id` 가 아니다** —
+      // core 는 SO 를 만들 때 자체 PK 를 새로 발급한다. 이 두 필드가 없으면 core 가 SO 를 찾지
+      // 못해 취소/환불이 전량 NotFound 로 DLQ 에 쌓인다. `OrderCreated` 가 쓰는 축과 같다.
+      const channelKey = {
+        salesChannel: provider.channel,
+        externalOrderId: item.externalOrderId,
+      };
+
       if (item.eventType === 'OrderCancelled') {
-        const cancelled: OrderCancelledPayload = { orderId: wmsOrderId, ...item.payload };
+        const cancelled: OrderCancelledPayload = { orderId: wmsOrderId, ...channelKey, ...item.payload };
         await this.ordersPublisher.enqueue({ eventType: 'OrderCancelled', payload: cancelled, ...common }, tx);
       } else {
-        const refunded: OrderRefundCreatedPayload = { orderId: wmsOrderId, ...item.payload };
+        const refunded: OrderRefundCreatedPayload = { orderId: wmsOrderId, ...channelKey, ...item.payload };
         await this.ordersPublisher.enqueue({ eventType: 'OrderRefundCreated', payload: refunded, ...common }, tx);
       }
 

--- a/apps/core/src/modules/sales-order/consumers/order-events.consumer.spec.ts
+++ b/apps/core/src/modules/sales-order/consumers/order-events.consumer.spec.ts
@@ -266,6 +266,68 @@ describe('OrderEventsConsumer', () => {
     expect(mocks.library.revokeOwnershipsForOrder).not.toHaveBeenCalled();
   });
 
+  // #656: 채널이 보내는 `orderId` 는 channel-adapter 가 만든 id 이고 core 의 `sales_orders.id` 는
+  // `defaultRandom()` PK 라 **서로 다른 id 공간**이다. PK 로 찾으면 구조적으로 절대 안 맞는다 —
+  // 라이브에서 lifecycle 이벤트 26건이 전부 NotFound 로 DLQ 갔다. `handleOrderCreated` 가 쓰는
+  // 채널 키(salesChannel + externalOrderId)로 찾아야 한다.
+  it('OrderCancelled 는 채널 키가 실려 있으면 그것으로 SO 를 찾고 해석된 id 로 취소한다', async () => {
+    const mocks = makeMocks();
+    const consumer = makeConsumer(mocks);
+    const payload = {
+      orderId: 'adapter-generated-uuid',
+      salesChannel: 'medusa',
+      externalOrderId: 'medusa_order_1',
+      reason: 'ADMIN_CANCEL',
+      cancelledBy: 'medusa',
+      cancelledAt: new Date().toISOString(),
+      refundRequired: false,
+    } as OrderCancelledPayload;
+    const cancelledEnvelope = {
+      messageId: 'cancel-msg-key-1',
+      correlationId: 'corr-1',
+    } as EnvelopeOf<typeof ORDER_STREAM, 'OrderCancelled'>;
+    mocks.salesOrders.findByChannelOrderId.mockResolvedValue({ id: 'so-real-1' } as any);
+
+    await consumer.handleOrderCancelled(payload, cancelledEnvelope);
+
+    expect(mocks.salesOrders.findByChannelOrderId).toHaveBeenCalledWith('medusa', 'medusa_order_1', mocks.fakeTx);
+    expect(mocks.salesOrders.cancel).toHaveBeenCalledWith('so-real-1', expect.anything(), mocks.fakeTx);
+    // 멱등 기록도 해석된 id 로 남아야 한다 (orderEvents.orderId 는 SO 를 가리킨다).
+    expect(mocks.txInserts).toEqual([
+      expect.objectContaining({ values: expect.objectContaining({ orderId: 'so-real-1' }) }),
+    ]);
+  });
+
+  it('OrderRefundCreated 는 채널 키로 찾은 SO id 로 환불 링크를 남긴다', async () => {
+    const mocks = makeMocks();
+    const consumer = makeConsumer(mocks);
+    const payload = {
+      orderId: 'adapter-generated-uuid',
+      salesChannel: 'medusa',
+      externalOrderId: 'medusa_order_1',
+      refundId: 'ref_1',
+      paymentId: 'pay_1',
+      amount: 10000,
+      currency: 'KRW',
+      reason: 'customer_request',
+      createdBy: 'medusa',
+      createdAt: new Date().toISOString(),
+    } as OrderRefundCreatedPayload;
+    const refundEnvelope = {
+      messageId: 'refund-msg-key-1',
+      correlationId: 'corr-1',
+    } as EnvelopeOf<typeof ORDER_STREAM, 'OrderRefundCreated'>;
+    mocks.salesOrders.findByChannelOrderId.mockResolvedValue({ id: 'so-real-1' } as any);
+
+    await consumer.handleOrderRefundCreated(payload, refundEnvelope);
+
+    expect(mocks.salesOrders.findByChannelOrderId).toHaveBeenCalledWith('medusa', 'medusa_order_1', mocks.fakeTx);
+    expect(mocks.txInserts).toEqual([
+      expect.objectContaining({ values: expect.objectContaining({ orderId: 'so-real-1' }) }),
+      expect.objectContaining({ values: expect.objectContaining({ sourceId: 'so-real-1' }) }),
+    ]);
+  });
+
   it('OrderCancelled 대상 SalesOrder 가 없으면 throw 로 실패를 표면화한다 (필터가 non-retryable 로 분류 → 즉시 DLQ)', async () => {
     const mocks = makeMocks();
     const consumer = makeConsumer(mocks);

--- a/apps/core/src/modules/sales-order/consumers/order-events.consumer.ts
+++ b/apps/core/src/modules/sales-order/consumers/order-events.consumer.ts
@@ -9,7 +9,7 @@ import { FulfillmentOrderCreationBacklogService } from '../../fulfillment/backlo
 import { FulfillmentWorkflowGate } from '../../fulfillment/services/fulfillment-workflow-gate.service';
 import { wmsTables, wmsSchema, DbTx } from '../../inventory/schema/inventory.schema';
 import { and, eq } from 'drizzle-orm';
-import { ORDER_STREAM } from '@packages/event-contracts/streams/orders.stream';
+import { ORDER_STREAM, SalesChannel } from '@packages/event-contracts/streams/orders.stream';
 import { EventPayloadOf, EnvelopeOf } from '@packages/event-contracts/types';
 
 /**
@@ -59,6 +59,35 @@ export class OrderEventsConsumer {
     });
 
     return false;
+  }
+
+  /**
+   * lifecycle 이벤트(`OrderCancelled`/`OrderRefundCreated`)가 가리키는 판매주문의 **core PK** 를 찾는다 (#656).
+   *
+   * `payload.orderId` 를 PK 로 조회하면 안 된다. 채널 수집 경로에서 그 값은 channel-adapter 가
+   * 만든 id 이고, core 는 `handleOrderCreated` 에서 SO 를 만들 때 `defaultRandom()` PK 를 새로
+   * 발급한다 — **두 id 공간이 겹치지 않는다.** 그래서 PK 조회는 구조적으로 항상 실패했고,
+   * 라이브에서 lifecycle 이벤트가 전량 NotFound 로 DLQ 에 쌓였다.
+   *
+   * `handleOrderCreated` 가 이미 쓰는 채널 키(`salesChannel` + `externalOrderId`)가 정본이다.
+   * 채널 키가 없는 **옛 메시지**(계약에 필드가 생기기 전 발행분, DLQ 재처리분 포함)는 종전대로
+   * PK 로 찾는다 — 자체 발행 주문처럼 두 id 가 같은 경우가 여기 해당한다.
+   */
+  private async resolveSalesOrderId(
+    payload: { orderId: string; salesChannel?: SalesChannel; externalOrderId?: string },
+    tx: DbTx,
+  ): Promise<string | null> {
+    if (payload.salesChannel && payload.externalOrderId) {
+      const byChannelKey = await this.salesOrdersService.findByChannelOrderId(
+        payload.salesChannel,
+        payload.externalOrderId,
+        tx,
+      );
+      return byChannelKey?.id ?? null;
+    }
+
+    const byPrimaryKey = await this.salesOrdersService.getOne(payload.orderId, tx);
+    return byPrimaryKey?.id ?? null;
   }
 
   @On(ORDER_STREAM, 'OrderCreated')
@@ -127,14 +156,14 @@ export class OrderEventsConsumer {
 
     try {
       await this.dbService.run(async (tx) => {
-        const salesOrder = await this.salesOrdersService.getOne(payload.orderId, tx);
-        if (!salesOrder) {
+        const salesOrderId = await this.resolveSalesOrderId(payload, tx);
+        if (!salesOrderId) {
           throw new NotFoundException(`Sales order ${payload.orderId} not found for OrderCancelled`);
         }
 
         const alreadyProcessed = await this.checkAndRecordEvent(
           envelope.messageId,
-          payload.orderId,
+          salesOrderId,
           'ORDER_CANCELLED',
           payload,
           tx,
@@ -142,7 +171,7 @@ export class OrderEventsConsumer {
         if (alreadyProcessed) return;
 
         await this.salesOrdersService.cancel(
-          payload.orderId,
+          salesOrderId,
           {
             reasonCode: payload.reason,
             reasonDetail: payload.reasonDetail,
@@ -158,7 +187,7 @@ export class OrderEventsConsumer {
           tx,
         );
 
-        this.logger.log(`[OrderCancelled] Cancelled sales order: ${payload.orderId}, reason: ${payload.reason}`);
+        this.logger.log(`[OrderCancelled] Cancelled sales order: ${salesOrderId}, reason: ${payload.reason}`);
       });
     } catch (error) {
       this.logger.error(`[OrderCancelled] Failed to process: ${payload.orderId}`, error.stack);
@@ -214,14 +243,14 @@ export class OrderEventsConsumer {
 
     try {
       await this.dbService.run(async (tx) => {
-        const salesOrder = await this.salesOrdersService.getOne(payload.orderId, tx);
-        if (!salesOrder) {
+        const salesOrderId = await this.resolveSalesOrderId(payload, tx);
+        if (!salesOrderId) {
           throw new NotFoundException(`Sales order ${payload.orderId} not found for OrderRefundCreated`);
         }
 
         const alreadyProcessed = await this.checkAndRecordEvent(
           envelope.messageId,
-          payload.orderId,
+          salesOrderId,
           'ORDER_REFUND_CREATED',
           payload,
           tx,
@@ -235,7 +264,7 @@ export class OrderEventsConsumer {
           .where(
             and(
               eq(wmsTables.businessLinks.sourceType, 'sales_order'),
-              eq(wmsTables.businessLinks.sourceId, payload.orderId),
+              eq(wmsTables.businessLinks.sourceId, salesOrderId),
               eq(wmsTables.businessLinks.relationName, 'order_lifecycle_refund_collected'),
               eq(wmsTables.businessLinks.targetExternalRef, refundExternalRef),
             ),
@@ -250,7 +279,7 @@ export class OrderEventsConsumer {
 
         await tx.insert(wmsTables.businessLinks).values({
           sourceType: 'sales_order',
-          sourceId: payload.orderId,
+          sourceId: salesOrderId,
           sourceExternalRef: null,
           targetType: 'wallet_refund',
           targetId: null,
@@ -268,7 +297,7 @@ export class OrderEventsConsumer {
           occurredAt: new Date(payload.createdAt),
         });
 
-        this.logger.log(`[OrderRefundCreated] Linked refund ${payload.refundId} to sales order ${payload.orderId}`);
+        this.logger.log(`[OrderRefundCreated] Linked refund ${payload.refundId} to sales order ${salesOrderId}`);
       });
     } catch (error) {
       this.logger.error(`[OrderRefundCreated] Failed to process: ${payload.orderId}`, error.stack);

--- a/packages/event-contracts/streams/orders.stream.ts
+++ b/packages/event-contracts/streams/orders.stream.ts
@@ -116,7 +116,15 @@ export interface OrderModifiedPayload {
  * 주문 취소 이벤트
  */
 export interface OrderCancelledPayload {
+  /**
+   * 발행자가 아는 주문 식별자. **채널 수집 경로에서는 core 의 `sales_orders.id` 가 아니다** —
+   * channel-adapter 가 만든 id 이고 core 는 SO 를 만들 때 자체 PK 를 새로 발급한다 (#656).
+   * 아래 채널 키가 있으면 그쪽이 정본이고, 이 값은 옛 메시지 폴백용으로만 남는다.
+   */
   orderId: string;
+  /** 채널 키 (#656). `OrderCreated` 와 같은 축이며, 소비자는 이 둘로 SO 를 찾는다. */
+  salesChannel?: SalesChannel;
+  externalOrderId?: string;
   reason: 'CUSTOMER_REQUEST' | 'OUT_OF_STOCK' | 'PAYMENT_FAILED' | 'ADMIN_CANCEL' | 'TIMEOUT';
   reasonDetail?: string;
   cancelledBy: string;
@@ -169,7 +177,11 @@ export interface OrderReturnRequestedPayload {
  * 환불 생성 이벤트
  */
 export interface OrderRefundCreatedPayload {
+  /** `OrderCancelledPayload.orderId` 와 같은 주의사항 — 채널 키가 정본이다 (#656). */
   orderId: string;
+  /** 채널 키 (#656). */
+  salesChannel?: SalesChannel;
+  externalOrderId?: string;
   refundId: string;
   paymentId: string;
 
@@ -266,6 +278,9 @@ const OrderModifiedSchema = z.object({
 
 const OrderCancelledSchema = z.object({
   orderId: z.string().min(1),
+  // 채널 키 (#656) — optional 이라 이 필드를 모르는 옛 소비자도 계속 통과한다.
+  salesChannel: SalesChannelSchema.optional(),
+  externalOrderId: z.string().min(1).optional(),
   reason: z.enum(['CUSTOMER_REQUEST', 'OUT_OF_STOCK', 'PAYMENT_FAILED', 'ADMIN_CANCEL', 'TIMEOUT']),
   reasonDetail: z.string().optional(),
   cancelledBy: z.string().min(1),
@@ -311,6 +326,9 @@ const OrderReturnRequestedSchema = z.object({
 
 const OrderRefundCreatedSchema = z.object({
   orderId: z.string().min(1),
+  // 채널 키 (#656).
+  salesChannel: SalesChannelSchema.optional(),
+  externalOrderId: z.string().min(1).optional(),
   refundId: z.string().min(1),
   paymentId: z.string().min(1),
   amount: z.number().nonnegative(),


### PR DESCRIPTION
## 무엇을 고치나

**Medusa 취소·환불이 core 에 한 건도 반영된 적이 없었다.** channel-adapter 가 보내는 `orderId` 와
core 의 `sales_orders.id` 가 **서로 다른 id 공간**이라 lifecycle 핸들러의 PK 조회가 구조적으로 절대
성공할 수 없었다.

| 항목 | 건수 |
|---|---|
| lifecycle 이벤트 수신 (2026-08-10 이후) | 26 |
| 처리 성공 | **0** |
| DLQ (`NotFoundException: Sales order … not found`) | **26** |

## 원인

- channel-adapter 는 **자기가 만든** `payload.orderId` 를 `wms_order_mappings.wmsOrderId` 로 적는다
  (`order-poller.orchestrator.ts`). 이후 이 컬럼을 UPDATE 하는 코드는 없다.
- core 의 `createFromEvent` 는 그 id 를 **쓰지 않는다.** `CreateSalesOrderDto` 에 `id` 필드가 없고
  `salesOrders.id` 는 `uuid().primaryKey().defaultRandom()` 이라 **항상 새 PK** 가 발급된다.
  그래서 `handleOrderCreated` 는 애초에 PK 로 찾지 않고 `findByChannelOrderId` 를 쓴다.
- 그런데 `handleOrderCancelled`·`handleOrderRefundCreated` **만** `getOne(payload.orderId)` 로 PK
  조회를 했다. `f69c2c528`(2026-05-31)부터 — 최근 회귀가 아니라 약 2.5개월 된 결함이다.

같은 주문의 로그가 이 구조를 그대로 보여준다:

```
08-17 09:00:05  [OrderCreated] Received: 472cc359-… from medusa      ← 정상(채널 키 조회)
08-17 11:00:05  [OrderCancelled] Received: orderId=472cc359-…        ← PK 조회 → not found → DLQ
08-17 11:00:05  [OrderRefundCreated] Received: orderId=472cc359-…    ← 동일
```

## 어떻게 고쳤나

1. **계약** — `OrderCancelledPayload`·`OrderRefundCreatedPayload` 에 `salesChannel?` · `externalOrderId?`
   를 **선택 필드**로 추가. 선택 필드는 zod 런타임 검증을 깨지 않으므로 소비자 선배포가 필요 없다
   (값이 추가되는 enum/literal 이었다면 필요했다).
2. **channel-adapter** — lifecycle 발행 시 그 키를 싣는다. `OrderCreated` 가 쓰는 축과 같다.
3. **core** — 채널 키가 있으면 `findByChannelOrderId`, 없으면 종전대로 PK 조회. 폴백이 있어
   **적체된 옛 메시지도 계속 처리**된다.
4. 해석된 SO id 를 `cancel` · `checkAndRecordEvent` · `businessLinks`(select/insert) 에 **모두** 전파.
   이 셋이 전부 core PK 를 요구한다 — 하나라도 `payload.orderId` 로 남으면 FK 가 깨진다.

곁들여 `ChannelOrderProvider.channel` 을 `string` → `SalesChannel` 로 좁혔다. 유일한 구현과
`ChannelOrderSource` 가 이미 `SalesChannel` 이었고, 이 느슨한 선언 하나 때문에 호출부가 캐스팅을
강요당하고 있었다. 덕분에 이 PR 이 캐스팅을 새로 도입하지 않는다.

## 영향 없음을 확인한 것

- **발행자는 channel-adapter 하나뿐**이다(grep 전수). 폴백 경로는 적체분 전용.
- **analytics 도 같은 두 이벤트를 구독**하지만, 자기 fact 를 `OrderCreated`·lifecycle 모두
  `payload.orderId` 로 **일관되게** 키잉하므로 같은 결함이 없고 선택 필드는 무시된다.

## 테스트

- core: `OrderCancelled` 가 채널 키로 SO 를 찾고 **해석된 id** 로 취소하는지 (`cancel` 인자 +
  `orderEvents.orderId` 둘 다 단언) — 수정 전 `NotFoundException` 으로 실패
- core: `OrderRefundCreated` 가 해석된 id 로 `businessLinks.sourceId` 를 남기는지 — 동일하게 실패
- 기존 PK 폴백 케이스 2건(채널 키 없는 payload)이 그대로 초록 = 적체분 호환 유지
- channel-adapter: lifecycle 발행 payload 에 `salesChannel`·`externalOrderId` 가 실리는지
  (`OrderCancelled`·`OrderRefundCreated` 둘 다)

## 게이트

- `npm run type-check` → **0**
- `npx jest --maxWorkers=2` → **417 suite 통과, 실패 0** (3502 tests)

## 배포

- **마이그레이션 없음** · 시크릿·env 변경 없음
- **순서: core → channel-adapter.** 둘 중 어느 쪽이 먼저여도 안전하지만(옛 소비자는 추가 필드를
  zod 가 strip 하고 PK 폴백 → 지금과 동일), core 를 먼저 올려야 channel-adapter 배포 시점부터
  곧바로 낫는다.

## ⚠️ 적체된 DLQ 26건은 이 PR 로 살아나지 않는다

옛 메시지에는 채널 키가 없어 재처리해도 PK 폴백 → 여전히 NotFound 다. 살리려면 채널 어댑터의
`wms_order_mappings` 에서 `wmsOrderId → externalOrderId` 를 되짚어 core SO 를 찾는 **일회성 스크립트**가
필요하다. 그 처분(재처리/폐기)은 #656 에 남은 항목이라 이 PR 범위 밖이다.

Closes #656

https://claude.ai/code/session_01D3NdaFakWfg3XLUomHsYzi