### PR TITLE
fix: ScheduleModule.forRoot() 를 한 벌로 공유해 크론 이중 등록을 없앤다 (#599 항목 2·3)

### DIFF
--- a/apps/channel-adapter/src/adapter.module.ts
+++ b/apps/channel-adapter/src/adapter.module.ts
@@ -4,7 +4,7 @@ import { AdminRealmGuard, AuthorizationModule, JwtAuthGuard } from '@app/authori
 import { LoggerModule } from 'nestjs-pino';
 import { loggerConfig } from '@app/shared/observability/logger.config';
 import { HttpModule } from '@nestjs/axios';
-import { ScheduleModule } from '@nestjs/schedule';
+import { SCHEDULE_ROOT } from '@app/shared/schedule/schedule-root';
 import { ClsModule } from 'nestjs-cls';
 import {
   EventsModule,
@@ -127,7 +127,7 @@ const NO_KAFKA_PUBLISHER_STREAMS: StreamConfig[] = [
       isGlobal: true,
       validate: validateChannelAdapterEnv,
     }),
-    ScheduleModule.forRoot(), // ← Cron 활성화
+    SCHEDULE_ROOT, // ← Cron 활성화
     HttpModule,
     DbModule.forRoot({
       config: {

--- a/apps/core/src/modules/inventory/core/inventory.module.ts
+++ b/apps/core/src/modules/inventory/core/inventory.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { ScheduleModule } from '@nestjs/schedule';
+import { SCHEDULE_ROOT } from '@app/shared/schedule/schedule-root';
 import { SharedModule } from '../shared/shared.module';
 import { ProductSellableQuantityModule } from '../product-sellable-quantity/product-sellable-quantity.module';
 
@@ -35,7 +35,7 @@ import { StockEventStore } from './repositories/stock-event.store';
 // Outbox (temporary — moves to Fulfillment BC in Phase 6)
 
 @Module({
-  imports: [ScheduleModule.forRoot(), SharedModule, ProductSellableQuantityModule],
+  imports: [SCHEDULE_ROOT, SharedModule, ProductSellableQuantityModule],
   controllers: [
     InventoryController,
     LocationController,

--- a/apps/membership/src/app.module.ts
+++ b/apps/membership/src/app.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { LoggerModule } from 'nestjs-pino';
 import { loggerConfig } from '@app/shared/observability/logger.config';
 import { HttpModule } from '@nestjs/axios';
-import { ScheduleModule } from '@nestjs/schedule';
+import { SCHEDULE_ROOT } from '@app/shared/schedule/schedule-root';
 import { DbModule } from '@app/db';
 import { EventsModule, EventTraceApiModule } from '@app/events';
 import { MEMBERSHIP_STREAM, PAYMENT_STREAM } from '@packages/event-contracts/streams';
@@ -88,7 +88,7 @@ import { InternalApiKeyGuard } from './shared/guards/internal-api-key.guard';
       roleMappings: MEMBERSHIP_ROLE_MAPPINGS,
     }),
     HttpModule,
-    ScheduleModule.forRoot(),
+    SCHEDULE_ROOT,
     DbModule.forRoot({
       config: {
         connectionString: process.env.DATABASE_URL || '',

--- a/apps/ugc-service/src/ugc-service.module.ts
+++ b/apps/ugc-service/src/ugc-service.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { LoggerModule } from 'nestjs-pino';
 import { loggerConfig } from '@app/shared/observability/logger.config';
 import { ConfigModule } from '@nestjs/config';
-import { ScheduleModule } from '@nestjs/schedule';
+import { SCHEDULE_ROOT } from '@app/shared/schedule/schedule-root';
 import { DbModule } from '@app/db';
 import { AuthorizationModule, authorizationSchema, JwtAuthGuard, ScopeGuard } from '@app/authorization';
 import { APP_GUARD } from '@nestjs/core';
@@ -34,7 +34,7 @@ const combinedSchema = { ...ugcServiceSchema, ...authorizationSchema };
       },
       schema: combinedSchema,
     }),
-    ScheduleModule.forRoot(),
+    SCHEDULE_ROOT,
     ReviewsModule,
     QnaModule,
   ],

--- a/apps/user-service/src/api/twilio/twilio.module.ts
+++ b/apps/user-service/src/api/twilio/twilio.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { ScheduleModule } from '@nestjs/schedule';
+import { SCHEDULE_ROOT } from '@app/shared/schedule/schedule-root';
 import { Twilio } from 'twilio';
 import { LookupController } from './controllers/lookup.controller';
 import { SendMessageController } from './controllers/send-verify-code.controller';
@@ -11,7 +11,7 @@ import { SendMessageService } from './services/send-verify-code.service';
 import { VerifyCodeService } from './services/verify-code.service';
 
 @Module({
-  imports: [ScheduleModule.forRoot()],
+  imports: [SCHEDULE_ROOT],
   controllers: [SendMessageController, LookupController, VerifyCodeController],
   providers: [
     SendMessageService,

--- a/apps/user-service/src/app.module.ts
+++ b/apps/user-service/src/app.module.ts
@@ -7,7 +7,7 @@ import { LoggerModule } from 'nestjs-pino';
 import { loggerConfig } from '@app/shared/observability/logger.config';
 import { ConfigModule } from '@nestjs/config';
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
-import { ScheduleModule } from '@nestjs/schedule';
+import { SCHEDULE_ROOT } from '@app/shared/schedule/schedule-root';
 import { USER_STREAM } from '@packages/event-contracts/streams';
 import { config } from 'dotenv';
 import { existsSync } from 'fs';
@@ -120,7 +120,7 @@ const staticRoot = existsSync(join(__dirname, 'static')) ? join(__dirname, 'stat
       },
     }),
 
-    ScheduleModule.forRoot(),
+    SCHEDULE_ROOT,
     AuthorizationModule.forRoot({
       microserviceName: 'user-service',
       scopes: [

--- a/apps/wallet/src/wallet.module.ts
+++ b/apps/wallet/src/wallet.module.ts
@@ -10,7 +10,7 @@ import { AUTH_CONFIG, AuthenticationService, JwtAccessStrategy, JwtAuthGuard } f
 import { ConfigModule } from '@nestjs/config';
 import { APP_GUARD, APP_INTERCEPTOR, Reflector } from '@nestjs/core';
 import { PassportModule } from '@nestjs/passport';
-import { ScheduleModule } from '@nestjs/schedule';
+import { SCHEDULE_ROOT } from '@app/shared/schedule/schedule-root';
 import { DbModule } from '@app/db';
 import { LoggerModule } from 'nestjs-pino';
 import { loggerConfig } from '@app/shared/observability/logger.config';
@@ -378,7 +378,7 @@ async function resolveCanActivate(result: boolean | Promise<boolean> | unknown):
       config: { connectionString: process.env.DATABASE_URL ?? '' },
       schema: walletSchema,
     }),
-    ScheduleModule.forRoot(),
+    SCHEDULE_ROOT,
     // 발행 능력 + 소비 정책을 한 자리에서. 옛 `forRoot`+`forConsumerModule` 두 벌에서
     // 합쳤다 — 소비 스트림 목록과 groupId 는 쓰이지 않던 선언이라 사라졌다 (ADR-0029 §1).
     EventsModule.forApp({

--- a/libs/events/src/events.module.ts
+++ b/libs/events/src/events.module.ts
@@ -33,7 +33,7 @@ import { OUTBOX_DISPATCH_GATE, type OutboxDispatchGate } from './outbox/outbox-d
 import { bootstrapKafkaTopics } from './bootstrap/topic-bootstrap.service';
 import { outboxSchema } from './outbox/outbox.schema';
 import { trackingSchema } from './tracking/tracking.schema';
-import { ScheduleModule } from '@nestjs/schedule';
+import { SCHEDULE_ROOT } from '@app/shared/schedule/schedule-root';
 import { DbService } from '@app/db';
 import { EVENT_TRANSPORT, EventTransport } from './transport/transport.port';
 import { KafkaTransport } from './transport/kafka.transport';
@@ -303,7 +303,7 @@ export class EventsModule {
       module: EventsModule,
       imports: [
         ClsModule.forRoot({ global: true, middleware: { mount: false } }),
-        ...(enableOutbox ? [ScheduleModule.forRoot()] : []),
+        ...(enableOutbox ? [SCHEDULE_ROOT] : []),
         ClientsModule.register([
           {
             name: 'KAFKA_CLIENT',

--- a/libs/shared/src/schedule/no-direct-schedule-forroot.spec.ts
+++ b/libs/shared/src/schedule/no-direct-schedule-forroot.spec.ts
@@ -1,0 +1,59 @@
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+/**
+ * `ScheduleModule.forRoot()` 는 저장소 전체에서 **딱 한 곳**(`schedule-root.ts`)만 부른다 (#599).
+ *
+ * Nest 11 은 동적 모듈을 **객체 참조**로 중복 제거하므로, 두 번째 호출은 두 번째 모듈 인스턴스를
+ * 만들고 그 앱의 **모든 `@Cron` 이 두 번 등록**된다. 근거와 재현은 `schedule-root.spec.ts`.
+ *
+ * 이 결함은 **증상이 조용하다** — 크론이 두 번 돌아도 대개 로그가 두 줄일 뿐이고, 멱등한
+ * 작업이면 결과도 같아 보인다. channel-adapter 에서는 취소/환불 이벤트가 실제로 중복 발행됐고
+ * (라이브 8건), 그걸 알아채는 데 8일이 걸렸다. 그래서 리뷰가 아니라 테스트로 막는다.
+ *
+ * ⚠️ 이 테스트는 **저장소 전체를 grep** 한다. 새 앱에서 무심코 `ScheduleModule.forRoot()` 를
+ * 부르면 그 앱의 diff 만 보는 리뷰로는 절대 안 걸리지만 여기서는 걸린다.
+ */
+const REPO = join(__dirname, '..', '..', '..', '..');
+
+/** 이 한 파일만이 `forRoot()` 를 부를 자격이 있다. */
+const CANONICAL = 'libs/shared/src/schedule/schedule-root.ts';
+
+/**
+ * 스펙은 제외한다. 스펙이 자기 `Test.createTestingModule` 안에서 `forRoot()` 를 한 번 부르는 것은
+ * 격리된 앱을 세우는 정상 사용이고, 이 규칙이 막으려는 것은 **프로덕션 모듈 배선의 두 번째 호출**이다.
+ * (`schedule-root.spec.ts` 는 근거를 고정하려고 일부러 두 번 부른다 — 그게 테스트의 내용이다.)
+ */
+const isSpec = (file: string) => file.endsWith('.spec.ts');
+
+describe('ScheduleModule.forRoot() 직접 호출 금지 (#599)', () => {
+  it('정본 파일과 근거 스펙 밖에서는 아무도 부르지 않는다', () => {
+    let out = '';
+    try {
+      out = execFileSync('git', ['grep', '-InE', String.raw`ScheduleModule\.forRoot\(`, '--', '*.ts'], {
+        cwd: REPO,
+        encoding: 'utf8',
+        maxBuffer: 32 * 1024 * 1024,
+      });
+    } catch (error) {
+      // git grep 은 매치가 없으면 exit 1 이다. 그 경우만 빈 결과로 취급한다.
+      const status = (error as { status?: number }).status;
+      if (status !== 1) throw error;
+      out = '';
+    }
+
+    const offenders = out
+      .split('\n')
+      .filter((line) => line.trim().length > 0)
+      // `file:line:content` — content 안에도 콜론이 나오므로 앞 2개만 구분자로 쓴다.
+      .map((line) => {
+        const [file, lineNo, ...rest] = line.split(':');
+        return { file, lineNo, content: rest.join(':').trim() };
+      })
+      .filter(({ file }) => file !== CANONICAL && !isSpec(file))
+      // 주석에서 이름을 언급하는 것은 호출이 아니다.
+      .filter(({ content }) => !content.startsWith('*') && !content.startsWith('//'));
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/libs/shared/src/schedule/schedule-root.spec.ts
+++ b/libs/shared/src/schedule/schedule-root.spec.ts
@@ -1,0 +1,45 @@
+import { Module } from '@nestjs/common';
+import { ModulesContainer } from '@nestjs/core';
+import { ScheduleModule } from '@nestjs/schedule';
+import { Test } from '@nestjs/testing';
+import { SCHEDULE_ROOT } from './schedule-root';
+
+const countScheduleModules = (container: ModulesContainer): number =>
+  [...container.values()].filter((moduleRef) => moduleRef.metatype?.name === 'ScheduleModule').length;
+
+describe('SCHEDULE_ROOT (#599)', () => {
+  /**
+   * 이 테스트는 고칠 대상이 아니라 **근거**다. Nest 11 은 동적 모듈을 구조 해시가 아니라
+   * **객체 참조**로 중복 제거한다 (`ByReferenceModuleOpaqueKeyFactory`, 기본 전략 `random`):
+   * `forRoot()` 가 돌려준 객체에 id 를 도장 찍고, 도장이 없으면 새 랜덤 id 를 준다.
+   *
+   * 그래서 `forRoot()` 를 두 번 부르면 토큰이 달라 **모듈이 두 벌** 생기고, `ScheduleExplorer`
+   * 도 둘이 되어 모든 `@Cron` 이 두 번 등록된다. Nest 10 의 기본은 구조 해시라 같은 코드가
+   * 중복 제거됐다 — 그래서 이 함정은 조용히 들어왔다.
+   *
+   * 이 단언이 1 로 바뀌면 Nest 가 동작을 되돌린 것이므로, 그때는 `SCHEDULE_ROOT` 를 걷어내도 된다.
+   */
+  it('forRoot() 를 두 번 부르면 ScheduleModule 이 두 벌 생긴다 (Nest 11 동작 고정)', async () => {
+    @Module({ imports: [ScheduleModule.forRoot()] })
+    class Leaf {}
+
+    @Module({ imports: [ScheduleModule.forRoot(), Leaf] })
+    class Root {}
+
+    const app = await Test.createTestingModule({ imports: [Root] }).compile();
+
+    expect(countScheduleModules(app.get(ModulesContainer))).toBe(2);
+  });
+
+  it('여러 모듈이 SCHEDULE_ROOT 를 함께 import 하면 한 벌만 생긴다', async () => {
+    @Module({ imports: [SCHEDULE_ROOT] })
+    class Leaf {}
+
+    @Module({ imports: [SCHEDULE_ROOT, Leaf] })
+    class Root {}
+
+    const app = await Test.createTestingModule({ imports: [Root] }).compile();
+
+    expect(countScheduleModules(app.get(ModulesContainer))).toBe(1);
+  });
+});

--- a/libs/shared/src/schedule/schedule-root.ts
+++ b/libs/shared/src/schedule/schedule-root.ts
@@ -1,0 +1,19 @@
+import { ScheduleModule } from '@nestjs/schedule';
+
+/**
+ * 앱 전체가 공유하는 **단 하나의** `ScheduleModule.forRoot()` 결과 (#599).
+ *
+ * Nest 11 은 동적 모듈을 구조 해시가 아니라 **객체 참조**로 중복 제거한다
+ * (`ByReferenceModuleOpaqueKeyFactory`, 기본 전략 `random`): `forRoot()` 가 돌려준 객체에
+ * id 를 도장 찍고, 도장이 없으면 새 랜덤 id 를 발급한다. 따라서 **`forRoot()` 를 두 번 부르면
+ * 토큰이 달라 모듈이 두 벌** 생기고, `ScheduleExplorer` 도 둘이 되어 그 앱의 **모든 `@Cron` 이
+ * 두 번 등록**된다. Nest 10 의 기본은 구조 해시라 같은 코드가 조용히 중복 제거됐다 — 그래서
+ * 이 함정은 증상 없이 들어왔다.
+ *
+ * 라이브에서 channel-adapter 의 5분 주문 폴러가 사이클마다 2회 돌던 원인이 이것이다.
+ *
+ * **`ScheduleModule.forRoot()` 를 직접 부르지 말고 이 상수를 import 할 것.** 모듈이 여러 곳에서
+ * import 해도 참조가 같으므로 한 벌만 생긴다. `global: true` 라 앱 어디서든 한 번이면 충분하다.
+ * 회귀는 `schedule-root.spec.ts` 와 `no-direct-schedule-forroot.spec.ts` 가 막는다.
+ */
+export const SCHEDULE_ROOT = ScheduleModule.forRoot();


### PR DESCRIPTION
## 근본 원인 — webpack 이 아니었다

**Nest 11 은 동적 모듈을 구조 해시가 아니라 「객체 참조」로 중복 제거한다.**

`ByReferenceModuleOpaqueKeyFactory.getOrCreateModuleId()`:

```js
if (originalRef[K_MODULE_ID]) return originalRef[K_MODULE_ID];  // 같은 참조면 같은 id
let moduleId;
if (this.keyGenerationStrategy === 'random') {
  moduleId = this.generateRandomString();                        // 아니면 새 랜덤 id
}
originalRef[K_MODULE_ID] = moduleId;
```

`ModuleCompiler.compile()` 이 `forRoot()` 가 돌려준 **객체 리터럴**을 `originalRef` 로 넘긴다.
매 호출이 새 객체이므로 도장이 없고 → 새 랜덤 id → **토큰이 달라 모듈이 두 벌** → `ScheduleExplorer`
도 둘 → **그 앱의 모든 `@Cron` 이 두 번 등록**된다.

Nest 10 의 기본은 구조 해시(deep-hash)라 같은 코드가 중복 제거됐다. 그래서 이 함정은 **증상 없이**
들어왔고, 이슈 본문의 *"`forRoot()` 가 결정적 구조라 Nest 가 module token 으로 dedupe"* 는 10 기준
으로 맞고 11 에서 깨진 것이다. 로컬 재현이 실패했던 것도 같은 이유로 설명된다.

### 🔴 이슈의 유력 가설은 기각한다

*"webpack 번들에서 `@nestjs/schedule` 이 두 벌로 해석돼 `ScheduleExplorer` 가 둘이 되는 경우"* —
**아니다.** 빌드 산출물을 직접 확인했다:

```
$ grep -o "class ScheduleModule" dist/apps/channel-adapter/main.js | wc -l
0
```

이 패키지는 번들되지 않고 런타임에 `require` 되는 **external** 이라 두 벌이 될 여지가 처음부터 없었다.
다음 사람이 같은 데를 파지 않도록 여기 남긴다.

## 영향 범위 (항목 3)

`forRoot()` 를 두 번 부르던 앱은 **5개**. 이슈가 지목한 4개에 **user-service** 가 더해진다 —
`enableOutbox` 와 무관하게 `app.module.ts:123` 과 `twilio.module.ts:14` 가 각각 부르고 있었다.

| 앱 | 직접 | enableOutbox | 총 | `@Cron` 파일 |
|---|---|---|---|---|
| channel-adapter | 1 | +1 | **2** | 4 |
| core | 1 (`inventory.module.ts:38`) | +1 | **2** | 13 |
| membership | 1 | +1 | **2** | 4 |
| wallet | 1 | +1 | **2** | 7 |
| **user-service** | **2** | 0 | **2** | 6 |
| ugc-service | 1 | 0 | 1 | 1 ✅ |

core 는 `@Cron` 보유 파일이 13개다 — 아웃박스 디스패처(5초 주기)까지 포함해 전부 두 번씩 돌고 있었다.

## 수정

`libs/shared/src/schedule/schedule-root.ts` 가 `SCHEDULE_ROOT` **하나**를 만들고 8개 호출부가 모두
그 **같은 참조**를 import 한다. 참조가 같으므로 Nest 가 한 벌로 묶는다.

소유권을 앱으로 옮기는 대안(`libs/events` 가 `forRoot` 를 안 부르고 앱에 맡김)은 택하지 않았다 —
앱이 잊으면 **아웃박스 디스패처 크론이 조용히 죽는다.** 지금 구조는 잊을 수가 없다.

## 회귀 방어

- **`schedule-root.spec.ts`** — 참조 공유가 한 벌을 만든다는 것과, `forRoot()` 2회가 두 벌을 만든다는
  **Nest 11 동작 자체**를 함께 고정한다. 후자의 기대값이 1 로 바뀌면 Nest 가 동작을 되돌린 것이므로
  그때는 `SCHEDULE_ROOT` 를 걷어내도 된다는 신호다.
- **`no-direct-schedule-forroot.spec.ts`** — 저장소 전체를 `git grep` 해 정본 밖의 직접 호출을 막는다.
  이 결함은 **증상이 조용해서** 앱별 diff 리뷰로는 구조적으로 안 걸린다(라이브에서 알아채는 데 8일
  걸렸다). 스펙이 자기 테스트 모듈에서 부르는 것은 정상이라 제외한다.

TDD 로 갔다 — 참조를 끊은 판본(`{ ...SCHEDULE_ROOT }`)으로 먼저 `Expected: 1, Received: 2` 실패를
확인한 뒤 고쳤다.

## 게이트

- `npm run type-check` → **0**
- `npx jest --maxWorkers=2` → **419 suite 통과, 실패 0** (3505 tests)
- `nest build` × 6개 앱(channel-adapter·core·membership·wallet·user-service·ugc-service) → 전부 OK
- 빌드 산출물 대조: channel-adapter 번들의 `ScheduleModule.forRoot(` 호출 **2 → 1**

## 배포

- **마이그레이션 없음** · 시크릿·env·이벤트 계약 변경 없음
- 5개 앱 전부 재배포해야 효과가 난다. 순서 제약은 없다(앱별로 독립).
- 배포 후 확인: channel-adapter 의 시간당 `Polled` 로그가 **24 → 12** 로 떨어지면 성공이다.

Closes #599

https://claude.ai/code/session_01D3NdaFakWfg3XLUomHsYzi