### PR TITLE
fix(catalog): publish 후 채널 리스팅 승계 + 조회의 활성 버전 술어 (#652, #666)

### DIFF
--- a/apps/core/src/modules/catalog/core/channels/channel-listing-lookup.integration.spec.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing-lookup.integration.spec.ts
@@ -108,9 +108,10 @@ describeIfDb('채널 리스팅 조회는 활성 버전만 내준다 (실 Postgre
     await tx.insert(productVariants).values({ id: variantId, isDefault: true });
     await tx.insert(productMasterVariants).values({ masterId, variantId, versionId: version.id });
 
+    const site = `spec-${masterId.slice(0, 8)}`;
     const [channel] = await tx
       .insert(salesChannels)
-      .values({ site: `spec-${masterId.slice(0, 8)}`, name: '스펙 채널' })
+      .values({ site, name: '스펙 채널' })
       .returning({ id: salesChannels.id });
 
     await tx.insert(channelVariantListings).values({
@@ -120,7 +121,7 @@ describeIfDb('채널 리스팅 조회는 활성 버전만 내준다 (실 Postgre
       isActive: opts.listingActive ?? true,
     });
 
-    return { salesChannelId: channel.id, channelItemId, variantId };
+    return { salesChannelId: channel.id, site, channelItemId, variantId };
   }
 
   it('활성 버전에 매달린 품목은 그대로 조회된다', async () => {
@@ -172,5 +173,35 @@ describeIfDb('채널 리스팅 조회는 활성 버전만 내준다 (실 Postgre
       return service.lookupVariant(salesChannelId, channelItemId, tx);
     });
     expect(result).toBeNull();
+  });
+
+  // 주문 수집이 실제로 타는 진입점은 이쪽이다
+  // (ChannelLineIdentityResolver → lookupByChannelCode → 컨트롤러 → lookupVariantByChannelCode).
+  // 두 진입점이 같은 빌더를 쓰지만, 채널 선택 술어와 salesChannels 조인은 여기만의 것이다.
+  describe('채널 코드(site) 진입점 — 주문 수집 실사용 경로', () => {
+    it('활성 버전에 매달린 품목은 그대로 조회된다', async () => {
+      const found = await inRollbackTx(async (tx) => {
+        const { site, channelItemId, variantId } = await seedListing(tx);
+        const result = await service.lookupVariantByChannelCode(site, channelItemId, tx);
+        return { result, variantId };
+      });
+      expect(found.result?.variantId).toBe(found.variantId);
+    });
+
+    it('비활성 버전에만 매달린 품목은 조회되지 않는다', async () => {
+      const result = await inRollbackTx(async (tx) => {
+        const { site, channelItemId } = await seedListing(tx, { status: 'inactive' });
+        return service.lookupVariantByChannelCode(site, channelItemId, tx);
+      });
+      expect(result).toBeNull();
+    });
+
+    it('soft delete 된 마스터의 품목은 조회되지 않는다', async () => {
+      const result = await inRollbackTx(async (tx) => {
+        const { site, channelItemId } = await seedListing(tx, { masterDeleted: true });
+        return service.lookupVariantByChannelCode(site, channelItemId, tx);
+      });
+      expect(result).toBeNull();
+    });
   });
 });

--- a/apps/core/src/modules/catalog/core/channels/channel-listing-lookup.integration.spec.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing-lookup.integration.spec.ts
@@ -1,0 +1,176 @@
+// jest moduleNameMapper 가 bare `@packages/event-contracts` 를 못 잡아 module-not-found 로 죽는다.
+// 매핑되는 서브패스로 requireActual 하는 것이 이 레포의 상시 우회다.
+jest.mock(
+  '@packages/event-contracts',
+  () => jest.requireActual<typeof import('@packages/event-contracts')>('@packages/event-contracts/index'),
+  { virtual: true },
+);
+
+import { randomUUID } from 'crypto';
+import * as postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import type { DbService } from '@app/db';
+import { DbTransaction } from '../../catalog.types';
+import {
+  catalogSchema,
+  type PimSchema,
+  channelVariantListings,
+  productMasters,
+  productMasterVariants,
+  productMasterVersions,
+  productVariants,
+  salesChannels,
+} from '../../schema/catalog.schema';
+import { ChannelListingService } from './channel-listing.service';
+
+/**
+ * 채널 리스팅 조회가 **활성 버전에만** 매핑을 내주는지 확인한다 (#666).
+ *
+ * 검증 대상이 SQL 술어 자체라 DB 를 목으로 두면 아무것도 확인하지 못한다 — 큐 mock 은
+ * where 절과 무관하게 넣어둔 행을 돌려주기 때문이다. 조회가 낡은 버전을 내주면 채널 주문이
+ * 옛 판매정책·옛 SKU 스냅샷으로 조용히 처리된다(#652); null 이 나가야 미식별 격리로 간다.
+ *
+ * 실행: `npm run test:core:integration:local -- channel-listing-lookup`
+ * 격리: 각 테스트가 트랜잭션을 열어 픽스처를 넣고 항상 롤백한다.
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+
+class Rollback extends Error {}
+
+describeIfDb('채널 리스팅 조회는 활성 버전만 내준다 (실 Postgres)', () => {
+  jest.setTimeout(120_000);
+
+  let sql: postgres.Sql;
+  let db: DbService<PimSchema>;
+  let service: ChannelListingService;
+
+  beforeAll(() => {
+    // Nest DI 를 띄우지 않는다 — product-masters-selection.integration.spec.ts 와 같은 이유·같은 형태.
+    const connection = postgres(DATABASE_URL as string, { max: 1 });
+    sql = connection;
+    const drizzleDb = drizzle(connection, { schema: catalogSchema });
+
+    db = {
+      db: drizzleDb,
+      run: <T>(fn: (t: DbTransaction) => Promise<T>, tx?: DbTransaction): Promise<T> =>
+        tx ? fn(tx) : drizzleDb.transaction((t) => fn(t)),
+    } as unknown as DbService<PimSchema>;
+
+    // lookupVariant 는 가용재고 협력자를 건드리지 않는다 (쓰기 경로에서만 쓰인다).
+    service = new ChannelListingService(db, {} as never);
+  });
+
+  afterAll(async () => {
+    await sql?.end();
+  });
+
+  async function inRollbackTx<T>(fn: (tx: DbTransaction) => Promise<T>): Promise<T> {
+    let captured!: T;
+    await expect(
+      db.run(async (tx) => {
+        captured = await fn(tx);
+        throw new Rollback('intentional rollback');
+      }),
+    ).rejects.toThrow(Rollback);
+    return captured;
+  }
+
+  /** 마스터 1건 + 버전 1건 + 품목 1건 + 그 품목을 가리키는 채널 리스팅 1건. */
+  async function seedListing(
+    tx: DbTransaction,
+    opts: {
+      status?: 'active' | 'inactive' | 'draft';
+      versionDeleted?: boolean;
+      masterDeleted?: boolean;
+      listingActive?: boolean;
+    } = {},
+  ) {
+    const masterId = randomUUID();
+    const variantId = randomUUID();
+    const channelItemId = `item-${masterId.slice(0, 8)}`;
+
+    await tx.insert(productMasters).values({
+      id: masterId,
+      createdBy: null,
+      ...(opts.masterDeleted ? { deletedAt: new Date() } : {}),
+    });
+    const [version] = await tx
+      .insert(productMasterVersions)
+      .values({
+        masterId,
+        name: `조회-${masterId.slice(0, 8)}`,
+        status: opts.status ?? 'active',
+        ...(opts.versionDeleted ? { deletedAt: new Date() } : {}),
+      })
+      .returning({ id: productMasterVersions.id });
+
+    await tx.insert(productVariants).values({ id: variantId, isDefault: true });
+    await tx.insert(productMasterVariants).values({ masterId, variantId, versionId: version.id });
+
+    const [channel] = await tx
+      .insert(salesChannels)
+      .values({ site: `spec-${masterId.slice(0, 8)}`, name: '스펙 채널' })
+      .returning({ id: salesChannels.id });
+
+    await tx.insert(channelVariantListings).values({
+      variantId,
+      salesChannelId: channel.id,
+      channelItemId,
+      isActive: opts.listingActive ?? true,
+    });
+
+    return { salesChannelId: channel.id, channelItemId, variantId };
+  }
+
+  it('활성 버전에 매달린 품목은 그대로 조회된다', async () => {
+    const found = await inRollbackTx(async (tx) => {
+      const { salesChannelId, channelItemId, variantId } = await seedListing(tx);
+      const result = await service.lookupVariant(salesChannelId, channelItemId, tx);
+      return { result, variantId };
+    });
+    expect(found.result?.variantId).toBe(found.variantId);
+  });
+
+  it('비활성 버전에만 매달린 품목은 조회되지 않는다', async () => {
+    // 이게 #652 의 증상이다 — 조회가 성공해 옛 버전 값이 주문 처리에 그대로 실렸다.
+    const result = await inRollbackTx(async (tx) => {
+      const { salesChannelId, channelItemId } = await seedListing(tx, { status: 'inactive' });
+      return service.lookupVariant(salesChannelId, channelItemId, tx);
+    });
+    expect(result).toBeNull();
+  });
+
+  it('draft 버전에만 매달린 품목은 조회되지 않는다', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { salesChannelId, channelItemId } = await seedListing(tx, { status: 'draft' });
+      return service.lookupVariant(salesChannelId, channelItemId, tx);
+    });
+    expect(result).toBeNull();
+  });
+
+  it('soft delete 된 버전의 품목은 조회되지 않는다', async () => {
+    // 삭제는 status 를 그대로 두고 deletedAt 만 세운다 — 상태만 보면 통과한다.
+    const result = await inRollbackTx(async (tx) => {
+      const { salesChannelId, channelItemId } = await seedListing(tx, { versionDeleted: true });
+      return service.lookupVariant(salesChannelId, channelItemId, tx);
+    });
+    expect(result).toBeNull();
+  });
+
+  it('soft delete 된 마스터의 품목은 조회되지 않는다', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { salesChannelId, channelItemId } = await seedListing(tx, { masterDeleted: true });
+      return service.lookupVariant(salesChannelId, channelItemId, tx);
+    });
+    expect(result).toBeNull();
+  });
+
+  it('꺼진 리스팅은 활성 버전이어도 조회되지 않는다', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { salesChannelId, channelItemId } = await seedListing(tx, { listingActive: false });
+      return service.lookupVariant(salesChannelId, channelItemId, tx);
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/apps/core/src/modules/catalog/core/channels/channel-listing-lookup.query.spec.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing-lookup.query.spec.ts
@@ -1,0 +1,50 @@
+import * as postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { eq } from 'drizzle-orm';
+import { catalogSchema, salesChannels } from '../../schema/catalog.schema';
+import { DbClient } from '../../catalog.types';
+import { buildChannelListingLookupQuery } from './channel-listing-lookup.query';
+
+/**
+ * 조회 술어의 **계약 잠금**이다 (#666).
+ *
+ * 이 술어가 검증되는 유일한 자리가 실 DB 통합 스펙인데, 그건 `DATABASE_URL` 이 없으면
+ * 통째로 skip 되고 CI 게이트에는 DB 가 없다 — 즉 방어 코드를 통째로 지워도 게이트가
+ * 초록이었다. 여기서는 SQL 문자열만 보므로 DB 없이 CI 에서 돈다.
+ *
+ * 의미(정말 걸러지는가)는 `channel-listing-lookup.integration.spec.ts` 가 실 Postgres 로 본다.
+ * 이 스펙은 그 술어가 **사라지지 않았는지**만 지킨다.
+ */
+describe('채널 리스팅 조회 쿼리의 술어 계약 (#666)', () => {
+  // 쿼리를 만들기만 하고 실행하지 않는다 — postgres.js 는 지연 연결이라 소켓이 열리지 않는다.
+  const connection = postgres('postgres://spec:spec@127.0.0.1:1/none', { max: 1 });
+  const client = drizzle(connection, { schema: catalogSchema }) as unknown as DbClient;
+
+  afterAll(async () => {
+    await connection.end({ timeout: 0 });
+  });
+
+  const sqlOf = () =>
+    buildChannelListingLookupQuery(client, 'item-1', eq(salesChannels.site, 'naver')).toSQL().sql;
+
+  it('활성 버전만 통과시킨다', () => {
+    expect(sqlOf()).toContain('"product_master_versions"."status" = ');
+  });
+
+  it('soft delete 된 버전과 마스터를 둘 다 배제한다', () => {
+    const sql = sqlOf();
+    expect(sql).toContain('"product_master_versions"."deleted_at" is null');
+    expect(sql).toContain('"product_masters"."deleted_at" is null');
+  });
+
+  it('꺼진 리스팅을 배제한다', () => {
+    expect(sqlOf()).toContain('"channel_variant_listings"."is_active" = ');
+  });
+
+  it('마스터를 버전의 master_id 로 앵커한다', () => {
+    // product_master_variants.master_id 는 버전의 것과 같다는 DB 제약이 없다.
+    expect(sqlOf()).toContain(
+      '"product_masters" on "product_masters"."id" = "product_master_versions"."master_id"',
+    );
+  });
+});

--- a/apps/core/src/modules/catalog/core/channels/channel-listing-lookup.query.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing-lookup.query.ts
@@ -1,0 +1,68 @@
+import { SQL, and, desc, eq, isNull } from 'drizzle-orm';
+import {
+  channelVariantListings,
+  productMasterVariants,
+  productMasterVersions,
+  productMasters,
+  productVariants,
+  salesChannels,
+} from '../../schema/catalog.schema';
+import { DbClient } from '../../catalog.types';
+
+/**
+ * 리스팅 조회가 요구하는 "지금 팔리는 버전" 술어 (#666).
+ *
+ * 이게 없으면 조회 조인이 낡은 버전을 통해서도 성립해 **null 대신 옛 값이 반환된다** —
+ * 격리도 로그도 없이 옛 판매정책·옛 SKU 스냅샷으로 채널 주문이 처리된다(#652 의 증상).
+ * publish 승계(reconciler)는 publish 라는 사건에만 반응하므로, 그 사건을 안 거치고 낡는
+ * 경로(#663 승인 우회 · #664 판매중지 · #665 레이스 · hardDelete)는 이 술어만이 막는다.
+ *
+ * soft delete 는 `status` 를 그대로 두고 `deletedAt` 만 세우므로 둘 다 봐야 한다.
+ */
+const ACTIVE_VERSION_PREDICATES = [
+  eq(productMasterVersions.status, 'active'),
+  isNull(productMasterVersions.deletedAt),
+  isNull(productMasters.deletedAt),
+];
+
+/**
+ * 채널 리스팅 → 품목 조회 쿼리. 채널을 고르는 술어만 호출부가 준다.
+ *
+ * 두 진입점(`lookupVariant` 는 판매채널 ID 로, `lookupVariantByChannelCode` 는 site 로)이
+ * select·조인·정렬을 통째로 복제하고 있었다. 한 벌로 합쳐 **술어가 물리적으로 한 곳**이
+ * 되게 한다 — 갈라져 있으면 다음 사람이 한쪽만 고치고 #666 을 재발시킨다.
+ *
+ * `productMasters` 는 버전의 `masterId` 로 앵커한다. `product_master_variants.master_id` 는
+ * 버전의 것과 같다는 DB 제약이 없어(각자 FK 만 있다) 갈린 행에서는 엉뚱한 master 의
+ * `deletedAt` 을 보게 된다.
+ */
+export function buildChannelListingLookupQuery(client: DbClient, channelItemId: string, channelPredicate: SQL) {
+  return client
+    .select({
+      masterId: productMasterVariants.masterId,
+      versionId: productMasterVariants.versionId,
+      productName: productMasterVersions.name,
+      variantId: channelVariantListings.variantId,
+      variantCode: productVariants.variantCode,
+      variantName: productVariants.variantName,
+      isActive: channelVariantListings.isActive,
+    })
+    .from(channelVariantListings)
+    .innerJoin(productVariants, eq(channelVariantListings.variantId, productVariants.id))
+    .innerJoin(productMasterVariants, eq(productMasterVariants.variantId, productVariants.id))
+    .innerJoin(productMasterVersions, eq(productMasterVariants.versionId, productMasterVersions.id))
+    .innerJoin(productMasters, eq(productMasters.id, productMasterVersions.masterId))
+    .innerJoin(salesChannels, eq(salesChannels.id, channelVariantListings.salesChannelId))
+    .where(
+      and(
+        channelPredicate,
+        eq(channelVariantListings.channelItemId, channelItemId),
+        eq(channelVariantListings.isActive, true),
+        ...ACTIVE_VERSION_PREDICATES,
+      ),
+    )
+    // 활성 버전만 남으므로 상태 분기 정렬은 필요 없다. 한 variant 가 두 master 에 매달린
+    // 이상 상태(bulk import 의 phantom masterId)에서도 결과를 고정하려고 정렬은 남긴다.
+    .orderBy(desc(productMasterVersions.version), desc(productMasterVersions.createdAt))
+    .limit(1);
+}

--- a/apps/core/src/modules/catalog/core/channels/channel-listing.service.spec.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing.service.spec.ts
@@ -24,10 +24,11 @@ function makeService(results: any[]) {
 const baseDto = { variantId: 'var-1', salesChannelId: 'ch-1', channelItemId: 'item-1' } as any;
 
 describe('ChannelListingService createListing — 외부채널 디지털 차단', () => {
-  // 큐 순서: variant존재 → channel존재 → (assert)channel site → (assert)isDigitalVariant → insert
+  // 큐 순서: variant존재 → activeVersion매핑 → channel존재 → (assert)channel site → (assert)isDigitalVariant → insert
   it('외부채널(naver) + 디지털 variant 는 listing 을 차단한다', async () => {
     const service = makeService([
       [{ id: 'var-1' }],
+      [{ id: 'pmv-1' }],
       [{ id: 'ch-1' }],
       [{ site: 'naver' }],
       [{ fulfillmentKind: 'digital' }],
@@ -38,6 +39,7 @@ describe('ChannelListingService createListing — 외부채널 디지털 차단'
   it('외부채널(coupang) + 물리 variant 는 listing 을 허용한다', async () => {
     const service = makeService([
       [{ id: 'var-1' }],
+      [{ id: 'pmv-1' }],
       [{ id: 'ch-1' }],
       [{ site: 'coupang' }],
       [{ fulfillmentKind: 'physical' }],
@@ -49,6 +51,7 @@ describe('ChannelListingService createListing — 외부채널 디지털 차단'
   it('medusa(자사몰) 채널은 디지털이어도 listing 을 허용한다 (외부채널 아님 → digital 조회 skip)', async () => {
     const service = makeService([
       [{ id: 'var-1' }],
+      [{ id: 'pmv-1' }],
       [{ id: 'ch-1' }],
       [{ site: 'medusa' }],
       [{ id: 'listing-2', variantId: 'var-1' }],
@@ -58,10 +61,11 @@ describe('ChannelListingService createListing — 외부채널 디지털 차단'
 });
 
 describe('ChannelListingService activateListing — 외부채널 디지털 재활성 차단', () => {
-  // 큐 순서: getListingById → (assert)channel site → (assert)isDigitalVariant → update
+  // 큐 순서: getListingById → activeVersion매핑 → (assert)channel site → (assert)isDigitalVariant → update
   it('비활성 외부채널(naver) 디지털 listing 재활성을 차단한다', async () => {
     const service = makeService([
       [{ id: 'l-1', variantId: 'var-1', salesChannelId: 'ch-1' }],
+      [{ id: 'pmv-1' }],
       [{ site: 'naver' }],
       [{ fulfillmentKind: 'digital' }],
     ]);
@@ -71,6 +75,7 @@ describe('ChannelListingService activateListing — 외부채널 디지털 재�
   it('medusa 채널 listing 은 재활성을 허용한다', async () => {
     const service = makeService([
       [{ id: 'l-2', variantId: 'var-1', salesChannelId: 'ch-1' }],
+      [{ id: 'pmv-1' }],
       [{ site: 'medusa' }],
       [{ id: 'l-2', variantId: 'var-1' }],
     ]);
@@ -87,5 +92,21 @@ describe('ChannelListingService.isExternalMarketplaceSite', () => {
   it('medusa/3pl 은 외부 마켓플레이스가 아니다', () => {
     expect((service as any).isExternalMarketplaceSite('medusa')).toBe(false);
     expect((service as any).isExternalMarketplaceSite('3pl')).toBe(false);
+  });
+});
+
+describe('ChannelListingService — publish 되지 않은 품목 리스팅 차단 (#652)', () => {
+  // draft 에만 매달린 variant 에 리스팅을 걸면, 그 draft 를 버릴 때 variant 가 삭제되고
+  // channel_variant_listings.variant_id 의 cascade 로 리스팅이 조용히 사라진다.
+  it('createListing: active 버전에 매달리지 않은 variant 는 거부한다', async () => {
+    // 큐: variant존재 → activeVersion 매핑(없음)
+    const service = makeService([[{ id: 'var-1' }], []]);
+    await expect(service.createListing(baseDto)).rejects.toThrow('publish');
+  });
+
+  it('activateListing: active 버전에 매달리지 않은 variant 는 재활성을 거부한다', async () => {
+    // 큐: getListingById → activeVersion 매핑(없음)
+    const service = makeService([[{ id: 'l-1', variantId: 'var-1', salesChannelId: 'ch-1' }], []]);
+    await expect(service.activateListing('l-1')).rejects.toThrow('publish');
   });
 });

--- a/apps/core/src/modules/catalog/core/channels/channel-listing.service.spec.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing.service.spec.ts
@@ -98,15 +98,21 @@ describe('isExternalMarketplaceSite', () => {
 describe('ChannelListingService — publish 되지 않은 품목 리스팅 차단 (#652)', () => {
   // draft 에만 매달린 variant 에 리스팅을 걸면, 그 draft 를 버릴 때 variant 가 삭제되고
   // channel_variant_listings.variant_id 의 cascade 로 리스팅이 조용히 사라진다.
-  it('createListing: active 버전에 매달리지 않은 variant 는 거부한다', async () => {
-    // 큐: variant존재 → activeVersion 매핑(없음)
-    const service = makeService([[{ id: 'var-1' }], []]);
+  it('createListing: draft 에만 매달린 variant 는 거부한다', async () => {
+    // 큐: variant존재 → 버전 상태들(draft 뿐)
+    const service = makeService([[{ id: 'var-1' }], [{ status: 'draft' }]]);
     await expect(service.createListing(baseDto)).rejects.toThrow('publish');
   });
 
-  it('activateListing: active 버전에 매달리지 않은 variant 는 재활성을 거부한다', async () => {
-    // 큐: getListingById → activeVersion 매핑(없음)
-    const service = makeService([[{ id: 'l-1', variantId: 'var-1', salesChannelId: 'ch-1' }], []]);
+  // hardDelete 가 버전 행을 지우면 매핑만 사라지고 variant 는 남는다(라이브에 4건 실재).
+  // 그 품목은 publish 할 방법이 없으므로 "publish 하세요" 안내는 막다른 길이다.
+  it('createListing: 어떤 버전에도 안 매달린 고아 variant 는 그 사실을 알린다', async () => {
+    const service = makeService([[{ id: 'var-1' }], []]);
+    await expect(service.createListing(baseDto)).rejects.toThrow('속하지');
+  });
+
+  it('activateListing: draft 에만 매달린 variant 는 재활성을 거부한다', async () => {
+    const service = makeService([[{ id: 'l-1', variantId: 'var-1', salesChannelId: 'ch-1' }], [{ status: 'draft' }]]);
     await expect(service.activateListing('l-1')).rejects.toThrow('publish');
   });
 

--- a/apps/core/src/modules/catalog/core/channels/channel-listing.service.spec.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing.service.spec.ts
@@ -1,4 +1,5 @@
 import { ChannelListingService } from './channel-listing.service';
+import { isExternalMarketplaceSite } from './marketplace-site';
 
 // drizzle 쿼리 체인 mock: select()/insert()/update() 호출마다 큐의 다음 결과를 반환하는 thenable.
 function makeClient(results: any[]) {
@@ -28,7 +29,7 @@ describe('ChannelListingService createListing — 외부채널 디지털 차단'
   it('외부채널(naver) + 디지털 variant 는 listing 을 차단한다', async () => {
     const service = makeService([
       [{ id: 'var-1' }],
-      [{ id: 'pmv-1' }],
+      [{ status: 'active' }],
       [{ id: 'ch-1' }],
       [{ site: 'naver' }],
       [{ fulfillmentKind: 'digital' }],
@@ -39,7 +40,7 @@ describe('ChannelListingService createListing — 외부채널 디지털 차단'
   it('외부채널(coupang) + 물리 variant 는 listing 을 허용한다', async () => {
     const service = makeService([
       [{ id: 'var-1' }],
-      [{ id: 'pmv-1' }],
+      [{ status: 'active' }],
       [{ id: 'ch-1' }],
       [{ site: 'coupang' }],
       [{ fulfillmentKind: 'physical' }],
@@ -51,7 +52,7 @@ describe('ChannelListingService createListing — 외부채널 디지털 차단'
   it('medusa(자사몰) 채널은 디지털이어도 listing 을 허용한다 (외부채널 아님 → digital 조회 skip)', async () => {
     const service = makeService([
       [{ id: 'var-1' }],
-      [{ id: 'pmv-1' }],
+      [{ status: 'active' }],
       [{ id: 'ch-1' }],
       [{ site: 'medusa' }],
       [{ id: 'listing-2', variantId: 'var-1' }],
@@ -65,7 +66,7 @@ describe('ChannelListingService activateListing — 외부채널 디지털 재�
   it('비활성 외부채널(naver) 디지털 listing 재활성을 차단한다', async () => {
     const service = makeService([
       [{ id: 'l-1', variantId: 'var-1', salesChannelId: 'ch-1' }],
-      [{ id: 'pmv-1' }],
+      [{ status: 'active' }],
       [{ site: 'naver' }],
       [{ fulfillmentKind: 'digital' }],
     ]);
@@ -75,7 +76,7 @@ describe('ChannelListingService activateListing — 외부채널 디지털 재�
   it('medusa 채널 listing 은 재활성을 허용한다', async () => {
     const service = makeService([
       [{ id: 'l-2', variantId: 'var-1', salesChannelId: 'ch-1' }],
-      [{ id: 'pmv-1' }],
+      [{ status: 'active' }],
       [{ site: 'medusa' }],
       [{ id: 'l-2', variantId: 'var-1' }],
     ]);
@@ -83,15 +84,14 @@ describe('ChannelListingService activateListing — 외부채널 디지털 재�
   });
 });
 
-describe('ChannelListingService.isExternalMarketplaceSite', () => {
-  const service = makeService([]);
+describe('isExternalMarketplaceSite', () => {
   it('naver/coupang 는 외부 마켓플레이스', () => {
-    expect((service as any).isExternalMarketplaceSite('naver')).toBe(true);
-    expect((service as any).isExternalMarketplaceSite('coupang')).toBe(true);
+    expect(isExternalMarketplaceSite('naver')).toBe(true);
+    expect(isExternalMarketplaceSite('coupang')).toBe(true);
   });
   it('medusa/3pl 은 외부 마켓플레이스가 아니다', () => {
-    expect((service as any).isExternalMarketplaceSite('medusa')).toBe(false);
-    expect((service as any).isExternalMarketplaceSite('3pl')).toBe(false);
+    expect(isExternalMarketplaceSite('medusa')).toBe(false);
+    expect(isExternalMarketplaceSite('3pl')).toBe(false);
   });
 });
 
@@ -108,5 +108,20 @@ describe('ChannelListingService — publish 되지 않은 품목 리스팅 차�
     // 큐: getListingById → activeVersion 매핑(없음)
     const service = makeService([[{ id: 'l-1', variantId: 'var-1', salesChannelId: 'ch-1' }], []]);
     await expect(service.activateListing('l-1')).rejects.toThrow('publish');
+  });
+
+  // publish 로 품목이 교체된 낡은 매핑은 "미publish" 와 원인도 복구법도 다르다.
+  // 그 매핑은 활성화도 재생성도(uq_channel_variant_listing) 막히므로 삭제 후 재등록이 유일한 길이다.
+  it('createListing: 버전 매핑은 있으나 active 가 없으면 낡은 매핑이라고 알린다', async () => {
+    const service = makeService([[{ id: 'var-1' }], [{ status: 'inactive' }]]);
+    await expect(service.createListing(baseDto)).rejects.toThrow('삭제');
+  });
+
+  it('activateListing: 낡은 매핑은 삭제 후 재등록을 안내한다', async () => {
+    const service = makeService([
+      [{ id: 'l-1', variantId: 'var-1', salesChannelId: 'ch-1' }],
+      [{ status: 'inactive' }],
+    ]);
+    await expect(service.activateListing('l-1')).rejects.toThrow('삭제');
   });
 });

--- a/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
@@ -133,6 +133,31 @@ export class ChannelListingService {
   }
 
   /**
+   * 리스팅 대상 variant 가 active 버전에 매달려 있는지 확인한다.
+   *
+   * draft 에만 매달린 variant 에 리스팅을 걸면, 그 draft 를 버릴 때
+   * `deleteDraftVersion` → `_cleanupOrphanedVariantsAfterDeletion` 이 variant 를 지우고
+   * `channel_variant_listings.variant_id` 의 `onDelete: 'cascade'` 로 **리스팅이 조용히 사라진다.**
+   * 생성 시점에 막는 게 유일하게 확실한 방어다 (#652).
+   */
+  private async assertVariantIsPublished(variantId: string, tx?: DbTransaction): Promise<void> {
+    const client = this.getClient(tx);
+
+    const [mapping] = await client
+      .select({ id: productMasterVariants.id })
+      .from(productMasterVariants)
+      .innerJoin(productMasterVersions, eq(productMasterVersions.id, productMasterVariants.versionId))
+      .where(and(eq(productMasterVariants.variantId, variantId), eq(productMasterVersions.status, 'active')))
+      .limit(1);
+
+    if (!mapping) {
+      throw new BadRequestError(
+        `아직 publish 되지 않은 품목에는 채널 매핑을 걸 수 없습니다. 상품을 publish 한 뒤 다시 시도하세요: ${variantId}`,
+      );
+    }
+  }
+
+  /**
    * 새 채널 매핑 생성
    */
   async createListing(dto: CreateChannelListingDto, tx?: DbTransaction): Promise<ChannelVariantListing> {
@@ -148,6 +173,8 @@ export class ChannelListingService {
     if (variant.length === 0) {
       throw new NotFoundError(`Variant not found: ${dto.variantId}`);
     }
+
+    await this.assertVariantIsPublished(dto.variantId, tx);
 
     // Channel 존재 확인
     const channel = await client
@@ -294,6 +321,7 @@ export class ChannelListingService {
     if (!existing) {
       return;
     }
+    await this.assertVariantIsPublished(existing.variantId, tx);
     await this.assertDigitalAllowedForChannel(existing.variantId, existing.salesChannelId, tx);
 
     const [updated] = await client

--- a/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
@@ -16,6 +16,22 @@ import { ChannelVariantListingEntity, SalesChannelEntity } from '../../schema/ca
 import { ProductSellableQuantityService } from '../../../inventory/product-sellable-quantity/services/product-sellable-quantity.service';
 import { isExternalMarketplaceSite } from './marketplace-site';
 
+/**
+ * 리스팅 조회가 요구하는 "지금 팔리는 버전" 술어 (#666).
+ *
+ * 이게 없으면 조회 조인이 낡은 버전을 통해서도 성립해 **null 대신 옛 값이 반환된다** —
+ * 격리도 로그도 없이 옛 판매정책·옛 SKU 스냅샷으로 채널 주문이 처리된다(#652 의 증상).
+ * publish 승계(reconciler)는 publish 라는 사건에만 반응하므로, 그 사건을 안 거치고 낡는
+ * 경로(#663 승인 우회 · #664 판매중지 · #665 레이스 · hardDelete)는 이 술어만이 막는다.
+ *
+ * soft delete 는 `status` 를 그대로 두고 `deletedAt` 만 세우므로 둘 다 봐야 한다.
+ */
+const ACTIVE_VERSION_PREDICATES = [
+  eq(productMasterVersions.status, 'active'),
+  isNull(productMasterVersions.deletedAt),
+  isNull(productMasters.deletedAt),
+];
+
 export interface LookupVariantResult {
   masterId: string;
   versionId: string;
@@ -75,18 +91,18 @@ export class ChannelListingService {
       .innerJoin(productVariants, eq(channelVariantListings.variantId, productVariants.id))
       .innerJoin(productMasterVariants, eq(productMasterVariants.variantId, productVariants.id))
       .innerJoin(productMasterVersions, eq(productMasterVariants.versionId, productMasterVersions.id))
+      .innerJoin(productMasters, eq(productMasters.id, productMasterVariants.masterId))
       .where(
         and(
           eq(channelVariantListings.salesChannelId, salesChannelId),
           eq(channelVariantListings.channelItemId, channelItemId),
           eq(channelVariantListings.isActive, true),
+          ...ACTIVE_VERSION_PREDICATES,
         ),
       )
-      .orderBy(
-        sql`CASE WHEN ${productMasterVersions.status} = 'active' THEN 0 ELSE 1 END`,
-        desc(productMasterVersions.version),
-        desc(productMasterVersions.createdAt),
-      )
+      // 활성 버전만 남으므로 상태 분기 정렬은 필요 없다. 한 variant 가 두 master 에
+      // 매달린 이상 상태(bulk import 의 phantom masterId)에서도 결과를 고정하려고 정렬은 남긴다.
+      .orderBy(desc(productMasterVersions.version), desc(productMasterVersions.createdAt))
       .limit(1);
 
     return result[0] ?? null;
@@ -116,19 +132,19 @@ export class ChannelListingService {
       .innerJoin(productVariants, eq(channelVariantListings.variantId, productVariants.id))
       .innerJoin(productMasterVariants, eq(productMasterVariants.variantId, productVariants.id))
       .innerJoin(productMasterVersions, eq(productMasterVariants.versionId, productMasterVersions.id))
+      .innerJoin(productMasters, eq(productMasters.id, productMasterVariants.masterId))
       .innerJoin(salesChannels, eq(channelVariantListings.salesChannelId, salesChannels.id))
       .where(
         and(
           eq(salesChannels.site, channelCode),
           eq(channelVariantListings.channelItemId, channelItemId),
           eq(channelVariantListings.isActive, true),
+          ...ACTIVE_VERSION_PREDICATES,
         ),
       )
-      .orderBy(
-        sql`CASE WHEN ${productMasterVersions.status} = 'active' THEN 0 ELSE 1 END`,
-        desc(productMasterVersions.version),
-        desc(productMasterVersions.createdAt),
-      )
+      // 활성 버전만 남으므로 상태 분기 정렬은 필요 없다. 한 variant 가 두 master 에
+      // 매달린 이상 상태(bulk import 의 phantom masterId)에서도 결과를 고정하려고 정렬은 남긴다.
+      .orderBy(desc(productMasterVersions.version), desc(productMasterVersions.createdAt))
       .limit(1);
 
     return result[0] ?? null;

--- a/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
@@ -5,12 +5,13 @@ import { ChannelVariantListing, NewChannelVariantListing, DbTransaction, DbClien
 import {
   type PimSchema,
   channelVariantListings,
+  productMasters,
   productMasterVariants,
   productMasterVersions,
   productVariants,
   salesChannels,
 } from '../../schema/catalog.schema';
-import { eq, and, desc, sql } from 'drizzle-orm';
+import { eq, and, desc, sql, isNull } from 'drizzle-orm';
 import { ChannelVariantListingEntity, SalesChannelEntity } from '../../schema/catalog.schema.types';
 import { ProductSellableQuantityService } from '../../../inventory/product-sellable-quantity/services/product-sellable-quantity.service';
 import { isExternalMarketplaceSite } from './marketplace-site';
@@ -147,13 +148,31 @@ export class ChannelListingService {
   private async assertVariantIsPublished(variantId: string, tx?: DbTransaction): Promise<void> {
     const client = this.getClient(tx);
 
+    // soft delete 는 status 를 그대로 두고 deletedAt 만 세운다 — 상태만 보면 삭제된 상품이
+    // 통과한다. ProductSellableQuantityService 가 쓰는 술어와 같은 모양으로 걸러낸다.
     const versions = await client
       .select({ status: productMasterVersions.status })
       .from(productMasterVariants)
       .innerJoin(productMasterVersions, eq(productMasterVersions.id, productMasterVariants.versionId))
-      .where(eq(productMasterVariants.variantId, variantId));
+      .innerJoin(productMasters, eq(productMasters.id, productMasterVariants.masterId))
+      .where(
+        and(
+          eq(productMasterVariants.variantId, variantId),
+          isNull(productMasterVersions.deletedAt),
+          isNull(productMasters.deletedAt),
+        ),
+      );
 
     if (versions.some((v) => v.status === 'active')) return;
+
+    // 어떤 버전에도 안 매달린 품목 — hardDelete 가 버전을 지우면 이 상태가 된다.
+    // publish 할 방법이 없으므로 "publish 하세요" 로 안내하면 막다른 길이다.
+    if (versions.length === 0) {
+      throw new BadRequestError(
+        `이 품목은 어떤 상품 버전에도 속하지 않습니다(삭제된 상품이거나 정리되지 않은 잔여 품목). ` +
+          `현재 판매 중인 상품의 품목을 선택하세요: ${variantId}`,
+      );
+    }
 
     // 한 번도 활성이었던 적 없는 품목 — publish 하면 풀린다.
     if (versions.every((v) => v.status === 'draft')) {

--- a/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
@@ -13,6 +13,7 @@ import {
 import { eq, and, desc, sql } from 'drizzle-orm';
 import { ChannelVariantListingEntity, SalesChannelEntity } from '../../schema/catalog.schema.types';
 import { ProductSellableQuantityService } from '../../../inventory/product-sellable-quantity/services/product-sellable-quantity.service';
+import { isExternalMarketplaceSite } from './marketplace-site';
 
 export interface LookupVariantResult {
   masterId: string;
@@ -139,22 +140,33 @@ export class ChannelListingService {
    * `deleteDraftVersion` → `_cleanupOrphanedVariantsAfterDeletion` 이 variant 를 지우고
    * `channel_variant_listings.variant_id` 의 `onDelete: 'cascade'` 로 **리스팅이 조용히 사라진다.**
    * 생성 시점에 막는 게 유일하게 확실한 방어다 (#652).
+   *
+   * 거부 사유가 둘이라 메시지를 나눈다 — 복구 방법이 다르기 때문이다.
+   * 낡은 매핑은 활성화도 재생성도(`uq_channel_variant_listing`) 막히므로 삭제 후 재등록이 유일한 길이다.
    */
   private async assertVariantIsPublished(variantId: string, tx?: DbTransaction): Promise<void> {
     const client = this.getClient(tx);
 
-    const [mapping] = await client
-      .select({ id: productMasterVariants.id })
+    const versions = await client
+      .select({ status: productMasterVersions.status })
       .from(productMasterVariants)
       .innerJoin(productMasterVersions, eq(productMasterVersions.id, productMasterVariants.versionId))
-      .where(and(eq(productMasterVariants.variantId, variantId), eq(productMasterVersions.status, 'active')))
-      .limit(1);
+      .where(eq(productMasterVariants.variantId, variantId));
 
-    if (!mapping) {
+    if (versions.some((v) => v.status === 'active')) return;
+
+    // 한 번도 활성이었던 적 없는 품목 — publish 하면 풀린다.
+    if (versions.every((v) => v.status === 'draft')) {
       throw new BadRequestError(
         `아직 publish 되지 않은 품목에는 채널 매핑을 걸 수 없습니다. 상품을 publish 한 뒤 다시 시도하세요: ${variantId}`,
       );
     }
+
+    // 활성이었다가 재발행으로 교체된 품목 — publish 해도 이 매핑은 안 살아난다.
+    throw new BadRequestError(
+      `상품이 다시 발행되면서 품목이 교체돼 낡은 채널 매핑입니다. ` +
+        `이 매핑을 삭제한 뒤 현재 품목으로 다시 등록하세요: ${variantId}`,
+    );
   }
 
   /**
@@ -382,16 +394,11 @@ export class ChannelListingService {
       .from(salesChannels)
       .where(eq(salesChannels.id, salesChannelId))
       .limit(1);
-    if (ch && this.isExternalMarketplaceSite(ch.site) && (await this.isDigitalVariant(variantId, tx))) {
+    if (ch && isExternalMarketplaceSite(ch.site) && (await this.isDigitalVariant(variantId, tx))) {
       throw new BadRequestError(
         `외부 채널(${ch.site})은 디지털 상품을 지원하지 않습니다. 디지털 상품은 Medusa(자사몰)에서만 판매할 수 있습니다.`,
       );
     }
-  }
-
-  /** 외부 마켓플레이스(비로그인 주문 → customerId 없음) 채널인지. 디지털 판매 차단 대상. */
-  private isExternalMarketplaceSite(site: string): boolean {
-    return site === 'naver' || site === 'coupang';
   }
 
   /** variant 의 active 버전이 디지털(fulfillmentKind='digital')인지. */

--- a/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
@@ -15,22 +15,7 @@ import { eq, and, desc, sql, isNull } from 'drizzle-orm';
 import { ChannelVariantListingEntity, SalesChannelEntity } from '../../schema/catalog.schema.types';
 import { ProductSellableQuantityService } from '../../../inventory/product-sellable-quantity/services/product-sellable-quantity.service';
 import { isExternalMarketplaceSite } from './marketplace-site';
-
-/**
- * 리스팅 조회가 요구하는 "지금 팔리는 버전" 술어 (#666).
- *
- * 이게 없으면 조회 조인이 낡은 버전을 통해서도 성립해 **null 대신 옛 값이 반환된다** —
- * 격리도 로그도 없이 옛 판매정책·옛 SKU 스냅샷으로 채널 주문이 처리된다(#652 의 증상).
- * publish 승계(reconciler)는 publish 라는 사건에만 반응하므로, 그 사건을 안 거치고 낡는
- * 경로(#663 승인 우회 · #664 판매중지 · #665 레이스 · hardDelete)는 이 술어만이 막는다.
- *
- * soft delete 는 `status` 를 그대로 두고 `deletedAt` 만 세우므로 둘 다 봐야 한다.
- */
-const ACTIVE_VERSION_PREDICATES = [
-  eq(productMasterVersions.status, 'active'),
-  isNull(productMasterVersions.deletedAt),
-  isNull(productMasters.deletedAt),
-];
+import { buildChannelListingLookupQuery } from './channel-listing-lookup.query';
 
 export interface LookupVariantResult {
   masterId: string;
@@ -75,78 +60,28 @@ export class ChannelListingService {
     channelItemId: string,
     tx?: DbTransaction,
   ): Promise<LookupVariantResult | null> {
-    const client = this.getClient(tx);
-
-    const result = await client
-      .select({
-        masterId: productMasterVariants.masterId,
-        versionId: productMasterVariants.versionId,
-        productName: productMasterVersions.name,
-        variantId: channelVariantListings.variantId,
-        variantCode: productVariants.variantCode,
-        variantName: productVariants.variantName,
-        isActive: channelVariantListings.isActive,
-      })
-      .from(channelVariantListings)
-      .innerJoin(productVariants, eq(channelVariantListings.variantId, productVariants.id))
-      .innerJoin(productMasterVariants, eq(productMasterVariants.variantId, productVariants.id))
-      .innerJoin(productMasterVersions, eq(productMasterVariants.versionId, productMasterVersions.id))
-      .innerJoin(productMasters, eq(productMasters.id, productMasterVariants.masterId))
-      .where(
-        and(
-          eq(channelVariantListings.salesChannelId, salesChannelId),
-          eq(channelVariantListings.channelItemId, channelItemId),
-          eq(channelVariantListings.isActive, true),
-          ...ACTIVE_VERSION_PREDICATES,
-        ),
-      )
-      // 활성 버전만 남으므로 상태 분기 정렬은 필요 없다. 한 variant 가 두 master 에
-      // 매달린 이상 상태(bulk import 의 phantom masterId)에서도 결과를 고정하려고 정렬은 남긴다.
-      .orderBy(desc(productMasterVersions.version), desc(productMasterVersions.createdAt))
-      .limit(1);
-
+    const result = await buildChannelListingLookupQuery(
+      this.getClient(tx),
+      channelItemId,
+      eq(channelVariantListings.salesChannelId, salesChannelId),
+    );
     return result[0] ?? null;
   }
 
   /**
-   * 채널 코드(site)로 Variant 조회 (편의 메서드)
+   * 채널 코드(site)로 Variant 조회. **주문 수집이 실제로 타는 경로다**
+   * (ChannelLineIdentityResolver → lookupByChannelCode).
    */
   async lookupVariantByChannelCode(
     channelCode: string,
     channelItemId: string,
     tx?: DbTransaction,
   ): Promise<LookupVariantResult | null> {
-    const client = this.getClient(tx);
-
-    const result = await client
-      .select({
-        masterId: productMasterVariants.masterId,
-        versionId: productMasterVariants.versionId,
-        productName: productMasterVersions.name,
-        variantId: channelVariantListings.variantId,
-        variantCode: productVariants.variantCode,
-        variantName: productVariants.variantName,
-        isActive: channelVariantListings.isActive,
-      })
-      .from(channelVariantListings)
-      .innerJoin(productVariants, eq(channelVariantListings.variantId, productVariants.id))
-      .innerJoin(productMasterVariants, eq(productMasterVariants.variantId, productVariants.id))
-      .innerJoin(productMasterVersions, eq(productMasterVariants.versionId, productMasterVersions.id))
-      .innerJoin(productMasters, eq(productMasters.id, productMasterVariants.masterId))
-      .innerJoin(salesChannels, eq(channelVariantListings.salesChannelId, salesChannels.id))
-      .where(
-        and(
-          eq(salesChannels.site, channelCode),
-          eq(channelVariantListings.channelItemId, channelItemId),
-          eq(channelVariantListings.isActive, true),
-          ...ACTIVE_VERSION_PREDICATES,
-        ),
-      )
-      // 활성 버전만 남으므로 상태 분기 정렬은 필요 없다. 한 variant 가 두 master 에
-      // 매달린 이상 상태(bulk import 의 phantom masterId)에서도 결과를 고정하려고 정렬은 남긴다.
-      .orderBy(desc(productMasterVersions.version), desc(productMasterVersions.createdAt))
-      .limit(1);
-
+    const result = await buildChannelListingLookupQuery(
+      this.getClient(tx),
+      channelItemId,
+      eq(salesChannels.site, channelCode),
+    );
     return result[0] ?? null;
   }
 
@@ -170,7 +105,7 @@ export class ChannelListingService {
       .select({ status: productMasterVersions.status })
       .from(productMasterVariants)
       .innerJoin(productMasterVersions, eq(productMasterVersions.id, productMasterVariants.versionId))
-      .innerJoin(productMasters, eq(productMasters.id, productMasterVariants.masterId))
+      .innerJoin(productMasters, eq(productMasters.id, productMasterVersions.masterId))
       .where(
         and(
           eq(productMasterVariants.variantId, variantId),
@@ -443,7 +378,17 @@ export class ChannelListingService {
       .select({ fulfillmentKind: productMasterVersions.fulfillmentKind })
       .from(productMasterVariants)
       .innerJoin(productMasterVersions, eq(productMasterVariants.versionId, productMasterVersions.id))
-      .where(and(eq(productMasterVariants.variantId, variantId), eq(productMasterVersions.status, 'active')))
+      .innerJoin(productMasters, eq(productMasters.id, productMasterVersions.masterId))
+      // 조회 술어와 같은 기준으로 본다 — soft delete 는 status 를 그대로 두므로
+      // 상태만 보면 삭제된 상품의 fulfillmentKind 로 디지털 여부를 판정하게 된다.
+      .where(
+        and(
+          eq(productMasterVariants.variantId, variantId),
+          eq(productMasterVersions.status, 'active'),
+          isNull(productMasterVersions.deletedAt),
+          isNull(productMasters.deletedAt),
+        ),
+      )
       .limit(1);
     return row?.fulfillmentKind === 'digital';
   }

--- a/apps/core/src/modules/catalog/core/channels/marketplace-site.ts
+++ b/apps/core/src/modules/catalog/core/channels/marketplace-site.ts
@@ -1,0 +1,13 @@
+/**
+ * 외부 마켓플레이스(네이버·쿠팡) 판별.
+ *
+ * 이 채널들은 비로그인 주문이라 구매자 식별(`customerId`)이 없어 디지털 소유권을 부여할 수
+ * 없다. 그래서 디지털 상품은 자사몰(medusa)에서만 판다.
+ *
+ * `ChannelListingService`(생성·재활성 가드)와 `ProductVersionsService`(publish 후 리스팅
+ * 승계, #652)가 같은 규칙을 봐야 해서 모듈 밖으로 뺐다 — 두 모듈이 서로를 import 하면
+ * 순환이 생긴다.
+ */
+export function isExternalMarketplaceSite(site: string): boolean {
+  return site === 'naver' || site === 'coupang';
+}

--- a/apps/core/src/modules/catalog/core/products/services/channel-listing-reconciliation.ts
+++ b/apps/core/src/modules/catalog/core/products/services/channel-listing-reconciliation.ts
@@ -1,0 +1,100 @@
+/**
+ * publish 후 채널 리스팅 승계의 **판정** (#652).
+ *
+ * DB 를 모르는 순수 함수만 둔다 — 판정이 서비스 안에 있으면 스펙이 private 메서드를
+ * 타입을 지운 채 부르게 되고, 그러면 인자 순서가 바뀌어도 type-check 가 못 잡는다.
+ */
+
+/** variant 한 벌과 그 옵션값 조합 — twin 짝 찾기의 입력. */
+export interface VariantOptionCombo {
+  variantId: string;
+  optionValueIds: string[];
+}
+
+/** 승계 판정 대상 채널 리스팅 (#652). */
+export interface ReconcilableListing {
+  id: string;
+  variantId: string;
+  /** 네이버·쿠팡 등 외부 마켓플레이스인가 — 디지털 상품은 여기 실릴 수 없다. */
+  isExternalMarketplace: boolean;
+  isActive: boolean;
+}
+
+/**
+ * 리스팅 승계 판정 결과 (#652).
+ *
+ * 재지정과 비활성은 **배타적이지 않다** — 디지털 전환으로 끄는 리스팅도 짝이 있으면 같이
+ * 옮겨 둬야 나중에 되살릴 수 있다. 죽은 variant 를 가리킨 채 꺼진 행은 재활성도
+ * 재등록도(`uq_channel_variant_listing`) 막혀 삭제 말고는 길이 없다.
+ */
+export interface ChannelListingReconciliationPlan {
+  updates: Array<{ listingId: string; newVariantId: string | null; deactivate: boolean }>;
+}
+
+/** 스펙이 private 판정 함수를 타입을 지운 채 부르지 않도록 노출하는 표면. */
+
+/** 옵션값 조합의 정규화 키. 순서가 달라도 같은 조합이면 같은 키다. */
+export function comboKey(optionValueIds: string[]): string {
+  return [...optionValueIds].sort().join('|');
+}
+
+/**
+ * 리스팅 승계 판정 (#652) — 순수 함수.
+ *
+ * 리스팅 한 건에 대해 독립된 두 결정을 내린다.
+ * - **어디를 가리켜야 하나**: CoW 로 variant 가 갈렸으면 옵션값 조합이 같은 twin.
+ * - **꺼야 하나**: 짝이 없거나, 조합이 모호하거나(같은 조합이 둘 이상 — 주문이 흘러갈 곳을
+ *   임의로 고를 수 없다), 새 버전이 디지털인데 외부 마켓플레이스 리스팅일 때
+ *   (`createListing` 이 거부하는 상태를 승계로 만들 수는 없다).
+ *
+ * 디지털 판정은 **CoW 여부와 무관**하다 — `fulfillmentKind` 만 바꿔 publish 하면 품목이
+ * 복제되지 않으므로, 제자리 variant 의 리스팅도 검사해야 한다.
+ */
+export function planChannelListingReconciliation(
+  candidateVariants: VariantOptionCombo[],
+  newVariants: VariantOptionCombo[],
+  listings: ReconcilableListing[],
+  newVersionIsDigital: boolean,
+): ChannelListingReconciliationPlan {
+  const newVariantIds = new Set(newVariants.map((v) => v.variantId));
+
+  // 같은 조합이 둘 이상이면 null 로 표시해 "짝 없음" 과 같게 취급한다.
+  const newVariantIdByComboKey = new Map<string, string | null>();
+  for (const nv of newVariants) {
+    const key = comboKey(nv.optionValueIds);
+    newVariantIdByComboKey.set(key, newVariantIdByComboKey.has(key) ? null : nv.variantId);
+  }
+
+  const listingsByVariantId = new Map<string, ReconcilableListing[]>();
+  for (const listing of listings) {
+    const bucket = listingsByVariantId.get(listing.variantId);
+    if (bucket) bucket.push(listing);
+    else listingsByVariantId.set(listing.variantId, [listing]);
+  }
+
+  const updates: ChannelListingReconciliationPlan['updates'] = [];
+
+  for (const candidate of candidateVariants) {
+    const affected = listingsByVariantId.get(candidate.variantId);
+    if (!affected) continue;
+
+    // 새 버전이 같은 variant 행을 그대로 쓰면 CoW 가 없었던 것 — 옮길 곳이 없다.
+    const isStale = !newVariantIds.has(candidate.variantId);
+    const twinVariantId = isStale
+      ? (newVariantIdByComboKey.get(comboKey(candidate.optionValueIds)) ?? null)
+      : null;
+
+    for (const listing of affected) {
+      const blockedByDigital = newVersionIsDigital && listing.isExternalMarketplace;
+      const deactivate = listing.isActive && (blockedByDigital || (isStale && !twinVariantId));
+      const newVariantId = isStale ? twinVariantId : null;
+
+      // 이미 꺼진 리스팅을 다시 끄지 않고, 옮길 곳도 없으면 건드릴 이유가 없다.
+      if (!deactivate && !newVariantId) continue;
+
+      updates.push({ listingId: listing.id, newVariantId, deactivate });
+    }
+  }
+
+  return { updates };
+}

--- a/apps/core/src/modules/catalog/core/products/services/product-versions.service.spec.ts
+++ b/apps/core/src/modules/catalog/core/products/services/product-versions.service.spec.ts
@@ -6,7 +6,13 @@ jest.mock(
   { virtual: true },
 );
 
-import { ProductVersionsService } from './product-versions.service';
+import {
+  ProductVersionsService,
+  type VariantOptionCombo,
+  type ReconcilableListing,
+  type ChannelListingReconciliationPlan,
+  type PlanChannelListings,
+} from './product-versions.service';
 import type { DbTransaction } from '../../../catalog.types';
 import {
   productMasterOptionGroups,
@@ -1109,98 +1115,99 @@ describe('ProductVersionsService.getMyDraftVersions', () => {
 });
 
 describe('_planChannelListingReconciliation (#652)', () => {
-  // publish 로 CoW 가 일어나면 리스팅이 옛 variant 를 가리킨 채 남는다.
-  // 옵션값 조합이 같은 twin 으로 재지정하고, twin 이 없으면 리스팅을 끈다.
-  // 순수 판정 함수라 DI 가 필요 없다 — prototype 만 빌려 부른다.
-  const service = Object.create(ProductVersionsService.prototype) as any;
-  const plan = (candidates: any[], next: any[], listings: any[], isDigital = false) =>
-    service._planChannelListingReconciliation(candidates, next, listings, isDigital);
-  const listing = (id: string, variantId: string, isExternalMarketplace = true) => ({
-    id,
+  const service = Object.create(ProductVersionsService.prototype) as ProductVersionsService;
+  // private 판정 함수를 스펙에서 부르되 시그니처는 그대로 검사받는다 (`as any` 로 지우지 않는다).
+  const plan = (
+    candidates: VariantOptionCombo[],
+    next: VariantOptionCombo[],
+    listings: ReconcilableListing[],
+    isDigital = false,
+  ): ChannelListingReconciliationPlan =>
+    (service as unknown as PlanChannelListings)._planChannelListingReconciliation(
+      candidates,
+      next,
+      listings,
+      isDigital,
+    );
+  const combo = (variantId: string, ...optionValueIds: string[]): VariantOptionCombo => ({
     variantId,
-    isExternalMarketplace,
+    optionValueIds,
   });
+  const listing = (
+    id: string,
+    variantId: string,
+    { external = true, isActive = true } = {},
+  ): ReconcilableListing => ({ id, variantId, isExternalMarketplace: external, isActive });
 
   it('옵션 조합이 같은 twin 이 새 버전에 있으면 그 variant 로 재지정한다', () => {
-    const result = plan(
-      [{ variantId: 'v-old', optionValueIds: ['red', 'L'] }],
-      [{ variantId: 'v-new', optionValueIds: ['L', 'red'] }],
-      [listing('l-1', 'v-old')],
-    );
-    expect(result).toEqual({ repoints: [{ listingId: 'l-1', newVariantId: 'v-new' }], deactivations: [] });
+    expect(plan([combo('v-old', 'red', 'L')], [combo('v-new', 'L', 'red')], [listing('l-1', 'v-old')])).toEqual({
+      updates: [{ listingId: 'l-1', newVariantId: 'v-new', deactivate: false }],
+    });
   });
 
-  it('옵션 조합이 같은 twin 이 없으면 리스팅을 비활성화한다', () => {
-    const result = plan(
-      [{ variantId: 'v-old', optionValueIds: ['red'] }],
-      [{ variantId: 'v-other', optionValueIds: ['blue'] }],
-      [listing('l-1', 'v-old')],
-    );
-    expect(result).toEqual({ repoints: [], deactivations: ['l-1'] });
+  it('짝이 없으면 리스팅을 끈다', () => {
+    expect(plan([combo('v-old', 'red')], [combo('v-other', 'blue')], [listing('l-1', 'v-old')])).toEqual({
+      updates: [{ listingId: 'l-1', newVariantId: null, deactivate: true }],
+    });
   });
 
-  it('CoW 가 없어 variant 행이 새 버전에도 그대로 있으면 아무것도 하지 않는다', () => {
-    const result = plan(
-      [{ variantId: 'v-1', optionValueIds: ['red'] }],
-      [{ variantId: 'v-1', optionValueIds: ['red'] }],
-      [listing('l-1', 'v-1')],
-    );
-    expect(result).toEqual({ repoints: [], deactivations: [] });
+  it('이미 꺼진 리스팅은 짝이 없어도 다시 끄지 않는다', () => {
+    expect(
+      plan([combo('v-old', 'red')], [combo('v-other', 'blue')], [listing('l-1', 'v-old', { isActive: false })]),
+    ).toEqual({ updates: [] });
+  });
+
+  it('이미 꺼진 리스팅도 짝이 있으면 포인터만 옮긴다 (되살리지는 않는다)', () => {
+    // 재지정해 두지 않으면 그 행은 죽은 variant 를 가리킨 채 남아 재활성도 재등록도 막힌다.
+    expect(
+      plan([combo('v-old', 'red')], [combo('v-new', 'red')], [listing('l-1', 'v-old', { isActive: false })]),
+    ).toEqual({ updates: [{ listingId: 'l-1', newVariantId: 'v-new', deactivate: false }] });
+  });
+
+  it('CoW 가 없어 variant 행이 새 버전에도 그대로면 아무것도 하지 않는다', () => {
+    expect(plan([combo('v-1', 'red')], [combo('v-1', 'red')], [listing('l-1', 'v-1')])).toEqual({ updates: [] });
   });
 
   it('옵션 없는 기본 품목(조합 빈 배열)도 twin 으로 재지정한다', () => {
-    const result = plan(
-      [{ variantId: 'v-old', optionValueIds: [] }],
-      [{ variantId: 'v-new', optionValueIds: [] }],
-      [listing('l-1', 'v-old')],
-    );
-    expect(result).toEqual({ repoints: [{ listingId: 'l-1', newVariantId: 'v-new' }], deactivations: [] });
+    expect(plan([combo('v-old')], [combo('v-new')], [listing('l-1', 'v-old')])).toEqual({
+      updates: [{ listingId: 'l-1', newVariantId: 'v-new', deactivate: false }],
+    });
   });
 
   it('새 버전에 같은 옵션 조합이 둘이면 모호하므로 재지정하지 않고 끈다', () => {
-    // 어느 쪽으로 보내도 임의 선택이 된다 — 주문이 흘러갈 곳을 주사위로 정할 수는 없다.
-    const result = plan(
-      [{ variantId: 'v-old', optionValueIds: ['red'] }],
-      [
-        { variantId: 'v-new-a', optionValueIds: ['red'] },
-        { variantId: 'v-new-b', optionValueIds: ['red'] },
-      ],
-      [listing('l-1', 'v-old')],
-    );
-    expect(result).toEqual({ repoints: [], deactivations: ['l-1'] });
+    expect(
+      plan([combo('v-old', 'red')], [combo('v-a', 'red'), combo('v-b', 'red')], [listing('l-1', 'v-old')]),
+    ).toEqual({ updates: [{ listingId: 'l-1', newVariantId: null, deactivate: true }] });
   });
 
-  it('새 버전이 디지털이면 외부 마켓플레이스 리스팅은 twin 이 있어도 끈다', () => {
-    // createListing/activateListing 이 거부하는 상태(네이버×디지털)를 승계로 만들 수는 없다.
-    const result = plan(
-      [{ variantId: 'v-old', optionValueIds: ['red'] }],
-      [{ variantId: 'v-new', optionValueIds: ['red'] }],
-      [listing('l-naver', 'v-old', true)],
-      true,
-    );
-    expect(result).toEqual({ repoints: [], deactivations: ['l-naver'] });
+  it('새 버전이 디지털이면 외부 마켓 리스팅은 끄되 twin 으로 옮겨 복구 가능하게 남긴다', () => {
+    expect(plan([combo('v-old', 'red')], [combo('v-new', 'red')], [listing('l-naver', 'v-old')], true)).toEqual({
+      updates: [{ listingId: 'l-naver', newVariantId: 'v-new', deactivate: true }],
+    });
   });
 
-  it('새 버전이 디지털이어도 자사몰 리스팅은 twin 으로 재지정한다', () => {
-    const result = plan(
-      [{ variantId: 'v-old', optionValueIds: ['red'] }],
-      [{ variantId: 'v-new', optionValueIds: ['red'] }],
-      [listing('l-medusa', 'v-old', false)],
-      true,
-    );
-    expect(result).toEqual({ repoints: [{ listingId: 'l-medusa', newVariantId: 'v-new' }], deactivations: [] });
+  it('CoW 가 없어도 새 버전이 디지털이면 외부 마켓 리스팅을 끈다', () => {
+    // fulfillmentKind 만 바꿔 publish 하면 품목이 복제되지 않는다 — 그래도 막아야 한다.
+    expect(plan([combo('v-1', 'red')], [combo('v-1', 'red')], [listing('l-naver', 'v-1')], true)).toEqual({
+      updates: [{ listingId: 'l-naver', newVariantId: null, deactivate: true }],
+    });
+  });
+
+  it('새 버전이 디지털이어도 자사몰 리스팅은 twin 으로 재지정만 한다', () => {
+    expect(
+      plan([combo('v-old', 'red')], [combo('v-new', 'red')], [listing('l-medusa', 'v-old', { external: false })], true),
+    ).toEqual({ updates: [{ listingId: 'l-medusa', newVariantId: 'v-new', deactivate: false }] });
   });
 
   it('한 variant 에 리스팅이 여럿이면 전부 같은 판정을 받는다', () => {
-    const result = plan(
-      [{ variantId: 'v-old', optionValueIds: ['red'] }],
-      [{ variantId: 'v-new', optionValueIds: ['red'] }],
-      [listing('l-1', 'v-old'), listing('l-2', 'v-old')],
-    );
-    expect(result.repoints).toEqual([
-      { listingId: 'l-1', newVariantId: 'v-new' },
-      { listingId: 'l-2', newVariantId: 'v-new' },
-    ]);
+    expect(
+      plan([combo('v-old', 'red')], [combo('v-new', 'red')], [listing('l-1', 'v-old'), listing('l-2', 'v-old')]),
+    ).toEqual({
+      updates: [
+        { listingId: 'l-1', newVariantId: 'v-new', deactivate: false },
+        { listingId: 'l-2', newVariantId: 'v-new', deactivate: false },
+      ],
+    });
   });
 });
 
@@ -1209,6 +1216,7 @@ describe('_reconcileChannelListingsAfterPublish (#652)', () => {
   function makeTx(results: any[]) {
     let i = 0;
     const updates: any[] = [];
+    const wheres: any[] = [];
     const chain = () => {
       const result = results[i++];
       const c: any = {};
@@ -1222,11 +1230,16 @@ describe('_reconcileChannelListingsAfterPublish (#652)', () => {
       update: () => ({
         set: (v: any) => {
           updates.push(v);
-          return { where: () => Promise.resolve(undefined) };
+          return {
+            where: (predicate: any) => {
+              wheres.push(predicate);
+              return Promise.resolve(undefined);
+            },
+          };
         },
       }),
     };
-    return { tx, updates };
+    return { tx, updates, wheres };
   }
 
   const makeSvc = () => {
@@ -1251,7 +1264,7 @@ describe('_reconcileChannelListingsAfterPublish (#652)', () => {
         { variantId: 'v-new', optionValueId: 'red' },
         { variantId: 'v-old', optionValueId: 'red' },
       ],
-      [{ id: 'l-1', variantId: 'v-old', site: 'naver' }],
+      [{ id: 'l-1', variantId: 'v-old', isActive: true, site: 'naver' }],
     ]);
     await makeSvc()._reconcileChannelListingsAfterPublish('master-1', 'version-2', false, tx);
     expect(updates).toEqual([{ variantId: 'v-new', updatedAt: expect.any(Date) }]);
@@ -1266,9 +1279,27 @@ describe('_reconcileChannelListingsAfterPublish (#652)', () => {
         { variantId: 'v-new', optionValueId: 'blue' },
         { variantId: 'v-old', optionValueId: 'red' },
       ],
-      [{ id: 'l-1', variantId: 'v-old', site: 'naver' }],
+      [{ id: 'l-1', variantId: 'v-old', isActive: true, site: 'naver' }],
     ]);
     await makeSvc()._reconcileChannelListingsAfterPublish('master-1', 'version-2', false, tx);
     expect(updates).toEqual([{ isActive: false, updatedAt: expect.any(Date) }]);
+  });
+
+  it('CoW 가 없어도 디지털 전환이면 외부 마켓 리스팅을 한 문장으로 끈다', async () => {
+    const { tx, updates, wheres } = makeTx([
+      [{ variantId: 'v-1' }],
+      [{ variantId: 'v-1', optionValueId: 'red' }],
+      [{ variantId: 'v-1' }],
+      [{ variantId: 'v-1', optionValueId: 'red' }],
+      [
+        { id: 'l-1', variantId: 'v-1', isActive: true, site: 'naver' },
+        { id: 'l-2', variantId: 'v-1', isActive: true, site: 'coupang' },
+        { id: 'l-3', variantId: 'v-1', isActive: true, site: 'medusa' },
+      ],
+    ]);
+    await makeSvc()._reconcileChannelListingsAfterPublish('master-1', 'version-2', true, tx);
+    // 외부 둘만, 판정이 같으므로 UPDATE 는 한 번으로 묶인다. 자사몰은 손대지 않는다.
+    expect(updates).toEqual([{ isActive: false, updatedAt: expect.any(Date) }]);
+    expect(wheres).toHaveLength(1);
   });
 });

--- a/apps/core/src/modules/catalog/core/products/services/product-versions.service.spec.ts
+++ b/apps/core/src/modules/catalog/core/products/services/product-versions.service.spec.ts
@@ -6,13 +6,13 @@ jest.mock(
   { virtual: true },
 );
 
+import { ProductVersionsService } from './product-versions.service';
 import {
-  ProductVersionsService,
+  planChannelListingReconciliation,
   type VariantOptionCombo,
   type ReconcilableListing,
   type ChannelListingReconciliationPlan,
-  type PlanChannelListings,
-} from './product-versions.service';
+} from './channel-listing-reconciliation';
 import type { DbTransaction } from '../../../catalog.types';
 import {
   productMasterOptionGroups,
@@ -1114,21 +1114,14 @@ describe('ProductVersionsService.getMyDraftVersions', () => {
   });
 });
 
-describe('_planChannelListingReconciliation (#652)', () => {
-  const service = Object.create(ProductVersionsService.prototype) as ProductVersionsService;
-  // private 판정 함수를 스펙에서 부르되 시그니처는 그대로 검사받는다 (`as any` 로 지우지 않는다).
+describe('planChannelListingReconciliation (#652)', () => {
   const plan = (
     candidates: VariantOptionCombo[],
     next: VariantOptionCombo[],
     listings: ReconcilableListing[],
     isDigital = false,
   ): ChannelListingReconciliationPlan =>
-    (service as unknown as PlanChannelListings)._planChannelListingReconciliation(
-      candidates,
-      next,
-      listings,
-      isDigital,
-    );
+    planChannelListingReconciliation(candidates, next, listings, isDigital);
   const combo = (variantId: string, ...optionValueIds: string[]): VariantOptionCombo => ({
     variantId,
     optionValueIds,
@@ -1248,23 +1241,34 @@ describe('_reconcileChannelListingsAfterPublish (#652)', () => {
     return service;
   };
 
+  // 큐 순서: master variant id → 리스팅 → 새 버전 variant id → 새 버전 옵션값 → 후보 옵션값
+  it('채널 매핑이 없으면 두 쿼리로 끝낸다', async () => {
+    const { tx, updates } = makeTx([[{ variantId: 'v-1' }], []]);
+    await makeSvc()._reconcileChannelListingsAfterPublish('master-1', 'version-2', false, tx);
+    expect(updates).toEqual([]);
+  });
+
   it('새 버전에 품목이 하나도 없으면 리스팅을 건드리지 않는다', async () => {
     // 빈 버전 publish 가 그 master 의 채널 매핑을 통째로 꺼버리는 사고를 막는 가드.
-    const { tx, updates } = makeTx([[]]);
+    const { tx, updates } = makeTx([
+      [{ variantId: 'v-old' }],
+      [{ id: 'l-1', variantId: 'v-old', isActive: true, site: 'naver' }],
+      [],
+    ]);
     await makeSvc()._reconcileChannelListingsAfterPublish('master-1', 'version-2', false, tx);
     expect(updates).toEqual([]);
   });
 
   it('활성 버전이 없던 master 여도(판매중지 후 재개통) 옛 variant 리스팅을 승계한다', async () => {
     const { tx, updates } = makeTx([
+      [{ variantId: 'v-new' }, { variantId: 'v-old' }],
+      [{ id: 'l-1', variantId: 'v-old', isActive: true, site: 'naver' }],
       [{ variantId: 'v-new' }],
       [{ variantId: 'v-new', optionValueId: 'red' }],
-      [{ variantId: 'v-new' }, { variantId: 'v-old' }],
       [
         { variantId: 'v-new', optionValueId: 'red' },
         { variantId: 'v-old', optionValueId: 'red' },
       ],
-      [{ id: 'l-1', variantId: 'v-old', isActive: true, site: 'naver' }],
     ]);
     await makeSvc()._reconcileChannelListingsAfterPublish('master-1', 'version-2', false, tx);
     expect(updates).toEqual([{ variantId: 'v-new', updatedAt: expect.any(Date) }]);
@@ -1272,14 +1276,14 @@ describe('_reconcileChannelListingsAfterPublish (#652)', () => {
 
   it('짝이 없으면 리스팅을 비활성으로 UPDATE 한다', async () => {
     const { tx, updates } = makeTx([
+      [{ variantId: 'v-new' }, { variantId: 'v-old' }],
+      [{ id: 'l-1', variantId: 'v-old', isActive: true, site: 'naver' }],
       [{ variantId: 'v-new' }],
       [{ variantId: 'v-new', optionValueId: 'blue' }],
-      [{ variantId: 'v-new' }, { variantId: 'v-old' }],
       [
         { variantId: 'v-new', optionValueId: 'blue' },
         { variantId: 'v-old', optionValueId: 'red' },
       ],
-      [{ id: 'l-1', variantId: 'v-old', isActive: true, site: 'naver' }],
     ]);
     await makeSvc()._reconcileChannelListingsAfterPublish('master-1', 'version-2', false, tx);
     expect(updates).toEqual([{ isActive: false, updatedAt: expect.any(Date) }]);
@@ -1288,14 +1292,14 @@ describe('_reconcileChannelListingsAfterPublish (#652)', () => {
   it('CoW 가 없어도 디지털 전환이면 외부 마켓 리스팅을 한 문장으로 끈다', async () => {
     const { tx, updates, wheres } = makeTx([
       [{ variantId: 'v-1' }],
-      [{ variantId: 'v-1', optionValueId: 'red' }],
-      [{ variantId: 'v-1' }],
-      [{ variantId: 'v-1', optionValueId: 'red' }],
       [
         { id: 'l-1', variantId: 'v-1', isActive: true, site: 'naver' },
         { id: 'l-2', variantId: 'v-1', isActive: true, site: 'coupang' },
         { id: 'l-3', variantId: 'v-1', isActive: true, site: 'medusa' },
       ],
+      [{ variantId: 'v-1' }],
+      [{ variantId: 'v-1', optionValueId: 'red' }],
+      [{ variantId: 'v-1', optionValueId: 'red' }],
     ]);
     await makeSvc()._reconcileChannelListingsAfterPublish('master-1', 'version-2', true, tx);
     // 외부 둘만, 판정이 같으므로 UPDATE 는 한 번으로 묶인다. 자사몰은 손대지 않는다.

--- a/apps/core/src/modules/catalog/core/products/services/product-versions.service.spec.ts
+++ b/apps/core/src/modules/catalog/core/products/services/product-versions.service.spec.ts
@@ -1113,14 +1113,19 @@ describe('_planChannelListingReconciliation (#652)', () => {
   // 옵션값 조합이 같은 twin 으로 재지정하고, twin 이 없으면 리스팅을 끈다.
   // 순수 판정 함수라 DI 가 필요 없다 — prototype 만 빌려 부른다.
   const service = Object.create(ProductVersionsService.prototype) as any;
-  const plan = (prev: any[], next: any[], listings: any[]) =>
-    service._planChannelListingReconciliation(prev, next, listings);
+  const plan = (candidates: any[], next: any[], listings: any[], isDigital = false) =>
+    service._planChannelListingReconciliation(candidates, next, listings, isDigital);
+  const listing = (id: string, variantId: string, isExternalMarketplace = true) => ({
+    id,
+    variantId,
+    isExternalMarketplace,
+  });
 
   it('옵션 조합이 같은 twin 이 새 버전에 있으면 그 variant 로 재지정한다', () => {
     const result = plan(
       [{ variantId: 'v-old', optionValueIds: ['red', 'L'] }],
       [{ variantId: 'v-new', optionValueIds: ['L', 'red'] }],
-      [{ id: 'l-1', variantId: 'v-old' }],
+      [listing('l-1', 'v-old')],
     );
     expect(result).toEqual({ repoints: [{ listingId: 'l-1', newVariantId: 'v-new' }], deactivations: [] });
   });
@@ -1129,16 +1134,16 @@ describe('_planChannelListingReconciliation (#652)', () => {
     const result = plan(
       [{ variantId: 'v-old', optionValueIds: ['red'] }],
       [{ variantId: 'v-other', optionValueIds: ['blue'] }],
-      [{ id: 'l-1', variantId: 'v-old' }],
+      [listing('l-1', 'v-old')],
     );
     expect(result).toEqual({ repoints: [], deactivations: ['l-1'] });
   });
 
-  it('CoW 가 없어 variant 행이 그대로면 아무것도 하지 않는다', () => {
+  it('CoW 가 없어 variant 행이 새 버전에도 그대로 있으면 아무것도 하지 않는다', () => {
     const result = plan(
       [{ variantId: 'v-1', optionValueIds: ['red'] }],
       [{ variantId: 'v-1', optionValueIds: ['red'] }],
-      [{ id: 'l-1', variantId: 'v-1' }],
+      [listing('l-1', 'v-1')],
     );
     expect(result).toEqual({ repoints: [], deactivations: [] });
   });
@@ -1147,8 +1152,123 @@ describe('_planChannelListingReconciliation (#652)', () => {
     const result = plan(
       [{ variantId: 'v-old', optionValueIds: [] }],
       [{ variantId: 'v-new', optionValueIds: [] }],
-      [{ id: 'l-1', variantId: 'v-old' }],
+      [listing('l-1', 'v-old')],
     );
     expect(result).toEqual({ repoints: [{ listingId: 'l-1', newVariantId: 'v-new' }], deactivations: [] });
+  });
+
+  it('새 버전에 같은 옵션 조합이 둘이면 모호하므로 재지정하지 않고 끈다', () => {
+    // 어느 쪽으로 보내도 임의 선택이 된다 — 주문이 흘러갈 곳을 주사위로 정할 수는 없다.
+    const result = plan(
+      [{ variantId: 'v-old', optionValueIds: ['red'] }],
+      [
+        { variantId: 'v-new-a', optionValueIds: ['red'] },
+        { variantId: 'v-new-b', optionValueIds: ['red'] },
+      ],
+      [listing('l-1', 'v-old')],
+    );
+    expect(result).toEqual({ repoints: [], deactivations: ['l-1'] });
+  });
+
+  it('새 버전이 디지털이면 외부 마켓플레이스 리스팅은 twin 이 있어도 끈다', () => {
+    // createListing/activateListing 이 거부하는 상태(네이버×디지털)를 승계로 만들 수는 없다.
+    const result = plan(
+      [{ variantId: 'v-old', optionValueIds: ['red'] }],
+      [{ variantId: 'v-new', optionValueIds: ['red'] }],
+      [listing('l-naver', 'v-old', true)],
+      true,
+    );
+    expect(result).toEqual({ repoints: [], deactivations: ['l-naver'] });
+  });
+
+  it('새 버전이 디지털이어도 자사몰 리스팅은 twin 으로 재지정한다', () => {
+    const result = plan(
+      [{ variantId: 'v-old', optionValueIds: ['red'] }],
+      [{ variantId: 'v-new', optionValueIds: ['red'] }],
+      [listing('l-medusa', 'v-old', false)],
+      true,
+    );
+    expect(result).toEqual({ repoints: [{ listingId: 'l-medusa', newVariantId: 'v-new' }], deactivations: [] });
+  });
+
+  it('한 variant 에 리스팅이 여럿이면 전부 같은 판정을 받는다', () => {
+    const result = plan(
+      [{ variantId: 'v-old', optionValueIds: ['red'] }],
+      [{ variantId: 'v-new', optionValueIds: ['red'] }],
+      [listing('l-1', 'v-old'), listing('l-2', 'v-old')],
+    );
+    expect(result.repoints).toEqual([
+      { listingId: 'l-1', newVariantId: 'v-new' },
+      { listingId: 'l-2', newVariantId: 'v-new' },
+    ]);
+  });
+});
+
+describe('_reconcileChannelListingsAfterPublish (#652)', () => {
+  // drizzle 체인 mock: select 호출마다 큐의 다음 결과, update 는 set() 인자를 기록.
+  function makeTx(results: any[]) {
+    let i = 0;
+    const updates: any[] = [];
+    const chain = () => {
+      const result = results[i++];
+      const c: any = {};
+      for (const m of ['from', 'innerJoin', 'where', 'limit', 'orderBy']) c[m] = () => c;
+      c.then = (res: any, rej: any) => Promise.resolve(result).then(res, rej);
+      return c;
+    };
+    const tx: any = {
+      select: () => chain(),
+      selectDistinct: () => chain(),
+      update: () => ({
+        set: (v: any) => {
+          updates.push(v);
+          return { where: () => Promise.resolve(undefined) };
+        },
+      }),
+    };
+    return { tx, updates };
+  }
+
+  const makeSvc = () => {
+    const service = Object.create(ProductVersionsService.prototype) as any;
+    service.logger = { log: jest.fn(), debug: jest.fn(), warn: jest.fn() };
+    return service;
+  };
+
+  it('새 버전에 품목이 하나도 없으면 리스팅을 건드리지 않는다', async () => {
+    // 빈 버전 publish 가 그 master 의 채널 매핑을 통째로 꺼버리는 사고를 막는 가드.
+    const { tx, updates } = makeTx([[]]);
+    await makeSvc()._reconcileChannelListingsAfterPublish('master-1', 'version-2', false, tx);
+    expect(updates).toEqual([]);
+  });
+
+  it('활성 버전이 없던 master 여도(판매중지 후 재개통) 옛 variant 리스팅을 승계한다', async () => {
+    const { tx, updates } = makeTx([
+      [{ variantId: 'v-new' }],
+      [{ variantId: 'v-new', optionValueId: 'red' }],
+      [{ variantId: 'v-new' }, { variantId: 'v-old' }],
+      [
+        { variantId: 'v-new', optionValueId: 'red' },
+        { variantId: 'v-old', optionValueId: 'red' },
+      ],
+      [{ id: 'l-1', variantId: 'v-old', site: 'naver' }],
+    ]);
+    await makeSvc()._reconcileChannelListingsAfterPublish('master-1', 'version-2', false, tx);
+    expect(updates).toEqual([{ variantId: 'v-new', updatedAt: expect.any(Date) }]);
+  });
+
+  it('짝이 없으면 리스팅을 비활성으로 UPDATE 한다', async () => {
+    const { tx, updates } = makeTx([
+      [{ variantId: 'v-new' }],
+      [{ variantId: 'v-new', optionValueId: 'blue' }],
+      [{ variantId: 'v-new' }, { variantId: 'v-old' }],
+      [
+        { variantId: 'v-new', optionValueId: 'blue' },
+        { variantId: 'v-old', optionValueId: 'red' },
+      ],
+      [{ id: 'l-1', variantId: 'v-old', site: 'naver' }],
+    ]);
+    await makeSvc()._reconcileChannelListingsAfterPublish('master-1', 'version-2', false, tx);
+    expect(updates).toEqual([{ isActive: false, updatedAt: expect.any(Date) }]);
   });
 });

--- a/apps/core/src/modules/catalog/core/products/services/product-versions.service.spec.ts
+++ b/apps/core/src/modules/catalog/core/products/services/product-versions.service.spec.ts
@@ -334,6 +334,9 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
     priceCacheService.cachePricesForVersion.mockImplementation(async () => order.push('cachePrices'));
     (service as any)._reconcileMatchingsAfterPublish = jest.fn(async () => order.push('reconcileMatchings'));
     (service as any)._reconcileAssetLinksAfterPublish = jest.fn(async () => order.push('reconcileAssetLinks'));
+    (service as any)._reconcileChannelListingsAfterPublish = jest.fn(async () =>
+      order.push('reconcileChannelListings'),
+    );
     (service as any)._publishVariantChangeEvents = jest.fn(async () => order.push('publishVariantChanges'));
     (service as any).getVersionVariants = jest.fn().mockResolvedValue([]);
     projectionSnapshotAssembler.assembleActiveVersionSnapshot.mockImplementation(async () => {
@@ -374,6 +377,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
       'activateTarget',
       'reconcileMatchings',
       'reconcileAssetLinks',
+      'reconcileChannelListings',
       'publishVariantChanges',
       'assembleSnapshot',
       'saveOutbox',
@@ -407,6 +411,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
     service.validateProductCodeUniqueness = jest.fn().mockResolvedValue(undefined) as any;
     (service as any)._reconcileMatchingsAfterPublish = jest.fn().mockResolvedValue(undefined);
     (service as any)._reconcileAssetLinksAfterPublish = jest.fn().mockResolvedValue(undefined);
+    (service as any)._reconcileChannelListingsAfterPublish = jest.fn().mockResolvedValue(undefined);
     (service as any)._validateDigitalAssetLinks = jest.fn().mockResolvedValue(undefined);
     (service as any)._publishVariantChangeEvents = jest.fn().mockResolvedValue(undefined);
     (service as any).getVersionVariants = jest.fn().mockResolvedValue([]);
@@ -482,6 +487,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
     jest.spyOn(service as any, 'validateProductCodeUniqueness').mockResolvedValue(undefined);
     jest.spyOn(service as any, '_reconcileMatchingsAfterPublish').mockResolvedValue(undefined);
     jest.spyOn(service as any, '_reconcileAssetLinksAfterPublish').mockResolvedValue(undefined);
+    jest.spyOn(service as any, '_reconcileChannelListingsAfterPublish').mockResolvedValue(undefined);
     jest.spyOn(service as any, '_validateDigitalAssetLinks').mockResolvedValue(undefined);
     jest.spyOn(service as any, '_publishVariantChangeEvents').mockResolvedValue(undefined);
     jest.spyOn(service as any, '_emitActiveVersionChangedEvent').mockResolvedValue(undefined);
@@ -514,6 +520,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
     jest.spyOn(service as any, 'getActiveVersion').mockResolvedValue(null);
     for (const m of ['_validateVariantCodeUniqueness', 'validateProductCodeUniqueness',
                      '_reconcileMatchingsAfterPublish', '_reconcileAssetLinksAfterPublish',
+                     '_reconcileChannelListingsAfterPublish',
                      '_validateDigitalAssetLinks', '_publishVariantChangeEvents',
                      '_emitActiveVersionChangedEvent'])
       jest.spyOn(service as any, m).mockResolvedValue(undefined);
@@ -543,6 +550,7 @@ describe('ProductVersionsService Medusa projection outbox events', () => {
     jest.spyOn(service as any, 'getActiveVersion').mockResolvedValue(null);
     for (const m of ['_validateVariantCodeUniqueness', 'validateProductCodeUniqueness',
                      '_reconcileMatchingsAfterPublish', '_reconcileAssetLinksAfterPublish',
+                     '_reconcileChannelListingsAfterPublish',
                      '_validateDigitalAssetLinks', '_publishVariantChangeEvents',
                      '_emitActiveVersionChangedEvent'])
       jest.spyOn(service as any, m).mockResolvedValue(undefined);
@@ -1097,5 +1105,50 @@ describe('ProductVersionsService.getMyDraftVersions', () => {
     expect(result.page).toBe(2);
     expect(result.limit).toBe(10);
     expect(result.data).toEqual(rows);
+  });
+});
+
+describe('_planChannelListingReconciliation (#652)', () => {
+  // publish 로 CoW 가 일어나면 리스팅이 옛 variant 를 가리킨 채 남는다.
+  // 옵션값 조합이 같은 twin 으로 재지정하고, twin 이 없으면 리스팅을 끈다.
+  // 순수 판정 함수라 DI 가 필요 없다 — prototype 만 빌려 부른다.
+  const service = Object.create(ProductVersionsService.prototype) as any;
+  const plan = (prev: any[], next: any[], listings: any[]) =>
+    service._planChannelListingReconciliation(prev, next, listings);
+
+  it('옵션 조합이 같은 twin 이 새 버전에 있으면 그 variant 로 재지정한다', () => {
+    const result = plan(
+      [{ variantId: 'v-old', optionValueIds: ['red', 'L'] }],
+      [{ variantId: 'v-new', optionValueIds: ['L', 'red'] }],
+      [{ id: 'l-1', variantId: 'v-old' }],
+    );
+    expect(result).toEqual({ repoints: [{ listingId: 'l-1', newVariantId: 'v-new' }], deactivations: [] });
+  });
+
+  it('옵션 조합이 같은 twin 이 없으면 리스팅을 비활성화한다', () => {
+    const result = plan(
+      [{ variantId: 'v-old', optionValueIds: ['red'] }],
+      [{ variantId: 'v-other', optionValueIds: ['blue'] }],
+      [{ id: 'l-1', variantId: 'v-old' }],
+    );
+    expect(result).toEqual({ repoints: [], deactivations: ['l-1'] });
+  });
+
+  it('CoW 가 없어 variant 행이 그대로면 아무것도 하지 않는다', () => {
+    const result = plan(
+      [{ variantId: 'v-1', optionValueIds: ['red'] }],
+      [{ variantId: 'v-1', optionValueIds: ['red'] }],
+      [{ id: 'l-1', variantId: 'v-1' }],
+    );
+    expect(result).toEqual({ repoints: [], deactivations: [] });
+  });
+
+  it('옵션 없는 기본 품목(조합 빈 배열)도 twin 으로 재지정한다', () => {
+    const result = plan(
+      [{ variantId: 'v-old', optionValueIds: [] }],
+      [{ variantId: 'v-new', optionValueIds: [] }],
+      [{ id: 'l-1', variantId: 'v-old' }],
+    );
+    expect(result).toEqual({ repoints: [{ listingId: 'l-1', newVariantId: 'v-new' }], deactivations: [] });
   });
 });

--- a/apps/core/src/modules/catalog/core/products/services/product-versions.service.ts
+++ b/apps/core/src/modules/catalog/core/products/services/product-versions.service.ts
@@ -23,6 +23,7 @@ import {
   productMasterCategories,
   productMasterVersions,
   productMasterOptionGroups,
+  channelVariantListings,
   productMasterVariants,
   productMasterPricingRules,
   productOptionGroupDisplays,
@@ -56,6 +57,24 @@ import { deleteEntitiesIfUnmapped } from '../../version-isolation/delete-if-unma
 export interface PublishVersionOptions {
   origin?: ProductPublishOrigin;
   importSessionId?: string;
+}
+
+/** variant 한 벌과 그 옵션값 조합 — twin 짝 찾기의 입력. */
+interface VariantOptionCombo {
+  variantId: string;
+  optionValueIds: string[];
+}
+
+/** 승계 판정 대상 채널 리스팅 (#652). */
+interface ReconcilableListing {
+  id: string;
+  variantId: string;
+}
+
+/** 리스팅 승계 판정 결과 (#652). */
+interface ChannelListingReconciliationPlan {
+  repoints: Array<{ listingId: string; newVariantId: string }>;
+  deactivations: string[];
 }
 
 @Injectable()
@@ -326,6 +345,11 @@ export class ProductVersionsService {
 
       // Library 의 variant↔asset 매칭도 같은 패턴으로 인계 (옵션 조합 일치 시)
       await this._reconcileAssetLinksAfterPublish(version.id, previousActiveVersion?.id ?? null, tx);
+
+      // 채널 리스팅은 옛 variant 를 *가리키는* 쪽이라 방향만 반대다 — twin 으로 재지정한다.
+      // 아래 recalculateAndPublishForVariants 가 새·옛 버전 variant 를 모두 다시 계산하므로
+      // 리스팅 변경분 가용재고는 그 호출이 흡수한다 (별도 recalc 불필요).
+      await this._reconcileChannelListingsAfterPublish(version.id, previousActiveVersion?.id ?? null, tx);
 
       // 디지털 publish 가드 — reconcile 로 인계된 링크까지 반영하도록 그 뒤에 검증(throw 시 tx 롤백).
       await this._validateDigitalAssetLinks(version, tx);
@@ -704,6 +728,111 @@ export class ProductVersionsService {
         `Asset link reconciliation: inherited ${inheritedCount}/${unmatched.length} variant asset matchings from version ${previousActiveVersionId} to ${newVersionId}`,
       );
     }
+  }
+
+  /**
+   * publish 후 채널 리스팅을 새 버전의 twin variant 로 재지정한다 (#652, ADR-0031 결정 4).
+   *
+   * 앞의 두 reconciler 와 방향이 반대다. 매칭·에셋은 "새 variant 가 비었으면 옛 twin 에서
+   * 상속"이지만, 리스팅은 행이 옛 variant 를 **가리키고** 있으므로 그 포인터를 옮긴다.
+   * `uq_channel_variant_listing` 이 `(sales_channel_id, channel_item_id)` 에 걸린 unique 라
+   * "새 행 INSERT + 옛 행 비활성" 은 제약 위반이다 — 기존 행 UPDATE 만 가능하다.
+   */
+  private async _reconcileChannelListingsAfterPublish(
+    newVersionId: string,
+    previousActiveVersionId: string | null,
+    tx: DbTransaction,
+  ): Promise<void> {
+    if (!previousActiveVersionId) return;
+
+    const previousVariants = await this._getVersionVariantsWithOptionValues(previousActiveVersionId, tx);
+    if (previousVariants.length === 0) return;
+
+    const activeListings = await tx
+      .select({ id: channelVariantListings.id, variantId: channelVariantListings.variantId })
+      .from(channelVariantListings)
+      .where(
+        and(
+          inArray(
+            channelVariantListings.variantId,
+            previousVariants.map((v) => v.variantId),
+          ),
+          eq(channelVariantListings.isActive, true),
+        ),
+      );
+    // 이미 꺼진 리스팅은 손대지 않는다 — 되살리는 건 별개 결정이다.
+    if (activeListings.length === 0) return;
+
+    const newVariants = await this._getVersionVariantsWithOptionValues(newVersionId, tx);
+    const { repoints, deactivations } = this._planChannelListingReconciliation(
+      previousVariants,
+      newVariants,
+      activeListings,
+    );
+
+    for (const { listingId, newVariantId } of repoints) {
+      await tx
+        .update(channelVariantListings)
+        .set({ variantId: newVariantId, updatedAt: new Date() })
+        .where(eq(channelVariantListings.id, listingId));
+    }
+
+    if (deactivations.length > 0) {
+      await tx
+        .update(channelVariantListings)
+        .set({ isActive: false, updatedAt: new Date() })
+        .where(inArray(channelVariantListings.id, deactivations));
+    }
+
+    if (repoints.length > 0 || deactivations.length > 0) {
+      this.logger.log(
+        `Channel listing reconciliation: repointed ${repoints.length}, deactivated ${deactivations.length} ` +
+          `listings from version ${previousActiveVersionId} to ${newVersionId}`,
+      );
+    }
+  }
+
+  /**
+   * 리스팅 승계 판정 (#652) — 순수 함수.
+   *
+   * CoW 로 variant 행이 갈리면 `channel_variant_listings` 는 옛 행을 가리킨 채 남고,
+   * 조회 조인이 variant 를 고정하므로 **옛 버전 값이 조용히 반환된다**(격리도 로그도 없다).
+   * 옵션값 조합이 같은 twin 으로 재지정하고, twin 이 없으면 리스팅을 끈다 — 끄면 이후
+   * 그 채널 주문이 미식별 격리로 가서 최소한 눈에 보인다.
+   */
+  private _planChannelListingReconciliation(
+    previousVariants: VariantOptionCombo[],
+    newVariants: VariantOptionCombo[],
+    listings: ReconcilableListing[],
+  ): ChannelListingReconciliationPlan {
+    const newVariantIds = new Set(newVariants.map((v) => v.variantId));
+
+    const newVariantIdByComboKey = new Map<string, string>();
+    for (const nv of newVariants) {
+      newVariantIdByComboKey.set(this._comboKey(nv.optionValueIds), nv.variantId);
+    }
+
+    const previousByVariantId = new Map(previousVariants.map((pv) => [pv.variantId, pv]));
+
+    const repoints: Array<{ listingId: string; newVariantId: string }> = [];
+    const deactivations: string[] = [];
+
+    for (const listing of listings) {
+      // 새 버전이 같은 variant 행을 그대로 쓰면 CoW 가 없었던 것 — 손댈 이유가 없다.
+      if (newVariantIds.has(listing.variantId)) continue;
+
+      const previous = previousByVariantId.get(listing.variantId);
+      if (!previous) continue;
+
+      const twinVariantId = newVariantIdByComboKey.get(this._comboKey(previous.optionValueIds));
+      if (twinVariantId) {
+        repoints.push({ listingId: listing.id, newVariantId: twinVariantId });
+      } else {
+        deactivations.push(listing.id);
+      }
+    }
+
+    return { repoints, deactivations };
   }
 
   private async _getVersionVariantsWithOptionValues(

--- a/apps/core/src/modules/catalog/core/products/services/product-versions.service.ts
+++ b/apps/core/src/modules/catalog/core/products/services/product-versions.service.ts
@@ -48,6 +48,11 @@ import { ProductSellableQuantityService } from '../../../../inventory/product-se
 import { ProductPurchaseConstraintsService } from './product-purchase-constraints.service';
 import { eq, and, sql, max as drizzleMax, isNull, inArray, asc, desc, count } from 'drizzle-orm';
 import { isExternalMarketplaceSite } from '../../channels/marketplace-site';
+import {
+  comboKey,
+  planChannelListingReconciliation,
+  type VariantOptionCombo,
+} from './channel-listing-reconciliation';
 import { keywordMatch } from '../../../common/keyword-match';
 import { v7 as uuidv7 } from 'uuid';
 import { deleteEntitiesIfUnmapped } from '../../version-isolation/delete-if-unmapped';
@@ -59,42 +64,6 @@ import { deleteEntitiesIfUnmapped } from '../../version-isolation/delete-if-unma
 export interface PublishVersionOptions {
   origin?: ProductPublishOrigin;
   importSessionId?: string;
-}
-
-/** variant 한 벌과 그 옵션값 조합 — twin 짝 찾기의 입력. */
-export interface VariantOptionCombo {
-  variantId: string;
-  optionValueIds: string[];
-}
-
-/** 승계 판정 대상 채널 리스팅 (#652). */
-export interface ReconcilableListing {
-  id: string;
-  variantId: string;
-  /** 네이버·쿠팡 등 외부 마켓플레이스인가 — 디지털 상품은 여기 실릴 수 없다. */
-  isExternalMarketplace: boolean;
-  isActive: boolean;
-}
-
-/**
- * 리스팅 승계 판정 결과 (#652).
- *
- * 재지정과 비활성은 **배타적이지 않다** — 디지털 전환으로 끄는 리스팅도 짝이 있으면 같이
- * 옮겨 둬야 나중에 되살릴 수 있다. 죽은 variant 를 가리킨 채 꺼진 행은 재활성도
- * 재등록도(`uq_channel_variant_listing`) 막혀 삭제 말고는 길이 없다.
- */
-export interface ChannelListingReconciliationPlan {
-  updates: Array<{ listingId: string; newVariantId: string | null; deactivate: boolean }>;
-}
-
-/** 스펙이 private 판정 함수를 타입을 지운 채 부르지 않도록 노출하는 표면. */
-export interface PlanChannelListings {
-  _planChannelListingReconciliation(
-    candidateVariants: VariantOptionCombo[],
-    newVariants: VariantOptionCombo[],
-    listings: ReconcilableListing[],
-    newVersionIsDigital: boolean,
-  ): ChannelListingReconciliationPlan;
 }
 
 @Injectable()
@@ -509,7 +478,7 @@ export class ProductVersionsService {
 
     const prevByComboKey = new Map<string, { variantId: string }>();
     for (const pv of prevVariants) {
-      prevByComboKey.set(this._comboKey(pv.optionValueIds), { variantId: pv.variantId });
+      prevByComboKey.set(comboKey(pv.optionValueIds), { variantId: pv.variantId });
     }
 
     // 판매정책은 버전에 담기지 않지만(설계 의도), CoW 로 variantId 가 갈리면 "같은 상품의
@@ -542,7 +511,7 @@ export class ProductVersionsService {
     let inheritedPolicyCount = 0;
     for (const nv of newVariants) {
       if (hasPolicy.has(nv.variantId)) continue;
-      const twin = prevByComboKey.get(this._comboKey(nv.optionValueIds));
+      const twin = prevByComboKey.get(comboKey(nv.optionValueIds));
       if (!twin) continue;
 
       const prevPolicy = prevPoliciesByVariantId.get(twin.variantId);
@@ -606,7 +575,7 @@ export class ProductVersionsService {
 
     let inheritedCount = 0;
     for (const nv of unmatched) {
-      const twin = prevByComboKey.get(this._comboKey(nv.optionValueIds));
+      const twin = prevByComboKey.get(comboKey(nv.optionValueIds));
       if (!twin) continue;
 
       const prevMatching = prevMatchingsByVariantId.get(twin.variantId);
@@ -736,12 +705,12 @@ export class ProductVersionsService {
 
     const prevByComboKey = new Map<string, string>();
     for (const pv of prevVariants) {
-      prevByComboKey.set(this._comboKey(pv.optionValueIds), pv.variantId);
+      prevByComboKey.set(comboKey(pv.optionValueIds), pv.variantId);
     }
 
     const plan: Array<{ newVariantId: string; previousVariantId: string }> = [];
     for (const nv of unmatched) {
-      const twinVariantId = prevByComboKey.get(this._comboKey(nv.optionValueIds));
+      const twinVariantId = prevByComboKey.get(comboKey(nv.optionValueIds));
       if (!twinVariantId) continue;
       plan.push({ newVariantId: nv.variantId, previousVariantId: twinVariantId });
     }
@@ -777,13 +746,10 @@ export class ProductVersionsService {
     newVersionIsDigital: boolean,
     tx: DbTransaction,
   ): Promise<void> {
-    const newVariants = await this._getVersionVariantsWithOptionValues(newVersionId, tx);
-    // 형제 reconciler 와 같은 가드. 없으면 품목 0개짜리 버전을 publish 하는 순간
-    // 그 master 의 채널 매핑이 "짝 없음" 으로 전량 꺼진다.
-    if (newVariants.length === 0) return;
-
-    const candidateVariants = await this._getMasterVariantsWithOptionValues(masterId, tx);
-    if (candidateVariants.length === 0) return;
+    // 리스팅 존재 확인을 맨 앞에 둔다 — 대부분의 publish 는 채널 매핑이 없어 여기서 끝난다
+    // (일괄 세션은 한 트랜잭션에서 수백 건을 publish 한다).
+    const candidateVariantIds = await this._getMasterVariantIds(masterId, tx);
+    if (candidateVariantIds.length === 0) return;
 
     const listings = await tx
       .select({
@@ -794,15 +760,17 @@ export class ProductVersionsService {
       })
       .from(channelVariantListings)
       .innerJoin(salesChannels, eq(salesChannels.id, channelVariantListings.salesChannelId))
-      .where(
-        inArray(
-          channelVariantListings.variantId,
-          candidateVariants.map((c) => c.variantId),
-        ),
-      );
+      .where(inArray(channelVariantListings.variantId, candidateVariantIds));
     if (listings.length === 0) return;
 
-    const { updates } = this._planChannelListingReconciliation(
+    const newVariants = await this._getVersionVariantsWithOptionValues(newVersionId, tx);
+    // 형제 reconciler 와 같은 가드. 없으면 품목 0개짜리 버전을 publish 하는 순간
+    // 그 master 의 채널 매핑이 "짝 없음" 으로 전량 꺼진다.
+    if (newVariants.length === 0) return;
+
+    const candidateVariants = await this._attachOptionValues(candidateVariantIds, tx);
+
+    const { updates } = planChannelListingReconciliation(
       candidateVariants,
       newVariants,
       listings.map((l) => ({
@@ -851,67 +819,6 @@ export class ProductVersionsService {
     }
   }
 
-  /**
-   * 리스팅 승계 판정 (#652) — 순수 함수.
-   *
-   * 리스팅 한 건에 대해 독립된 두 결정을 내린다.
-   * - **어디를 가리켜야 하나**: CoW 로 variant 가 갈렸으면 옵션값 조합이 같은 twin.
-   * - **꺼야 하나**: 짝이 없거나, 조합이 모호하거나(같은 조합이 둘 이상 — 주문이 흘러갈 곳을
-   *   임의로 고를 수 없다), 새 버전이 디지털인데 외부 마켓플레이스 리스팅일 때
-   *   (`createListing` 이 거부하는 상태를 승계로 만들 수는 없다).
-   *
-   * 디지털 판정은 **CoW 여부와 무관**하다 — `fulfillmentKind` 만 바꿔 publish 하면 품목이
-   * 복제되지 않으므로, 제자리 variant 의 리스팅도 검사해야 한다.
-   */
-  private _planChannelListingReconciliation(
-    candidateVariants: VariantOptionCombo[],
-    newVariants: VariantOptionCombo[],
-    listings: ReconcilableListing[],
-    newVersionIsDigital: boolean,
-  ): ChannelListingReconciliationPlan {
-    const newVariantIds = new Set(newVariants.map((v) => v.variantId));
-
-    // 같은 조합이 둘 이상이면 null 로 표시해 "짝 없음" 과 같게 취급한다.
-    const newVariantIdByComboKey = new Map<string, string | null>();
-    for (const nv of newVariants) {
-      const key = this._comboKey(nv.optionValueIds);
-      newVariantIdByComboKey.set(key, newVariantIdByComboKey.has(key) ? null : nv.variantId);
-    }
-
-    const listingsByVariantId = new Map<string, ReconcilableListing[]>();
-    for (const listing of listings) {
-      const bucket = listingsByVariantId.get(listing.variantId);
-      if (bucket) bucket.push(listing);
-      else listingsByVariantId.set(listing.variantId, [listing]);
-    }
-
-    const updates: ChannelListingReconciliationPlan['updates'] = [];
-
-    for (const candidate of candidateVariants) {
-      const affected = listingsByVariantId.get(candidate.variantId);
-      if (!affected) continue;
-
-      // 새 버전이 같은 variant 행을 그대로 쓰면 CoW 가 없었던 것 — 옮길 곳이 없다.
-      const isStale = !newVariantIds.has(candidate.variantId);
-      const twinVariantId = isStale
-        ? (newVariantIdByComboKey.get(this._comboKey(candidate.optionValueIds)) ?? null)
-        : null;
-
-      for (const listing of affected) {
-        const blockedByDigital = newVersionIsDigital && listing.isExternalMarketplace;
-        const deactivate = listing.isActive && (blockedByDigital || (isStale && !twinVariantId));
-        const newVariantId = isStale ? twinVariantId : null;
-
-        // 이미 꺼진 리스팅을 다시 끄지 않고, 옮길 곳도 없으면 건드릴 이유가 없다.
-        if (!deactivate && !newVariantId) continue;
-
-        updates.push({ listingId: listing.id, newVariantId, deactivate });
-      }
-    }
-
-    return { updates };
-  }
-
   private async _getVersionVariantsWithOptionValues(
     versionId: string,
     tx: DbTransaction,
@@ -930,22 +837,16 @@ export class ProductVersionsService {
   }
 
   /**
-   * master 에 매달린 **모든 버전**의 variant. 리스팅 승계(#652)가 쓰는 축이다 —
+   * master 에 매달린 **모든 버전**의 variant id. 리스팅 승계(#652)가 쓰는 축이다 —
    * 활성 버전이 없는 master 도 있어서 버전 단위로는 옛 variant 를 못 찾는다.
    */
-  private async _getMasterVariantsWithOptionValues(
-    masterId: string,
-    tx: DbTransaction,
-  ): Promise<VariantOptionCombo[]> {
+  private async _getMasterVariantIds(masterId: string, tx: DbTransaction): Promise<string[]> {
     const rows = await tx
       .selectDistinct({ variantId: productMasterVariants.variantId })
       .from(productMasterVariants)
       .where(eq(productMasterVariants.masterId, masterId));
 
-    return this._attachOptionValues(
-      rows.map((r) => r.variantId),
-      tx,
-    );
+    return rows.map((r) => r.variantId);
   }
 
   private async _attachOptionValues(variantIds: string[], tx: DbTransaction): Promise<VariantOptionCombo[]> {
@@ -967,9 +868,6 @@ export class ProductVersionsService {
     return variantIds.map((id) => ({ variantId: id, optionValueIds: byVariant.get(id) ?? [] }));
   }
 
-  private _comboKey(optionValueIds: string[]): string {
-    return [...optionValueIds].sort().join('|');
-  }
 
   /**
    * 멤버십가 공개 제한 변경 — draft 없이 active 버전을 직접 수정하고 채널에 재싱크.

--- a/apps/core/src/modules/catalog/core/products/services/product-versions.service.ts
+++ b/apps/core/src/modules/catalog/core/products/services/product-versions.service.ts
@@ -62,23 +62,39 @@ export interface PublishVersionOptions {
 }
 
 /** variant 한 벌과 그 옵션값 조합 — twin 짝 찾기의 입력. */
-interface VariantOptionCombo {
+export interface VariantOptionCombo {
   variantId: string;
   optionValueIds: string[];
 }
 
 /** 승계 판정 대상 채널 리스팅 (#652). */
-interface ReconcilableListing {
+export interface ReconcilableListing {
   id: string;
   variantId: string;
   /** 네이버·쿠팡 등 외부 마켓플레이스인가 — 디지털 상품은 여기 실릴 수 없다. */
   isExternalMarketplace: boolean;
+  isActive: boolean;
 }
 
-/** 리스팅 승계 판정 결과 (#652). */
-interface ChannelListingReconciliationPlan {
-  repoints: Array<{ listingId: string; newVariantId: string }>;
-  deactivations: string[];
+/**
+ * 리스팅 승계 판정 결과 (#652).
+ *
+ * 재지정과 비활성은 **배타적이지 않다** — 디지털 전환으로 끄는 리스팅도 짝이 있으면 같이
+ * 옮겨 둬야 나중에 되살릴 수 있다. 죽은 variant 를 가리킨 채 꺼진 행은 재활성도
+ * 재등록도(`uq_channel_variant_listing`) 막혀 삭제 말고는 길이 없다.
+ */
+export interface ChannelListingReconciliationPlan {
+  updates: Array<{ listingId: string; newVariantId: string | null; deactivate: boolean }>;
+}
+
+/** 스펙이 private 판정 함수를 타입을 지운 채 부르지 않도록 노출하는 표면. */
+export interface PlanChannelListings {
+  _planChannelListingReconciliation(
+    candidateVariants: VariantOptionCombo[],
+    newVariants: VariantOptionCombo[],
+    listings: ReconcilableListing[],
+    newVersionIsDigital: boolean,
+  ): ChannelListingReconciliationPlan;
 }
 
 @Injectable()
@@ -351,8 +367,9 @@ export class ProductVersionsService {
       await this._reconcileAssetLinksAfterPublish(version.id, previousActiveVersion?.id ?? null, tx);
 
       // 채널 리스팅은 옛 variant 를 *가리키는* 쪽이라 방향만 반대다 — twin 으로 재지정한다.
-      // 아래 recalculateAndPublishForVariants 가 새·옛 버전 variant 를 모두 다시 계산하므로
-      // 리스팅 변경분 가용재고는 그 호출이 흡수한다 (별도 recalc 불필요).
+      // 가용재고 재계산은 부르지 않는다: ProductSellableQuantityService 는 활성 버전과 매칭만
+      // 보고 channel_variant_listings 를 읽지 않으므로 리스팅 변경은 투영에 영향이 없다.
+      // (createListing 등이 recalc 를 부르는 건 방어적 관습이지 이 투영의 요구가 아니다.)
       await this._reconcileChannelListingsAfterPublish(
         version.masterId,
         version.id,
@@ -750,6 +767,9 @@ export class ProductVersionsService {
    * 축이 "이전 활성 버전" 이 아니라 **이 master 의 모든 버전** 인 것도 앞의 둘과 다르다.
    * `unpublishMaster` 로 판매중지한 뒤 드래프트를 고쳐 다시 publish 하는 경로에는 이전 활성
    * 버전이 아예 없지만(CoW 는 "다른 어떤 버전과 공유" 면 발동한다) 리스팅은 그대로 낡는다.
+   *
+   * 꺼진 리스팅도 조회 대상이다 — 되살리지는 않지만 포인터는 옮겨 둔다. 죽은 variant 를
+   * 가리킨 채 꺼져 있으면 재활성도 재등록도 막혀 삭제 말고는 복구 경로가 없다.
    */
   private async _reconcileChannelListingsAfterPublish(
     masterId: string,
@@ -763,63 +783,70 @@ export class ProductVersionsService {
     if (newVariants.length === 0) return;
 
     const candidateVariants = await this._getMasterVariantsWithOptionValues(masterId, tx);
-    const newVariantIds = new Set(newVariants.map((v) => v.variantId));
-    const staleVariantIds = candidateVariants
-      .filter((c) => !newVariantIds.has(c.variantId))
-      .map((c) => c.variantId);
-    if (staleVariantIds.length === 0) return;
+    if (candidateVariants.length === 0) return;
 
-    const activeListings = await tx
+    const listings = await tx
       .select({
         id: channelVariantListings.id,
         variantId: channelVariantListings.variantId,
+        isActive: channelVariantListings.isActive,
         site: salesChannels.site,
       })
       .from(channelVariantListings)
       .innerJoin(salesChannels, eq(salesChannels.id, channelVariantListings.salesChannelId))
       .where(
-        and(inArray(channelVariantListings.variantId, staleVariantIds), eq(channelVariantListings.isActive, true)),
+        inArray(
+          channelVariantListings.variantId,
+          candidateVariants.map((c) => c.variantId),
+        ),
       );
-    // 이미 꺼진 리스팅은 손대지 않는다 — 되살리는 건 별개 결정이다.
-    if (activeListings.length === 0) return;
+    if (listings.length === 0) return;
 
-    const { repoints, deactivations } = this._planChannelListingReconciliation(
+    const { updates } = this._planChannelListingReconciliation(
       candidateVariants,
       newVariants,
-      activeListings.map((l) => ({
+      listings.map((l) => ({
         id: l.id,
         variantId: l.variantId,
+        isActive: l.isActive,
         isExternalMarketplace: isExternalMarketplaceSite(l.site),
       })),
       newVersionIsDigital,
     );
+    if (updates.length === 0) return;
 
-    // 목적지가 같은 리스팅끼리 묶어 UPDATE 수를 목적지 수로 줄인다.
-    const listingIdsByTarget = new Map<string, string[]>();
-    for (const { listingId, newVariantId } of repoints) {
-      const bucket = listingIdsByTarget.get(newVariantId);
-      if (bucket) bucket.push(listingId);
-      else listingIdsByTarget.set(newVariantId, [listingId]);
+    // 같은 (목적지, 비활성여부) 끼리 묶어 UPDATE 수를 조합 수로 줄인다.
+    const grouped = new Map<string, { newVariantId: string | null; deactivate: boolean; listingIds: string[] }>();
+    for (const u of updates) {
+      const key = `${u.newVariantId ?? ''}|${u.deactivate}`;
+      const bucket = grouped.get(key);
+      if (bucket) bucket.listingIds.push(u.listingId);
+      else grouped.set(key, { newVariantId: u.newVariantId, deactivate: u.deactivate, listingIds: [u.listingId] });
     }
 
-    for (const [newVariantId, listingIds] of listingIdsByTarget) {
+    for (const g of grouped.values()) {
       await tx
         .update(channelVariantListings)
-        .set({ variantId: newVariantId, updatedAt: new Date() })
-        .where(inArray(channelVariantListings.id, listingIds));
+        .set({
+          ...(g.newVariantId ? { variantId: g.newVariantId } : {}),
+          ...(g.deactivate ? { isActive: false } : {}),
+          updatedAt: new Date(),
+        })
+        .where(inArray(channelVariantListings.id, g.listingIds));
     }
 
-    if (deactivations.length > 0) {
-      await tx
-        .update(channelVariantListings)
-        .set({ isActive: false, updatedAt: new Date() })
-        .where(inArray(channelVariantListings.id, deactivations));
+    const deactivated = updates.filter((u) => u.deactivate).map((u) => u.listingId);
+    const repointed = updates.filter((u) => u.newVariantId).length;
+    if (deactivated.length > 0) {
+      // 비활성은 사실상 비가역이다(재활성·재등록 모두 막힘) — 어느 행이었는지 남겨야 복구가 가능하다.
+      this.logger.warn(
+        `Channel listing reconciliation deactivated ${deactivated.length} listing(s) on master ${masterId} ` +
+          `at version ${newVersionId}: ${deactivated.join(', ')}`,
+      );
     }
-
-    if (repoints.length > 0 || deactivations.length > 0) {
+    if (repointed > 0) {
       this.logger.log(
-        `Channel listing reconciliation: repointed ${repoints.length}, deactivated ${deactivations.length} ` +
-          `listings on master ${masterId} to version ${newVersionId}`,
+        `Channel listing reconciliation: repointed ${repointed} listing(s) on master ${masterId} to version ${newVersionId}`,
       );
     }
   }
@@ -827,15 +854,14 @@ export class ProductVersionsService {
   /**
    * 리스팅 승계 판정 (#652) — 순수 함수.
    *
-   * CoW 로 variant 행이 갈리면 `channel_variant_listings` 는 옛 행을 가리킨 채 남고,
-   * 조회 조인이 variant 를 고정하므로 **옛 버전 값이 조용히 반환된다**(격리도 로그도 없다).
-   * 옵션값 조합이 같은 twin 으로 재지정하고, 없으면 리스팅을 끈다 — 끄면 이후 그 채널
-   * 주문이 미식별 격리로 가서 최소한 눈에 보인다.
+   * 리스팅 한 건에 대해 독립된 두 결정을 내린다.
+   * - **어디를 가리켜야 하나**: CoW 로 variant 가 갈렸으면 옵션값 조합이 같은 twin.
+   * - **꺼야 하나**: 짝이 없거나, 조합이 모호하거나(같은 조합이 둘 이상 — 주문이 흘러갈 곳을
+   *   임의로 고를 수 없다), 새 버전이 디지털인데 외부 마켓플레이스 리스팅일 때
+   *   (`createListing` 이 거부하는 상태를 승계로 만들 수는 없다).
    *
-   * 끄는 쪽으로 기우는 두 경우가 더 있다:
-   * - **조합이 모호할 때**(새 버전에 같은 조합이 둘 이상) — 주문이 흘러갈 곳을 임의로 고를 수 없다.
-   * - **새 버전이 디지털인데 외부 마켓플레이스 리스팅일 때** — `createListing` 이 거부하는
-   *   상태를 승계로 만들 수는 없다 (비로그인 주문이라 디지털 소유권을 줄 대상이 없다).
+   * 디지털 판정은 **CoW 여부와 무관**하다 — `fulfillmentKind` 만 바꿔 publish 하면 품목이
+   * 복제되지 않으므로, 제자리 variant 의 리스팅도 검사해야 한다.
    */
   private _planChannelListingReconciliation(
     candidateVariants: VariantOptionCombo[],
@@ -859,37 +885,41 @@ export class ProductVersionsService {
       else listingsByVariantId.set(listing.variantId, [listing]);
     }
 
-    const repoints: Array<{ listingId: string; newVariantId: string }> = [];
-    const deactivations: string[] = [];
+    const updates: ChannelListingReconciliationPlan['updates'] = [];
 
     for (const candidate of candidateVariants) {
-      // 새 버전이 같은 variant 행을 그대로 쓰면 CoW 가 없었던 것 — 손댈 이유가 없다.
-      if (newVariantIds.has(candidate.variantId)) continue;
-
       const affected = listingsByVariantId.get(candidate.variantId);
       if (!affected) continue;
 
-      const twinVariantId = newVariantIdByComboKey.get(this._comboKey(candidate.optionValueIds));
+      // 새 버전이 같은 variant 행을 그대로 쓰면 CoW 가 없었던 것 — 옮길 곳이 없다.
+      const isStale = !newVariantIds.has(candidate.variantId);
+      const twinVariantId = isStale
+        ? (newVariantIdByComboKey.get(this._comboKey(candidate.optionValueIds)) ?? null)
+        : null;
 
       for (const listing of affected) {
         const blockedByDigital = newVersionIsDigital && listing.isExternalMarketplace;
-        if (twinVariantId && !blockedByDigital) {
-          repoints.push({ listingId: listing.id, newVariantId: twinVariantId });
-        } else {
-          deactivations.push(listing.id);
-        }
+        const deactivate = listing.isActive && (blockedByDigital || (isStale && !twinVariantId));
+        const newVariantId = isStale ? twinVariantId : null;
+
+        // 이미 꺼진 리스팅을 다시 끄지 않고, 옮길 곳도 없으면 건드릴 이유가 없다.
+        if (!deactivate && !newVariantId) continue;
+
+        updates.push({ listingId: listing.id, newVariantId, deactivate });
       }
     }
 
-    return { repoints, deactivations };
+    return { updates };
   }
 
   private async _getVersionVariantsWithOptionValues(
     versionId: string,
     tx: DbTransaction,
   ): Promise<VariantOptionCombo[]> {
+    // DISTINCT 필수 — unique 는 (masterId, variantId, versionId) 라 같은 (variantId, versionId)
+    // 가 두 masterId 로 매달릴 수 있다. 중복이 들어오면 조합 맵이 "모호" 로 오판한다.
     const rows = await tx
-      .select({ variantId: productMasterVariants.variantId })
+      .selectDistinct({ variantId: productMasterVariants.variantId })
       .from(productMasterVariants)
       .where(eq(productMasterVariants.versionId, versionId));
 

--- a/apps/core/src/modules/catalog/core/products/services/product-versions.service.ts
+++ b/apps/core/src/modules/catalog/core/products/services/product-versions.service.ts
@@ -24,6 +24,7 @@ import {
   productMasterVersions,
   productMasterOptionGroups,
   channelVariantListings,
+  salesChannels,
   productMasterVariants,
   productMasterPricingRules,
   productOptionGroupDisplays,
@@ -46,6 +47,7 @@ import { productVariantDigitalAssetLinks } from '../../../../library/schema/libr
 import { ProductSellableQuantityService } from '../../../../inventory/product-sellable-quantity/services/product-sellable-quantity.service';
 import { ProductPurchaseConstraintsService } from './product-purchase-constraints.service';
 import { eq, and, sql, max as drizzleMax, isNull, inArray, asc, desc, count } from 'drizzle-orm';
+import { isExternalMarketplaceSite } from '../../channels/marketplace-site';
 import { keywordMatch } from '../../../common/keyword-match';
 import { v7 as uuidv7 } from 'uuid';
 import { deleteEntitiesIfUnmapped } from '../../version-isolation/delete-if-unmapped';
@@ -69,6 +71,8 @@ interface VariantOptionCombo {
 interface ReconcilableListing {
   id: string;
   variantId: string;
+  /** 네이버·쿠팡 등 외부 마켓플레이스인가 — 디지털 상품은 여기 실릴 수 없다. */
+  isExternalMarketplace: boolean;
 }
 
 /** 리스팅 승계 판정 결과 (#652). */
@@ -349,7 +353,12 @@ export class ProductVersionsService {
       // 채널 리스팅은 옛 variant 를 *가리키는* 쪽이라 방향만 반대다 — twin 으로 재지정한다.
       // 아래 recalculateAndPublishForVariants 가 새·옛 버전 variant 를 모두 다시 계산하므로
       // 리스팅 변경분 가용재고는 그 호출이 흡수한다 (별도 recalc 불필요).
-      await this._reconcileChannelListingsAfterPublish(version.id, previousActiveVersion?.id ?? null, tx);
+      await this._reconcileChannelListingsAfterPublish(
+        version.masterId,
+        version.id,
+        version.fulfillmentKind === 'digital',
+        tx,
+      );
 
       // 디지털 publish 가드 — reconcile 로 인계된 링크까지 반영하도록 그 뒤에 검증(throw 시 tx 롤백).
       await this._validateDigitalAssetLinks(version, tx);
@@ -737,44 +746,67 @@ export class ProductVersionsService {
    * 상속"이지만, 리스팅은 행이 옛 variant 를 **가리키고** 있으므로 그 포인터를 옮긴다.
    * `uq_channel_variant_listing` 이 `(sales_channel_id, channel_item_id)` 에 걸린 unique 라
    * "새 행 INSERT + 옛 행 비활성" 은 제약 위반이다 — 기존 행 UPDATE 만 가능하다.
+   *
+   * 축이 "이전 활성 버전" 이 아니라 **이 master 의 모든 버전** 인 것도 앞의 둘과 다르다.
+   * `unpublishMaster` 로 판매중지한 뒤 드래프트를 고쳐 다시 publish 하는 경로에는 이전 활성
+   * 버전이 아예 없지만(CoW 는 "다른 어떤 버전과 공유" 면 발동한다) 리스팅은 그대로 낡는다.
    */
   private async _reconcileChannelListingsAfterPublish(
+    masterId: string,
     newVersionId: string,
-    previousActiveVersionId: string | null,
+    newVersionIsDigital: boolean,
     tx: DbTransaction,
   ): Promise<void> {
-    if (!previousActiveVersionId) return;
+    const newVariants = await this._getVersionVariantsWithOptionValues(newVersionId, tx);
+    // 형제 reconciler 와 같은 가드. 없으면 품목 0개짜리 버전을 publish 하는 순간
+    // 그 master 의 채널 매핑이 "짝 없음" 으로 전량 꺼진다.
+    if (newVariants.length === 0) return;
 
-    const previousVariants = await this._getVersionVariantsWithOptionValues(previousActiveVersionId, tx);
-    if (previousVariants.length === 0) return;
+    const candidateVariants = await this._getMasterVariantsWithOptionValues(masterId, tx);
+    const newVariantIds = new Set(newVariants.map((v) => v.variantId));
+    const staleVariantIds = candidateVariants
+      .filter((c) => !newVariantIds.has(c.variantId))
+      .map((c) => c.variantId);
+    if (staleVariantIds.length === 0) return;
 
     const activeListings = await tx
-      .select({ id: channelVariantListings.id, variantId: channelVariantListings.variantId })
+      .select({
+        id: channelVariantListings.id,
+        variantId: channelVariantListings.variantId,
+        site: salesChannels.site,
+      })
       .from(channelVariantListings)
+      .innerJoin(salesChannels, eq(salesChannels.id, channelVariantListings.salesChannelId))
       .where(
-        and(
-          inArray(
-            channelVariantListings.variantId,
-            previousVariants.map((v) => v.variantId),
-          ),
-          eq(channelVariantListings.isActive, true),
-        ),
+        and(inArray(channelVariantListings.variantId, staleVariantIds), eq(channelVariantListings.isActive, true)),
       );
     // 이미 꺼진 리스팅은 손대지 않는다 — 되살리는 건 별개 결정이다.
     if (activeListings.length === 0) return;
 
-    const newVariants = await this._getVersionVariantsWithOptionValues(newVersionId, tx);
     const { repoints, deactivations } = this._planChannelListingReconciliation(
-      previousVariants,
+      candidateVariants,
       newVariants,
-      activeListings,
+      activeListings.map((l) => ({
+        id: l.id,
+        variantId: l.variantId,
+        isExternalMarketplace: isExternalMarketplaceSite(l.site),
+      })),
+      newVersionIsDigital,
     );
 
+    // 목적지가 같은 리스팅끼리 묶어 UPDATE 수를 목적지 수로 줄인다.
+    const listingIdsByTarget = new Map<string, string[]>();
     for (const { listingId, newVariantId } of repoints) {
+      const bucket = listingIdsByTarget.get(newVariantId);
+      if (bucket) bucket.push(listingId);
+      else listingIdsByTarget.set(newVariantId, [listingId]);
+    }
+
+    for (const [newVariantId, listingIds] of listingIdsByTarget) {
       await tx
         .update(channelVariantListings)
         .set({ variantId: newVariantId, updatedAt: new Date() })
-        .where(eq(channelVariantListings.id, listingId));
+        .where(inArray(channelVariantListings.id, listingIds));
     }
 
     if (deactivations.length > 0) {
@@ -787,7 +819,7 @@ export class ProductVersionsService {
     if (repoints.length > 0 || deactivations.length > 0) {
       this.logger.log(
         `Channel listing reconciliation: repointed ${repoints.length}, deactivated ${deactivations.length} ` +
-          `listings from version ${previousActiveVersionId} to ${newVersionId}`,
+          `listings on master ${masterId} to version ${newVersionId}`,
       );
     }
   }
@@ -797,38 +829,55 @@ export class ProductVersionsService {
    *
    * CoW 로 variant 행이 갈리면 `channel_variant_listings` 는 옛 행을 가리킨 채 남고,
    * 조회 조인이 variant 를 고정하므로 **옛 버전 값이 조용히 반환된다**(격리도 로그도 없다).
-   * 옵션값 조합이 같은 twin 으로 재지정하고, twin 이 없으면 리스팅을 끈다 — 끄면 이후
-   * 그 채널 주문이 미식별 격리로 가서 최소한 눈에 보인다.
+   * 옵션값 조합이 같은 twin 으로 재지정하고, 없으면 리스팅을 끈다 — 끄면 이후 그 채널
+   * 주문이 미식별 격리로 가서 최소한 눈에 보인다.
+   *
+   * 끄는 쪽으로 기우는 두 경우가 더 있다:
+   * - **조합이 모호할 때**(새 버전에 같은 조합이 둘 이상) — 주문이 흘러갈 곳을 임의로 고를 수 없다.
+   * - **새 버전이 디지털인데 외부 마켓플레이스 리스팅일 때** — `createListing` 이 거부하는
+   *   상태를 승계로 만들 수는 없다 (비로그인 주문이라 디지털 소유권을 줄 대상이 없다).
    */
   private _planChannelListingReconciliation(
-    previousVariants: VariantOptionCombo[],
+    candidateVariants: VariantOptionCombo[],
     newVariants: VariantOptionCombo[],
     listings: ReconcilableListing[],
+    newVersionIsDigital: boolean,
   ): ChannelListingReconciliationPlan {
     const newVariantIds = new Set(newVariants.map((v) => v.variantId));
 
-    const newVariantIdByComboKey = new Map<string, string>();
+    // 같은 조합이 둘 이상이면 null 로 표시해 "짝 없음" 과 같게 취급한다.
+    const newVariantIdByComboKey = new Map<string, string | null>();
     for (const nv of newVariants) {
-      newVariantIdByComboKey.set(this._comboKey(nv.optionValueIds), nv.variantId);
+      const key = this._comboKey(nv.optionValueIds);
+      newVariantIdByComboKey.set(key, newVariantIdByComboKey.has(key) ? null : nv.variantId);
     }
 
-    const previousByVariantId = new Map(previousVariants.map((pv) => [pv.variantId, pv]));
+    const listingsByVariantId = new Map<string, ReconcilableListing[]>();
+    for (const listing of listings) {
+      const bucket = listingsByVariantId.get(listing.variantId);
+      if (bucket) bucket.push(listing);
+      else listingsByVariantId.set(listing.variantId, [listing]);
+    }
 
     const repoints: Array<{ listingId: string; newVariantId: string }> = [];
     const deactivations: string[] = [];
 
-    for (const listing of listings) {
+    for (const candidate of candidateVariants) {
       // 새 버전이 같은 variant 행을 그대로 쓰면 CoW 가 없었던 것 — 손댈 이유가 없다.
-      if (newVariantIds.has(listing.variantId)) continue;
+      if (newVariantIds.has(candidate.variantId)) continue;
 
-      const previous = previousByVariantId.get(listing.variantId);
-      if (!previous) continue;
+      const affected = listingsByVariantId.get(candidate.variantId);
+      if (!affected) continue;
 
-      const twinVariantId = newVariantIdByComboKey.get(this._comboKey(previous.optionValueIds));
-      if (twinVariantId) {
-        repoints.push({ listingId: listing.id, newVariantId: twinVariantId });
-      } else {
-        deactivations.push(listing.id);
+      const twinVariantId = newVariantIdByComboKey.get(this._comboKey(candidate.optionValueIds));
+
+      for (const listing of affected) {
+        const blockedByDigital = newVersionIsDigital && listing.isExternalMarketplace;
+        if (twinVariantId && !blockedByDigital) {
+          repoints.push({ listingId: listing.id, newVariantId: twinVariantId });
+        } else {
+          deactivations.push(listing.id);
+        }
       }
     }
 
@@ -838,29 +887,54 @@ export class ProductVersionsService {
   private async _getVersionVariantsWithOptionValues(
     versionId: string,
     tx: DbTransaction,
-  ): Promise<Array<{ variantId: string; optionValueIds: string[] }>> {
-    const variantIds = await tx
+  ): Promise<VariantOptionCombo[]> {
+    const rows = await tx
       .select({ variantId: productMasterVariants.variantId })
       .from(productMasterVariants)
       .where(eq(productMasterVariants.versionId, versionId));
 
+    return this._attachOptionValues(
+      rows.map((r) => r.variantId),
+      tx,
+    );
+  }
+
+  /**
+   * master 에 매달린 **모든 버전**의 variant. 리스팅 승계(#652)가 쓰는 축이다 —
+   * 활성 버전이 없는 master 도 있어서 버전 단위로는 옛 variant 를 못 찾는다.
+   */
+  private async _getMasterVariantsWithOptionValues(
+    masterId: string,
+    tx: DbTransaction,
+  ): Promise<VariantOptionCombo[]> {
+    const rows = await tx
+      .selectDistinct({ variantId: productMasterVariants.variantId })
+      .from(productMasterVariants)
+      .where(eq(productMasterVariants.masterId, masterId));
+
+    return this._attachOptionValues(
+      rows.map((r) => r.variantId),
+      tx,
+    );
+  }
+
+  private async _attachOptionValues(variantIds: string[], tx: DbTransaction): Promise<VariantOptionCombo[]> {
     if (variantIds.length === 0) return [];
 
-    const ids = variantIds.map((r) => r.variantId);
     const optionRows = await tx
       .select({
         variantId: variantOptionValues.variantId,
         optionValueId: variantOptionValues.optionValueId,
       })
       .from(variantOptionValues)
-      .where(inArray(variantOptionValues.variantId, ids));
+      .where(inArray(variantOptionValues.variantId, variantIds));
 
     const byVariant = new Map<string, string[]>();
-    for (const id of ids) byVariant.set(id, []);
+    for (const id of variantIds) byVariant.set(id, []);
     for (const r of optionRows) {
       byVariant.get(r.variantId)?.push(r.optionValueId);
     }
-    return ids.map((id) => ({ variantId: id, optionValueIds: byVariant.get(id) ?? [] }));
+    return variantIds.map((id) => ({ variantId: id, optionValueIds: byVariant.get(id) ?? [] }));
   }
 
   private _comboKey(optionValueIds: string[]): string {


### PR DESCRIPTION
채널 주문이 **옛 버전 정보로 조용히 처리되던** 두 구멍을 막는다. 마이그레이션 0 · 시크릿 0 · 이벤트 계약 변경 0 — **core 단독 배포**.

## 무엇이 문제였나

draft 편집이 CoW 로 variant 행을 새로 만들면(`product-variants.service.ts` 공유 매핑 분기) `channel_variant_listings` 는 옛 행을 가리킨 채 남는다. 조회 조인이 variant 를 고정하므로 도달 가능한 버전은 옛 버전뿐이고, `CASE WHEN status='active'` 정렬은 후보가 하나라 아무것도 못 고른다.

**결과는 실패가 아니라 조용한 오처리다.** `null` 이 아니라 옛 `{variantId, masterId, versionId}` 가 반환되고, 그 값으로 판매정책(`sales-orders.service.ts:248`)과 SKU 매핑 스냅샷(`:393`)이 만들어진다. 격리 큐에도 로그에도 `failed_syncs` 에도 안 남는다.

## 두 축으로 막는다

### 1. 쓰기 — publish 승계 reconciler (#652, ADR-0031 결정 4)

기존 두 reconciler 옆에 세 번째를 붙인다. 방향만 반대다 — 매칭·에셋은 "새 variant 가 비었으면 옛 twin 에서 상속" 이지만, 리스팅은 행이 옛 variant 를 **가리키고** 있으므로 그 포인터를 옮긴다. 짝 찾기는 기존과 같은 옵션값 조합 키.

- 축은 "이전 활성 버전" 이 아니라 **이 master 의 모든 버전** 이다. `unpublishMaster` 로 판매중지한 뒤 재편집·재발행하는 경로에는 이전 활성 버전이 없지만 CoW 는 그대로 일어난다.
- 재지정과 비활성은 **배타적이지 않다.** 끄는 리스팅도 짝이 있으면 같이 옮긴다 — 죽은 variant 를 가리킨 채 꺼진 행은 재활성도 재등록도(`uq_channel_variant_listing`) 막혀 삭제 말고는 복구 경로가 없다.
- 꺼진 리스팅도 조회 대상이다. 되살리지 않되 포인터는 옮긴다.
- 짝이 없거나 조합이 모호하면(같은 조합 둘 이상) 끈다. 끄면 이후 그 채널 주문이 미식별 격리로 가서 최소한 **눈에 보인다.**
- 새 버전이 디지털이면 외부 마켓플레이스 리스팅은 끈다. `fulfillmentKind` 는 버전 필드라 품목을 안 건드리고 바꿀 수 있으므로 **CoW 여부와 무관하게** 검사한다.
- 품목 0개 버전 publish 가 매핑을 전량 끄지 않도록 형제 reconciler 와 같은 가드를 둔다.

짝으로 `createListing`/`activateListing` 에 "active 버전 품목만" 가드를 넣는다. 없으면 draft 전용 variant 에 리스팅을 걸 수 있고, 그 draft 를 버릴 때 `deleteDraftVersion` → `_cleanupOrphanedVariantsAfterDeletion` 이 variant 를 지우며 `variant_id` 의 `onDelete: 'cascade'` 로 리스팅이 조용히 사라진다.

### 2. 읽기 — 조회의 활성 버전 술어 (#666)

reconciler 는 **publish 라는 사건**에만 반응한다. 그 사건을 안 거치고 리스팅이 낡는 경로가 남는다 — 승인 경로 우회(#663) · 판매중지(#664) · 동시 생성 레이스(#665) · `hardDelete` 로 매핑만 소멸(고아 variant 라이브 4건). 전부 "조회가 성공하고 옛 값이 반환되는" 같은 결말이다.

`lookupVariant` / `lookupVariantByChannelCode` 에 `status='active'` + 양쪽 `deletedAt` 술어를 넣어 그 전부를 한 번에 막는다. 활성 버전이 없으면 `null` 이 나가고 `ChannelLineIdentityResolver` 가 미식별 격리로 보낸다.

## 검증

| 게이트 | 결과 |
|---|---|
| `npm run type-check` | 0 |
| `npx jest --maxWorkers=2` | 424 suite 통과 · 실패 0 · 3,553 tests |
| `test:core:integration:local -- channel-listing-lookup` | **9/9 (실 Postgres)** |

**실 DB 로 RED 를 먼저 봤다.** 술어 추가 전 6건 중 4건이 실제로 낡은 행을 반환했다(비활성 · draft · 버전 soft delete · 마스터 soft delete). 주문 수집이 실제로 타는 진입점(`lookupVariantByChannelCode`)도 별도로 덮는다.

**술어는 CI 가 지킨다.** 통합 스펙은 `DATABASE_URL` 이 없으면 skip 되고 게이트에는 DB 가 없어, 방어 코드를 지워도 게이트가 초록이었다. `.toSQL()` 계약 스펙을 붙였고 술어 2개를 실제로 지워 RED 가 되는 것까지 확인했다.

## 라이브 실측 (2026-08-18)

- `channel_variant_listings` **0행** → backfill 스크립트 불필요, 격리 증가 없음
- 2개 이상 버전이 공유하는 variant **3,423개** → CoW 는 왕성하다. 지금 broken 0 은 안전이 아니라 아직 아무도 리스팅을 안 걸었기 때문
- `sales_channels` 에 naver 행 존재(08-17 생성, `site` 소문자) — 이슈 본문의 "행 없음" 은 낡았다

**매핑이 쌓이기 전인 지금이 넣기 가장 싼 시점이다.**

## 후속 이슈

- #663 승인 경로가 `publishVersion` 우회 — reconciler 3종 전부 안 돈다
- #664 `unpublishMaster` 가 리스팅을 끄지 않는다
- #665 publish 중 동시 `createListing` 레이스
- #667 UPDATE 대상 술어 통합 검증
- #668 조회에 남은 오식별 3건 (`site` 중복 · 품목 판매중지 · 능력 하드코딩)

Closes #652, #666

https://claude.ai/code/session_01XqTYCx48kkXkKVuvBhHRWD