### PR TITLE
feat(catalog,channel-adapter): 격리 사유를 라인 단위로 세분화한다 (#674)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -231,7 +231,8 @@
 - 정의: 채널 주문 라인이 Core 판매상품 variant 로 식별되지 않아 판매주문 라인으로 번역할 수 없는 운영 예외.
 - Medusa 주문 라인에 `pimVariantId` 가 없으면 SKU 매칭 없음이 아니라 채널 상품 식별 실패다. 보통 Core Catalog 를 통하지 않고 Medusa 관리자에서 직접 만든 상품이 주문된 경우다.
 - 채널 상품 식별 실패 주문은 정상 판매주문으로 조용히 생성하지 않는다. 운영자가 확인할 수 있도록 격리되어야 한다.
-- **격리 큐는 채널 능력과 무관하게 하나다.** Medusa 의 식별 실패(metadata·리스팅 둘 다 없음)와 네이버·쿠팡의 미매핑([[채널 리스팅]] 없음)은 같은 운영 문제이므로 같은 큐·같은 화면에서 해소한다. 해소 수단도 하나다 — 리스팅을 만들면 격리된 주문이 재처리된다.
+- **격리 큐는 채널 능력과 무관하게 하나다.** Medusa 의 식별 실패(metadata·리스팅 둘 다 없음)와 네이버·쿠팡의 미매핑([[채널 리스팅]] 없음)은 같은 운영 문제이므로 같은 큐·같은 화면에서 해소한다.
+- **해소 수단은 하나가 아니다.** 리스팅 조회가 버전·품목·채널 세 축을 보므로(#670) 조치가 갈린다 — 격리 행의 `affected_lines[].cause` 가 라인마다 무엇을 해야 하는지 말한다: `listing_not_found`→리스팅 생성 · `listing_inactive`→리스팅 활성화 · `channel_inactive`→채널 활성화 · `variant_inactive`→품목 활성화 · `no_active_version`→publish · `product_deleted`→다른 상품으로 재매핑 · `no_embedded_ids`→Core 를 통해 상품 재생성 · `no_lookup_key`→채널 데이터 확인 · `unknown`→판정 불가. 어휘 정본은 `@packages/domain-types` 다 (#674).
 - _Avoid_: SKU 매칭 없음과 혼동하기, 유료 주문을 silent skip 하기.
 
 ### SKU Group — 재고상품의 느슨한 묶음

--- a/apps/channel-adapter/drizzle/20260818170942_add-affected-lines.sql
+++ b/apps/channel-adapter/drizzle/20260818170942_add-affected-lines.sql
@@ -1,0 +1,8 @@
+-- 격리 사유를 라인 단위로 담는다 (#674).
+--
+-- nullable 인 이유: 옛 행과 `collected_order_modification_not_accepted` 행은 사유를 모른다.
+-- 백필하지 않는다 — 사후에 사유를 만들어내는 것보다 "판정 불가" 가 정직하다.
+--
+-- additive 이므로 **`migrate` 가 `deploy` 앞이다** (ADR-0005 §5 expand phase). 새 컬럼을
+-- 읽고 쓰는 코드가 컬럼보다 먼저 뜨면 깨진다.
+ALTER TABLE "order_collection_failures" ADD COLUMN "affected_lines" jsonb;

--- a/apps/channel-adapter/drizzle/meta/20260818170942_snapshot.json
+++ b/apps/channel-adapter/drizzle/meta/20260818170942_snapshot.json
@@ -1,0 +1,2557 @@
+{
+  "id": "33d9691c-30f6-4bf6-97e7-2b4eddce9e8c",
+  "prevId": "42d5fe13-d366-4172-a17b-b0bf8e9e7829",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.cafe24_member_mappings": {
+      "name": "cafe24_member_mappings",
+      "schema": "",
+      "columns": {
+        "cafe24_member_id": {
+          "name": "cafe24_member_id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_dispatch_operations": {
+      "name": "channel_dispatch_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "inbox_event_id": {
+          "name": "inbox_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispatch_attempt_id": {
+          "name": "dispatch_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipment_id": {
+          "name": "shipment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_order_id": {
+          "name": "sales_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_idempotency_key": {
+          "name": "provider_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_snapshot": {
+          "name": "request_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_snapshot": {
+          "name": "result_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_acknowledged_at": {
+          "name": "provider_acknowledged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "succeeded_at": {
+          "name": "succeeded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_channel_dispatch_attempt_order_operation": {
+          "name": "uq_channel_dispatch_attempt_order_operation",
+          "columns": [
+            {
+              "expression": "dispatch_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_channel_dispatch_inbox_order_operation": {
+          "name": "uq_channel_dispatch_inbox_order_operation",
+          "columns": [
+            {
+              "expression": "inbox_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_channel_dispatch_cancel_order": {
+          "name": "uq_channel_dispatch_cancel_order",
+          "columns": [
+            {
+              "expression": "sales_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"channel_dispatch_operations\".\"operation\" = 'cancel'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_dispatch_status_created": {
+          "name": "idx_channel_dispatch_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_dispatch_status_lease": {
+          "name": "idx_channel_dispatch_status_lease",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_dispatch_attempt": {
+          "name": "idx_channel_dispatch_attempt",
+          "columns": [
+            {
+              "expression": "dispatch_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_dispatch_operations_inbox_event_id_inbox_events_id_fk": {
+          "name": "channel_dispatch_operations_inbox_event_id_inbox_events_id_fk",
+          "tableFrom": "channel_dispatch_operations",
+          "tableTo": "inbox_events",
+          "columnsFrom": [
+            "inbox_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_channel_dispatch_operation": {
+          "name": "chk_channel_dispatch_operation",
+          "value": "\"channel_dispatch_operations\".\"operation\" in ('dispatch', 'delivery', 'recall', 'cancel')"
+        },
+        "chk_channel_dispatch_status": {
+          "name": "chk_channel_dispatch_status",
+          "value": "\"channel_dispatch_operations\".\"status\" in ('pending', 'processing', 'provider_acknowledged', 'succeeded', 'failed', 'manual_adjustment_required')"
+        },
+        "chk_channel_dispatch_attempts_nonnegative": {
+          "name": "chk_channel_dispatch_attempts_nonnegative",
+          "value": "\"channel_dispatch_operations\".\"attempts\" >= 0"
+        },
+        "chk_channel_dispatch_identity_shape": {
+          "name": "chk_channel_dispatch_identity_shape",
+          "value": "(\n        (\"channel_dispatch_operations\".\"operation\" = 'cancel' and \"channel_dispatch_operations\".\"dispatch_attempt_id\" is null and \"channel_dispatch_operations\".\"shipment_id\" is null)\n        or\n        (\"channel_dispatch_operations\".\"operation\" <> 'cancel' and \"channel_dispatch_operations\".\"dispatch_attempt_id\" is not null and \"channel_dispatch_operations\".\"shipment_id\" is not null)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.event_logs": {
+      "name": "event_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_claim_id": {
+          "name": "external_claim_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transformed_data": {
+          "name": "transformed_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_events": {
+      "name": "inbox_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregate_type": {
+          "name": "aggregate_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partition_key": {
+          "name": "partition_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_occurred_at": {
+          "name": "event_occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_inbox_status_created": {
+          "name": "idx_inbox_status_created",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_pending_next_attempt": {
+          "name": "idx_inbox_pending_next_attempt",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_partition_key": {
+          "name": "idx_inbox_partition_key",
+          "columns": [
+            {
+              "expression": "partition_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_inbox_aggregate_event_occurred": {
+          "name": "idx_inbox_aggregate_event_occurred",
+          "columns": [
+            {
+              "expression": "aggregate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_inbox_event_idempotency": {
+          "name": "uq_inbox_event_idempotency",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"inbox_events\".\"idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_failures": {
+      "name": "migration_failures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stack_trace": {
+          "name": "stack_trace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_retry_at": {
+          "name": "last_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_migration_failures_session": {
+          "name": "idx_migration_failures_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_migration_failures_master": {
+          "name": "idx_migration_failures_master",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_migration_failures_resolved": {
+          "name": "idx_migration_failures_resolved",
+          "columns": [
+            {
+              "expression": "resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_progress": {
+      "name": "migration_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "total_masters": {
+          "name": "total_masters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_count": {
+          "name": "processed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "batch_size": {
+          "name": "batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "current_offset": {
+          "name": "current_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_processed_master_id": {
+          "name": "last_processed_master_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack_trace": {
+          "name": "error_stack_trace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_migration_session": {
+          "name": "idx_migration_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_migration_status": {
+          "name": "idx_migration_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_migration_started": {
+          "name": "idx_migration_started",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "migration_progress_session_id_unique": {
+          "name": "migration_progress_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_collection_failures": {
+      "name": "order_collection_failures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affected_line_ids": {
+          "name": "affected_line_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affected_lines": {
+          "name": "affected_lines",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_order": {
+          "name": "raw_order",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'quarantined'"
+        },
+        "replayed_at": {
+          "name": "replayed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replayed_wms_order_id": {
+          "name": "replayed_wms_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_order_collection_failure": {
+          "name": "uq_order_collection_failure",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_order_collection_failures_status": {
+          "name": "idx_order_collection_failures_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_order_collection_failures_channel": {
+          "name": "idx_order_collection_failures_channel",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_order_collection_failures_source_updated": {
+          "name": "idx_order_collection_failures_source_updated",
+          "columns": [
+            {
+              "expression": "source_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_orders": {
+      "name": "pending_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_mapping'"
+        },
+        "unmapped_items": {
+          "name": "unmapped_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_order_event": {
+          "name": "raw_order_event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_retry_at": {
+          "name": "last_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_pending_orders_status": {
+          "name": "idx_pending_orders_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_orders_channel": {
+          "name": "idx_pending_orders_channel",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_pending_orders_external": {
+          "name": "uq_pending_orders_external",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_orders_created": {
+          "name": "idx_pending_orders_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pim_medusa_mappings": {
+      "name": "pim_medusa_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pim_master_id": {
+          "name": "pim_master_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pim_version_id": {
+          "name": "pim_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pim_version": {
+          "name": "pim_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medusa_product_id": {
+          "name": "medusa_product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medusa_handle": {
+          "name": "medusa_handle",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_status": {
+          "name": "sync_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synced'"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_sync_action": {
+          "name": "last_sync_action",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_error_count": {
+          "name": "sync_error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_pim_medusa_master": {
+          "name": "uq_pim_medusa_master",
+          "columns": [
+            {
+              "expression": "pim_master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pim_medusa_product": {
+          "name": "idx_pim_medusa_product",
+          "columns": [
+            {
+              "expression": "medusa_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pim_medusa_handle": {
+          "name": "idx_pim_medusa_handle",
+          "columns": [
+            {
+              "expression": "medusa_handle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pim_medusa_sync_status": {
+          "name": "idx_pim_medusa_sync_status",
+          "columns": [
+            {
+              "expression": "sync_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pim_medusa_last_synced": {
+          "name": "idx_pim_medusa_last_synced",
+          "columns": [
+            {
+              "expression": "last_synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polling_change_hashes": {
+      "name": "polling_change_hashes",
+      "schema": "",
+      "columns": {
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_polling_hashes_last_seen": {
+          "name": "idx_polling_hashes_last_seen",
+          "columns": [
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "polling_change_hashes_source_resource_type_resource_id_pk": {
+          "name": "polling_change_hashes_source_resource_type_resource_id_pk",
+          "columns": [
+            "source",
+            "resource_type",
+            "resource_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.processed_events": {
+      "name": "processed_events",
+      "schema": "",
+      "columns": {
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_version": {
+          "name": "event_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PROCESSED'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_retry_at": {
+          "name": "last_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_processed_source_event": {
+          "name": "uq_processed_source_event",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_processed_status": {
+          "name": "idx_processed_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_processed_created": {
+          "name": "idx_processed_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_histories": {
+      "name": "sync_histories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_type": {
+          "name": "sync_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_count": {
+          "name": "total_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_statuses": {
+      "name": "sync_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_count": {
+          "name": "last_event_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_syncs": {
+          "name": "total_syncs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "successful_syncs": {
+          "name": "successful_syncs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "failed_syncs": {
+          "name": "failed_syncs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "avg_processing_time_ms": {
+          "name": "avg_processing_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_sync_status_channel_data": {
+          "name": "uq_sync_status_channel_data",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "data_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sync_status_status": {
+          "name": "idx_sync_status_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sync_status_last_sync": {
+          "name": "idx_sync_status_last_sync",
+          "columns": [
+            {
+              "expression": "last_sync_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wms_order_mappings": {
+      "name": "wms_order_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sales_channel": {
+          "name": "sales_channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_order_id": {
+          "name": "channel_order_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wms_order_id": {
+          "name": "wms_order_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wms_status": {
+          "name": "wms_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_wms_mapping_channel_order": {
+          "name": "uq_wms_mapping_channel_order",
+          "columns": [
+            {
+              "expression": "sales_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wms_mapping_wms_id": {
+          "name": "idx_wms_mapping_wms_id",
+          "columns": [
+            {
+              "expression": "wms_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wms_mapping_created": {
+          "name": "idx_wms_mapping_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "event.outbox_events": {
+      "name": "outbox_events",
+      "schema": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_type": {
+          "name": "aggregate_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "partition_key": {
+          "name": "partition_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "outbox_status_idx": {
+          "name": "outbox_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_processing_started_idx": {
+          "name": "outbox_processing_started_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processing_started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_topic_idx": {
+          "name": "outbox_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_status_next_attempt_idx": {
+          "name": "outbox_status_next_attempt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_partition_created_idx": {
+          "name": "outbox_partition_created_idx",
+          "columns": [
+            {
+              "expression": "partition_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_event_outbox_topic_event_idempotency": {
+          "name": "uq_event_outbox_topic_event_idempotency",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "event.event_resource_links": {
+      "name": "event_resource_links",
+      "schema": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(26)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "erl_chain_idx": {
+          "name": "erl_chain_idx",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "erl_resource_idx": {
+          "name": "erl_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "erl_event_idx": {
+          "name": "erl_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.role_scope_mapping": {
+      "name": "role_scope_mapping",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_scope_unique_idx": {
+          "name": "role_scope_unique_idx",
+          "columns": [
+            {
+              "expression": "role_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_scope_mapping_scope_id_scopes_id_fk": {
+          "name": "role_scope_mapping_scope_id_scopes_id_fk",
+          "tableFrom": "role_scope_mapping",
+          "tableTo": "scopes",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.scopes": {
+      "name": "scopes",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microservice_name": {
+          "name": "microservice_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scopes_key_unique": {
+          "name": "scopes_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "event": "event",
+    "auth": "auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/channel-adapter/drizzle/meta/_journal.json
+++ b/apps/channel-adapter/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1786312672407,
       "tag": "20260809215752_drop-inbox-aggregate-type-default",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1787072982896,
+      "tag": "20260818170942_add-affected-lines",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/channel-adapter/src/schema.ts
+++ b/apps/channel-adapter/src/schema.ts
@@ -17,6 +17,7 @@ import {
 
 import { sql } from 'drizzle-orm';
 import { v7 as uuidv7 } from 'uuid'; // uuid v7 지원 라이브러리 사용
+import type { AffectedLine } from '@packages/domain-types';
 
 export const eventLogs = pgTable(
   'event_logs',
@@ -227,6 +228,12 @@ export const orderCollectionFailures = pgTable(
     externalOrderId: varchar('external_order_id', { length: 255 }).notNull(),
     reason: varchar('reason', { length: 100 }).notNull(),
     affectedLineIds: jsonb('affected_line_ids').$type<string[]>().notNull(),
+    /**
+     * 라인별 실패 사유 (#674). nullable 이다 — 옛 행과
+     * `collected_order_modification_not_accepted` 행은 사유를 모르는 게 사실이므로
+     * 지어내지 않는다. `affected_line_ids` 는 두 사유가 함께 쓰므로 그대로 둔다(rename 아님).
+     */
+    affectedLines: jsonb('affected_lines').$type<AffectedLine[]>(),
     rawOrder: jsonb('raw_order').$type<Record<string, unknown>>().notNull(),
     sourceUpdatedAt: timestamp('source_updated_at').notNull(),
 

--- a/apps/channel-adapter/src/services/clients/channel-listing-resolve.client.spec.ts
+++ b/apps/channel-adapter/src/services/clients/channel-listing-resolve.client.spec.ts
@@ -1,0 +1,75 @@
+import { of, throwError } from 'rxjs';
+import type { HttpService } from '@nestjs/axios';
+import type { ConfigService } from '@nestjs/config';
+import { ChannelListingClient } from './channel-listing.client';
+
+/**
+ * 배포 순서는 Core → 어댑터지만, **Core 를 롤백하면 순서가 뒤집힌다.** 그때
+ * `/resolve` 는 404 다. 폴백이 없으면 그 순간 모든 라인 해석이 예외가 되어 수집이 통째로
+ * 멈춘다 — 사유를 얻으려다 수집을 잃는 것은 명백한 퇴행이다 (#674).
+ */
+describe('ChannelListingClient.resolveByChannelCode (#674)', () => {
+  const listing = {
+    masterId: 'm1',
+    versionId: 'v1',
+    productName: '상품',
+    variantId: 'var1',
+    variantCode: null,
+    variantName: null,
+    isActive: true,
+  };
+
+  function clientWith(get: jest.Mock): ChannelListingClient {
+    const http = { get } as unknown as HttpService;
+    const config = { get: () => 'http://core.test' } as unknown as ConfigService;
+    return new ChannelListingClient(http, config);
+  }
+
+  it('성공하면 found: true 와 매핑을 준다', async () => {
+    const get = jest.fn().mockReturnValue(of({ status: 200, data: { found: true, listing } }));
+    const result = await clientWith(get).resolveByChannelCode('naver', 'item-1');
+    expect(result).toEqual({ found: true, listing });
+  });
+
+  it('실패 사유를 그대로 전달한다', async () => {
+    const get = jest.fn().mockReturnValue(of({ status: 200, data: { found: false, cause: 'variant_inactive' } }));
+    const result = await clientWith(get).resolveByChannelCode('naver', 'item-1');
+    expect(result).toEqual({ found: false, cause: 'variant_inactive' });
+  });
+
+  it('모르는 사유는 unknown 으로 낮춘다', async () => {
+    const get = jest.fn().mockReturnValue(of({ status: 200, data: { found: false, cause: 'from_the_future' } }));
+    const result = await clientWith(get).resolveByChannelCode('naver', 'item-1');
+    expect(result).toEqual({ found: false, cause: 'unknown' });
+  });
+
+  it('/resolve 가 404 면 /lookup 으로 폴백한다 — 매핑이 있으면 found: true', async () => {
+    const get = jest
+      .fn()
+      .mockReturnValueOnce(throwError(() => ({ response: { status: 404 } })))
+      .mockReturnValueOnce(of({ status: 200, data: listing }));
+
+    const result = await clientWith(get).resolveByChannelCode('naver', 'item-1');
+
+    expect(result).toEqual({ found: true, listing });
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(get.mock.calls[0][0]).toContain('/channel-listings/resolve');
+    expect(get.mock.calls[1][0]).toContain('/channel-listings/lookup');
+  });
+
+  it('폴백에서 매핑이 없으면 사유를 지어내지 않고 unknown 이다', async () => {
+    const get = jest
+      .fn()
+      .mockReturnValueOnce(throwError(() => ({ response: { status: 404 } })))
+      .mockReturnValueOnce(of({ status: 204, data: null }));
+
+    const result = await clientWith(get).resolveByChannelCode('naver', 'item-1');
+
+    expect(result).toEqual({ found: false, cause: 'unknown' });
+  });
+
+  it('404 가 아닌 오류는 삼키지 않는다', async () => {
+    const get = jest.fn().mockReturnValue(throwError(() => ({ response: { status: 500 }, message: 'boom' })));
+    await expect(clientWith(get).resolveByChannelCode('naver', 'item-1')).rejects.toBeDefined();
+  });
+});

--- a/apps/channel-adapter/src/services/clients/channel-listing-resolve.client.spec.ts
+++ b/apps/channel-adapter/src/services/clients/channel-listing-resolve.client.spec.ts
@@ -69,7 +69,17 @@ describe('ChannelListingClient.resolveByChannelCode (#674)', () => {
   });
 
   it('404 가 아닌 오류는 삼키지 않는다', async () => {
-    const get = jest.fn().mockReturnValue(throwError(() => ({ response: { status: 500 }, message: 'boom' })));
+    const get = jest
+      .fn()
+      .mockReturnValueOnce(throwError(() => ({ response: { status: 500 }, message: 'boom' })));
     await expect(clientWith(get).resolveByChannelCode('naver', 'item-1')).rejects.toBeDefined();
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it('found=true 인데 listing 이 없으면 Core 응답 오류로 던진다', async () => {
+    const get = jest.fn().mockReturnValue(of({ status: 200, data: { found: true } }));
+    await expect(clientWith(get).resolveByChannelCode('naver', 'item-1')).rejects.toThrow(
+      /Core.*resolve.*found=true.*listing/,
+    );
   });
 });

--- a/apps/channel-adapter/src/services/clients/channel-listing-resolve.client.spec.ts
+++ b/apps/channel-adapter/src/services/clients/channel-listing-resolve.client.spec.ts
@@ -57,6 +57,22 @@ describe('ChannelListingClient.resolveByChannelCode (#674)', () => {
     expect(get.mock.calls[1][0]).toContain('/channel-listings/lookup');
   });
 
+  it('/resolve 가 401 이어도 /lookup 으로 폴백한다 — 옛 Core 는 :id 라우트가 인증을 요구한다', async () => {
+    // 옛 Core 는 `/channel-listings/resolve` 라우트가 없어 `@Get(':id')` 가 id="resolve" 로
+    // 가로챈다. 그 핸들러는 @Public() 이 아니라서 미인증 요청은 401 로 거절된다 (#674 회귀).
+    const get = jest
+      .fn()
+      .mockReturnValueOnce(throwError(() => ({ response: { status: 401 } })))
+      .mockReturnValueOnce(of({ status: 200, data: listing }));
+
+    const result = await clientWith(get).resolveByChannelCode('naver', 'item-1');
+
+    expect(result).toEqual({ found: true, listing });
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(get.mock.calls[0][0]).toContain('/channel-listings/resolve');
+    expect(get.mock.calls[1][0]).toContain('/channel-listings/lookup');
+  });
+
   it('폴백에서 매핑이 없으면 사유를 지어내지 않고 unknown 이다', async () => {
     const get = jest
       .fn()

--- a/apps/channel-adapter/src/services/clients/channel-listing.client.ts
+++ b/apps/channel-adapter/src/services/clients/channel-listing.client.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
 import { firstValueFrom } from 'rxjs';
+import { type ListingResolutionCause, toListingResolutionCause } from '@packages/domain-types';
 
 export interface LookupVariantResult {
   masterId: string;
@@ -12,6 +13,11 @@ export interface LookupVariantResult {
   variantName: string | null;
   isActive: boolean;
 }
+
+/** Core `/channel-listings/resolve` 의 응답 (#674). Core 쪽 동명 타입과 짝이다. */
+export type ListingResolveResult =
+  | { found: true; listing: LookupVariantResult }
+  | { found: false; cause: ListingResolutionCause };
 
 export interface CreateChannelListingRequest {
   variantId: string;
@@ -69,6 +75,41 @@ export class ChannelListingClient {
 
       this.logger.error(`❌ 채널 매핑 조회 실패: ${channelCode}/${channelItemId}`, error.message);
       throw error;
+    }
+  }
+
+  /**
+   * 채널 코드 + 채널 상품 ID 로 Variant 를 **사유와 함께** 해석한다 (#674).
+   *
+   * Core 가 아직 `/resolve` 를 모르면(배포 순서가 뒤집혔거나 롤백됐으면) 404 가 온다. 그때
+   * 옛 `/lookup` 으로 폴백한다 — 사유를 얻으려다 수집을 통째로 멈추는 건 명백한 퇴행이다.
+   * 폴백 경로에서는 사유를 알 길이 없으므로 지어내지 않고 `unknown` 이다.
+   *
+   * 폴백 제거는 Core 배포가 안정된 뒤 후속 PR.
+   */
+  async resolveByChannelCode(channelCode: string, channelItemId: string): Promise<ListingResolveResult> {
+    try {
+      const response = await firstValueFrom(
+        this.httpService.get<{ found: boolean; listing?: LookupVariantResult; cause?: unknown }>(
+          `${this.pimBaseUrl}/channel-listings/resolve`,
+          { params: { channelCode, channelItemId }, timeout: 5000 },
+        ),
+      );
+
+      const body = response.data;
+      if (body?.found && body.listing) {
+        return { found: true, listing: body.listing };
+      }
+      return { found: false, cause: toListingResolutionCause(body?.cause) };
+    } catch (error: any) {
+      if (error.response?.status !== 404) {
+        this.logger.error(`❌ 채널 매핑 해석 실패: ${channelCode}/${channelItemId}`, error.message);
+        throw error;
+      }
+
+      this.logger.warn(`/resolve 가 없어 /lookup 으로 폴백한다 (Core 가 구버전): ${channelCode}/${channelItemId}`);
+      const listing = await this.lookupByChannelCode(channelCode, channelItemId);
+      return listing ? { found: true, listing } : { found: false, cause: 'unknown' };
     }
   }
 

--- a/apps/channel-adapter/src/services/clients/channel-listing.client.ts
+++ b/apps/channel-adapter/src/services/clients/channel-listing.client.ts
@@ -81,8 +81,12 @@ export class ChannelListingClient {
   /**
    * 채널 코드 + 채널 상품 ID 로 Variant 를 **사유와 함께** 해석한다 (#674).
    *
-   * Core 가 아직 `/resolve` 를 모르면(배포 순서가 뒤집혔거나 롤백됐으면) 404 가 온다. 그때
+   * Core 가 아직 `/resolve` 를 모르면(배포 순서가 뒤집혔거나 롤백됐으면) 두 가지 응답이 올 수
+   * 있다. 라우트 자체가 없으면 404. 하지만 옛 Core 의 `@Get(':id')` 가 `id="resolve"` 로
+   * 이 요청을 가로채면 — 그 핸들러는 `@Public()` 이 아니고 `JwtAuthGuard` 가 전역 등록돼 있어
+   * 미인증 요청은 **401** 로 거절된다. 그래서 두 상태 코드 모두 "구버전 Core" 신호로 보고
    * 옛 `/lookup` 으로 폴백한다 — 사유를 얻으려다 수집을 통째로 멈추는 건 명백한 퇴행이다.
+   * (새 Core 의 `/resolve` 는 `@Public()` 이므로 401 을 낼 수 없다 — 모호하지 않다.)
    * 폴백 경로에서는 사유를 알 길이 없으므로 지어내지 않고 `unknown` 이다.
    *
    * 폴백 제거는 Core 배포가 안정된 뒤 후속 PR.
@@ -108,12 +112,15 @@ export class ChannelListingClient {
       }
       return { found: false, cause: toListingResolutionCause(body?.cause) };
     } catch (error: any) {
-      if (error.response?.status !== 404) {
+      const status = error.response?.status;
+      if (status !== 404 && status !== 401) {
         this.logger.error(`❌ 채널 매핑 해석 실패: ${channelCode}/${channelItemId}`, error.message);
         throw error;
       }
 
-      this.logger.warn(`/resolve 가 없어 /lookup 으로 폴백한다 (Core 가 구버전): ${channelCode}/${channelItemId}`);
+      this.logger.warn(
+        `/resolve 가 없어 /lookup 으로 폴백한다 (Core 가 구버전, status=${status}): ${channelCode}/${channelItemId}`,
+      );
       const listing = await this.lookupByChannelCode(channelCode, channelItemId);
       return listing ? { found: true, listing } : { found: false, cause: 'unknown' };
     }

--- a/apps/channel-adapter/src/services/clients/channel-listing.client.ts
+++ b/apps/channel-adapter/src/services/clients/channel-listing.client.ts
@@ -97,7 +97,13 @@ export class ChannelListingClient {
       );
 
       const body = response.data;
-      if (body?.found && body.listing) {
+      if (body?.found) {
+        if (!body.listing) {
+          throw new Error(
+            `Core /resolve 응답이 found=true 인데 listing 이 없다 (${channelCode}/${channelItemId}). ` +
+              `Core 버그인지 배포 타이밍 오류인지 확인해라.`,
+          );
+        }
         return { found: true, listing: body.listing };
       }
       return { found: false, cause: toListingResolutionCause(body?.cause) };

--- a/apps/channel-adapter/src/services/order-collection/channel-line-identity-cause.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/channel-line-identity-cause.spec.ts
@@ -1,0 +1,53 @@
+import { ChannelLineIdentityResolver } from './channel-line-identity.resolver';
+import type { ChannelListingClient } from '../clients/channel-listing.client';
+import type { ChannelOrderLineSnapshot } from './channel-order-source.interface';
+
+/**
+ * 해석 실패는 예외가 아니라 **사유를 실은 값**이다 (#674). 전에는 `null` 이라 호출자가
+ * "왜" 를 알 수 없었고, 격리 행에는 사유가 한 종류뿐이라 운영자도 알 수 없었다.
+ */
+describe('ChannelLineIdentityResolver 사유 (#674)', () => {
+  function line(overrides: Partial<ChannelOrderLineSnapshot> = {}): ChannelOrderLineSnapshot {
+    return {
+      channelOrderItemId: 'L1',
+      productName: '테스트 상품',
+      quantity: 1,
+      unitPrice: 1000,
+      ...overrides,
+    } as ChannelOrderLineSnapshot;
+  }
+
+  function resolverWith(resolveByChannelCode: jest.Mock): ChannelLineIdentityResolver {
+    return new ChannelLineIdentityResolver({ resolveByChannelCode } as unknown as ChannelListingClient);
+  }
+
+  it('embedded 채널에서 식별자 3종이 없으면 no_embedded_ids', async () => {
+    const resolver = resolverWith(jest.fn());
+    const result = await resolver.resolve('medusa', line({ embeddedVariantId: 'v1' }));
+    expect(result).toEqual({ identified: false, cause: 'no_embedded_ids' });
+  });
+
+  it('embedded 채널에서 식별자 3종이 다 있으면 식별된다', async () => {
+    const resolver = resolverWith(jest.fn());
+    const result = await resolver.resolve(
+      'medusa',
+      line({ embeddedVariantId: 'v1', embeddedMasterId: 'm1', embeddedVersionId: 'ver1' }),
+    );
+    expect(result.identified).toBe(true);
+  });
+
+  it('리스팅 채널에서 조회 키가 없으면 no_lookup_key — Core 를 부르지 않는다', async () => {
+    const resolveByChannelCode = jest.fn();
+    const resolver = resolverWith(resolveByChannelCode);
+    const result = await resolver.resolve('naver', line({ channelOrderItemId: '', channelProductId: '' }));
+    expect(result).toEqual({ identified: false, cause: 'no_lookup_key' });
+    expect(resolveByChannelCode).not.toHaveBeenCalled();
+  });
+
+  it('Core 가 준 사유를 그대로 올린다', async () => {
+    const resolveByChannelCode = jest.fn().mockResolvedValue({ found: false, cause: 'variant_inactive' });
+    const resolver = resolverWith(resolveByChannelCode);
+    const result = await resolver.resolve('naver', line({ channelProductId: 'P1' }));
+    expect(result).toEqual({ identified: false, cause: 'variant_inactive' });
+  });
+});

--- a/apps/channel-adapter/src/services/order-collection/channel-line-identity.resolver.ts
+++ b/apps/channel-adapter/src/services/order-collection/channel-line-identity.resolver.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import type { SalesChannel } from '@packages/event-contracts/streams';
+import type { ListingResolutionCause } from '@packages/domain-types';
 import { ChannelListingClient } from '../clients/channel-listing.client';
 import { getChannelCapabilities } from '../channel-capabilities';
 import type { ChannelOrderLineSnapshot } from './channel-order-source.interface';
@@ -10,9 +11,9 @@ import type { ChannelOrderLineSnapshot } from './channel-order-source.interface'
  * **분기 근거는 채널 이름이 아니라 능력(`lineIdentity`)이다.** 그래서 채널이 늘어도 이 파일은
  * 그대로다 — 새 채널은 능력 표에 한 줄을 더할 뿐이다.
  *
- * 해석 실패는 예외가 아니라 `null` 이다. 무엇을 할지(격리할지, 조용히 넘길지)는 호출자인
- * `ChannelOrderTranslator` 의 정책이다 — 유료 주문 라인이 미식별이면 격리하고, 이미 종결된
- * 라이프사이클 스냅샷이면 격리하지 않는다.
+ * 해석 실패는 예외가 아니라 사유를 실은 값이다 (#674). 무엇을 할지(격리할지, 조용히 넘길지)는
+ * 호출자인 `ChannelOrderTranslator` 의 정책이다 — 유료 주문 라인이 미식별이면 격리하고, 이미
+ * 종결된 라이프사이클 스냅샷이면 격리하지 않는다.
  */
 export interface ResolvedLineIdentity {
   variantId: string;
@@ -22,17 +23,26 @@ export interface ResolvedLineIdentity {
   productName?: string;
 }
 
+/**
+ * **판별 유니온이다.** 전에는 실패가 `null` 이라 "왜" 가 사라졌다 — 이 파일의
+ * `OrderLifecycleEventItem` 주석이 말하는 것과 같은 실패 모드다(계약이 잡아 줄 것을
+ * 호출부의 추측으로 덮기).
+ */
+export type LineResolution =
+  | { identified: true; identity: ResolvedLineIdentity }
+  | { identified: false; cause: ListingResolutionCause };
+
 @Injectable()
 export class ChannelLineIdentityResolver {
   private readonly logger = new Logger(ChannelLineIdentityResolver.name);
 
   constructor(private readonly channelListingClient: ChannelListingClient) {}
 
-  async resolve(channel: SalesChannel, line: ChannelOrderLineSnapshot): Promise<ResolvedLineIdentity | null> {
+  async resolve(channel: SalesChannel, line: ChannelOrderLineSnapshot): Promise<LineResolution> {
     const capabilities = getChannelCapabilities(channel);
     if (!capabilities || capabilities.integration !== 'api') {
       this.logger.warn(`No order-collection capability registered for channel ${channel}`);
-      return null;
+      return { identified: false, cause: 'unknown' };
     }
 
     if (capabilities.lineIdentity === 'embedded') {
@@ -45,14 +55,14 @@ export class ChannelLineIdentityResolver {
    * 채널이 심어둔 우리 식별자를 읽는다. **셋 다 있어야 한다** — 하나라도 비면 그 라인은
    * Core Catalog 를 통하지 않고 채널에서 직접 만들어진 상품이다 (CONTEXT §채널 상품 식별 실패).
    */
-  private fromEmbedded(line: ChannelOrderLineSnapshot): ResolvedLineIdentity | null {
+  private fromEmbedded(line: ChannelOrderLineSnapshot): LineResolution {
     const variantId = nonEmpty(line.embeddedVariantId);
     const masterId = nonEmpty(line.embeddedMasterId);
     const versionId = nonEmpty(line.embeddedVersionId);
     if (!variantId || !masterId || !versionId) {
-      return null;
+      return { identified: false, cause: 'no_embedded_ids' };
     }
-    return { variantId, masterId, versionId };
+    return { identified: true, identity: { variantId, masterId, versionId } };
   }
 
   /**
@@ -62,22 +72,25 @@ export class ChannelLineIdentityResolver {
   private async fromChannelListing(
     channel: SalesChannel,
     line: ChannelOrderLineSnapshot,
-  ): Promise<ResolvedLineIdentity | null> {
+  ): Promise<LineResolution> {
     const lookupId = nonEmpty(line.channelProductId) ?? nonEmpty(line.channelOrderItemId);
     if (!lookupId) {
-      return null;
+      return { identified: false, cause: 'no_lookup_key' };
     }
 
-    const listing = await this.channelListingClient.lookupByChannelCode(channel, lookupId);
-    if (!listing) {
-      return null;
+    const resolution = await this.channelListingClient.resolveByChannelCode(channel, lookupId);
+    if (!resolution.found) {
+      return { identified: false, cause: resolution.cause };
     }
 
     return {
-      variantId: listing.variantId,
-      masterId: listing.masterId,
-      versionId: listing.versionId,
-      productName: nonEmpty(listing.productName),
+      identified: true,
+      identity: {
+        variantId: resolution.listing.variantId,
+        masterId: resolution.listing.masterId,
+        versionId: resolution.listing.versionId,
+        productName: nonEmpty(resolution.listing.productName),
+      },
     };
   }
 }

--- a/apps/channel-adapter/src/services/order-collection/channel-line-identity.resolver.ts
+++ b/apps/channel-adapter/src/services/order-collection/channel-line-identity.resolver.ts
@@ -41,6 +41,10 @@ export class ChannelLineIdentityResolver {
   async resolve(channel: SalesChannel, line: ChannelOrderLineSnapshot): Promise<LineResolution> {
     const capabilities = getChannelCapabilities(channel);
     if (!capabilities || capabilities.integration !== 'api') {
+      // `unknown` 은 어휘를 확장하지 않고 쓰는 의도적 선택이다. `ListingResolutionCause` 는
+      // Core catalog 상태(리스팅/상품/버전/품목)를 설명하는 어휘이지 어댑터 설정 오류를
+      // 설명하는 어휘가 아니다 — 능력 표 누락은 그 범주 밖의 운영 설정 문제다. 원인은
+      // 바로 위 warn 로그가 이미 시끄럽게 알리므로, 여기서 새 cause 를 만들 필요가 없다.
       this.logger.warn(`No order-collection capability registered for channel ${channel}`);
       return { identified: false, cause: 'unknown' };
     }

--- a/apps/channel-adapter/src/services/order-collection/channel-order-provider.interface.ts
+++ b/apps/channel-adapter/src/services/order-collection/channel-order-provider.interface.ts
@@ -6,6 +6,7 @@ import {
   SalesChannel,
   ShippingAddress,
 } from '@packages/event-contracts/streams';
+import type { AffectedLine } from '@packages/domain-types';
 
 export const CHANNEL_ORDER_PROVIDER = Symbol('CHANNEL_ORDER_PROVIDER');
 export const CHANNEL_PRODUCT_IDENTIFICATION_FAILED = 'channel_product_identification_failed' as const;
@@ -20,6 +21,15 @@ export interface OrderCollectionFailureItem {
   sourceUpdatedAt: string;
   reason: OrderCollectionFailureReason;
   affectedLineIds: string[];
+  /**
+   * 라인별 실패 사유 (#674). `channel_product_identification_failed` 에서만 채워진다 —
+   * `collected_order_modification_not_accepted` 는 식별 문제가 아니라 사유가 없다.
+   *
+   * `reason` 을 쪼개지 않고 여기 담는 이유: 사유는 **라인 단위**인데 `reason` 은 주문당 한
+   * 칸이라, 거기 넣으면 라인이 여럿일 때 나머지 사유가 유실된다. 또 `reason` 은
+   * `uq_order_collection_failure` 의 일부라 값이 바뀌면 같은 주문에 행이 하나 더 생긴다.
+   */
+  affectedLines?: AffectedLine[];
   rawOrder: Record<string, unknown>;
 }
 

--- a/apps/channel-adapter/src/services/order-collection/channel-order.translator.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/channel-order.translator.spec.ts
@@ -36,12 +36,14 @@ function makeSnapshot(overrides: Partial<ChannelOrderSnapshot> = {}): ChannelOrd
   };
 }
 
-function makeTranslator(lookupResult: unknown) {
-  const lookupByChannelCode = jest.fn().mockResolvedValue(lookupResult);
+function makeTranslator(listing: unknown) {
+  const resolveByChannelCode = jest
+    .fn()
+    .mockResolvedValue(listing ? { found: true, listing } : { found: false, cause: 'listing_not_found' });
   const translator = new ChannelOrderTranslator(
-    new ChannelLineIdentityResolver({ lookupByChannelCode } as never),
+    new ChannelLineIdentityResolver({ resolveByChannelCode } as never),
   );
-  return { translator, lookupByChannelCode };
+  return { translator, resolveByChannelCode };
 }
 
 const LISTING = {
@@ -56,11 +58,11 @@ const LISTING = {
 
 describe('ChannelOrderTranslator — lineIdentity: mapped (naver/coupang)', () => {
   it('채널 리스팅으로 라인 정체성을 해석하고 Core 판매상품명을 싣는다', async () => {
-    const { translator, lookupByChannelCode } = makeTranslator(LISTING);
+    const { translator, resolveByChannelCode } = makeTranslator(LISTING);
 
     const { outcome } = await translator.translate('naver', makeSnapshot());
 
-    expect(lookupByChannelCode).toHaveBeenCalledWith('naver', 'naver-product-1');
+    expect(resolveByChannelCode).toHaveBeenCalledWith('naver', 'naver-product-1');
     expect(outcome.kind).toBe('order');
     if (outcome.kind !== 'order') throw new Error('unreachable');
 

--- a/apps/channel-adapter/src/services/order-collection/channel-order.translator.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/channel-order.translator.spec.ts
@@ -99,6 +99,51 @@ describe('ChannelOrderTranslator — lineIdentity: mapped (naver/coupang)', () =
       affectedLineIds: ['naver-product-order-1'],
       rawOrder: { source: 'naver' },
     });
+    // resolver 가 준 사유(#674)가 라인 ID 와 정확히 짝지어 실려야 한다 — 순서가 바뀌거나
+    // 필드가 뒤바뀌면(lineId↔cause) 여기서 잡힌다.
+    expect(outcome.failure.affectedLines).toEqual([{ lineId: 'naver-product-order-1', cause: 'listing_not_found' }]);
+  });
+
+  it('여러 라인 중 일부만 미식별이면 그 라인의 사유만, Core 가 준 값 그대로 싣는다', async () => {
+    // 기본값(listing_not_found)만으로는 "항상 같은 값을 하드코딩" 하는 버그를 못 잡으므로
+    // resolveByChannelCode 가 라인별로 다른 결과를 주도록 직접 구성한다 (#674 리뷰 지적).
+    const resolveByChannelCode = jest.fn((_channel: string, lookupId: string) => {
+      if (lookupId === 'naver-product-1') {
+        return Promise.resolve({ found: true, listing: LISTING });
+      }
+      return Promise.resolve({ found: false, cause: 'variant_inactive' });
+    });
+    const translator = new ChannelOrderTranslator(
+      new ChannelLineIdentityResolver({ resolveByChannelCode } as never),
+    );
+
+    const { outcome } = await translator.translate(
+      'naver',
+      makeSnapshot({
+        lines: [
+          {
+            channelOrderItemId: 'naver-product-order-1',
+            channelProductId: 'naver-product-1',
+            productName: '식별되는 상품',
+            quantity: 2,
+            unitPrice: 5000,
+          },
+          {
+            channelOrderItemId: 'naver-product-order-2',
+            channelProductId: 'naver-product-2',
+            productName: '비활성 옵션',
+            quantity: 1,
+            unitPrice: 3000,
+          },
+        ],
+      }),
+    );
+
+    expect(outcome.kind).toBe('failure');
+    if (outcome.kind !== 'failure') throw new Error('unreachable');
+    // 식별된 첫 라인은 빠지고, 미식별인 두 번째 라인만 — Core 가 준 cause 그대로 — 남아야 한다.
+    expect(outcome.failure.affectedLineIds).toEqual(['naver-product-order-2']);
+    expect(outcome.failure.affectedLines).toEqual([{ lineId: 'naver-product-order-2', cause: 'variant_inactive' }]);
   });
 
   it('이미 종결된 스냅샷은 매핑이 없어도 격리하지 않는다 — 판매주문을 만들지 않기 때문', async () => {

--- a/apps/channel-adapter/src/services/order-collection/channel-order.translator.ts
+++ b/apps/channel-adapter/src/services/order-collection/channel-order.translator.ts
@@ -34,17 +34,18 @@ export class ChannelOrderTranslator {
     const eligibleForOrderCreation = snapshot.paymentState === 'accepted';
     const lifecycle = this.buildLifecycleItems(snapshot);
 
-    const identities = await Promise.all(
+    const resolutions = await Promise.all(
       snapshot.lines.map((line) => this.identityResolver.resolve(channel, line)),
     );
 
     // 유료 주문 라인이 미식별이면 조용히 넘기지 않고 격리한다 (CONTEXT §채널 상품 식별 실패).
     // 이미 종결된 스냅샷(취소/환불 관측)은 판매주문을 만들지 않으므로 식별을 요구하지 않는다.
-    const unidentifiedLineIds = snapshot.lines
-      .filter((_, index) => identities[index] === null)
-      .map((line) => line.channelOrderItemId);
+    const unidentified = snapshot.lines.flatMap((line, index) => {
+      const resolution = resolutions[index];
+      return resolution.identified ? [] : [{ lineId: line.channelOrderItemId, cause: resolution.cause }];
+    });
 
-    if (eligibleForOrderCreation && unidentifiedLineIds.length > 0) {
+    if (eligibleForOrderCreation && unidentified.length > 0) {
       return {
         outcome: {
           kind: 'failure',
@@ -52,7 +53,8 @@ export class ChannelOrderTranslator {
             externalOrderId: snapshot.externalOrderId,
             sourceUpdatedAt: snapshot.sourceUpdatedAt,
             reason: CHANNEL_PRODUCT_IDENTIFICATION_FAILED,
-            affectedLineIds: unidentifiedLineIds,
+            affectedLineIds: unidentified.map((line) => line.lineId),
+            affectedLines: unidentified,
             rawOrder: snapshot.raw,
           } satisfies OrderCollectionFailureItem,
         },
@@ -60,7 +62,10 @@ export class ChannelOrderTranslator {
       };
     }
 
-    const items = snapshot.lines.map((line, index) => this.buildOrderItem(line, identities[index]));
+    const items = snapshot.lines.map((line, index) => {
+      const resolution = resolutions[index];
+      return this.buildOrderItem(line, resolution.identified ? resolution.identity : null);
+    });
 
     const createPayload: OrderCreatedPayload = {
       orderId: uuidv4(),

--- a/apps/channel-adapter/src/services/order-collection/order-collection-failure-cause.integration.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/order-collection-failure-cause.integration.spec.ts
@@ -1,0 +1,106 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- postgres publishes `export =`; Jest compiles CJS.
+import postgres = require('postgres');
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { and, eq } from 'drizzle-orm';
+import { OrderCollectionFailureService } from './order-collection-failure.service';
+import { CHANNEL_PRODUCT_IDENTIFICATION_FAILED, OrderCollectionFailureItem } from './channel-order-provider.interface';
+import { orderCollectionFailures } from '../../schema';
+import type { ListingResolutionCause } from '@packages/domain-types';
+
+/**
+ * 사유는 **폴링마다 달라진다** — 매핑을 만들면 `listing_not_found` → `variant_inactive` 로
+ * 바뀐다. 그때 행이 하나로 유지되는지가 이 설계의 핵심이다 (#674).
+ *
+ * `reason` 을 쪼갰다면 `uq_order_collection_failure` 가 `(channel, external_order_id, reason)`
+ * 이므로 같은 주문에 행이 두 개 생기고 옛 행이 `quarantined` 로 영원히 남았을 것이다. 그
+ * 사실은 실 Postgres 로만 증명된다.
+ *
+ * 실행:
+ *   DATABASE_URL=postgresql://postgres:postgres@localhost:5432/channel_adapter \
+ *   npx jest --runInBand apps/channel-adapter/src/services/order-collection/order-collection-failure-cause.integration.spec.ts
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+
+describeIfDb('격리 사유 갱신 (PostgreSQL integration)', () => {
+  jest.setTimeout(120_000);
+
+  let client: ReturnType<typeof postgres>;
+  let service: OrderCollectionFailureService;
+  let db: ReturnType<typeof drizzle>;
+  const channels: string[] = [];
+
+  const newChannel = () => {
+    const channel = `spec-${Math.random().toString(36).slice(2, 10)}`;
+    channels.push(channel);
+    return channel;
+  };
+
+  beforeAll(() => {
+    client = postgres(DATABASE_URL as string, { max: 2, prepare: false });
+    db = drizzle(client);
+    service = new OrderCollectionFailureService({ db } as never);
+  });
+
+  afterAll(async () => {
+    for (const channel of channels) {
+      await db.delete(orderCollectionFailures).where(eq(orderCollectionFailures.channel, channel));
+    }
+    await client.end({ timeout: 0 });
+  });
+
+  function failure(lines: { lineId: string; cause: ListingResolutionCause }[]): OrderCollectionFailureItem {
+    return {
+      externalOrderId: 'ORDER-1',
+      sourceUpdatedAt: new Date().toISOString(),
+      reason: CHANNEL_PRODUCT_IDENTIFICATION_FAILED,
+      affectedLineIds: lines.map((line) => line.lineId),
+      affectedLines: lines,
+      rawOrder: { hello: 'world' },
+    };
+  }
+
+  it('사유를 그대로 저장한다', async () => {
+    const channel = newChannel();
+    const record = await service.recordFailure(channel, failure([{ lineId: 'L1', cause: 'listing_not_found' }]));
+    expect(record.affectedLines).toEqual([{ lineId: 'L1', cause: 'listing_not_found' }]);
+  });
+
+  it('사유가 바뀌어도 행은 하나로 유지되고 갱신된다', async () => {
+    const channel = newChannel();
+    await service.recordFailure(channel, failure([{ lineId: 'L1', cause: 'listing_not_found' }]));
+    await service.recordFailure(channel, failure([{ lineId: 'L1', cause: 'variant_inactive' }]));
+
+    const rows = await db
+      .select()
+      .from(orderCollectionFailures)
+      .where(
+        and(eq(orderCollectionFailures.channel, channel), eq(orderCollectionFailures.externalOrderId, 'ORDER-1')),
+      );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].affectedLines).toEqual([{ lineId: 'L1', cause: 'variant_inactive' }]);
+  });
+
+  it('목록 조회에도 사유가 실린다 — 화면(#640)이 읽을 자리다', async () => {
+    const channel = newChannel();
+    await service.recordFailure(channel, failure([{ lineId: 'L1', cause: 'no_active_version' }]));
+
+    const listed = await service.list({ channel });
+
+    expect(listed).toHaveLength(1);
+    expect(listed[0].affectedLines).toEqual([{ lineId: 'L1', cause: 'no_active_version' }]);
+  });
+
+  it('사유가 없는 실패는 null 로 남는다', async () => {
+    const channel = newChannel();
+    const record = await service.recordFailure(channel, {
+      externalOrderId: 'ORDER-1',
+      sourceUpdatedAt: new Date().toISOString(),
+      reason: CHANNEL_PRODUCT_IDENTIFICATION_FAILED,
+      affectedLineIds: ['L1'],
+      rawOrder: {},
+    });
+    expect(record.affectedLines).toBeNull();
+  });
+});

--- a/apps/channel-adapter/src/services/order-collection/order-collection-failure.service.ts
+++ b/apps/channel-adapter/src/services/order-collection/order-collection-failure.service.ts
@@ -24,6 +24,7 @@ export class OrderCollectionFailureService {
       externalOrderId: failure.externalOrderId,
       reason: failure.reason,
       affectedLineIds: failure.affectedLineIds,
+      affectedLines: failure.affectedLines ?? null,
       rawOrder: failure.rawOrder,
       sourceUpdatedAt: parseTimestamp(failure.sourceUpdatedAt),
       status: 'quarantined',
@@ -45,6 +46,7 @@ export class OrderCollectionFailureService {
           ],
           set: {
             affectedLineIds: values.affectedLineIds,
+            affectedLines: values.affectedLines,
             rawOrder: values.rawOrder,
             sourceUpdatedAt: values.sourceUpdatedAt,
             status: 'quarantined',

--- a/apps/core/src/modules/catalog/core/channels/channel-listing-diagnosis.query.spec.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing-diagnosis.query.spec.ts
@@ -83,6 +83,10 @@ describe('채널 리스팅 진단 쿼리 (#674)', () => {
       expect(causeFromDiagnosisRow({ ...healthy, masterDeletedAt: new Date() })).toBe('product_deleted');
     });
 
+    it('soft delete 된 버전도 product_deleted', () => {
+      expect(causeFromDiagnosisRow({ ...healthy, versionDeletedAt: new Date() })).toBe('product_deleted');
+    });
+
     it('활성 아닌 버전은 no_active_version', () => {
       expect(causeFromDiagnosisRow({ ...healthy, versionStatus: 'draft' })).toBe('no_active_version');
     });

--- a/apps/core/src/modules/catalog/core/channels/channel-listing-diagnosis.query.spec.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing-diagnosis.query.spec.ts
@@ -1,0 +1,117 @@
+import * as postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { eq } from 'drizzle-orm';
+import { catalogSchema, salesChannels } from '../../schema/catalog.schema';
+import { DbClient } from '../../catalog.types';
+import {
+  ChannelListingDiagnosisRow,
+  buildChannelListingDiagnosisQuery,
+  causeFromDiagnosisRow,
+} from './channel-listing-diagnosis.query';
+
+/**
+ * 진단은 조회(`channel-listing-lookup.query.ts`)가 0행을 냈을 때만 돈다 (#674).
+ *
+ * 여기서는 DB 없이 두 가지를 지킨다.
+ * 1. 진단 쿼리가 **sellable 술어를 걸지 않는다** — 걸면 진단도 0행이 되어 전부
+ *    `listing_not_found` 로 오진한다.
+ * 2. 진단 쿼리가 **LEFT JOIN 이다** — inner join 이면 `product_master_variants` 행이 없는
+ *    리스팅이 0행을 내 역시 `listing_not_found` 로 오진한다.
+ *
+ * 우선순위는 순수 함수라 DB 가 필요 없다. 의미(정말 그 사유가 나오는가)는
+ * `channel-listing-resolve.integration.spec.ts` 가 실 Postgres 로 본다.
+ */
+describe('채널 리스팅 진단 쿼리 (#674)', () => {
+  const connection = postgres('postgres://spec:spec@127.0.0.1:1/none', { max: 1 });
+  const client = drizzle(connection, { schema: catalogSchema }) as unknown as DbClient;
+
+  afterAll(async () => {
+    await connection.end({ timeout: 0 });
+  });
+
+  const sqlOf = () =>
+    buildChannelListingDiagnosisQuery(client, 'item-1', eq(salesChannels.site, 'naver')).toSQL().sql;
+
+  describe('쿼리 모양', () => {
+    it('상태 술어를 하나도 걸지 않는다', () => {
+      const sql = sqlOf();
+      expect(sql).not.toContain('"product_variants"."status" = ');
+      expect(sql).not.toContain('"product_master_versions"."status" = ');
+      expect(sql).not.toContain('"sales_channels"."is_active" = ');
+      expect(sql).not.toContain('"channel_variant_listings"."is_active" = ');
+      expect(sql).not.toContain('deleted_at" is null');
+    });
+
+    it('버전 사슬을 LEFT JOIN 으로 붙인다', () => {
+      const sql = sqlOf();
+      expect(sql).toContain('left join "product_master_variants"');
+      expect(sql).toContain('left join "product_master_versions"');
+      expect(sql).toContain('left join "product_masters"');
+    });
+
+    it('리스팅과 채널로만 좁힌다', () => {
+      const sql = sqlOf();
+      expect(sql).toContain('"channel_variant_listings"."channel_item_id" = ');
+      expect(sql).toContain('"sales_channels"."site" = ');
+    });
+  });
+
+  describe('우선순위', () => {
+    const healthy: ChannelListingDiagnosisRow = {
+      listingIsActive: true,
+      channelIsActive: true,
+      variantStatus: 'active',
+      versionStatus: 'active',
+      versionDeletedAt: null,
+      masterDeletedAt: null,
+      hasVersionLink: true,
+    };
+
+    it('행이 없으면 listing_not_found', () => {
+      expect(causeFromDiagnosisRow(undefined)).toBe('listing_not_found');
+    });
+
+    it('꺼진 리스팅은 listing_inactive', () => {
+      expect(causeFromDiagnosisRow({ ...healthy, listingIsActive: false })).toBe('listing_inactive');
+    });
+
+    it('꺼진 채널은 channel_inactive', () => {
+      expect(causeFromDiagnosisRow({ ...healthy, channelIsActive: false })).toBe('channel_inactive');
+    });
+
+    it('soft delete 된 마스터는 product_deleted', () => {
+      expect(causeFromDiagnosisRow({ ...healthy, masterDeletedAt: new Date() })).toBe('product_deleted');
+    });
+
+    it('활성 아닌 버전은 no_active_version', () => {
+      expect(causeFromDiagnosisRow({ ...healthy, versionStatus: 'draft' })).toBe('no_active_version');
+    });
+
+    it('어떤 버전에도 안 매달린 품목은 no_active_version', () => {
+      expect(causeFromDiagnosisRow({ ...healthy, hasVersionLink: false, versionStatus: null })).toBe(
+        'no_active_version',
+      );
+    });
+
+    it('판매중지 품목은 variant_inactive', () => {
+      expect(causeFromDiagnosisRow({ ...healthy, variantStatus: 'inactive' })).toBe('variant_inactive');
+    });
+
+    it('삭제가 판매중지보다 앞선다 — 조치가 재매핑 하나이기 때문', () => {
+      expect(
+        causeFromDiagnosisRow({ ...healthy, masterDeletedAt: new Date(), variantStatus: 'inactive' }),
+      ).toBe('product_deleted');
+    });
+
+    it('리스팅 비활성이 채널 비활성보다 앞선다 — 더 좁은 조치가 먼저다', () => {
+      expect(causeFromDiagnosisRow({ ...healthy, listingIsActive: false, channelIsActive: false })).toBe(
+        'listing_inactive',
+      );
+    });
+
+    it('전부 정상인데 조회가 0행이었다면 unknown', () => {
+      // 여기 오면 sellable 조회와 진단이 어긋난 것이다. 사유를 지어내지 않는다.
+      expect(causeFromDiagnosisRow(healthy)).toBe('unknown');
+    });
+  });
+});

--- a/apps/core/src/modules/catalog/core/channels/channel-listing-diagnosis.query.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing-diagnosis.query.ts
@@ -30,8 +30,15 @@ export interface ChannelListingDiagnosisRow {
  * 2. **버전 사슬은 LEFT JOIN 이다.** `product_master_variants` 행이 없는 품목(어떤 버전에도
  *    안 매달린 상태)이 inner join 에서 0행을 내 역시 `listing_not_found` 로 오진한다.
  *
- * 한 품목이 여러 버전에 매달릴 수 있으므로 조회와 같은 정렬로 하나를 고정한다. 어느 행을
- * 골라도 사유가 성립한다 — 성립하지 않는 행이 하나라도 있었다면 애초에 조회가 맞았을 것이다.
+ * 한 variant 가 여러 버전에 매달린 이상 상태(bulk import 의 phantom masterId, #666)에서는
+ * 조회와 같은 정렬(`version desc, createdAt desc`)로 고른 단 한 행만 보고 판정한다. 그래서
+ * `product_deleted` 와 `no_active_version` 경계에서는 — 예를 들어 고른 행이 삭제 안 된
+ * draft 이고 링크된 다른 버전이 soft delete 된 상태라면 — 어느 행이 뽑히느냐에 따라
+ * 보고되는 사유가 달라질 수 있다.
+ *
+ * 그래도 조회와 다른 정렬을 쓰지 않는다. 다르게 고르면 진단이 **조회가 후보로 삼지도 않은
+ * 행**을 설명하게 되어 더 나쁘다. 사유는 운영자에게 주는 힌트일 뿐 자동 처리가 소비하지
+ * 않으므로, 이 경계에서의 오차는 격리 자체(조회가 0행을 낸다는 사실)를 망가뜨리지 않는다.
  */
 export function buildChannelListingDiagnosisQuery(client: DbClient, channelItemId: string, channelPredicate: SQL) {
   return client

--- a/apps/core/src/modules/catalog/core/channels/channel-listing-diagnosis.query.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing-diagnosis.query.ts
@@ -1,0 +1,77 @@
+import { SQL, and, desc, eq, isNotNull } from 'drizzle-orm';
+import type { ListingResolutionCause } from '@packages/domain-types';
+import {
+  channelVariantListings,
+  productMasterVariants,
+  productMasterVersions,
+  productMasters,
+  productVariants,
+  salesChannels,
+} from '../../schema/catalog.schema';
+import { DbClient } from '../../catalog.types';
+
+/** 진단 한 행. 술어를 걸지 않고 **상태를 그대로 실어 온다.** */
+export interface ChannelListingDiagnosisRow {
+  listingIsActive: boolean;
+  channelIsActive: boolean;
+  variantStatus: string | null;
+  versionStatus: string | null;
+  versionDeletedAt: Date | null;
+  masterDeletedAt: Date | null;
+  hasVersionLink: boolean;
+}
+
+/**
+ * 조회가 0행을 냈을 때 **왜인지** 알아내는 쿼리 (#674).
+ *
+ * 두 가지가 필수다.
+ * 1. **상태 술어를 하나도 걸지 않는다.** 걸면 진단도 0행이 되어 전부 `listing_not_found` 로
+ *    오진한다 — 진단의 존재 이유가 사라진다.
+ * 2. **버전 사슬은 LEFT JOIN 이다.** `product_master_variants` 행이 없는 품목(어떤 버전에도
+ *    안 매달린 상태)이 inner join 에서 0행을 내 역시 `listing_not_found` 로 오진한다.
+ *
+ * 한 품목이 여러 버전에 매달릴 수 있으므로 조회와 같은 정렬로 하나를 고정한다. 어느 행을
+ * 골라도 사유가 성립한다 — 성립하지 않는 행이 하나라도 있었다면 애초에 조회가 맞았을 것이다.
+ */
+export function buildChannelListingDiagnosisQuery(client: DbClient, channelItemId: string, channelPredicate: SQL) {
+  return client
+    .select({
+      listingIsActive: channelVariantListings.isActive,
+      channelIsActive: salesChannels.isActive,
+      variantStatus: productVariants.status,
+      versionStatus: productMasterVersions.status,
+      versionDeletedAt: productMasterVersions.deletedAt,
+      masterDeletedAt: productMasters.deletedAt,
+      hasVersionLink: isNotNull(productMasterVariants.versionId),
+    })
+    .from(channelVariantListings)
+    .innerJoin(salesChannels, eq(salesChannels.id, channelVariantListings.salesChannelId))
+    .innerJoin(productVariants, eq(channelVariantListings.variantId, productVariants.id))
+    .leftJoin(productMasterVariants, eq(productMasterVariants.variantId, productVariants.id))
+    .leftJoin(productMasterVersions, eq(productMasterVariants.versionId, productMasterVersions.id))
+    .leftJoin(productMasters, eq(productMasters.id, productMasterVersions.masterId))
+    .where(and(channelPredicate, eq(channelVariantListings.channelItemId, channelItemId)))
+    .orderBy(desc(productMasterVersions.version), desc(productMasterVersions.createdAt))
+    .limit(1);
+}
+
+/**
+ * 우선순위 (여럿이 동시에 성립할 때):
+ *
+ * `listing_not_found` → `listing_inactive` → `channel_inactive`
+ *   → `product_deleted` → `no_active_version` → `variant_inactive`
+ *
+ * - **삭제가 판매중지보다 앞이다**: 상품이 지워졌으면 품목 상태를 볼 의미가 없고 조치도
+ *   재매핑 하나다.
+ * - **리스팅 비활성이 채널 비활성보다 앞이다**: 더 좁은 조치(리스팅만 켜기)가 먼저다.
+ */
+export function causeFromDiagnosisRow(row: ChannelListingDiagnosisRow | undefined): ListingResolutionCause {
+  if (!row) return 'listing_not_found';
+  if (!row.listingIsActive) return 'listing_inactive';
+  if (!row.channelIsActive) return 'channel_inactive';
+  if (row.masterDeletedAt !== null || row.versionDeletedAt !== null) return 'product_deleted';
+  if (!row.hasVersionLink || row.versionStatus !== 'active') return 'no_active_version';
+  if (row.variantStatus !== 'active') return 'variant_inactive';
+  // 여기 오면 sellable 조회와 진단이 어긋난 것이다. 사유를 지어내지 않는다.
+  return 'unknown';
+}

--- a/apps/core/src/modules/catalog/core/channels/channel-listing-diagnosis.query.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing-diagnosis.query.ts
@@ -1,4 +1,4 @@
-import { SQL, and, desc, eq, isNotNull } from 'drizzle-orm';
+import { SQL, and, desc, eq, sql } from 'drizzle-orm';
 import type { ListingResolutionCause } from '@packages/domain-types';
 import {
   channelVariantListings,
@@ -49,7 +49,9 @@ export function buildChannelListingDiagnosisQuery(client: DbClient, channelItemI
       versionStatus: productMasterVersions.status,
       versionDeletedAt: productMasterVersions.deletedAt,
       masterDeletedAt: productMasters.deletedAt,
-      hasVersionLink: isNotNull(productMasterVariants.versionId),
+      // isNotNull() 은 SQL<unknown> 을 내 drizzle 이 boolean 을 못 잡는다 — 타입 있는 표현식으로
+      // 직접 써서 서비스단 `as` 캐스팅 없이 boolean 이 추론되게 한다 (CLAUDE.md: `as` 금지).
+      hasVersionLink: sql<boolean>`${productMasterVariants.versionId} is not null`,
     })
     .from(channelVariantListings)
     .innerJoin(salesChannels, eq(salesChannels.id, channelVariantListings.salesChannelId))

--- a/apps/core/src/modules/catalog/core/channels/channel-listing-resolve.integration.spec.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing-resolve.integration.spec.ts
@@ -187,6 +187,14 @@ describeIfDb('리스팅 해석 실패 사유 (실 Postgres)', () => {
     expect(result).toEqual({ found: false, cause: 'product_deleted' });
   });
 
+  it('soft delete 된 버전도 product_deleted', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site, channelItemId } = await seed(tx, { versionDeleted: true });
+      return service.resolveVariantByChannelCode(site, channelItemId, tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'product_deleted' });
+  });
+
   it('삭제와 판매중지가 겹치면 product_deleted 가 이긴다', async () => {
     const result = await inRollbackTx(async (tx) => {
       const { site, channelItemId } = await seed(tx, { masterDeleted: true, variantStatus: 'inactive' });

--- a/apps/core/src/modules/catalog/core/channels/channel-listing-resolve.integration.spec.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing-resolve.integration.spec.ts
@@ -1,0 +1,210 @@
+// jest moduleNameMapper 가 bare `@packages/event-contracts` 를 못 잡아 module-not-found 로 죽는다.
+jest.mock(
+  '@packages/event-contracts',
+  () => jest.requireActual<typeof import('@packages/event-contracts')>('@packages/event-contracts/index'),
+  { virtual: true },
+);
+
+import { randomUUID } from 'crypto';
+import * as postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { eq } from 'drizzle-orm';
+import type { DbService } from '@app/db';
+import { DbTransaction } from '../../catalog.types';
+import {
+  catalogSchema,
+  channelVariantListings,
+  productMasterVariants,
+  productMasterVersions,
+  productMasters,
+  productVariants,
+  salesChannels,
+  type PimSchema,
+} from '../../schema/catalog.schema';
+import { ChannelListingService } from './channel-listing.service';
+
+/**
+ * 진단이 **정말 그 사유를 내는지**는 실 DB 로만 확인된다 (#674). 계약 스펙은 쿼리 모양만 본다.
+ *
+ * 실행: `npm run test:core:integration:local -- channel-listing-resolve`
+ * 격리: 각 테스트가 트랜잭션을 열어 픽스처를 넣고 항상 롤백한다.
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+
+class Rollback extends Error {}
+
+describeIfDb('리스팅 해석 실패 사유 (실 Postgres)', () => {
+  jest.setTimeout(120_000);
+
+  let sql: postgres.Sql;
+  let db: DbService<PimSchema>;
+  let service: ChannelListingService;
+
+  beforeAll(() => {
+    const connection = postgres(DATABASE_URL as string, { max: 1 });
+    sql = connection;
+    const drizzleDb = drizzle(connection, { schema: catalogSchema });
+    db = {
+      db: drizzleDb,
+      run: <T>(fn: (t: DbTransaction) => Promise<T>, tx?: DbTransaction): Promise<T> =>
+        tx ? fn(tx) : drizzleDb.transaction((t) => fn(t)),
+    } as unknown as DbService<PimSchema>;
+    service = new ChannelListingService(db, {} as never);
+  });
+
+  afterAll(async () => {
+    await sql?.end({ timeout: 0 });
+  });
+
+  async function inRollbackTx<T>(fn: (tx: DbTransaction) => Promise<T>): Promise<T> {
+    let captured!: T;
+    await expect(
+      db.run(async (tx) => {
+        captured = await fn(tx);
+        throw new Rollback('intentional rollback');
+      }),
+    ).rejects.toThrow(Rollback);
+    return captured;
+  }
+
+  /** 마스터 1 + 버전 1 + 품목 1 + 리스팅 1. opts 로 한 축씩 망가뜨린다. */
+  async function seed(
+    tx: DbTransaction,
+    opts: {
+      versionStatus?: 'active' | 'inactive' | 'draft';
+      versionDeleted?: boolean;
+      masterDeleted?: boolean;
+      listingActive?: boolean;
+      channelActive?: boolean;
+      variantStatus?: 'active' | 'inactive';
+      linkVersion?: boolean;
+    } = {},
+  ) {
+    const masterId = randomUUID();
+    const variantId = randomUUID();
+    const channelItemId = `item-${masterId.slice(0, 8)}`;
+
+    await tx.insert(productMasters).values({
+      id: masterId,
+      createdBy: null,
+      ...(opts.masterDeleted ? { deletedAt: new Date() } : {}),
+    });
+    const [version] = await tx
+      .insert(productMasterVersions)
+      .values({
+        masterId,
+        name: `해석-${masterId.slice(0, 8)}`,
+        status: opts.versionStatus ?? 'active',
+        ...(opts.versionDeleted ? { deletedAt: new Date() } : {}),
+      })
+      .returning({ id: productMasterVersions.id });
+
+    await tx.insert(productVariants).values({ id: variantId, isDefault: true, status: opts.variantStatus ?? 'active' });
+
+    if (opts.linkVersion !== false) {
+      await tx.insert(productMasterVariants).values({ masterId, variantId, versionId: version.id });
+    }
+
+    const site = `spec-${masterId.slice(0, 8)}`;
+    const [channel] = await tx
+      .insert(salesChannels)
+      .values({ site, name: '스펙 채널', isActive: opts.channelActive ?? true })
+      .returning({ id: salesChannels.id });
+
+    await tx.insert(channelVariantListings).values({
+      variantId,
+      salesChannelId: channel.id,
+      channelItemId,
+      isActive: opts.listingActive ?? true,
+    });
+
+    return { site, channelItemId, variantId };
+  }
+
+  it('정상이면 found: true 와 매핑을 준다', async () => {
+    const out = await inRollbackTx(async (tx) => {
+      const { site, channelItemId, variantId } = await seed(tx);
+      return { result: await service.resolveVariantByChannelCode(site, channelItemId, tx), variantId };
+    });
+    expect(out.result.found).toBe(true);
+    if (out.result.found) expect(out.result.listing.variantId).toBe(out.variantId);
+  });
+
+  it('매핑이 없으면 listing_not_found', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site } = await seed(tx);
+      return service.resolveVariantByChannelCode(site, 'item-does-not-exist', tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'listing_not_found' });
+  });
+
+  it('꺼진 리스팅은 listing_inactive', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site, channelItemId } = await seed(tx, { listingActive: false });
+      return service.resolveVariantByChannelCode(site, channelItemId, tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'listing_inactive' });
+  });
+
+  it('꺼진 채널은 channel_inactive', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site, channelItemId } = await seed(tx, { channelActive: false });
+      return service.resolveVariantByChannelCode(site, channelItemId, tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'channel_inactive' });
+  });
+
+  it('판매중지 품목은 variant_inactive', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site, channelItemId } = await seed(tx, { variantStatus: 'inactive' });
+      return service.resolveVariantByChannelCode(site, channelItemId, tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'variant_inactive' });
+  });
+
+  it('draft 버전만 있으면 no_active_version', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site, channelItemId } = await seed(tx, { versionStatus: 'draft' });
+      return service.resolveVariantByChannelCode(site, channelItemId, tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'no_active_version' });
+  });
+
+  it('어떤 버전에도 안 매달린 품목은 no_active_version', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site, channelItemId } = await seed(tx, { linkVersion: false });
+      return service.resolveVariantByChannelCode(site, channelItemId, tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'no_active_version' });
+  });
+
+  it('soft delete 된 마스터는 product_deleted', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site, channelItemId } = await seed(tx, { masterDeleted: true });
+      return service.resolveVariantByChannelCode(site, channelItemId, tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'product_deleted' });
+  });
+
+  it('삭제와 판매중지가 겹치면 product_deleted 가 이긴다', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site, channelItemId } = await seed(tx, { masterDeleted: true, variantStatus: 'inactive' });
+      return service.resolveVariantByChannelCode(site, channelItemId, tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'product_deleted' });
+  });
+
+  it('판매채널 ID 진입점도 같은 사유를 낸다', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site, channelItemId } = await seed(tx, { variantStatus: 'inactive' });
+      const [channel] = await tx
+        .select({ id: salesChannels.id })
+        .from(salesChannels)
+        .where(eq(salesChannels.site, site))
+        .limit(1);
+      return service.resolveVariant(channel.id, channelItemId, tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'variant_inactive' });
+  });
+});

--- a/apps/core/src/modules/catalog/core/channels/channel-listing.controller.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing.controller.ts
@@ -20,6 +20,7 @@ import {
   ChannelListingDto,
   ChannelListingWithChannelDto,
   LookupChannelListingResponseDto,
+  ResolveChannelListingResponseDto,
 } from './dto';
 import { ChannelListingMapper } from './mappers';
 
@@ -77,6 +78,39 @@ export class ChannelListingController {
       return this.channelListingService.lookupVariant(salesChannelId, channelItemId);
     }
     return this.channelListingService.lookupVariantByChannelCode(channelCode!, channelItemId);
+  }
+
+  @Get('resolve')
+  @Public()
+  @ApiOperation({
+    summary: '채널 상품 ID로 Variant 해석 (사유 포함)',
+    description:
+      '`/lookup` 과 같은 조회에 **실패 사유**를 붙여 돌려준다. 미스도 204 가 아니라 200 이며 ' +
+      '`{ found: false, cause }` 본문을 갖는다. `/lookup` 은 미스가 204 라 같은 경로를 200 으로 ' +
+      '바꾸면 옛 클라이언트가 본문을 매핑으로 오독한다 — 그래서 경로를 나눴다 (#674).',
+  })
+  @ApiQuery({ name: 'salesChannelId', required: false, description: '판매 채널 ID (UUID)' })
+  @ApiQuery({ name: 'channelCode', required: false, description: '채널 코드 (site). salesChannelId 대신 사용 가능' })
+  @ApiQuery({ name: 'channelItemId', required: true, description: '채널에서의 상품 ID' })
+  @ApiResponse({ status: 200, description: '해석 결과 (성공·실패 모두)', type: ResolveChannelListingResponseDto })
+  @ApiResponse({ status: 400, description: '잘못된 요청' })
+  async resolve(
+    @Query('salesChannelId') salesChannelId?: string,
+    @Query('channelCode') channelCode?: string,
+    @Query('channelItemId') channelItemId?: string,
+  ): Promise<ResolveChannelListingResponseDto> {
+    if (!channelItemId) {
+      throw new BadRequestException('channelItemId is required');
+    }
+    if (!salesChannelId && !channelCode) {
+      throw new BadRequestException('Either salesChannelId or channelCode is required');
+    }
+
+    const result = salesChannelId
+      ? await this.channelListingService.resolveVariant(salesChannelId, channelItemId)
+      : await this.channelListingService.resolveVariantByChannelCode(channelCode!, channelItemId);
+
+    return result.found ? { found: true, listing: result.listing } : { found: false, cause: result.cause };
   }
 
   @Post()

--- a/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
@@ -11,11 +11,17 @@ import {
   productVariants,
   salesChannels,
 } from '../../schema/catalog.schema';
-import { eq, and, desc, sql, isNull } from 'drizzle-orm';
+import { SQL, eq, and, desc, sql, isNull } from 'drizzle-orm';
 import { ChannelVariantListingEntity, SalesChannelEntity } from '../../schema/catalog.schema.types';
 import { ProductSellableQuantityService } from '../../../inventory/product-sellable-quantity/services/product-sellable-quantity.service';
 import { isExternalMarketplaceSite } from './marketplace-site';
 import { buildChannelListingLookupQuery } from './channel-listing-lookup.query';
+import type { ListingResolutionCause } from '@packages/domain-types';
+import {
+  ChannelListingDiagnosisRow,
+  buildChannelListingDiagnosisQuery,
+  causeFromDiagnosisRow,
+} from './channel-listing-diagnosis.query';
 
 export interface LookupVariantResult {
   masterId: string;
@@ -26,6 +32,13 @@ export interface LookupVariantResult {
   variantName: string | null;
   isActive: boolean;
 }
+
+/**
+ * 해석 결과 (#674). 미스도 **본문을 가진 값**이다 — 옛 `/lookup` 의 `null`/204 와 다르다.
+ */
+export type ListingResolveResult =
+  | { found: true; listing: LookupVariantResult }
+  | { found: false; cause: ListingResolutionCause };
 
 export type ChannelListingWithChannel = ChannelVariantListingEntity & {
   channel: SalesChannelEntity;
@@ -83,6 +96,47 @@ export class ChannelListingService {
       eq(salesChannels.site, channelCode),
     );
     return result[0] ?? null;
+  }
+
+  /**
+   * 판매채널 ID 진입점의 해석 (#674).
+   */
+  async resolveVariant(
+    salesChannelId: string,
+    channelItemId: string,
+    tx?: DbTransaction,
+  ): Promise<ListingResolveResult> {
+    return this.resolveWith(eq(channelVariantListings.salesChannelId, salesChannelId), channelItemId, tx);
+  }
+
+  /**
+   * 채널 코드(site) 진입점의 해석. **주문 수집이 실제로 타는 경로다.**
+   */
+  async resolveVariantByChannelCode(
+    channelCode: string,
+    channelItemId: string,
+    tx?: DbTransaction,
+  ): Promise<ListingResolveResult> {
+    return this.resolveWith(eq(salesChannels.site, channelCode), channelItemId, tx);
+  }
+
+  /**
+   * 진단은 **미스 경로에서만** 돈다 — 성공 경로의 비용은 그대로다.
+   */
+  private async resolveWith(
+    channelPredicate: SQL,
+    channelItemId: string,
+    tx?: DbTransaction,
+  ): Promise<ListingResolveResult> {
+    const client = this.getClient(tx);
+
+    const found = await buildChannelListingLookupQuery(client, channelItemId, channelPredicate);
+    if (found[0]) {
+      return { found: true, listing: found[0] };
+    }
+
+    const diagnosis = await buildChannelListingDiagnosisQuery(client, channelItemId, channelPredicate);
+    return { found: false, cause: causeFromDiagnosisRow(diagnosis[0] as ChannelListingDiagnosisRow | undefined) };
   }
 
   /**

--- a/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
+++ b/apps/core/src/modules/catalog/core/channels/channel-listing.service.ts
@@ -17,11 +17,7 @@ import { ProductSellableQuantityService } from '../../../inventory/product-sella
 import { isExternalMarketplaceSite } from './marketplace-site';
 import { buildChannelListingLookupQuery } from './channel-listing-lookup.query';
 import type { ListingResolutionCause } from '@packages/domain-types';
-import {
-  ChannelListingDiagnosisRow,
-  buildChannelListingDiagnosisQuery,
-  causeFromDiagnosisRow,
-} from './channel-listing-diagnosis.query';
+import { buildChannelListingDiagnosisQuery, causeFromDiagnosisRow } from './channel-listing-diagnosis.query';
 
 export interface LookupVariantResult {
   masterId: string;
@@ -122,6 +118,11 @@ export class ChannelListingService {
 
   /**
    * 진단은 **미스 경로에서만** 돈다 — 성공 경로의 비용은 그대로다.
+   *
+   * 조회와 진단은 한 스냅샷이 아니라 별개의 두 문이다. 그 사이에 상태가 고쳐지면(예:
+   * 매핑을 막 살렸는데 그 순간 사이에 조회가 지나갔다면) 진단 술어가 전부 통과해
+   * `causeFromDiagnosisRow` 가 `unknown` 을 낸다. 사고가 아니라 정직한 답이다 — 디버깅하다
+   * 여기서 원인을 찾으려 하지 말 것.
    */
   private async resolveWith(
     channelPredicate: SQL,
@@ -136,7 +137,7 @@ export class ChannelListingService {
     }
 
     const diagnosis = await buildChannelListingDiagnosisQuery(client, channelItemId, channelPredicate);
-    return { found: false, cause: causeFromDiagnosisRow(diagnosis[0] as ChannelListingDiagnosisRow | undefined) };
+    return { found: false, cause: causeFromDiagnosisRow(diagnosis[0]) };
   }
 
   /**

--- a/apps/core/src/modules/catalog/core/channels/dto/channel-listings/channel-listing-response.dto.ts
+++ b/apps/core/src/modules/catalog/core/channels/dto/channel-listings/channel-listing-response.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { LISTING_RESOLUTION_CAUSES, type ListingResolutionCause } from '@packages/domain-types';
 
 export class LookupChannelListingResponseDto {
   @ApiProperty({ description: 'PIM Master ID' })
@@ -104,4 +105,23 @@ export class ChannelListingListResponseDto {
 
   @ApiProperty({ description: '전체 개수' })
   total: number;
+}
+
+export class ResolveChannelListingResponseDto {
+  @ApiProperty({ description: '매핑 해석 성공 여부' })
+  found: boolean;
+
+  @ApiProperty({
+    description: '해석된 매핑 (found=true 일 때만)',
+    required: false,
+    type: LookupChannelListingResponseDto,
+  })
+  listing?: LookupChannelListingResponseDto;
+
+  @ApiProperty({
+    description: '해석 실패 사유 (found=false 일 때만). 어휘 정본은 @packages/domain-types',
+    required: false,
+    enum: LISTING_RESOLUTION_CAUSES,
+  })
+  cause?: ListingResolutionCause;
 }

--- a/docs/superpowers/plans/2026-08-19-listing-resolution-cause.md
+++ b/docs/superpowers/plans/2026-08-19-listing-resolution-cause.md
@@ -1,0 +1,1544 @@
+# 격리 사유 라인 단위 세분화 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 채널 주문 라인이 왜 식별되지 않았는지를 라인 단위 사유로 기록해, 운영자가 격리 건마다 무엇을 해야 하는지 알 수 있게 한다.
+
+**Architecture:** Core 가 `/channel-listings/resolve` 를 새로 내어 미스도 200 으로 `{ found:false, cause }` 를 준다 (옛 `/lookup` 은 미스가 HTTP 204 라 손대면 옛 어댑터가 조용히 오염된다). 어댑터는 라인별 `{ lineId, cause }` 를 모아 `order_collection_failures.affected_lines` nullable jsonb 에 넣는다. `reason` 은 그대로 두어 `uq_order_collection_failure` 의미를 보존한다.
+
+**Tech Stack:** NestJS · Drizzle ORM (postgres-js) · Jest · TypeScript
+
+**Spec:** `docs/superpowers/specs/2026-08-19-listing-resolution-cause-design.md`
+
+## Global Constraints
+
+- 사유 어휘 9종은 정확히 이 문자열이다: `listing_not_found` `listing_inactive` `channel_inactive` `variant_inactive` `no_active_version` `product_deleted` `no_embedded_ids` `no_lookup_key` `unknown`
+- 어휘의 정본은 `@packages/domain-types` 하나다. 어느 앱에도 재정의하지 않는다
+- `order_collection_failures.reason` 은 **바꾸지 않는다** (`channel_product_identification_failed` 유지). unique 키 `(channel, external_order_id, reason)` 의미가 바뀌면 고아 행이 생긴다
+- Core 마이그레이션 0건. channel-adapter 마이그레이션 1건(additive, nullable)
+- 옛 행 백필 없음
+- 검증 게이트: `npm run type-check` 0 · `npx jest --maxWorkers=2` 실패 0
+- TDD. 모든 태스크는 RED 확인 → 최소 구현 → GREEN → 커밋
+- `npx jest` 는 OOM 나므로 항상 `--maxWorkers=2`
+
+---
+
+### Task 1: 사유 어휘를 `@packages/domain-types` 에 만든다
+
+**Files:**
+- Create: `packages/domain-types/listing-resolution-cause.ts`
+- Create: `packages/domain-types/listing-resolution-cause.spec.ts`
+- Modify: `packages/domain-types/index.ts`
+
+**Interfaces:**
+- Consumes: 없음 (최초 태스크)
+- Produces:
+  - `type ListingResolutionCause` — 위 9개 문자열의 유니온
+  - `const LISTING_RESOLUTION_CAUSES: readonly ListingResolutionCause[]`
+  - `function toListingResolutionCause(value: unknown): ListingResolutionCause` — 모르는 값은 `'unknown'`
+  - `interface AffectedLine { lineId: string; cause: ListingResolutionCause }`
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/domain-types/listing-resolution-cause.spec.ts`:
+
+```typescript
+import {
+  LISTING_RESOLUTION_CAUSES,
+  toListingResolutionCause,
+} from './listing-resolution-cause';
+
+/**
+ * 어휘의 정본은 여기 하나다 (#674). Core 가 내고 channel-adapter 가 영속하며 화면이 렌더하므로,
+ * 양쪽에 재정의하면 한쪽만 값이 늘었을 때 조용히 틀린다.
+ *
+ * 배포는 Core 가 먼저라, **어댑터는 자기가 모르는 값을 만날 수 있다.** 그때 타입이 거짓말하게
+ * 두는 것보다 `unknown` 으로 낮춰 저장하는 편이 낫다 — 화면도 "판정 불가" 로 일관되게 읽는다.
+ */
+describe('ListingResolutionCause 어휘', () => {
+  it('9종을 모두 가진다', () => {
+    expect([...LISTING_RESOLUTION_CAUSES].sort()).toEqual(
+      [
+        'channel_inactive',
+        'listing_inactive',
+        'listing_not_found',
+        'no_active_version',
+        'no_embedded_ids',
+        'no_lookup_key',
+        'product_deleted',
+        'unknown',
+        'variant_inactive',
+      ].sort(),
+    );
+  });
+
+  it('알려진 값은 그대로 통과시킨다', () => {
+    expect(toListingResolutionCause('variant_inactive')).toBe('variant_inactive');
+  });
+
+  it('모르는 값은 unknown 으로 낮춘다', () => {
+    expect(toListingResolutionCause('listing_haunted')).toBe('unknown');
+  });
+
+  it('문자열이 아닌 값도 unknown 으로 낮춘다', () => {
+    expect(toListingResolutionCause(null)).toBe('unknown');
+    expect(toListingResolutionCause(undefined)).toBe('unknown');
+    expect(toListingResolutionCause(42)).toBe('unknown');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest --maxWorkers=2 --testPathPattern="listing-resolution-cause"`
+Expected: FAIL — `Cannot find module './listing-resolution-cause'`
+
+모듈 부재는 에러지 실패가 아니다. Step 3 에서 스텁을 먼저 만들고 어설션 단위 RED 를 다시 확인한다.
+
+- [ ] **Step 3: 스텁을 만들어 어설션 단위 RED 를 본다**
+
+`packages/domain-types/listing-resolution-cause.ts`:
+
+```typescript
+export const LISTING_RESOLUTION_CAUSES = [] as const;
+export type ListingResolutionCause = string;
+export function toListingResolutionCause(_value: unknown): ListingResolutionCause {
+  return 'unknown';
+}
+export interface AffectedLine {
+  lineId: string;
+  cause: ListingResolutionCause;
+}
+```
+
+Run: `npx jest --maxWorkers=2 --testPathPattern="listing-resolution-cause"`
+Expected: FAIL 2건 — "9종을 모두 가진다"(빈 배열), "알려진 값은 그대로 통과시킨다"(`unknown` 반환)
+
+- [ ] **Step 4: 최소 구현**
+
+`packages/domain-types/listing-resolution-cause.ts` 전체를 아래로 교체:
+
+```typescript
+/**
+ * 채널 주문 라인이 우리 판매상품 variant 로 해석되지 않은 이유 (#674).
+ *
+ * 가르는 기준은 "증상이 다른가" 가 아니라 **"운영자가 할 일이 다른가"** 다.
+ *
+ * | cause               | 조치                          |
+ * |---------------------|-------------------------------|
+ * | listing_not_found   | 리스팅을 만든다               |
+ * | listing_inactive    | 리스팅을 켠다                 |
+ * | channel_inactive    | 판매채널을 켠다               |
+ * | variant_inactive    | 품목을 활성화한다             |
+ * | no_active_version   | publish 한다                  |
+ * | product_deleted     | 다른 상품으로 재매핑한다      |
+ * | no_embedded_ids     | Core 를 통해 상품을 다시 만든다 |
+ * | no_lookup_key       | 채널 데이터를 확인한다        |
+ * | unknown             | 판정 불가 (구 Core 폴백·옛 행) |
+ *
+ * 전부 **Core 카탈로그 상태**에 대한 말이고 채널 특성이 아니다. 그래서 채널이 열 개가 돼도
+ * 이 표는 안 늘어난다 — CONTEXT.md 의 "격리 큐는 채널 능력과 무관하게 하나다" 가 유지된다.
+ */
+export const LISTING_RESOLUTION_CAUSES = [
+  'listing_not_found',
+  'listing_inactive',
+  'channel_inactive',
+  'variant_inactive',
+  'no_active_version',
+  'product_deleted',
+  'no_embedded_ids',
+  'no_lookup_key',
+  'unknown',
+] as const;
+
+export type ListingResolutionCause = (typeof LISTING_RESOLUTION_CAUSES)[number];
+
+/**
+ * 바깥에서 들어온 값을 어휘 안으로 좁힌다.
+ *
+ * 배포 순서가 Core → 어댑터라, 어댑터는 자기가 모르는 값을 받을 수 있다. 그대로 저장하면
+ * 타입이 거짓말하고 화면이 렌더할 수 없는 값이 영속된다.
+ */
+export function toListingResolutionCause(value: unknown): ListingResolutionCause {
+  return typeof value === 'string' && (LISTING_RESOLUTION_CAUSES as readonly string[]).includes(value)
+    ? (value as ListingResolutionCause)
+    : 'unknown';
+}
+
+/** 격리된 주문에서 식별에 실패한 라인 하나. */
+export interface AffectedLine {
+  lineId: string;
+  cause: ListingResolutionCause;
+}
+```
+
+- [ ] **Step 5: index 에서 내보낸다**
+
+`packages/domain-types/index.ts` 의 export 목록에 한 줄 추가:
+
+```typescript
+export * from './listing-resolution-cause';
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npx jest --maxWorkers=2 --testPathPattern="listing-resolution-cause"`
+Expected: PASS 4/4
+
+Run: `npm run type-check`
+Expected: 에러 0
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/domain-types/
+git commit -m "feat(domain-types): 리스팅 해석 실패 사유 어휘를 정본 한 벌로 만든다 (#674)"
+```
+
+---
+
+### Task 2: Core 진단 쿼리와 우선순위 판정
+
+**Files:**
+- Create: `apps/core/src/modules/catalog/core/channels/channel-listing-diagnosis.query.ts`
+- Create: `apps/core/src/modules/catalog/core/channels/channel-listing-diagnosis.query.spec.ts`
+
+**Interfaces:**
+- Consumes: `ListingResolutionCause` (Task 1)
+- Produces:
+  - `interface ChannelListingDiagnosisRow { listingIsActive: boolean; channelIsActive: boolean; variantStatus: string | null; versionStatus: string | null; versionDeletedAt: Date | null; masterDeletedAt: Date | null; hasVersionLink: boolean }`
+  - `function buildChannelListingDiagnosisQuery(client: DbClient, channelItemId: string, channelPredicate: SQL)`
+  - `function causeFromDiagnosisRow(row: ChannelListingDiagnosisRow | undefined): ListingResolutionCause`
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/core/src/modules/catalog/core/channels/channel-listing-diagnosis.query.spec.ts`:
+
+```typescript
+import * as postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { eq } from 'drizzle-orm';
+import { catalogSchema, salesChannels } from '../../schema/catalog.schema';
+import { DbClient } from '../../catalog.types';
+import {
+  ChannelListingDiagnosisRow,
+  buildChannelListingDiagnosisQuery,
+  causeFromDiagnosisRow,
+} from './channel-listing-diagnosis.query';
+
+/**
+ * 진단은 조회(`channel-listing-lookup.query.ts`)가 0행을 냈을 때만 돈다 (#674).
+ *
+ * 여기서는 DB 없이 두 가지를 지킨다.
+ * 1. 진단 쿼리가 **sellable 술어를 걸지 않는다** — 걸면 진단도 0행이 되어 전부
+ *    `listing_not_found` 로 오진한다.
+ * 2. 진단 쿼리가 **LEFT JOIN 이다** — inner join 이면 `product_master_variants` 행이 없는
+ *    리스팅이 0행을 내 역시 `listing_not_found` 로 오진한다.
+ *
+ * 우선순위는 순수 함수라 DB 가 필요 없다. 의미(정말 그 사유가 나오는가)는
+ * `channel-listing-resolve.integration.spec.ts` 가 실 Postgres 로 본다.
+ */
+describe('채널 리스팅 진단 쿼리 (#674)', () => {
+  const connection = postgres('postgres://spec:spec@127.0.0.1:1/none', { max: 1 });
+  const client = drizzle(connection, { schema: catalogSchema }) as unknown as DbClient;
+
+  afterAll(async () => {
+    await connection.end({ timeout: 0 });
+  });
+
+  const sqlOf = () =>
+    buildChannelListingDiagnosisQuery(client, 'item-1', eq(salesChannels.site, 'naver')).toSQL().sql;
+
+  describe('쿼리 모양', () => {
+    it('상태 술어를 하나도 걸지 않는다', () => {
+      const sql = sqlOf();
+      expect(sql).not.toContain('"product_variants"."status" = ');
+      expect(sql).not.toContain('"product_master_versions"."status" = ');
+      expect(sql).not.toContain('"sales_channels"."is_active" = ');
+      expect(sql).not.toContain('"channel_variant_listings"."is_active" = ');
+      expect(sql).not.toContain('deleted_at" is null');
+    });
+
+    it('버전 사슬을 LEFT JOIN 으로 붙인다', () => {
+      const sql = sqlOf();
+      expect(sql).toContain('left join "product_master_variants"');
+      expect(sql).toContain('left join "product_master_versions"');
+      expect(sql).toContain('left join "product_masters"');
+    });
+
+    it('리스팅과 채널로만 좁힌다', () => {
+      const sql = sqlOf();
+      expect(sql).toContain('"channel_variant_listings"."channel_item_id" = ');
+      expect(sql).toContain('"sales_channels"."site" = ');
+    });
+  });
+
+  describe('우선순위', () => {
+    const healthy: ChannelListingDiagnosisRow = {
+      listingIsActive: true,
+      channelIsActive: true,
+      variantStatus: 'active',
+      versionStatus: 'active',
+      versionDeletedAt: null,
+      masterDeletedAt: null,
+      hasVersionLink: true,
+    };
+
+    it('행이 없으면 listing_not_found', () => {
+      expect(causeFromDiagnosisRow(undefined)).toBe('listing_not_found');
+    });
+
+    it('꺼진 리스팅은 listing_inactive', () => {
+      expect(causeFromDiagnosisRow({ ...healthy, listingIsActive: false })).toBe('listing_inactive');
+    });
+
+    it('꺼진 채널은 channel_inactive', () => {
+      expect(causeFromDiagnosisRow({ ...healthy, channelIsActive: false })).toBe('channel_inactive');
+    });
+
+    it('soft delete 된 마스터는 product_deleted', () => {
+      expect(causeFromDiagnosisRow({ ...healthy, masterDeletedAt: new Date() })).toBe('product_deleted');
+    });
+
+    it('활성 아닌 버전은 no_active_version', () => {
+      expect(causeFromDiagnosisRow({ ...healthy, versionStatus: 'draft' })).toBe('no_active_version');
+    });
+
+    it('어떤 버전에도 안 매달린 품목은 no_active_version', () => {
+      expect(causeFromDiagnosisRow({ ...healthy, hasVersionLink: false, versionStatus: null })).toBe(
+        'no_active_version',
+      );
+    });
+
+    it('판매중지 품목은 variant_inactive', () => {
+      expect(causeFromDiagnosisRow({ ...healthy, variantStatus: 'inactive' })).toBe('variant_inactive');
+    });
+
+    it('삭제가 판매중지보다 앞선다 — 조치가 재매핑 하나이기 때문', () => {
+      expect(
+        causeFromDiagnosisRow({ ...healthy, masterDeletedAt: new Date(), variantStatus: 'inactive' }),
+      ).toBe('product_deleted');
+    });
+
+    it('리스팅 비활성이 채널 비활성보다 앞선다 — 더 좁은 조치가 먼저다', () => {
+      expect(causeFromDiagnosisRow({ ...healthy, listingIsActive: false, channelIsActive: false })).toBe(
+        'listing_inactive',
+      );
+    });
+
+    it('전부 정상인데 조회가 0행이었다면 unknown', () => {
+      // 여기 오면 sellable 조회와 진단이 어긋난 것이다. 사유를 지어내지 않는다.
+      expect(causeFromDiagnosisRow(healthy)).toBe('unknown');
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest --maxWorkers=2 --testPathPattern="channel-listing-diagnosis"`
+Expected: FAIL — `Cannot find module './channel-listing-diagnosis.query'`
+
+- [ ] **Step 3: 구현**
+
+`apps/core/src/modules/catalog/core/channels/channel-listing-diagnosis.query.ts`:
+
+```typescript
+import { SQL, and, desc, eq, isNotNull } from 'drizzle-orm';
+import type { ListingResolutionCause } from '@packages/domain-types';
+import {
+  channelVariantListings,
+  productMasterVariants,
+  productMasterVersions,
+  productMasters,
+  productVariants,
+  salesChannels,
+} from '../../schema/catalog.schema';
+import { DbClient } from '../../catalog.types';
+
+/** 진단 한 행. 술어를 걸지 않고 **상태를 그대로 실어 온다.** */
+export interface ChannelListingDiagnosisRow {
+  listingIsActive: boolean;
+  channelIsActive: boolean;
+  variantStatus: string | null;
+  versionStatus: string | null;
+  versionDeletedAt: Date | null;
+  masterDeletedAt: Date | null;
+  hasVersionLink: boolean;
+}
+
+/**
+ * 조회가 0행을 냈을 때 **왜인지** 알아내는 쿼리 (#674).
+ *
+ * 두 가지가 필수다.
+ * 1. **상태 술어를 하나도 걸지 않는다.** 걸면 진단도 0행이 되어 전부 `listing_not_found` 로
+ *    오진한다 — 진단의 존재 이유가 사라진다.
+ * 2. **버전 사슬은 LEFT JOIN 이다.** `product_master_variants` 행이 없는 품목(어떤 버전에도
+ *    안 매달린 상태)이 inner join 에서 0행을 내 역시 `listing_not_found` 로 오진한다.
+ *
+ * 한 품목이 여러 버전에 매달릴 수 있으므로 조회와 같은 정렬로 하나를 고정한다. 어느 행을
+ * 골라도 사유가 성립한다 — 성립하지 않는 행이 하나라도 있었다면 애초에 조회가 맞았을 것이다.
+ */
+export function buildChannelListingDiagnosisQuery(client: DbClient, channelItemId: string, channelPredicate: SQL) {
+  return client
+    .select({
+      listingIsActive: channelVariantListings.isActive,
+      channelIsActive: salesChannels.isActive,
+      variantStatus: productVariants.status,
+      versionStatus: productMasterVersions.status,
+      versionDeletedAt: productMasterVersions.deletedAt,
+      masterDeletedAt: productMasters.deletedAt,
+      hasVersionLink: isNotNull(productMasterVariants.versionId),
+    })
+    .from(channelVariantListings)
+    .innerJoin(salesChannels, eq(salesChannels.id, channelVariantListings.salesChannelId))
+    .innerJoin(productVariants, eq(channelVariantListings.variantId, productVariants.id))
+    .leftJoin(productMasterVariants, eq(productMasterVariants.variantId, productVariants.id))
+    .leftJoin(productMasterVersions, eq(productMasterVariants.versionId, productMasterVersions.id))
+    .leftJoin(productMasters, eq(productMasters.id, productMasterVersions.masterId))
+    .where(and(channelPredicate, eq(channelVariantListings.channelItemId, channelItemId)))
+    .orderBy(desc(productMasterVersions.version), desc(productMasterVersions.createdAt))
+    .limit(1);
+}
+
+/**
+ * 우선순위 (여럿이 동시에 성립할 때):
+ *
+ * `listing_not_found` → `listing_inactive` → `channel_inactive`
+ *   → `product_deleted` → `no_active_version` → `variant_inactive`
+ *
+ * - **삭제가 판매중지보다 앞이다**: 상품이 지워졌으면 품목 상태를 볼 의미가 없고 조치도
+ *   재매핑 하나다.
+ * - **리스팅 비활성이 채널 비활성보다 앞이다**: 더 좁은 조치(리스팅만 켜기)가 먼저다.
+ */
+export function causeFromDiagnosisRow(row: ChannelListingDiagnosisRow | undefined): ListingResolutionCause {
+  if (!row) return 'listing_not_found';
+  if (!row.listingIsActive) return 'listing_inactive';
+  if (!row.channelIsActive) return 'channel_inactive';
+  if (row.masterDeletedAt !== null || row.versionDeletedAt !== null) return 'product_deleted';
+  if (!row.hasVersionLink || row.versionStatus !== 'active') return 'no_active_version';
+  if (row.variantStatus !== 'active') return 'variant_inactive';
+  // 여기 오면 sellable 조회와 진단이 어긋난 것이다. 사유를 지어내지 않는다.
+  return 'unknown';
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest --maxWorkers=2 --testPathPattern="channel-listing-diagnosis"`
+Expected: PASS 13/13
+
+만약 `hasVersionLink` 어설션이 타입 에러를 내면 `isNotNull(...)` 대신
+`sql<boolean>`&#96;${productMasterVariants.versionId} is not null&#96;.as('has_version_link')` 를 쓴다 (`sql` 을 drizzle-orm 에서 import).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/core/src/modules/catalog/core/channels/channel-listing-diagnosis.query.ts \
+        apps/core/src/modules/catalog/core/channels/channel-listing-diagnosis.query.spec.ts
+git commit -m "feat(catalog): 리스팅 조회 실패 사유 진단 쿼리와 우선순위 (#674)"
+```
+
+---
+
+### Task 3: Core 서비스 `resolveVariant*` 와 `/channel-listings/resolve`
+
+**Files:**
+- Modify: `apps/core/src/modules/catalog/core/channels/channel-listing.service.ts`
+- Modify: `apps/core/src/modules/catalog/core/channels/channel-listing.controller.ts`
+- Modify: `apps/core/src/modules/catalog/core/channels/dto/channel-listings/channel-listing-response.dto.ts`
+- Create: `apps/core/src/modules/catalog/core/channels/channel-listing-resolve.integration.spec.ts`
+
+**Interfaces:**
+- Consumes: `buildChannelListingDiagnosisQuery`, `causeFromDiagnosisRow` (Task 2); `ListingResolutionCause` (Task 1)
+- Produces:
+  - `type ListingResolveResult = { found: true; listing: LookupVariantResult } | { found: false; cause: ListingResolutionCause }`
+  - `ChannelListingService.resolveVariant(salesChannelId: string, channelItemId: string, tx?: DbTransaction): Promise<ListingResolveResult>`
+  - `ChannelListingService.resolveVariantByChannelCode(channelCode: string, channelItemId: string, tx?: DbTransaction): Promise<ListingResolveResult>`
+  - `GET /channel-listings/resolve` — 미스도 **200**
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/core/src/modules/catalog/core/channels/channel-listing-resolve.integration.spec.ts`:
+
+```typescript
+// jest moduleNameMapper 가 bare `@packages/event-contracts` 를 못 잡아 module-not-found 로 죽는다.
+jest.mock(
+  '@packages/event-contracts',
+  () => jest.requireActual<typeof import('@packages/event-contracts')>('@packages/event-contracts/index'),
+  { virtual: true },
+);
+
+import { randomUUID } from 'crypto';
+import * as postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { eq } from 'drizzle-orm';
+import type { DbService } from '@app/db';
+import { DbTransaction } from '../../catalog.types';
+import {
+  catalogSchema,
+  channelVariantListings,
+  productMasterVariants,
+  productMasterVersions,
+  productMasters,
+  productVariants,
+  salesChannels,
+  type PimSchema,
+} from '../../schema/catalog.schema';
+import { ChannelListingService } from './channel-listing.service';
+
+/**
+ * 진단이 **정말 그 사유를 내는지**는 실 DB 로만 확인된다 (#674). 계약 스펙은 쿼리 모양만 본다.
+ *
+ * 실행: `npm run test:core:integration:local -- channel-listing-resolve`
+ * 격리: 각 테스트가 트랜잭션을 열어 픽스처를 넣고 항상 롤백한다.
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+
+class Rollback extends Error {}
+
+describeIfDb('리스팅 해석 실패 사유 (실 Postgres)', () => {
+  jest.setTimeout(120_000);
+
+  let sql: postgres.Sql;
+  let db: DbService<PimSchema>;
+  let service: ChannelListingService;
+
+  beforeAll(() => {
+    const connection = postgres(DATABASE_URL as string, { max: 1 });
+    sql = connection;
+    const drizzleDb = drizzle(connection, { schema: catalogSchema });
+    db = {
+      db: drizzleDb,
+      run: <T>(fn: (t: DbTransaction) => Promise<T>, tx?: DbTransaction): Promise<T> =>
+        tx ? fn(tx) : drizzleDb.transaction((t) => fn(t)),
+    } as unknown as DbService<PimSchema>;
+    service = new ChannelListingService(db, {} as never);
+  });
+
+  afterAll(async () => {
+    await sql?.end({ timeout: 0 });
+  });
+
+  async function inRollbackTx<T>(fn: (tx: DbTransaction) => Promise<T>): Promise<T> {
+    let captured!: T;
+    await expect(
+      db.run(async (tx) => {
+        captured = await fn(tx);
+        throw new Rollback('intentional rollback');
+      }),
+    ).rejects.toThrow(Rollback);
+    return captured;
+  }
+
+  /** 마스터 1 + 버전 1 + 품목 1 + 리스팅 1. opts 로 한 축씩 망가뜨린다. */
+  async function seed(
+    tx: DbTransaction,
+    opts: {
+      versionStatus?: 'active' | 'inactive' | 'draft';
+      versionDeleted?: boolean;
+      masterDeleted?: boolean;
+      listingActive?: boolean;
+      channelActive?: boolean;
+      variantStatus?: 'active' | 'inactive';
+      linkVersion?: boolean;
+    } = {},
+  ) {
+    const masterId = randomUUID();
+    const variantId = randomUUID();
+    const channelItemId = `item-${masterId.slice(0, 8)}`;
+
+    await tx.insert(productMasters).values({
+      id: masterId,
+      createdBy: null,
+      ...(opts.masterDeleted ? { deletedAt: new Date() } : {}),
+    });
+    const [version] = await tx
+      .insert(productMasterVersions)
+      .values({
+        masterId,
+        name: `해석-${masterId.slice(0, 8)}`,
+        status: opts.versionStatus ?? 'active',
+        ...(opts.versionDeleted ? { deletedAt: new Date() } : {}),
+      })
+      .returning({ id: productMasterVersions.id });
+
+    await tx
+      .insert(productVariants)
+      .values({ id: variantId, isDefault: true, status: opts.variantStatus ?? 'active' });
+
+    if (opts.linkVersion !== false) {
+      await tx.insert(productMasterVariants).values({ masterId, variantId, versionId: version.id });
+    }
+
+    const site = `spec-${masterId.slice(0, 8)}`;
+    const [channel] = await tx
+      .insert(salesChannels)
+      .values({ site, name: '스펙 채널', isActive: opts.channelActive ?? true })
+      .returning({ id: salesChannels.id });
+
+    await tx.insert(channelVariantListings).values({
+      variantId,
+      salesChannelId: channel.id,
+      channelItemId,
+      isActive: opts.listingActive ?? true,
+    });
+
+    return { site, channelItemId, variantId };
+  }
+
+  it('정상이면 found: true 와 매핑을 준다', async () => {
+    const out = await inRollbackTx(async (tx) => {
+      const { site, channelItemId, variantId } = await seed(tx);
+      return { result: await service.resolveVariantByChannelCode(site, channelItemId, tx), variantId };
+    });
+    expect(out.result.found).toBe(true);
+    if (out.result.found) expect(out.result.listing.variantId).toBe(out.variantId);
+  });
+
+  it('매핑이 없으면 listing_not_found', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site } = await seed(tx);
+      return service.resolveVariantByChannelCode(site, 'item-does-not-exist', tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'listing_not_found' });
+  });
+
+  it('꺼진 리스팅은 listing_inactive', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site, channelItemId } = await seed(tx, { listingActive: false });
+      return service.resolveVariantByChannelCode(site, channelItemId, tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'listing_inactive' });
+  });
+
+  it('꺼진 채널은 channel_inactive', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site, channelItemId } = await seed(tx, { channelActive: false });
+      return service.resolveVariantByChannelCode(site, channelItemId, tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'channel_inactive' });
+  });
+
+  it('판매중지 품목은 variant_inactive', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site, channelItemId } = await seed(tx, { variantStatus: 'inactive' });
+      return service.resolveVariantByChannelCode(site, channelItemId, tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'variant_inactive' });
+  });
+
+  it('draft 버전만 있으면 no_active_version', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site, channelItemId } = await seed(tx, { versionStatus: 'draft' });
+      return service.resolveVariantByChannelCode(site, channelItemId, tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'no_active_version' });
+  });
+
+  it('어떤 버전에도 안 매달린 품목은 no_active_version', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site, channelItemId } = await seed(tx, { linkVersion: false });
+      return service.resolveVariantByChannelCode(site, channelItemId, tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'no_active_version' });
+  });
+
+  it('soft delete 된 마스터는 product_deleted', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site, channelItemId } = await seed(tx, { masterDeleted: true });
+      return service.resolveVariantByChannelCode(site, channelItemId, tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'product_deleted' });
+  });
+
+  it('삭제와 판매중지가 겹치면 product_deleted 가 이긴다', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site, channelItemId } = await seed(tx, { masterDeleted: true, variantStatus: 'inactive' });
+      return service.resolveVariantByChannelCode(site, channelItemId, tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'product_deleted' });
+  });
+
+  it('판매채널 ID 진입점도 같은 사유를 낸다', async () => {
+    const result = await inRollbackTx(async (tx) => {
+      const { site, channelItemId } = await seed(tx, { variantStatus: 'inactive' });
+      const [channel] = await tx
+        .select({ id: salesChannels.id })
+        .from(salesChannels)
+        .where(eq(salesChannels.site, site))
+        .limit(1);
+      return service.resolveVariant(channel.id, channelItemId, tx);
+    });
+    expect(result).toEqual({ found: false, cause: 'variant_inactive' });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:core:integration:local -- channel-listing-resolve`
+Expected: FAIL — `service.resolveVariantByChannelCode is not a function`
+
+- [ ] **Step 3: 서비스에 두 메서드를 더한다**
+
+`channel-listing.service.ts` 상단 import 에 추가:
+
+```typescript
+import type { ListingResolutionCause } from '@packages/domain-types';
+import {
+  ChannelListingDiagnosisRow,
+  buildChannelListingDiagnosisQuery,
+  causeFromDiagnosisRow,
+} from './channel-listing-diagnosis.query';
+```
+
+`LookupVariantResult` 인터페이스 바로 아래에 타입 추가:
+
+```typescript
+/**
+ * 해석 결과 (#674). 미스도 **본문을 가진 값**이다 — 옛 `/lookup` 의 `null`/204 와 다르다.
+ */
+export type ListingResolveResult =
+  | { found: true; listing: LookupVariantResult }
+  | { found: false; cause: ListingResolutionCause };
+```
+
+`lookupVariantByChannelCode` 아래에 세 메서드 추가:
+
+```typescript
+  /**
+   * 판매채널 ID 진입점의 해석 (#674).
+   */
+  async resolveVariant(
+    salesChannelId: string,
+    channelItemId: string,
+    tx?: DbTransaction,
+  ): Promise<ListingResolveResult> {
+    return this.resolveWith(eq(channelVariantListings.salesChannelId, salesChannelId), channelItemId, tx);
+  }
+
+  /**
+   * 채널 코드(site) 진입점의 해석. **주문 수집이 실제로 타는 경로다.**
+   */
+  async resolveVariantByChannelCode(
+    channelCode: string,
+    channelItemId: string,
+    tx?: DbTransaction,
+  ): Promise<ListingResolveResult> {
+    return this.resolveWith(eq(salesChannels.site, channelCode), channelItemId, tx);
+  }
+
+  /**
+   * 진단은 **미스 경로에서만** 돈다 — 성공 경로의 비용은 그대로다.
+   */
+  private async resolveWith(
+    channelPredicate: SQL,
+    channelItemId: string,
+    tx?: DbTransaction,
+  ): Promise<ListingResolveResult> {
+    const client = this.getClient(tx);
+
+    const found = await buildChannelListingLookupQuery(client, channelItemId, channelPredicate);
+    if (found[0]) {
+      return { found: true, listing: found[0] };
+    }
+
+    const diagnosis = await buildChannelListingDiagnosisQuery(client, channelItemId, channelPredicate);
+    return { found: false, cause: causeFromDiagnosisRow(diagnosis[0] as ChannelListingDiagnosisRow | undefined) };
+  }
+```
+
+`SQL` 타입이 아직 import 되어 있지 않으면 `import { SQL, and, eq, ... } from 'drizzle-orm'` 에 더한다.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test:core:integration:local -- channel-listing-resolve`
+Expected: PASS 10/10
+
+- [ ] **Step 5: 응답 DTO 를 만든다**
+
+`dto/channel-listings/channel-listing-response.dto.ts` 끝에 추가:
+
+```typescript
+export class ResolveChannelListingResponseDto {
+  @ApiProperty({ description: '매핑 해석 성공 여부' })
+  found: boolean;
+
+  @ApiProperty({ description: '해석된 매핑 (found=true 일 때만)', required: false, type: LookupChannelListingResponseDto })
+  listing?: LookupChannelListingResponseDto;
+
+  @ApiProperty({
+    description: '해석 실패 사유 (found=false 일 때만). 어휘 정본은 @packages/domain-types',
+    required: false,
+    enum: LISTING_RESOLUTION_CAUSES,
+  })
+  cause?: ListingResolutionCause;
+}
+```
+
+같은 파일 상단에 import 추가:
+
+```typescript
+import { LISTING_RESOLUTION_CAUSES, type ListingResolutionCause } from '@packages/domain-types';
+```
+
+`dto/channel-listings/index.ts` (또는 그 폴더의 배럴 파일) 이 `export *` 라면 추가 작업 없음. 명시 목록이면 `ResolveChannelListingResponseDto` 를 더한다.
+
+- [ ] **Step 6: 컨트롤러에 엔드포인트를 더한다**
+
+`channel-listing.controller.ts` 의 `lookup` 핸들러 **바로 아래**에 추가:
+
+```typescript
+  @Get('resolve')
+  @Public()
+  @ApiOperation({
+    summary: '채널 상품 ID로 Variant 해석 (사유 포함)',
+    description:
+      '`/lookup` 과 같은 조회에 **실패 사유**를 붙여 돌려준다. 미스도 204 가 아니라 200 이며 ' +
+      '`{ found: false, cause }` 본문을 갖는다. `/lookup` 은 미스가 204 라 같은 경로를 200 으로 ' +
+      '바꾸면 옛 클라이언트가 본문을 매핑으로 오독한다 — 그래서 경로를 나눴다 (#674).',
+  })
+  @ApiQuery({ name: 'salesChannelId', required: false, description: '판매 채널 ID (UUID)' })
+  @ApiQuery({ name: 'channelCode', required: false, description: '채널 코드 (site). salesChannelId 대신 사용 가능' })
+  @ApiQuery({ name: 'channelItemId', required: true, description: '채널에서의 상품 ID' })
+  @ApiResponse({ status: 200, description: '해석 결과 (성공·실패 모두)', type: ResolveChannelListingResponseDto })
+  @ApiResponse({ status: 400, description: '잘못된 요청' })
+  async resolve(
+    @Query('salesChannelId') salesChannelId?: string,
+    @Query('channelCode') channelCode?: string,
+    @Query('channelItemId') channelItemId?: string,
+  ): Promise<ResolveChannelListingResponseDto> {
+    if (!channelItemId) {
+      throw new BadRequestException('channelItemId is required');
+    }
+    if (!salesChannelId && !channelCode) {
+      throw new BadRequestException('Either salesChannelId or channelCode is required');
+    }
+
+    const result = salesChannelId
+      ? await this.channelListingService.resolveVariant(salesChannelId, channelItemId)
+      : await this.channelListingService.resolveVariantByChannelCode(channelCode!, channelItemId);
+
+    return result.found ? { found: true, listing: result.listing } : { found: false, cause: result.cause };
+  }
+```
+
+컨트롤러 상단 import 목록의 `./dto` 블록에 `ResolveChannelListingResponseDto` 를 더한다.
+
+⚠️ **`@Get('resolve')` 는 `@Get(':id')` 류의 와일드카드 라우트보다 먼저 선언되어야 한다.** 이 컨트롤러의 `lookup` 이 이미 그 위치에 있으므로 바로 아래에 두면 안전하다.
+
+- [ ] **Step 7: 게이트**
+
+Run: `npm run type-check`
+Expected: 에러 0
+
+Run: `npx jest --maxWorkers=2 --testPathPattern="channel-listing"`
+Expected: 실패 0
+
+Run: `npm run test:core:integration:local -- channel-listing`
+Expected: 실패 0 (기존 19 + 신규 10)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/core/src/modules/catalog/core/channels/
+git commit -m "feat(catalog): /channel-listings/resolve 로 해석 실패 사유를 준다 (#674)"
+```
+
+---
+
+### Task 4: 어댑터 클라이언트 `/resolve` + 404 폴백
+
+**Files:**
+- Modify: `apps/channel-adapter/src/services/clients/channel-listing.client.ts`
+- Create: `apps/channel-adapter/src/services/clients/channel-listing-resolve.client.spec.ts`
+
+**Interfaces:**
+- Consumes: `GET /channel-listings/resolve` (Task 3); `ListingResolutionCause`, `toListingResolutionCause` (Task 1)
+- Produces:
+  - `type ListingResolveResult = { found: true; listing: LookupVariantResult } | { found: false; cause: ListingResolutionCause }` — Core 쪽 동명 타입과 **의도적으로 같은 이름**이다. 두 서비스가 HTTP 로만 묶여 있어 타입을 공유하지 않지만(이 저장소는 `LookupVariantResult` 도 같은 방식으로 양쪽에 둔다), 이름까지 갈리면 대응 관계가 안 보인다
+  - `ChannelListingClient.resolveByChannelCode(channelCode: string, channelItemId: string): Promise<ListingResolveResult>`
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/channel-adapter/src/services/clients/channel-listing-resolve.client.spec.ts`:
+
+```typescript
+import { of, throwError } from 'rxjs';
+import type { HttpService } from '@nestjs/axios';
+import type { ConfigService } from '@nestjs/config';
+import { ChannelListingClient } from './channel-listing.client';
+
+/**
+ * 배포 순서는 Core → 어댑터지만, **Core 를 롤백하면 순서가 뒤집힌다.** 그때
+ * `/resolve` 는 404 다. 폴백이 없으면 그 순간 모든 라인 해석이 예외가 되어 수집이 통째로
+ * 멈춘다 — 사유를 얻으려다 수집을 잃는 것은 명백한 퇴행이다 (#674).
+ */
+describe('ChannelListingClient.resolveByChannelCode (#674)', () => {
+  const listing = {
+    masterId: 'm1',
+    versionId: 'v1',
+    productName: '상품',
+    variantId: 'var1',
+    variantCode: null,
+    variantName: null,
+    isActive: true,
+  };
+
+  function clientWith(get: jest.Mock): ChannelListingClient {
+    const http = { get } as unknown as HttpService;
+    const config = { get: () => 'http://core.test' } as unknown as ConfigService;
+    return new ChannelListingClient(http, config);
+  }
+
+  it('성공하면 found: true 와 매핑을 준다', async () => {
+    const get = jest.fn().mockReturnValue(of({ status: 200, data: { found: true, listing } }));
+    const result = await clientWith(get).resolveByChannelCode('naver', 'item-1');
+    expect(result).toEqual({ found: true, listing });
+  });
+
+  it('실패 사유를 그대로 전달한다', async () => {
+    const get = jest.fn().mockReturnValue(of({ status: 200, data: { found: false, cause: 'variant_inactive' } }));
+    const result = await clientWith(get).resolveByChannelCode('naver', 'item-1');
+    expect(result).toEqual({ found: false, cause: 'variant_inactive' });
+  });
+
+  it('모르는 사유는 unknown 으로 낮춘다', async () => {
+    const get = jest.fn().mockReturnValue(of({ status: 200, data: { found: false, cause: 'from_the_future' } }));
+    const result = await clientWith(get).resolveByChannelCode('naver', 'item-1');
+    expect(result).toEqual({ found: false, cause: 'unknown' });
+  });
+
+  it('/resolve 가 404 면 /lookup 으로 폴백한다 — 매핑이 있으면 found: true', async () => {
+    const get = jest
+      .fn()
+      .mockReturnValueOnce(throwError(() => ({ response: { status: 404 } })))
+      .mockReturnValueOnce(of({ status: 200, data: listing }));
+
+    const result = await clientWith(get).resolveByChannelCode('naver', 'item-1');
+
+    expect(result).toEqual({ found: true, listing });
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(get.mock.calls[0][0]).toContain('/channel-listings/resolve');
+    expect(get.mock.calls[1][0]).toContain('/channel-listings/lookup');
+  });
+
+  it('폴백에서 매핑이 없으면 사유를 지어내지 않고 unknown 이다', async () => {
+    const get = jest
+      .fn()
+      .mockReturnValueOnce(throwError(() => ({ response: { status: 404 } })))
+      .mockReturnValueOnce(of({ status: 204, data: null }));
+
+    const result = await clientWith(get).resolveByChannelCode('naver', 'item-1');
+
+    expect(result).toEqual({ found: false, cause: 'unknown' });
+  });
+
+  it('404 가 아닌 오류는 삼키지 않는다', async () => {
+    const get = jest.fn().mockReturnValue(throwError(() => ({ response: { status: 500 }, message: 'boom' })));
+    await expect(clientWith(get).resolveByChannelCode('naver', 'item-1')).rejects.toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest --maxWorkers=2 --testPathPattern="channel-listing-resolve.client"`
+Expected: FAIL — `client.resolveByChannelCode is not a function`
+
+- [ ] **Step 3: 구현**
+
+`channel-listing.client.ts` 상단 import 에 추가:
+
+```typescript
+import { type ListingResolutionCause, toListingResolutionCause } from '@packages/domain-types';
+```
+
+`LookupVariantResult` 인터페이스 아래에 추가:
+
+```typescript
+/** Core `/channel-listings/resolve` 의 응답 (#674). Core 쪽 동명 타입과 짝이다. */
+export type ListingResolveResult =
+  | { found: true; listing: LookupVariantResult }
+  | { found: false; cause: ListingResolutionCause };
+```
+
+`lookupByChannelCode` 메서드 **아래**에 추가:
+
+```typescript
+  /**
+   * 채널 코드 + 채널 상품 ID 로 Variant 를 **사유와 함께** 해석한다 (#674).
+   *
+   * Core 가 아직 `/resolve` 를 모르면(배포 순서가 뒤집혔거나 롤백됐으면) 404 가 온다. 그때
+   * 옛 `/lookup` 으로 폴백한다 — 사유를 얻으려다 수집을 통째로 멈추는 건 명백한 퇴행이다.
+   * 폴백 경로에서는 사유를 알 길이 없으므로 지어내지 않고 `unknown` 이다.
+   *
+   * 폴백 제거는 Core 배포가 안정된 뒤 후속 PR.
+   */
+  async resolveByChannelCode(channelCode: string, channelItemId: string): Promise<ListingResolveResult> {
+    try {
+      const response = await firstValueFrom(
+        this.httpService.get<{ found: boolean; listing?: LookupVariantResult; cause?: unknown }>(
+          `${this.pimBaseUrl}/channel-listings/resolve`,
+          { params: { channelCode, channelItemId }, timeout: 5000 },
+        ),
+      );
+
+      const body = response.data;
+      if (body?.found && body.listing) {
+        return { found: true, listing: body.listing };
+      }
+      return { found: false, cause: toListingResolutionCause(body?.cause) };
+    } catch (error: any) {
+      if (error.response?.status !== 404) {
+        this.logger.error(`❌ 채널 매핑 해석 실패: ${channelCode}/${channelItemId}`, error.message);
+        throw error;
+      }
+
+      this.logger.warn(`/resolve 가 없어 /lookup 으로 폴백한다 (Core 가 구버전): ${channelCode}/${channelItemId}`);
+      const listing = await this.lookupByChannelCode(channelCode, channelItemId);
+      return listing ? { found: true, listing } : { found: false, cause: 'unknown' };
+    }
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest --maxWorkers=2 --testPathPattern="channel-listing-resolve.client"`
+Expected: PASS 6/6
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/channel-adapter/src/services/clients/
+git commit -m "feat(channel-adapter): /resolve 로 사유를 받고 404 는 /lookup 으로 폴백한다 (#674)"
+```
+
+---
+
+### Task 5: 어댑터 전파 — resolver 유니온과 translator 수집
+
+**Files:**
+- Modify: `apps/channel-adapter/src/services/order-collection/channel-line-identity.resolver.ts`
+- Modify: `apps/channel-adapter/src/services/order-collection/channel-order.translator.ts`
+- Modify: `apps/channel-adapter/src/services/order-collection/channel-order-provider.interface.ts`
+- Create: `apps/channel-adapter/src/services/order-collection/channel-line-identity-cause.spec.ts`
+
+**Interfaces:**
+- Consumes: `ChannelListingClient.resolveByChannelCode` (Task 4); `AffectedLine`, `ListingResolutionCause` (Task 1)
+- Produces:
+  - `type LineResolution = { identified: true; identity: ResolvedLineIdentity } | { identified: false; cause: ListingResolutionCause }`
+  - `ChannelLineIdentityResolver.resolve(channel, line): Promise<LineResolution>` — **반환 타입이 바뀐다**
+  - `OrderCollectionFailureItem.affectedLines?: AffectedLine[]`
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/channel-adapter/src/services/order-collection/channel-line-identity-cause.spec.ts`:
+
+```typescript
+import { ChannelLineIdentityResolver } from './channel-line-identity.resolver';
+import type { ChannelListingClient } from '../clients/channel-listing.client';
+import type { ChannelOrderLineSnapshot } from './channel-order-source.interface';
+
+/**
+ * 해석 실패는 예외가 아니라 **사유를 실은 값**이다 (#674). 전에는 `null` 이라 호출자가
+ * "왜" 를 알 수 없었고, 격리 행에는 사유가 한 종류뿐이라 운영자도 알 수 없었다.
+ */
+describe('ChannelLineIdentityResolver 사유 (#674)', () => {
+  function line(overrides: Partial<ChannelOrderLineSnapshot> = {}): ChannelOrderLineSnapshot {
+    return { channelOrderItemId: 'L1', quantity: 1, unitPrice: 1000, ...overrides } as ChannelOrderLineSnapshot;
+  }
+
+  function resolverWith(resolveByChannelCode: jest.Mock): ChannelLineIdentityResolver {
+    return new ChannelLineIdentityResolver({ resolveByChannelCode } as unknown as ChannelListingClient);
+  }
+
+  it('embedded 채널에서 식별자 3종이 없으면 no_embedded_ids', async () => {
+    const resolver = resolverWith(jest.fn());
+    const result = await resolver.resolve('medusa', line({ embeddedVariantId: 'v1' }));
+    expect(result).toEqual({ identified: false, cause: 'no_embedded_ids' });
+  });
+
+  it('embedded 채널에서 식별자 3종이 다 있으면 식별된다', async () => {
+    const resolver = resolverWith(jest.fn());
+    const result = await resolver.resolve(
+      'medusa',
+      line({ embeddedVariantId: 'v1', embeddedMasterId: 'm1', embeddedVersionId: 'ver1' }),
+    );
+    expect(result.identified).toBe(true);
+  });
+
+  it('리스팅 채널에서 조회 키가 없으면 no_lookup_key — Core 를 부르지 않는다', async () => {
+    const resolveByChannelCode = jest.fn();
+    const resolver = resolverWith(resolveByChannelCode);
+    const result = await resolver.resolve('naver', line({ channelOrderItemId: '', channelProductId: '' }));
+    expect(result).toEqual({ identified: false, cause: 'no_lookup_key' });
+    expect(resolveByChannelCode).not.toHaveBeenCalled();
+  });
+
+  it('Core 가 준 사유를 그대로 올린다', async () => {
+    const resolveByChannelCode = jest.fn().mockResolvedValue({ found: false, cause: 'variant_inactive' });
+    const resolver = resolverWith(resolveByChannelCode);
+    const result = await resolver.resolve('naver', line({ channelProductId: 'P1' }));
+    expect(result).toEqual({ identified: false, cause: 'variant_inactive' });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest --maxWorkers=2 --testPathPattern="channel-line-identity-cause"`
+Expected: FAIL — `resolve` 가 `ResolvedLineIdentity | null` 을 돌려주므로 `toEqual({identified:...})` 불일치
+
+- [ ] **Step 3: resolver 를 유니온으로 바꾼다**
+
+`channel-line-identity.resolver.ts`:
+
+상단 import 에 추가:
+
+```typescript
+import type { ListingResolutionCause } from '@packages/domain-types';
+```
+
+`ResolvedLineIdentity` 인터페이스 아래에 추가:
+
+```typescript
+/**
+ * **판별 유니온이다.** 전에는 실패가 `null` 이라 "왜" 가 사라졌다 — 이 파일의
+ * `OrderLifecycleEventItem` 주석이 말하는 것과 같은 실패 모드다(계약이 잡아 줄 것을
+ * 호출부의 추측으로 덮기).
+ */
+export type LineResolution =
+  | { identified: true; identity: ResolvedLineIdentity }
+  | { identified: false; cause: ListingResolutionCause };
+```
+
+`resolve` 를 아래로 교체:
+
+```typescript
+  async resolve(channel: SalesChannel, line: ChannelOrderLineSnapshot): Promise<LineResolution> {
+    const capabilities = getChannelCapabilities(channel);
+    if (!capabilities || capabilities.integration !== 'api') {
+      this.logger.warn(`No order-collection capability registered for channel ${channel}`);
+      return { identified: false, cause: 'unknown' };
+    }
+
+    if (capabilities.lineIdentity === 'embedded') {
+      return this.fromEmbedded(line);
+    }
+    return this.fromChannelListing(channel, line);
+  }
+```
+
+`fromEmbedded` 를 아래로 교체:
+
+```typescript
+  private fromEmbedded(line: ChannelOrderLineSnapshot): LineResolution {
+    const variantId = nonEmpty(line.embeddedVariantId);
+    const masterId = nonEmpty(line.embeddedMasterId);
+    const versionId = nonEmpty(line.embeddedVersionId);
+    if (!variantId || !masterId || !versionId) {
+      return { identified: false, cause: 'no_embedded_ids' };
+    }
+    return { identified: true, identity: { variantId, masterId, versionId } };
+  }
+```
+
+`fromChannelListing` 를 아래로 교체:
+
+```typescript
+  private async fromChannelListing(
+    channel: SalesChannel,
+    line: ChannelOrderLineSnapshot,
+  ): Promise<LineResolution> {
+    const lookupId = nonEmpty(line.channelProductId) ?? nonEmpty(line.channelOrderItemId);
+    if (!lookupId) {
+      return { identified: false, cause: 'no_lookup_key' };
+    }
+
+    const resolution = await this.channelListingClient.resolveByChannelCode(channel, lookupId);
+    if (!resolution.found) {
+      return { identified: false, cause: resolution.cause };
+    }
+
+    return {
+      identified: true,
+      identity: {
+        variantId: resolution.listing.variantId,
+        masterId: resolution.listing.masterId,
+        versionId: resolution.listing.versionId,
+        productName: nonEmpty(resolution.listing.productName),
+      },
+    };
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest --maxWorkers=2 --testPathPattern="channel-line-identity-cause"`
+Expected: PASS 4/4
+
+- [ ] **Step 5: 실패 항목 계약에 `affectedLines` 를 더한다**
+
+`channel-order-provider.interface.ts` 상단 import 에 추가:
+
+```typescript
+import type { AffectedLine } from '@packages/domain-types';
+```
+
+`OrderCollectionFailureItem` 을 아래로 교체:
+
+```typescript
+export interface OrderCollectionFailureItem {
+  externalOrderId: string;
+  sourceUpdatedAt: string;
+  reason: OrderCollectionFailureReason;
+  affectedLineIds: string[];
+  /**
+   * 라인별 실패 사유 (#674). `channel_product_identification_failed` 에서만 채워진다 —
+   * `collected_order_modification_not_accepted` 는 식별 문제가 아니라 사유가 없다.
+   *
+   * `reason` 을 쪼개지 않고 여기 담는 이유: 사유는 **라인 단위**인데 `reason` 은 주문당 한
+   * 칸이라, 거기 넣으면 라인이 여럿일 때 나머지 사유가 유실된다. 또 `reason` 은
+   * `uq_order_collection_failure` 의 일부라 값이 바뀌면 같은 주문에 행이 하나 더 생긴다.
+   */
+  affectedLines?: AffectedLine[];
+  rawOrder: Record<string, unknown>;
+}
+```
+
+- [ ] **Step 6: translator 가 사유를 모으게 한다**
+
+`channel-order.translator.ts` 의 `translate` 안에서, `identities` 계산부터 격리 반환까지를 아래로 교체:
+
+```typescript
+    const resolutions = await Promise.all(
+      snapshot.lines.map((line) => this.identityResolver.resolve(channel, line)),
+    );
+
+    // 유료 주문 라인이 미식별이면 조용히 넘기지 않고 격리한다 (CONTEXT §채널 상품 식별 실패).
+    // 이미 종결된 스냅샷(취소/환불 관측)은 판매주문을 만들지 않으므로 식별을 요구하지 않는다.
+    const unidentified = snapshot.lines.flatMap((line, index) => {
+      const resolution = resolutions[index];
+      return resolution.identified ? [] : [{ lineId: line.channelOrderItemId, cause: resolution.cause }];
+    });
+
+    if (eligibleForOrderCreation && unidentified.length > 0) {
+      return {
+        outcome: {
+          kind: 'failure',
+          failure: {
+            externalOrderId: snapshot.externalOrderId,
+            sourceUpdatedAt: snapshot.sourceUpdatedAt,
+            reason: CHANNEL_PRODUCT_IDENTIFICATION_FAILED,
+            affectedLineIds: unidentified.map((line) => line.lineId),
+            affectedLines: unidentified,
+            rawOrder: snapshot.raw,
+          } satisfies OrderCollectionFailureItem,
+        },
+        lifecycle,
+      };
+    }
+
+    const items = snapshot.lines.map((line, index) => {
+      const resolution = resolutions[index];
+      return this.buildOrderItem(line, resolution.identified ? resolution.identity : null);
+    });
+```
+
+`buildOrderItem` 의 두 번째 매개변수 타입이 `ResolvedLineIdentity | null` 인지 확인한다. 아니면 그렇게 맞춘다.
+
+- [ ] **Step 7: 게이트**
+
+Run: `npm run type-check`
+Expected: 에러 0. 에러가 나면 대부분 `resolve()` 의 옛 `null` 비교가 남은 곳이다 — 전부 유니온으로 고친다.
+
+Run: `npx jest --maxWorkers=2 --testPathPattern="channel-order|channel-line-identity"`
+Expected: 실패 0. 기존 translator 스펙이 `resolve` 목을 `null`/객체로 두고 있으면 유니온 모양으로 고친다.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/channel-adapter/src/services/order-collection/
+git commit -m "feat(channel-adapter): 라인 해석 실패를 사유 실은 유니온으로 올린다 (#674)"
+```
+
+---
+
+### Task 6: 저장 — 마이그레이션과 `recordFailure`
+
+**Files:**
+- Modify: `apps/channel-adapter/src/schema.ts:218-255`
+- Create: `apps/channel-adapter/drizzle/<timestamp>_add-affected-lines.sql` (생성됨)
+- Modify: `apps/channel-adapter/src/services/order-collection/order-collection-failure.service.ts`
+- Create: `apps/channel-adapter/src/services/order-collection/order-collection-failure-cause.integration.spec.ts`
+
+**Interfaces:**
+- Consumes: `OrderCollectionFailureItem.affectedLines` (Task 5); `AffectedLine` (Task 1)
+- Produces: `order_collection_failures.affected_lines` jsonb nullable
+
+- [ ] **Step 1: Write the failing test**
+
+`apps/channel-adapter/src/services/order-collection/order-collection-failure-cause.integration.spec.ts`:
+
+```typescript
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- postgres publishes `export =`; Jest compiles CJS.
+import postgres = require('postgres');
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { and, eq } from 'drizzle-orm';
+import { OrderCollectionFailureService } from './order-collection-failure.service';
+import { CHANNEL_PRODUCT_IDENTIFICATION_FAILED } from './channel-order-provider.interface';
+import { orderCollectionFailures } from '../../schema';
+
+/**
+ * 사유는 **폴링마다 달라진다** — 매핑을 만들면 `listing_not_found` → `variant_inactive` 로
+ * 바뀐다. 그때 행이 하나로 유지되는지가 이 설계의 핵심이다 (#674).
+ *
+ * `reason` 을 쪼갰다면 `uq_order_collection_failure` 가 `(channel, external_order_id, reason)`
+ * 이므로 같은 주문에 행이 두 개 생기고 옛 행이 `quarantined` 로 영원히 남았을 것이다. 그
+ * 사실은 실 Postgres 로만 증명된다.
+ *
+ * 실행:
+ *   DATABASE_URL=postgresql://postgres:postgres@localhost:5432/channel_adapter \
+ *   npx jest --runInBand apps/channel-adapter/src/services/order-collection/order-collection-failure-cause.integration.spec.ts
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+
+describeIfDb('격리 사유 갱신 (PostgreSQL integration)', () => {
+  jest.setTimeout(120_000);
+
+  let client: ReturnType<typeof postgres>;
+  let service: OrderCollectionFailureService;
+  let db: ReturnType<typeof drizzle>;
+  const channels: string[] = [];
+
+  const newChannel = () => {
+    const channel = `spec-${Math.random().toString(36).slice(2, 10)}`;
+    channels.push(channel);
+    return channel;
+  };
+
+  beforeAll(() => {
+    client = postgres(DATABASE_URL as string, { max: 2, prepare: false });
+    db = drizzle(client);
+    service = new OrderCollectionFailureService({ db } as never);
+  });
+
+  afterAll(async () => {
+    for (const channel of channels) {
+      await db.delete(orderCollectionFailures).where(eq(orderCollectionFailures.channel, channel));
+    }
+    await client.end({ timeout: 0 });
+  });
+
+  function failure(lines: { lineId: string; cause: string }[]) {
+    return {
+      externalOrderId: 'ORDER-1',
+      sourceUpdatedAt: new Date().toISOString(),
+      reason: CHANNEL_PRODUCT_IDENTIFICATION_FAILED,
+      affectedLineIds: lines.map((line) => line.lineId),
+      affectedLines: lines,
+      rawOrder: { hello: 'world' },
+    } as never;
+  }
+
+  it('사유를 그대로 저장한다', async () => {
+    const channel = newChannel();
+    const record = await service.recordFailure(channel, failure([{ lineId: 'L1', cause: 'listing_not_found' }]));
+    expect(record.affectedLines).toEqual([{ lineId: 'L1', cause: 'listing_not_found' }]);
+  });
+
+  it('사유가 바뀌어도 행은 하나로 유지되고 갱신된다', async () => {
+    const channel = newChannel();
+    await service.recordFailure(channel, failure([{ lineId: 'L1', cause: 'listing_not_found' }]));
+    await service.recordFailure(channel, failure([{ lineId: 'L1', cause: 'variant_inactive' }]));
+
+    const rows = await db
+      .select()
+      .from(orderCollectionFailures)
+      .where(
+        and(eq(orderCollectionFailures.channel, channel), eq(orderCollectionFailures.externalOrderId, 'ORDER-1')),
+      );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].affectedLines).toEqual([{ lineId: 'L1', cause: 'variant_inactive' }]);
+  });
+
+  it('목록 조회에도 사유가 실린다 — 화면(#640)이 읽을 자리다', async () => {
+    const channel = newChannel();
+    await service.recordFailure(channel, failure([{ lineId: 'L1', cause: 'no_active_version' }]));
+
+    const listed = await service.list({ channel });
+
+    expect(listed).toHaveLength(1);
+    expect(listed[0].affectedLines).toEqual([{ lineId: 'L1', cause: 'no_active_version' }]);
+  });
+
+  it('사유가 없는 실패는 null 로 남는다', async () => {
+    const channel = newChannel();
+    const record = await service.recordFailure(channel, {
+      externalOrderId: 'ORDER-1',
+      sourceUpdatedAt: new Date().toISOString(),
+      reason: CHANNEL_PRODUCT_IDENTIFICATION_FAILED,
+      affectedLineIds: ['L1'],
+      rawOrder: {},
+    } as never);
+    expect(record.affectedLines).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+docker compose up -d postgres
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/channel_adapter \
+  npx jest --runInBand apps/channel-adapter/src/services/order-collection/order-collection-failure-cause.integration.spec.ts
+```
+
+Expected: FAIL — `affectedLines` 가 스키마에 없다 (타입/컬럼 에러)
+
+- [ ] **Step 3: 스키마에 컬럼을 더한다**
+
+`apps/channel-adapter/src/schema.ts` 상단 import 에 추가:
+
+```typescript
+import type { AffectedLine } from '@packages/domain-types';
+```
+
+`orderCollectionFailures` 의 `affectedLineIds` **바로 아래**에 추가:
+
+```typescript
+    /**
+     * 라인별 실패 사유 (#674). nullable 이다 — 옛 행과
+     * `collected_order_modification_not_accepted` 행은 사유를 모르는 게 사실이므로
+     * 지어내지 않는다. `affected_line_ids` 는 두 사유가 함께 쓰므로 그대로 둔다(rename 아님).
+     */
+    affectedLines: jsonb('affected_lines').$type<AffectedLine[]>(),
+```
+
+- [ ] **Step 4: 마이그레이션 생성**
+
+```bash
+npm run db:generate:channel-adapter -- --name add-affected-lines
+```
+
+생성된 `apps/channel-adapter/drizzle/<timestamp>_add-affected-lines.sql` 을 열어 **`ADD COLUMN` 한 줄뿐인지** 확인한다. `DROP` / `NOT NULL` 이 섞여 있으면 스키마 편집이 잘못된 것이다 — 파일을 `git rm` 하고 스키마를 고친 뒤 다시 생성한다.
+
+파일 맨 위에 주석을 붙인다:
+
+```sql
+-- 격리 사유를 라인 단위로 담는다 (#674).
+--
+-- nullable 인 이유: 옛 행과 `collected_order_modification_not_accepted` 행은 사유를 모른다.
+-- 백필하지 않는다 — 사후에 사유를 만들어내는 것보다 "판정 불가" 가 정직하다.
+--
+-- additive 이므로 **`migrate` 가 `deploy` 앞이다** (ADR-0005 §5 expand phase). 새 컬럼을
+-- 읽고 쓰는 코드가 컬럼보다 먼저 뜨면 깨진다.
+```
+
+- [ ] **Step 5: 로컬 DB 에 적용**
+
+```bash
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/channel_adapter \
+  npx drizzle-kit migrate --config apps/channel-adapter/drizzle.config.ts
+```
+
+- [ ] **Step 6: `recordFailure` 가 쓰고 갱신하게 한다**
+
+`order-collection-failure.service.ts` 의 `values` 객체에서 `affectedLineIds` 아래에 추가:
+
+```typescript
+      affectedLines: failure.affectedLines ?? null,
+```
+
+같은 파일 `onConflictDoUpdate` 의 `set` 객체에서 `affectedLineIds` 아래에 추가:
+
+```typescript
+            affectedLines: values.affectedLines,
+```
+
+⚠️ **`set` 에 넣는 것이 이 태스크의 핵심이다.** 빠뜨리면 첫 폴링의 사유가 굳어, 매핑을 만든 뒤에도 화면이 `listing_not_found` 를 계속 보여준다.
+
+- [ ] **Step 7: Run test to verify it passes**
+
+```bash
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/channel_adapter \
+  npx jest --runInBand apps/channel-adapter/src/services/order-collection/order-collection-failure-cause.integration.spec.ts
+```
+
+Expected: PASS 4/4
+
+- [ ] **Step 8: 게이트**
+
+Run: `npm run type-check`
+Expected: 에러 0
+
+Run: `npx jest --maxWorkers=2`
+Expected: 실패 0
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/channel-adapter/src/schema.ts \
+        apps/channel-adapter/drizzle/ \
+        apps/channel-adapter/src/services/order-collection/
+git commit -m "feat(channel-adapter): 격리 행에 라인별 사유를 적재한다 (#674)"
+```
+
+---
+
+### Task 7: CONTEXT.md 를 사유별 조치표로 고친다
+
+**Files:**
+- Modify: `CONTEXT.md:230-236`
+
+**Interfaces:**
+- Consumes: Task 1 의 어휘
+- Produces: 없음 (문서)
+
+- [ ] **Step 1: 현재 문장을 확인한다**
+
+Run: `sed -n '230,236p' CONTEXT.md`
+
+`- **격리 큐는 채널 능력과 무관하게 하나다.** …` 로 시작하는 줄에 *"해소 수단도 하나다 — 리스팅을 만들면 격리된 주문이 재처리된다."* 가 들어 있다.
+
+- [ ] **Step 2: 그 줄을 교체한다**
+
+해당 한 줄을 아래 두 줄로 바꾼다:
+
+```markdown
+- **격리 큐는 채널 능력과 무관하게 하나다.** Medusa 의 식별 실패(metadata·리스팅 둘 다 없음)와 네이버·쿠팡의 미매핑([[채널 리스팅]] 없음)은 같은 운영 문제이므로 같은 큐·같은 화면에서 해소한다.
+- **해소 수단은 하나가 아니다.** 리스팅 조회가 버전·품목·채널 세 축을 보므로(#670) 조치가 갈린다 — 격리 행의 `affected_lines[].cause` 가 라인마다 무엇을 해야 하는지 말한다: `listing_not_found`→리스팅 생성 · `listing_inactive`→리스팅 활성화 · `channel_inactive`→채널 활성화 · `variant_inactive`→품목 활성화 · `no_active_version`→publish · `product_deleted`→다른 상품으로 재매핑 · `no_embedded_ids`→Core 를 통해 상품 재생성 · `no_lookup_key`→채널 데이터 확인 · `unknown`→판정 불가. 어휘 정본은 `@packages/domain-types` 다 (#674).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CONTEXT.md
+git commit -m "docs(context): 격리 해소 수단이 하나가 아님을 적는다 (#670, #674)"
+```
+
+---
+
+## 알려진 한계 (구현하지 않는다)
+
+- **판매채널 행 자체가 없을 때** `listing_not_found` 로 보고된다. 실제 조치는 "채널을 먼저 만든다" 라 미묘하게 다르지만, `site` 어휘가 4종으로 닫혀 있고 채널 생성은 리스팅 생성의 선행이라 실무상 같은 흐름이다. 별도 cause 는 스펙 승인 범위 밖이다
+- 옛 격리 행 백필 없음 (`affected_lines = null` → 화면에서 "판정 불가")
+- 사유 필터 API 없음. 필요해지면 `affected_lines` 에 GIN 인덱스 + `@>` containment
+- `/lookup` 삭제, 폴백 제거, auto-replay 정책, 사유별 알림, 격리 큐 화면(#640)
+
+## 배포 순서
+
+```
+1) channel-adapter migrate   — additive nullable 컬럼 (expand: migrate → deploy)
+2) Core deploy               — /channel-listings/resolve 신설
+3) channel-adapter deploy    — /resolve 사용 + 컬럼 기록
+```
+
+2·3 이 뒤집혀도 Task 4 의 404 폴백이 받는다. **1 은 3 보다 반드시 앞.**
+
+라이브 영향 없음 — 네이버·쿠팡 리스팅 0행이고 Medusa 는 `embedded` 라 이 조회를 타지 않는다. 실효는 #643 개통 시점.

--- a/docs/superpowers/specs/2026-08-19-listing-resolution-cause-design.md
+++ b/docs/superpowers/specs/2026-08-19-listing-resolution-cause-design.md
@@ -1,0 +1,175 @@
+# 격리 사유 라인 단위 세분화 (#674)
+
+- 날짜: 2026-08-19
+- 이슈: #674
+- 선행: #670 (PR #673) — 이 설계는 그 술어 세 축을 전제한다
+- 관련: #640 (화면) · #643 (네이버 개통) · ADR-0031 · CONTEXT.md §채널 상품 식별 실패
+
+## 1. 문제
+
+CONTEXT.md line 234 는 이렇게 못 박고 있다.
+
+> **격리 큐는 채널 능력과 무관하게 하나다.** … **해소 수단도 하나다 — 리스팅을 만들면 격리된 주문이 재처리된다.**
+
+**#670 이 그 불변식을 깼다.** 리스팅 조회 술어가 버전·품목·채널 세 축으로 늘면서 해소 수단이 갈렸다.
+
+| 원인 | 조치 |
+|---|---|
+| 매핑 없음 | 리스팅을 만든다 |
+| 품목 판매중지 | 품목을 활성화한다 |
+| 활성 버전 없음 | publish 한다 |
+
+그런데 `order_collection_failures.reason` 은 `channel_product_identification_failed` **한 종류**다. 운영자는 셋 중 무엇을 해야 하는지 알 수 없고, **리스팅을 만들어도 안 풀리는 격리**가 생겼다.
+
+이건 UX 개선이 아니라 #670 이 만든 부채를 갚는 일이다.
+
+## 2. 핵심 판단 — 사유는 주문이 아니라 **라인** 단위다
+
+네이버 주문 한 건에 라인이 셋이면 라인 A 는 매핑 없음, 라인 B 는 품목 판매중지일 수 있다. `reason` 은 주문당 한 칸이므로, 거기에 세분화된 값을 넣으면 **우선순위 규칙을 강제하고 나머지 라인의 사유를 버린다.** 채널·라인 수가 늘수록 손실이 커진다 — 다채널 미래에서 정확히 반대 방향이다.
+
+따라서 세분화는 `reason` 을 쪼개는 게 아니라 **라인별 진단을 담는 새 필드**로 간다.
+
+부수 효과 둘이 이 선택을 더 밀어준다.
+
+1. **unique 키가 조용히 옳아진다.** `uq_order_collection_failure` 는 `(channel, external_order_id, reason)` 이고 `recordFailure` 가 그 키로 upsert 한다. `reason` 이 상수로 고정되면 실질 키가 `(channel, external_order_id)` 가 된다 — 채널당 주문당 격리 하나. `reason` 을 쪼갰다면 사유가 바뀌는 주문이 큐에 **두 건으로** 보이고 옛 행이 `quarantined` 인 채 영원히 남는다.
+2. **필터는 이 선택의 대가가 아니다.** jsonb 배열에 GIN 인덱스 + containment(`@>`) 면 "품목 판매중지가 낀 격리만" 을 그대로 거른다. 인덱스는 필요해질 때(#640) 붙인다.
+
+## 3. Core 계약
+
+### 3.1 `/channel-listings/resolve` 신설
+
+옛 `GET /channel-listings/lookup` 은 **손대지 않는다.**
+
+이유: 미스가 JSON `null` 이 아니라 **HTTP 204** 다 (`channel-listing.client.ts:60`). 같은 경로를 200+본문으로 바꾸면 옛 어댑터가 `{found:false, cause}` 를 `LookupVariantResult` 로 읽어 **`variantId: undefined` 인 채 "식별 성공"으로 처리한다.** 배포 순서를 지켜도 롤백 한 번이면 발생하는 조용한 오염이다.
+
+경로로 버전을 가르면 배포 순서가 어느 쪽이든 안전하다.
+
+```ts
+type ResolveResult =
+  | { found: true;  listing: LookupVariantResult }
+  | { found: false; cause: ListingResolutionCause };
+```
+
+쿼리 파라미터는 `/lookup` 과 동일: `salesChannelId` | `channelCode`, `channelItemId`. 미스도 **200** 이다.
+
+`/lookup` 삭제는 어댑터가 다 넘어간 뒤 후속 PR (expand-contract).
+
+### 3.2 사유 어휘
+
+가르는 기준은 "증상이 다른가"가 아니라 **"운영자가 할 일이 다른가"** 다.
+
+| cause | 상태 | 조치 | 산출 |
+|---|---|---|---|
+| `listing_not_found` | 매핑 행 자체가 없다 | 리스팅을 만든다 | Core |
+| `listing_inactive` | 매핑은 있으나 꺼져 있다 | 리스팅을 켠다 | Core |
+| `channel_inactive` | 판매채널이 꺼져 있다 | 채널을 켠다 | Core |
+| `variant_inactive` | 품목이 판매중지 | 품목을 활성화한다 | Core |
+| `no_active_version` | 활성 버전이 없다 (비활성·draft) | publish 한다 | Core |
+| `product_deleted` | 마스터/버전이 soft delete | 다른 상품으로 재매핑한다 | Core |
+| `no_embedded_ids` | `embedded` 채널인데 라인에 식별자 3종이 없다 | Core 를 통해 상품을 다시 만든다 | 어댑터 |
+| `no_lookup_key` | 라인에 채널 상품 id 조차 없다 | 채널 데이터 확인 | 어댑터 |
+| `unknown` | 판정 불가 (구 Core 폴백·옛 행) | — | 어댑터 |
+
+전부 **Core 카탈로그 상태**에 대한 말이고 채널 특성이 아니다. 채널이 열 개가 돼도 이 표는 안 늘어난다 — CONTEXT.md 234 의 "격리 큐는 채널 능력과 무관하게 하나다"가 유지된다.
+
+뒤 셋은 Core 를 부르기 전/후에 어댑터가 낸다. 어휘는 한 벌, 산출 지점은 둘이다.
+
+**어휘의 집은 `@packages/domain-types` 다.** 어댑터는 지금 `LookupVariantResult` 를 자체 재정의해 쓰고 있는데(`channel-listing.client.ts:6`), 그 방식을 이 어휘에 그대로 쓰면 안 된다 — 이 값들은 **영속되고** 화면이 렌더한다. 한쪽에만 값이 늘면 다른 쪽은 조용히 틀린다.
+
+그래도 **어댑터는 모르는 값을 만날 수 있다** (Core 를 먼저 배포하므로). 받은 문자열이 알려진 집합 밖이면 `unknown` 으로 낮춰 저장한다 — 타입이 거짓말하는 것보다 낫고, 화면도 "판정 불가"로 일관되게 읽는다.
+
+### 3.3 사유 계산
+
+```
+sellable 술어로 조회 → 행 있으면 { found: true }   ← 지금과 동일, 비용 동일
+                     → 0행이면 진단 쿼리 1회 추가   ← 미스 경로에서만
+```
+
+진단 쿼리는 `channel_variant_listings` 에서 시작해 **전부 LEFT JOIN** 한다. inner join 이면 master-variant 행이 없는 리스팅이 0행을 내 `listing_not_found` 로 오진된다.
+
+우선순위 (여럿이 동시에 성립할 때):
+
+```
+listing_not_found → listing_inactive → channel_inactive
+  → product_deleted → no_active_version → variant_inactive
+```
+
+`product_deleted` 를 `variant_inactive` 앞에 두는 이유: 상품이 지워졌으면 품목 상태를 볼 의미가 없고 조치도 재매핑 하나다.
+
+**경계 하나를 명시한다**: 리스팅과 품목은 있는데 `product_master_variants` 행이 없어 어떤 버전에도 안 매달린 경우 → `no_active_version`. 조치가 publish 로 같기 때문이다. (반대로 품목 행 자체가 없는 경우는 생기지 않는다 — `channel_variant_listings.variant_id` 가 `onDelete: 'cascade'` 라 리스팅이 품목보다 오래 살 수 없다.)
+
+별도 진단 엔드포인트를 두지 않는다 — 다채널일수록 HTTP 왕복 수가 곱해지므로 한 번에 끝낸다.
+
+### 3.4 파일
+
+- `apps/core/.../channels/channel-listing-diagnosis.query.ts` — 진단 쿼리 + 우선순위
+- Core 마이그레이션 **0** (읽기만)
+
+## 4. 어댑터
+
+### 4.1 전파 — `null` 을 판별 유니온으로
+
+```ts
+// ChannelLineIdentityResolver.resolve
+type LineResolution =
+  | { identified: true;  identity: ResolvedLineIdentity }
+  | { identified: false; cause: ListingResolutionCause };
+```
+
+이 파일은 이미 `OrderLifecycleEventItem` 주석에서 같은 이유로 판별 유니온을 채택했다 (*"계약이 잡아 줄 것을 캐스팅으로 덮는 것은 ADR-0029 가 없애려는 실패 모드"*).
+
+`ChannelOrderTranslator` 는 `unidentifiedLineIds: string[]` 대신 `{ lineId, cause }[]` 를 모은다.
+
+### 4.2 저장
+
+```ts
+affectedLines: jsonb('affected_lines').$type<{ lineId: string; cause: ListingResolutionCause }[]>()
+```
+
+- **nullable.** `COLLECTED_ORDER_MODIFICATION_NOT_ACCEPTED` 행과 기존 행은 `null` 이다 — 옛 격리 건은 사유를 모르는 게 사실이므로 `null` 이 정직하다. 백필하지 않는다
+- `affected_line_ids` 는 **그대로 둔다.** rename 이 아니다 — `order-poller.orchestrator.ts:480` 의 다른 사유가 같은 필드를 쓴다. 따라서 ADR-0005 §5 의 3-PR 이관이 필요 없다
+- `reason` 은 그대로 ⇒ unique 키 의미 불변
+- `recordFailure` 의 `onConflictDoUpdate` `set` 에 새 필드를 **반드시** 넣는다. 사유는 폴링마다 달라진다 (매핑을 만들면 `listing_not_found` → `variant_inactive`)
+
+마이그레이션 **1건** (channel-adapter, additive).
+
+### 4.3 롤아웃 폴백
+
+`ChannelListingClient` 가 `/resolve` 를 부르고 **404 면 `/lookup` 으로 폴백**한다 (미스 → `cause: 'unknown'`). Core 를 롤백해도 어댑터가 안 깨진다. 폴백 제거는 후속 PR.
+
+### 4.4 운영 표면
+
+`GET /adapter/order-collection-failures` 목록·상세에 필드가 그대로 실린다 (행 전체 반환 구조). **사유 필터는 만들지 않는다** — 화면이 없어 쓸 데가 없고, 필요해지면 GIN + containment 한 줄이다.
+
+## 5. 문서
+
+CONTEXT.md line 234 의 *"해소 수단도 하나다 — 리스팅을 만들면 격리된 주문이 재처리된다"* 를 §3.2 의 사유별 조치표로 대체한다. 이 문장이 남으면 다음 사람이 사유 세분화를 불필요한 것으로 읽는다.
+
+## 6. 검증
+
+전부 TDD — RED 를 먼저 확인한다.
+
+| 층 | 대상 |
+|---|---|
+| Core 계약 스펙 (`.toSQL()`, DB 불필요) | 진단 쿼리가 LEFT JOIN 이고 sellable 술어를 안 건다 |
+| Core 통합 (실 Postgres) | Core 산출 사유 6종 각각 → 기대 cause. 우선순위 겹침 2건 |
+| 어댑터 유닛 | resolver 유니온 · translator 수집 · `recordFailure` 사유 flip 시 **행이 하나로 유지** |
+| 어댑터 유닛 | `/resolve` 404 → `/lookup` 폴백 → `unknown` |
+
+게이트: `npm run type-check` 0 · `npx jest --maxWorkers=2` 실패 0 · `npm run test:core:integration:local`.
+
+## 7. 배포 순서
+
+```
+1) channel-adapter migrate   (nullable 컬럼 — expand 이므로 migrate → deploy)
+2) Core deploy               (/resolve 신설)
+3) channel-adapter deploy    (/resolve 사용 + 컬럼 기록)
+```
+
+2·3 이 뒤집혀도 §4.3 폴백이 받는다. **1 은 3 보다 반드시 앞.**
+
+라이브 영향: 없다. 네이버·쿠팡 리스팅이 0행이고 Medusa 는 `embedded` 라 이 조회를 타지 않는다. 실효는 #643 개통 시점.
+
+## 8. 범위 밖
+
+auto-replay 정책 · 사유별 알림 · `/lookup` 삭제 · jsonb GIN 인덱스 · 격리 큐 화면(#640) · 옛 행 백필.

--- a/docs/superpowers/specs/2026-08-19-listing-resolution-cause-design.md
+++ b/docs/superpowers/specs/2026-08-19-listing-resolution-cause-design.md
@@ -135,7 +135,7 @@ affectedLines: jsonb('affected_lines').$type<{ lineId: string; cause: ListingRes
 
 ### 4.3 롤아웃 폴백
 
-`ChannelListingClient` 가 `/resolve` 를 부르고 **404 면 `/lookup` 으로 폴백**한다 (미스 → `cause: 'unknown'`). Core 를 롤백해도 어댑터가 안 깨진다. 폴백 제거는 후속 PR.
+`ChannelListingClient` 가 `/resolve` 를 부르고 **401 또는 404 면 `/lookup` 으로 폴백**한다 (미스 → `cause: 'unknown'`). 404 는 라우트 자체가 없는 옛 Core, 401 은 옛 Core 의 `@Get(':id')` 가 `id="resolve"` 로 이 요청을 가로챈 경우다 — 그 핸들러는 `@Public()` 이 아니라 전역 `JwtAuthGuard` 가 미인증 요청을 401 로 거절한다 (새 `/resolve` 는 `@Public()` 이므로 401 을 낼 수 없어 모호하지 않다). 두 상태 코드 모두를 폴백 트리거로 다루지 않으면 롤백 시나리오에서 401 이 그대로 던져져 `Promise.all` 이 reject 되고 그 채널의 폴링이 통째로 멎는다 (#674 회귀, 수정됨). Core 를 롤백해도 어댑터가 안 깨진다. 폴백 제거는 후속 PR.
 
 ### 4.4 운영 표면
 
@@ -154,7 +154,7 @@ CONTEXT.md line 234 의 *"해소 수단도 하나다 — 리스팅을 만들면 
 | Core 계약 스펙 (`.toSQL()`, DB 불필요) | 진단 쿼리가 LEFT JOIN 이고 sellable 술어를 안 건다 |
 | Core 통합 (실 Postgres) | Core 산출 사유 6종 각각 → 기대 cause. 우선순위 겹침 2건 |
 | 어댑터 유닛 | resolver 유니온 · translator 수집 · `recordFailure` 사유 flip 시 **행이 하나로 유지** |
-| 어댑터 유닛 | `/resolve` 404 → `/lookup` 폴백 → `unknown` |
+| 어댑터 유닛 | `/resolve` 401 또는 404 → `/lookup` 폴백 → `unknown` |
 
 게이트: `npm run type-check` 0 · `npx jest --maxWorkers=2` 실패 0 · `npm run test:core:integration:local`.
 
@@ -166,7 +166,7 @@ CONTEXT.md line 234 의 *"해소 수단도 하나다 — 리스팅을 만들면 
 3) channel-adapter deploy    (/resolve 사용 + 컬럼 기록)
 ```
 
-2·3 이 뒤집혀도 §4.3 폴백이 받는다. **1 은 3 보다 반드시 앞.**
+2·3 이 뒤집혀도 §4.3 폴백(401·404 모두)이 받는다. **1 은 3 보다 반드시 앞.**
 
 라이브 영향: 없다. 네이버·쿠팡 리스팅이 0행이고 Medusa 는 `embedded` 라 이 조회를 타지 않는다. 실효는 #643 개통 시점.
 

--- a/packages/domain-types/index.ts
+++ b/packages/domain-types/index.ts
@@ -6,3 +6,4 @@
 
 export * from './channel-adapter.types';
 export * from './medusa-inventory-projection';
+export * from './listing-resolution-cause';

--- a/packages/domain-types/listing-resolution-cause.spec.ts
+++ b/packages/domain-types/listing-resolution-cause.spec.ts
@@ -1,0 +1,43 @@
+import {
+  LISTING_RESOLUTION_CAUSES,
+  toListingResolutionCause,
+} from './listing-resolution-cause';
+
+/**
+ * 어휘의 정본은 여기 하나다 (#674). Core 가 내고 channel-adapter 가 영속하며 화면이 렌더하므로,
+ * 양쪽에 재정의하면 한쪽만 값이 늘었을 때 조용히 틀린다.
+ *
+ * 배포는 Core 가 먼저라, **어댑터는 자기가 모르는 값을 만날 수 있다.** 그때 타입이 거짓말하게
+ * 두는 것보다 `unknown` 으로 낮춰 저장하는 편이 낫다 — 화면도 "판정 불가" 로 일관되게 읽는다.
+ */
+describe('ListingResolutionCause 어휘', () => {
+  it('9종을 모두 가진다', () => {
+    expect([...LISTING_RESOLUTION_CAUSES].sort()).toEqual(
+      [
+        'channel_inactive',
+        'listing_inactive',
+        'listing_not_found',
+        'no_active_version',
+        'no_embedded_ids',
+        'no_lookup_key',
+        'product_deleted',
+        'unknown',
+        'variant_inactive',
+      ].sort(),
+    );
+  });
+
+  it('알려진 값은 그대로 통과시킨다', () => {
+    expect(toListingResolutionCause('variant_inactive')).toBe('variant_inactive');
+  });
+
+  it('모르는 값은 unknown 으로 낮춘다', () => {
+    expect(toListingResolutionCause('listing_haunted')).toBe('unknown');
+  });
+
+  it('문자열이 아닌 값도 unknown 으로 낮춘다', () => {
+    expect(toListingResolutionCause(null)).toBe('unknown');
+    expect(toListingResolutionCause(undefined)).toBe('unknown');
+    expect(toListingResolutionCause(42)).toBe('unknown');
+  });
+});

--- a/packages/domain-types/listing-resolution-cause.ts
+++ b/packages/domain-types/listing-resolution-cause.ts
@@ -1,0 +1,51 @@
+/**
+ * 채널 주문 라인이 우리 판매상품 variant 로 해석되지 않은 이유 (#674).
+ *
+ * 가르는 기준은 "증상이 다른가" 가 아니라 **"운영자가 할 일이 다른가"** 다.
+ *
+ * | cause               | 조치                          |
+ * |---------------------|-------------------------------|
+ * | listing_not_found   | 리스팅을 만든다               |
+ * | listing_inactive    | 리스팅을 켠다                 |
+ * | channel_inactive    | 판매채널을 켠다               |
+ * | variant_inactive    | 품목을 활성화한다             |
+ * | no_active_version   | publish 한다                  |
+ * | product_deleted     | 다른 상품으로 재매핑한다      |
+ * | no_embedded_ids     | Core 를 통해 상품을 다시 만든다 |
+ * | no_lookup_key       | 채널 데이터를 확인한다        |
+ * | unknown             | 판정 불가 (구 Core 폴백·옛 행) |
+ *
+ * 전부 **Core 카탈로그 상태**에 대한 말이고 채널 특성이 아니다. 그래서 채널이 열 개가 돼도
+ * 이 표는 안 늘어난다 — CONTEXT.md 의 "격리 큐는 채널 능력과 무관하게 하나다" 가 유지된다.
+ */
+export const LISTING_RESOLUTION_CAUSES = [
+  'listing_not_found',
+  'listing_inactive',
+  'channel_inactive',
+  'variant_inactive',
+  'no_active_version',
+  'product_deleted',
+  'no_embedded_ids',
+  'no_lookup_key',
+  'unknown',
+] as const;
+
+export type ListingResolutionCause = (typeof LISTING_RESOLUTION_CAUSES)[number];
+
+/**
+ * 바깥에서 들어온 값을 어휘 안으로 좁힌다.
+ *
+ * 배포 순서가 Core → 어댑터라, 어댑터는 자기가 모르는 값을 받을 수 있다. 그대로 저장하면
+ * 타입이 거짓말하고 화면이 렌더할 수 없는 값이 영속된다.
+ */
+export function toListingResolutionCause(value: unknown): ListingResolutionCause {
+  return typeof value === 'string' && (LISTING_RESOLUTION_CAUSES as readonly string[]).includes(value)
+    ? (value as ListingResolutionCause)
+    : 'unknown';
+}
+
+/** 격리된 주문에서 식별에 실패한 라인 하나. */
+export interface AffectedLine {
+  lineId: string;
+  cause: ListingResolutionCause;
+}


### PR DESCRIPTION
Closes #674

## 왜

CONTEXT.md 는 이렇게 못 박고 있었다.

> **격리 큐는 채널 능력과 무관하게 하나다.** … **해소 수단도 하나다 — 리스팅을 만들면 격리된 주문이 재처리된다.**

**#670 이 그 불변식을 깼다.** 리스팅 조회 술어가 버전·품목·채널 세 축으로 늘면서 해소 수단이 갈렸다 — 매핑 없음이면 리스팅을 만들고, 품목 판매중지면 품목을 되살리고, 버전이 낡았으면 publish 해야 한다. 그런데 격리 행의 `reason` 은 `channel_product_identification_failed` **한 종류**라, 운영자는 셋 중 무엇을 해야 하는지 알 수 없었다. **리스팅을 만들어도 안 풀리는 격리**가 생긴 것이다.

이건 UX 개선이 아니라 #670 이 만든 부채를 갚는 일이다.

## 핵심 판단 — 사유는 주문이 아니라 **라인** 단위다

네이버 주문 한 건에 라인이 셋이면 라인 A 는 매핑 없음, 라인 B 는 품목 판매중지일 수 있다. `reason` 은 주문당 한 칸이므로 거기에 세분화된 값을 넣으면 **우선순위 규칙을 강제하고 나머지 라인의 사유를 버린다.** 채널·라인 수가 늘수록 손실이 커진다 — 다채널 미래에서 정확히 반대 방향이다.

부수 효과 둘이 이 선택을 밀어준다.

1. **unique 키가 조용히 옳아진다.** `uq_order_collection_failure` 가 `(channel, external_order_id, reason)` 인데 `reason` 이 상수로 고정되면 실질 키가 `(channel, external_order_id)` 가 된다 — 채널당 주문당 격리 하나. `reason` 을 쪼갰다면 사유가 바뀌는 주문이 큐에 **두 건**으로 보이고 옛 행이 `quarantined` 로 영원히 남았다.
2. **필터는 대가가 아니다.** 필요해지면 jsonb GIN + `@>` containment 한 줄이다. 지금은 화면(#640)이 없어 만들지 않았다.

## 무엇을

| 층 | 변경 |
|---|---|
| `@packages/domain-types` | 사유 어휘 9종 정본 + `toListingResolutionCause`(모르는 값 → `unknown`) |
| Core | 진단 쿼리(LEFT JOIN, 상태 술어 없음) + 우선순위 순수 함수 |
| Core | `GET /channel-listings/resolve` 신설 — **미스도 200**, `{found:false, cause}` |
| channel-adapter | `resolveByChannelCode` + **401/404 폴백** |
| channel-adapter | 라인 해석을 `null` → 판별 유니온으로 |
| channel-adapter | `order_collection_failures.affected_lines` nullable jsonb (마이그 1건) |
| 문서 | CONTEXT.md 를 사유별 조치표로 |

**옛 `GET /channel-listings/lookup` 은 손대지 않았다.** 그 경로는 미스가 HTTP 204 라, 같은 경로를 200+본문으로 바꾸면 이미 배포된 옛 어댑터가 `{found:false,…}` 를 `LookupVariantResult` 로 읽어 **`variantId: undefined` 인 채 "식별 성공"으로 처리한다.** 배포 순서를 지켜도 롤백 한 번이면 발생하는 조용한 오염이라, 경로를 나눴다.

**`reason` 컬럼도 손대지 않았다** — 위 unique 키 이유.

## 사유 어휘

가르는 기준은 "증상이 다른가"가 아니라 **"운영자가 할 일이 다른가"** 다.

| cause | 조치 |
|---|---|
| `listing_not_found` | 리스팅을 만든다 |
| `listing_inactive` | 리스팅을 켠다 |
| `channel_inactive` | 채널을 켠다 |
| `variant_inactive` | 품목을 활성화한다 |
| `no_active_version` | publish 한다 |
| `product_deleted` | 다른 상품으로 재매핑한다 |
| `no_embedded_ids` | Core 를 통해 상품을 다시 만든다 |
| `no_lookup_key` | 채널 데이터를 확인한다 |
| `unknown` | 판정 불가 (구 Core 폴백·옛 행) |

전부 **Core 카탈로그 상태**에 대한 말이고 채널 특성이 아니다 — 채널이 열 개가 돼도 이 표는 안 늘어난다. CONTEXT.md 의 "격리 큐는 채널 능력과 무관하게 하나다"가 유지된다.

## ⚠️ 리뷰 때 봐 주면 좋을 것 — 리뷰가 잡은 퇴행

태스크별 리뷰 7회가 전부 놓치고 **브랜치 전체 리뷰가 잡은** 버그가 하나 있었다.

폴백은 "Core 를 롤백하면 `/resolve` 가 404 니까 `/lookup` 으로 돌아간다"는 전제였다. 그런데 **옛 Core 는 404 를 주지 않는다.** `/resolve` 라우트가 없으므로 그 요청은 `@Get(':id')` 에 `id="resolve"` 로 매칭되는데, 그 핸들러는 `@Public()` 이 아니고 `JwtAuthGuard` 가 전역(`app.module.ts:56`)이라 **401** 이 난다. 404 만 보는 폴백은 안 걸리고 throw → `Promise.all` 거부 → **그 채널 폴링이 통째로 멈춘다.** 이 브랜치 이전엔 `/lookup` 을 직접 불러 정상 동작했으므로 명백한 퇴행이었다.

401 을 폴백 트리거에 넣어 고쳤다. 401 이 안전한 이유: 새 `/resolve` 는 `@Public()` 이라 **새 Core 는 이 경로에 401 을 낼 수 없다** — 401 은 곧 "옛 Core" 를 뜻한다. 비-401/404(500·네트워크 오류)는 여전히 그대로 던진다.

## 검증

- `npm run type-check` — 0
- `npx jest --maxWorkers=2` — **430 suite 통과, 실패 0** (3,594 tests)
- `npm run test:core:integration:local -- channel-listing` — 실 Postgres **64 통과**
- channel-adapter 실 Postgres — 4 통과

전 태스크 TDD. RED 를 먼저 확인하고 구현했다. 리뷰에서 **테스트 자체의 무력함**이 세 번 잡혔고 전부 고쳤다:

1. "404 아닌 오류는 삼키지 않는다" 테스트가 `rejects.toBeDefined()` 만 봐서, 판별이 망가져 모든 오류가 폴백을 타도 통과했다 (폴백 대상에도 재던지기 가드가 있어서) → 호출이 **1회**임을 증명하도록
2. `affectedLines` 를 어설션하는 스펙이 **아예 없었다** — `lineId`↔`cause` 를 뒤바꿔도 `satisfies` 가 구조적 타이핑이라 못 잡는다 → 두 필드를 concrete 값으로 고정 + non-default 사유로 하드코딩까지 검출
3. `versionDeletedAt` 술어를 지워도 전 테스트가 통과했다 → 단위·통합 양쪽에 케이스 추가

## ⚠️ 배포

```
1) channel-adapter migrate   ← additive nullable 컬럼 (expand phase: migrate → deploy)
2) Core deploy               ← /channel-listings/resolve 신설
3) channel-adapter deploy    ← /resolve 사용 + 컬럼 기록
```

2·3 이 뒤집혀도 401/404 폴백이 받는다. **1 은 3 보다 반드시 앞.**

**라이브 영향 없음** — 네이버·쿠팡 `channel_variant_listings` 가 0행이고 Medusa 는 `lineIdentity: 'embedded'` 라 이 조회를 타지 않는다. 실효는 #643(네이버 개통) 시점.

## 알려진 한계 (의도)

- **판매채널 행 자체가 없으면** `listing_not_found` 로 보고된다. 실제 조치는 "채널을 먼저 만든다"라 미묘하게 다르지만, `site` 어휘가 4종으로 닫혀 있고 채널 생성이 리스팅 생성의 선행이라 실무상 같은 흐름이다
- **다중 버전 링크**(bulk import phantom masterId 이상 상태)에서는 `product_deleted` ↔ `no_active_version` 경계에서 보고 사유가 정렬 순서에 좌우된다. 조회와 같은 정렬을 쓰는 이유는 다르게 고르면 조회가 후보로도 안 본 행을 설명하게 되기 때문이다. 코드 주석에 명시했다
- **옛 행 백필 없음** — `affected_lines = null` 은 "판정 불가"로 읽힌다. 사후에 사유를 만들어내는 것보다 정직하다
- `docs/api-authz-audit-2026-08.md` 에 `/resolve` 를 기재하려 했으나 그 문서에 라우트 레지스트리 구조가 없었다(`/lookup` 도 미등재). 구조를 새로 만들지 않고 넘어갔다

## 범위 밖 (후속)

auto-replay 정책 · 사유별 알림 · `/lookup` 삭제 · 폴백 제거 · jsonb GIN 인덱스 · 격리 큐 화면(#640).

## 설계 문서

- 스펙: `docs/superpowers/specs/2026-08-19-listing-resolution-cause-design.md`
- 계획: `docs/superpowers/plans/2026-08-19-listing-resolution-cause.md`

https://claude.ai/code/session_01XqTYCx48kkXkKVuvBhHRWD