### PR TITLE
fix(catalog): 리스팅 조회에 품목·채널 축 술어를 더한다 (#670)

### DIFF
--- a/apps/core/src/modules/catalog/core/channels/channel-listing-lookup.integration.spec.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing-lookup.integration.spec.ts
@@ -84,6 +84,8 @@ describeIfDb('채널 리스팅 조회는 활성 버전만 내준다 (실 Postgre
       versionDeleted?: boolean;
       masterDeleted?: boolean;
       listingActive?: boolean;
+      variantStatus?: 'active' | 'inactive';
+      channelActive?: boolean;
     } = {},
   ) {
     const masterId = randomUUID();
@@ -105,13 +107,13 @@ describeIfDb('채널 리스팅 조회는 활성 버전만 내준다 (실 Postgre
       })
       .returning({ id: productMasterVersions.id });
 
-    await tx.insert(productVariants).values({ id: variantId, isDefault: true });
+    await tx.insert(productVariants).values({ id: variantId, isDefault: true, status: opts.variantStatus ?? 'active' });
     await tx.insert(productMasterVariants).values({ masterId, variantId, versionId: version.id });
 
     const site = `spec-${masterId.slice(0, 8)}`;
     const [channel] = await tx
       .insert(salesChannels)
-      .values({ site, name: '스펙 채널' })
+      .values({ site, name: '스펙 채널', isActive: opts.channelActive ?? true })
       .returning({ id: salesChannels.id });
 
     await tx.insert(channelVariantListings).values({
@@ -167,6 +169,24 @@ describeIfDb('채널 리스팅 조회는 활성 버전만 내준다 (실 Postgre
     expect(result).toBeNull();
   });
 
+  it('판매중지된 품목은 활성 버전이어도 조회되지 않는다', async () => {
+    // "블랙 L 사이즈만 판매중지" 는 실재하는 운영 동작이고, 가용재고는 이미 이 값을 판매
+    // 게이트로 쓴다. 조회만 안 봐서 가용 0 인데 주문은 수집되는 틈이 있었다 (#670).
+    const result = await inRollbackTx(async (tx) => {
+      const { salesChannelId, channelItemId } = await seedListing(tx, { variantStatus: 'inactive' });
+      return service.lookupVariant(salesChannelId, channelItemId, tx);
+    });
+    expect(result).toBeNull();
+  });
+
+  it('비활성 판매채널의 매핑은 조회되지 않는다', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { salesChannelId, channelItemId } = await seedListing(tx, { channelActive: false });
+      return service.lookupVariant(salesChannelId, channelItemId, tx);
+    });
+    expect(result).toBeNull();
+  });
+
   it('꺼진 리스팅은 활성 버전이어도 조회되지 않는다', async () => {
     const result = await inRollbackTx(async (tx) => {
       const { salesChannelId, channelItemId } = await seedListing(tx, { listingActive: false });
@@ -199,6 +219,22 @@ describeIfDb('채널 리스팅 조회는 활성 버전만 내준다 (실 Postgre
     it('soft delete 된 마스터의 품목은 조회되지 않는다', async () => {
       const result = await inRollbackTx(async (tx) => {
         const { site, channelItemId } = await seedListing(tx, { masterDeleted: true });
+        return service.lookupVariantByChannelCode(site, channelItemId, tx);
+      });
+      expect(result).toBeNull();
+    });
+
+    it('판매중지된 품목은 조회되지 않는다', async () => {
+      const result = await inRollbackTx(async (tx) => {
+        const { site, channelItemId } = await seedListing(tx, { variantStatus: 'inactive' });
+        return service.lookupVariantByChannelCode(site, channelItemId, tx);
+      });
+      expect(result).toBeNull();
+    });
+
+    it('비활성 판매채널의 매핑은 조회되지 않는다', async () => {
+      const result = await inRollbackTx(async (tx) => {
+        const { site, channelItemId } = await seedListing(tx, { channelActive: false });
         return service.lookupVariantByChannelCode(site, channelItemId, tx);
       });
       expect(result).toBeNull();

--- a/apps/core/src/modules/catalog/core/channels/channel-listing-lookup.query.spec.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing-lookup.query.spec.ts
@@ -24,8 +24,7 @@ describe('채널 리스팅 조회 쿼리의 술어 계약 (#666)', () => {
     await connection.end({ timeout: 0 });
   });
 
-  const sqlOf = () =>
-    buildChannelListingLookupQuery(client, 'item-1', eq(salesChannels.site, 'naver')).toSQL().sql;
+  const sqlOf = () => buildChannelListingLookupQuery(client, 'item-1', eq(salesChannels.site, 'naver')).toSQL().sql;
 
   it('활성 버전만 통과시킨다', () => {
     expect(sqlOf()).toContain('"product_master_versions"."status" = ');
@@ -41,10 +40,21 @@ describe('채널 리스팅 조회 쿼리의 술어 계약 (#666)', () => {
     expect(sqlOf()).toContain('"channel_variant_listings"."is_active" = ');
   });
 
+  it('판매중지된 품목을 배제한다', () => {
+    // `product_variants.status` 는 가용재고 계산이 판매 게이트로 쓰는 값이다
+    // (product-sellable-quantity.calculator.ts). 조회가 이걸 안 보면 가용재고 0/판매불가인
+    // 품목으로 채널 주문이 정상 수집돼 판매주문이 생성된다 (#670).
+    expect(sqlOf()).toContain('"product_variants"."status" = ');
+  });
+
+  it('비활성 판매채널을 배제한다', () => {
+    // 조회는 리스팅의 is_active 만 봤고 채널 자체의 is_active 는 안 봤다. 지금은 폴러 게이트
+    // (#654/#660)가 수집을 먼저 막아 도달 경로가 없지만, 조회 자체는 열려 있었다 (#670 곁가지).
+    expect(sqlOf()).toContain('"sales_channels"."is_active" = ');
+  });
+
   it('마스터를 버전의 master_id 로 앵커한다', () => {
     // product_master_variants.master_id 는 버전의 것과 같다는 DB 제약이 없다.
-    expect(sqlOf()).toContain(
-      '"product_masters" on "product_masters"."id" = "product_master_versions"."master_id"',
-    );
+    expect(sqlOf()).toContain('"product_masters" on "product_masters"."id" = "product_master_versions"."master_id"');
   });
 });

--- a/apps/core/src/modules/catalog/core/channels/channel-listing-lookup.query.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing-lookup.query.ts
@@ -10,19 +10,37 @@ import {
 import { DbClient } from '../../catalog.types';
 
 /**
- * 리스팅 조회가 요구하는 "지금 팔리는 버전" 술어 (#666).
+ * 리스팅 조회가 요구하는 "지금 이 채널에서 팔리는가" 술어.
  *
- * 이게 없으면 조회 조인이 낡은 버전을 통해서도 성립해 **null 대신 옛 값이 반환된다** —
- * 격리도 로그도 없이 옛 판매정책·옛 SKU 스냅샷으로 채널 주문이 처리된다(#652 의 증상).
- * publish 승계(reconciler)는 publish 라는 사건에만 반응하므로, 그 사건을 안 거치고 낡는
- * 경로(#663 승인 우회 · #664 판매중지 · #665 레이스 · hardDelete)는 이 술어만이 막는다.
+ * 이게 없으면 조회 조인이 팔리지 않는 상태를 통해서도 성립해 **null 대신 값이 반환된다** —
+ * 격리도 로그도 없이 채널 주문이 판매주문으로 넘어간다. 세 축을 모두 봐야 하고, 한 축만
+ * 빠져도 증상은 같다.
  *
- * soft delete 는 `status` 를 그대로 두고 `deletedAt` 만 세우므로 둘 다 봐야 한다.
+ * **버전 축** (#666·#652): 옛 판매정책·옛 SKU 스냅샷으로 처리되는 것을 막는다. publish 승계
+ * (reconciler)는 publish 라는 사건에만 반응하므로, 그 사건을 안 거치고 낡는 경로(#663 승인
+ * 우회 · #664 판매중지 · #665 레이스 · hardDelete)는 이 술어만이 막는다. soft delete 는
+ * `status` 를 그대로 두고 `deletedAt` 만 세우므로 둘 다 봐야 한다.
+ *
+ * **품목 축** (#670): `product_variants.status` 는 가용재고 계산이 **판매 게이트로 쓰는 값**
+ * 이다(`product-sellable-quantity.calculator.ts` 의 `variantStatus !== 'active'`). "블랙 L
+ * 사이즈만 판매중지" 는 실재하는 운영 동작이라, 이 축이 빠지면 가용재고 0/판매불가인 품목으로
+ * 채널 주문이 정상 수집돼 판매주문이 생성된다.
+ *
+ * **채널 축** (#670 곁가지): 리스팅의 `is_active` 만 보고 채널 자체의 `is_active` 를 안 보면
+ * 꺼둔 채널의 매핑도 그대로 해석된다. 지금은 폴러 게이트(#654/#660)가 수집을 먼저 막아
+ * 도달 경로가 없지만, 조회 자체는 열려 있었다 — 게이트가 유일한 방어선이면 안 된다.
+ *
+ * 이름을 버전 축으로 좁히지 말 것. 좁게 부르면 다음 사람이 나머지 축을 다시 빠뜨린다.
  */
-const ACTIVE_VERSION_PREDICATES = [
+const SELLABLE_LISTING_PREDICATES = [
+  // 버전 축
   eq(productMasterVersions.status, 'active'),
   isNull(productMasterVersions.deletedAt),
   isNull(productMasters.deletedAt),
+  // 품목 축
+  eq(productVariants.status, 'active'),
+  // 채널 축
+  eq(salesChannels.isActive, true),
 ];
 
 /**
@@ -37,32 +55,34 @@ const ACTIVE_VERSION_PREDICATES = [
  * `deletedAt` 을 보게 된다.
  */
 export function buildChannelListingLookupQuery(client: DbClient, channelItemId: string, channelPredicate: SQL) {
-  return client
-    .select({
-      masterId: productMasterVariants.masterId,
-      versionId: productMasterVariants.versionId,
-      productName: productMasterVersions.name,
-      variantId: channelVariantListings.variantId,
-      variantCode: productVariants.variantCode,
-      variantName: productVariants.variantName,
-      isActive: channelVariantListings.isActive,
-    })
-    .from(channelVariantListings)
-    .innerJoin(productVariants, eq(channelVariantListings.variantId, productVariants.id))
-    .innerJoin(productMasterVariants, eq(productMasterVariants.variantId, productVariants.id))
-    .innerJoin(productMasterVersions, eq(productMasterVariants.versionId, productMasterVersions.id))
-    .innerJoin(productMasters, eq(productMasters.id, productMasterVersions.masterId))
-    .innerJoin(salesChannels, eq(salesChannels.id, channelVariantListings.salesChannelId))
-    .where(
-      and(
-        channelPredicate,
-        eq(channelVariantListings.channelItemId, channelItemId),
-        eq(channelVariantListings.isActive, true),
-        ...ACTIVE_VERSION_PREDICATES,
-      ),
-    )
-    // 활성 버전만 남으므로 상태 분기 정렬은 필요 없다. 한 variant 가 두 master 에 매달린
-    // 이상 상태(bulk import 의 phantom masterId)에서도 결과를 고정하려고 정렬은 남긴다.
-    .orderBy(desc(productMasterVersions.version), desc(productMasterVersions.createdAt))
-    .limit(1);
+  return (
+    client
+      .select({
+        masterId: productMasterVariants.masterId,
+        versionId: productMasterVariants.versionId,
+        productName: productMasterVersions.name,
+        variantId: channelVariantListings.variantId,
+        variantCode: productVariants.variantCode,
+        variantName: productVariants.variantName,
+        isActive: channelVariantListings.isActive,
+      })
+      .from(channelVariantListings)
+      .innerJoin(productVariants, eq(channelVariantListings.variantId, productVariants.id))
+      .innerJoin(productMasterVariants, eq(productMasterVariants.variantId, productVariants.id))
+      .innerJoin(productMasterVersions, eq(productMasterVariants.versionId, productMasterVersions.id))
+      .innerJoin(productMasters, eq(productMasters.id, productMasterVersions.masterId))
+      .innerJoin(salesChannels, eq(salesChannels.id, channelVariantListings.salesChannelId))
+      .where(
+        and(
+          channelPredicate,
+          eq(channelVariantListings.channelItemId, channelItemId),
+          eq(channelVariantListings.isActive, true),
+          ...SELLABLE_LISTING_PREDICATES,
+        ),
+      )
+      // 팔리는 것만 남으므로 상태 분기 정렬은 필요 없다. 한 variant 가 두 master 에 매달린
+      // 이상 상태(bulk import 의 phantom masterId)에서도 결과를 고정하려고 정렬은 남긴다.
+      .orderBy(desc(productMasterVersions.version), desc(productMasterVersions.createdAt))
+      .limit(1)
+  );
 }


### PR DESCRIPTION
Closes #670

## 왜

#666 이 더한 술어는 **버전** 축뿐이었다 — 품목 축과 채널 축이 비어 있었다. 세 축 모두 결말이 같다: 조인이 팔리지 않는 상태를 통해서도 성립해 **null 대신 값이 반환되고**, 격리도 로그도 없이 채널 주문이 판매주문으로 넘어간다.

**품목 축.** `product_variants.status` 는 가용재고 계산이 **판매 게이트로 쓰는 값**이다 (`product-sellable-quantity.calculator.ts:90` 의 `variantStatus !== 'active'`). 즉 "블랙 L 사이즈만 판매중지" 는 실재하는 운영 동작이다. 그런데 조회는 `product_variants` 를 조인만 하고 `status` 를 안 봤다 ⇒ **가용재고 0/판매불가인 품목으로 채널 주문이 정상 수집돼 판매주문이 생성된다.**

**채널 축(곁가지).** 조회가 `channel_variant_listings.is_active` 만 보고 `sales_channels.is_active` 는 안 봤다. 지금은 폴러 게이트(#654/#660)가 수집을 먼저 막아 도달 경로가 없지만, 게이트가 유일한 방어선이면 안 된다. 성격이 같아 같이 넣는다 — 따로 빼면 같은 파일을 두 번 건드린다.

## 무엇을

`channel-listing-lookup.query.ts` 술어 2개 추가. **마이그레이션 0, API 계약 변경 0.**

```ts
eq(productVariants.status, 'active')   // 품목 축
eq(salesChannels.isActive, true)       // 채널 축
```

상수명을 `ACTIVE_VERSION_PREDICATES` → `SELLABLE_LISTING_PREDICATES` 로 바꿨다. 이름이 범위를 좁게 말하면 다음 사람이 나머지 축을 다시 빠뜨린다 — 실제로 그렇게 빠졌다.

호출부는 channel-adapter 의 주문 수집 경로뿐이다 (`ChannelListingClient.lookupByChannelCode` / `lookupBatch`). admin-web 소비자는 없다.

## #640 을 선행으로 걸지 않은 이유

이슈는 "격리 큐 화면(#640)이 없으면 *조용한 오처리*가 *조용한 미처리*로 바뀔 뿐" 이라고 봤다. 실측하니 그 근거가 약하다.

**1. 이 변경은 오늘 프로덕션에서 no-op 이다.** `ChannelLineIdentityResolver` 는 능력 `lineIdentity` 로 갈라지는데 Medusa 는 `embedded` — 라인에 심긴 id 를 직접 읽으므로 **이 조회를 타지 않는다**. 조회를 타는 건 네이버·쿠팡뿐이고 라이브 `channel_variant_listings` 는 0행이다. #643 개통 전까지 거동 변화가 없다.

**2. 격리는 조용히 사라지지 않는다.** 이미 갖춰져 있다:
- `order_collection_failures` 에 **`rawOrder` 스냅샷까지 담긴 내구성 행** (status `quarantined`)
- `GET /adapter/order-collection-failures` 목록 · `GET :id` 상세 · replay 엔드포인트
- 폴러의 `logger.warn` + 주기별 요약 로그 (`order-poller.orchestrator.ts:229`)

없는 건 **화면**뿐이다. 데이터도 복구 경로도 이미 있으므로 #640 을 기다릴 이유가 없다.

## 검증

- `npm run type-check` — 0
- `npx jest --maxWorkers=2` — 426 suite 통과, 실패 0 (3,563 tests)
- `npm run test:core:integration:local -- channel-listing-lookup` — 실 Postgres 19/19

TDD. 술어를 넣기 **전에 RED 6건**을 먼저 확인했다 — 계약 스펙 2건(`.toSQL()` 에 술어 없음) + 통합 4건(조회가 null 대신 행을 돌려줌).

두 층으로 지킨다:
- `channel-listing-lookup.query.spec.ts` — `.toSQL()` 계약 잠금. DB 없이 CI 에서 돈다 (실 DB 스펙은 `DATABASE_URL` 없으면 통째로 skip 되므로, 이게 없으면 술어를 지워도 게이트가 초록이다)
- `channel-listing-lookup.integration.spec.ts` — 실 Postgres 로 의미 확인. 두 진입점(`lookupVariant` · `lookupVariantByChannelCode`) 양쪽에 판매중지 품목·비활성 채널 케이스를 넣었다

## 리뷰 노트

`query.ts` 의 들여쓰기 변화는 **prettier 다.** 이 파일은 develop 에서 이미 위반 28건이었다 (#669 가 포맷 없이 머지됨). 의미 변경 아님 — 실제 변경은 술어 2줄 + 상수명 + 주석이다.

## 남은 것 (범위 밖)

격리 사유가 `CHANNEL_PRODUCT_IDENTIFICATION_FAILED` 한 종류라 운영자는 **"매핑 없음"인지 "품목 판매중지"인지 "버전이 낡음"인지 구분할 수 없다.** 고치려면 Core 조회가 null 대신 사유를 돌려주도록 계약을 바꿔야 한다. 별도 이슈로 올릴지는 이 PR 이후 판단.

https://claude.ai/code/session_01XqTYCx48kkXkKVuvBhHRWD