### PR TITLE
fix(user-service): 국세청 조회 실패 건을 자동 재검증한다

### DIFF
--- a/apps/user-service/src/api/business-licenses/business-licenses.nts-retry.spec.ts
+++ b/apps/user-service/src/api/business-licenses/business-licenses.nts-retry.spec.ts
@@ -12,18 +12,22 @@ function makeService(post: jest.Mock) {
     {} as never,
     { post } as unknown as HttpService,
     { get: () => 'test-key' } as never,
+    { publishEvent: jest.fn() } as never,
   );
 }
 
-function http5xx(status: number) {
-  return throwError(() => new AxiosError('boom', undefined, undefined, undefined, { status } as never));
+function http5xx(status: number, data?: unknown) {
+  return throwError(() => new AxiosError('boom', undefined, undefined, undefined, { status, data } as never));
 }
 
 const okStatus = { status_code: 'OK', data: [{ b_no: '1234567890', b_stt: '계속사업자', b_stt_cd: '01' }] };
 
 describe('NTS 호출 재시도', () => {
   it('5xx 뒤 성공하면 결과를 돌려준다', async () => {
-    const post = jest.fn().mockReturnValueOnce(http5xx(503)).mockReturnValueOnce(of({ data: okStatus }));
+    const post = jest
+      .fn()
+      .mockReturnValueOnce(http5xx(503))
+      .mockReturnValueOnce(of({ data: okStatus }));
 
     const result = await makeService(post).fetchBusinessLicense({ businessNumber: '1234567890' });
 
@@ -47,5 +51,89 @@ describe('NTS 호출 재시도', () => {
 
     expect(post).toHaveBeenCalledTimes(1);
     expect(result.result).toBe('lookup_failed');
+  });
+});
+
+describe('진위확인 입력값 보존', () => {
+  it('조회가 실패해도 입력값을 남긴다 — 이게 없으면 개업일자가 유실돼 재검증이 불가능하다', async () => {
+    const post = jest.fn().mockReturnValue(http5xx(503));
+
+    const result = await makeService(post)['verifyWithNts']('1234567890', '홍길동', '20200101');
+
+    expect(result.status).toBe('lookup_failed');
+    expect(result.requested).toEqual({
+      businessNumber: '1234567890',
+      representativeName: '홍길동',
+      startDate: '20200101',
+    });
+  });
+});
+
+describe('조회 실패 건 재검증', () => {
+  const okValidate = { status_code: 'OK', data: [{ valid: '01', status: { b_stt_cd: '01' } }] };
+
+  function makeDb(rows: unknown[]) {
+    const updates: Record<string, unknown>[] = [];
+    const db = {
+      select: () => ({ from: () => ({ innerJoin: () => ({ where: () => Promise.resolve(rows) }) }) }),
+      update: () => ({
+        set: (values: Record<string, unknown>) => ({
+          where: () => Promise.resolve(updates.push(values)),
+        }),
+      }),
+    };
+    return { dbService: { db } as never, updates };
+  }
+
+  function row(id: string, requested?: Record<string, string>) {
+    return { id, userId: `user-${id}`, email: 'a@b.c', username: '홍길동', metadata: { ntsValidate: { requested } } };
+  }
+
+  it('입력값 없는 건은 건너뛰고, 여전히 실패하면 두지 않으며, 통과하면 승인하고 이벤트를 쏜다', async () => {
+    const post = jest
+      .fn()
+      .mockReturnValueOnce(http5xx(503))
+      .mockReturnValueOnce(http5xx(503))
+      .mockReturnValueOnce(http5xx(503))
+      .mockReturnValueOnce(of({ data: okValidate }));
+    const publishEvent = jest.fn<void, [{ aggregateId: string }]>();
+    const { dbService, updates } = makeDb([
+      row('no-input'),
+      row('still-down', { businessNumber: '1234567890', representativeName: '김', startDate: '20200101' }),
+      row('recovered', { businessNumber: '1234567890', representativeName: '박', startDate: '20200101' }),
+    ]);
+
+    const service = new BusinessLicensesService(
+      dbService,
+      { post } as unknown as HttpService,
+      { get: () => 'test-key' } as never,
+      { publishEvent } as never,
+    );
+    await service.revalidateFailedLookups();
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0].status).toBe('approved');
+    expect(publishEvent).toHaveBeenCalledTimes(1);
+    expect(publishEvent.mock.calls[0][0].aggregateId).toBe('user-recovered');
+  });
+});
+
+describe('실패 응답 흔적 보관', () => {
+  it('5xx 의 상태코드와 본문을 남긴다 — 라이브 한정 5xx 를 사후에 볼 유일한 재료다', async () => {
+    const post = jest.fn().mockReturnValue(http5xx(503, { code: 'SERVICE_UNAVAILABLE' }));
+
+    const result = await makeService(post).fetchBusinessLicense({ businessNumber: '1234567890' });
+
+    expect(result.errorStatus).toBe(503);
+    expect(result.errorBody).toBe('{"code":"SERVICE_UNAVAILABLE"}');
+  });
+
+  it('본문이 길면 잘라서 담는다', async () => {
+    const post = jest.fn().mockReturnValue(http5xx(504, 'x'.repeat(5000)));
+
+    const result = await makeService(post).fetchBusinessLicense({ businessNumber: '1234567890' });
+
+    expect(result.errorBody).toHaveLength(1001);
+    expect(result.errorBody?.endsWith('…')).toBe(true);
   });
 });

--- a/apps/user-service/src/api/business-licenses/business-licenses.service.ts
+++ b/apps/user-service/src/api/business-licenses/business-licenses.service.ts
@@ -1,12 +1,16 @@
 import { DbService, InjectDb } from '@app/db';
+import { InjectPublisher, PublisherFor } from '@app/events';
 import { HttpService } from '@nestjs/axios';
-import { BadRequestException, HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, HttpStatus, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
 import { AxiosError } from 'axios';
 import { ConfigService } from '@nestjs/config';
-import { and, eq } from 'drizzle-orm';
+import { USER_STREAM } from '@packages/event-contracts';
+import { and, eq, gte, isNull, sql } from 'drizzle-orm';
 import { firstValueFrom } from 'rxjs';
-import { BusinessLicense, businessLicenses, type UserServiceSchema } from '../../../database/drizzle/schema';
+import { BusinessLicense, businessLicenses, users, type UserServiceSchema } from '../../../database/drizzle/schema';
 import {
+  BusinessMetadata,
   CreateBusinessLicenseDto,
   FetchBusinessLicenseDto,
   NtsLookupResult,
@@ -27,6 +31,12 @@ const NTS_VALIDATE_URL = 'https://api.odcloud.kr/api/nts-businessman/v1/validate
 const NTS_MAX_ATTEMPTS = 3;
 const NTS_TIMEOUT_MS = 10_000;
 
+// 재검증 대상 기간. 이보다 오래 묵은 건은 장애가 아니라 다른 사유일 가능성이 커 사람이 본다.
+const REVALIDATE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+// 에러 본문 보관 한도. 5xx 는 JSON 대신 게이트웨이 HTML 이 통째로 오기도 한다.
+const ERROR_BODY_MAX_CHARS = 1000;
+
 /**
  * 사업자등록번호 가운데 2자리가 법인 구분자다 (81~88: 영리/비영리 법인).
  *
@@ -36,6 +46,34 @@ const NTS_TIMEOUT_MS = 10_000;
 function isCorporateBusinessNumber(businessNumber: string): boolean {
   const middle = Number(businessNumber.slice(3, 5));
   return middle >= 81 && middle <= 88;
+}
+
+/**
+ * 실패한 국세청 호출에서 사후 분석에 쓸 흔적을 뽑는다.
+ *
+ * 이 호출은 예외를 위로 던지지 않고 metadata 로 흡수되므로 앱 로그에 아무것도 남지 않는다 —
+ * 여기서 담는 값이 곧 로그다. 상태코드만 남기던 시절엔 "라이브에서만 5xx" 라는 사실 외에
+ * 더 팔 재료가 없었다.
+ */
+function describeNtsFailure(error: unknown): { error: string; errorStatus?: number; errorBody?: string } {
+  const response = (error as AxiosError<unknown>).response;
+
+  return {
+    error: error instanceof Error ? error.message : 'request_failed',
+    errorStatus: response?.status,
+    errorBody: stringifyErrorBody(response?.data),
+  };
+}
+
+function stringifyErrorBody(body: unknown): string | undefined {
+  if (body === undefined || body === null) return undefined;
+
+  try {
+    const text = typeof body === 'string' ? body : JSON.stringify(body);
+    return text.length > ERROR_BODY_MAX_CHARS ? `${text.slice(0, ERROR_BODY_MAX_CHARS)}…` : text;
+  } catch {
+    return undefined;
+  }
 }
 
 interface NtsStatusRow {
@@ -66,12 +104,78 @@ interface NtsValidateResponse {
 
 @Injectable()
 export class BusinessLicensesService {
+  private readonly logger = new Logger(BusinessLicensesService.name);
+
   constructor(
     @InjectDb()
     private readonly dbService: DbService<UserServiceSchema>,
     private readonly httpService: HttpService,
     private readonly configService: ConfigService,
+    @InjectPublisher(USER_STREAM)
+    private readonly eventPublisher: PublisherFor<typeof USER_STREAM>,
   ) {}
+
+  /**
+   * 국세청 조회 실패(`lookup_failed`)로 심사중에 갇힌 신청을 다시 확인한다.
+   *
+   * odcloud 5xx 는 요청 단위로 랜덤이라 즉시 3회 재시도로는 못 뚫는 구간이 있다. 그 구간에
+   * 걸린 정상 사업자가 사람 손을 기다리며 쌓이는 걸 막는 게 목적이다. 판정 기준은 신규 등록과
+   * 같고(`deriveStatus`), 여전히 조회가 안 되면 손대지 않고 다음 사이클로 넘긴다.
+   */
+  @Cron(CronExpression.EVERY_30_MINUTES)
+  async revalidateFailedLookups(): Promise<void> {
+    const since = new Date(Date.now() - REVALIDATE_WINDOW_MS);
+
+    const rows = await this.dbService.db
+      .select({
+        id: businessLicenses.id,
+        userId: businessLicenses.userId,
+        metadata: businessLicenses.metadata,
+        email: users.email,
+        username: users.username,
+      })
+      .from(businessLicenses)
+      .innerJoin(users, eq(users.id, businessLicenses.userId))
+      .where(
+        and(
+          eq(businessLicenses.status, 'under_review'),
+          isNull(businessLicenses.fileUrl),
+          isNull(businessLicenses.deletedAt),
+          gte(businessLicenses.createdAt, since),
+          sql`${businessLicenses.metadata}->'ntsValidate'->>'status' = 'lookup_failed'`,
+        ),
+      );
+
+    for (const row of rows) {
+      // jsonb 컬럼이라 타입이 unknown 으로 내려온다. 우리가 쓴 모양이므로 여기서 좁힌다.
+      const requested = (row.metadata as BusinessMetadata | null)?.ntsValidate?.requested;
+      // 입력값을 남기기 전에 접수된 건 — 개업일자가 없어 재검증이 불가능하다. 사람이 봐야 한다.
+      if (!requested) continue;
+
+      const verification = await this.verifyWithNts(
+        requested.businessNumber,
+        requested.representativeName,
+        requested.startDate,
+      );
+      if (verification.status === 'lookup_failed') continue;
+
+      const status = this.deriveStatus(verification);
+      await this.dbService.db
+        .update(businessLicenses)
+        .set({ status, metadata: { ntsValidate: verification }, updatedAt: new Date() })
+        .where(eq(businessLicenses.id, row.id));
+
+      this.logger.log(`사업자 재검증: ${row.id} → ${status}`);
+
+      if (status === 'approved') {
+        await this.eventPublisher.publishEvent({
+          eventType: 'BusinessLicenseApproved',
+          aggregateId: row.userId,
+          payload: { userId: row.userId, email: row.email, name: row.username },
+        });
+      }
+    }
+  }
 
   async createBusinessLicense(userId: string, data: CreateBusinessLicenseDto): Promise<void> {
     try {
@@ -109,11 +213,7 @@ export class BusinessLicensesService {
 
       this.assertNotCorporate(data.businessNumber!);
 
-      const verification = await this.verifyWithNts(
-        data.businessNumber!,
-        data.representativeName!,
-        data.startDate!,
-      );
+      const verification = await this.verifyWithNts(data.businessNumber!, data.representativeName!, data.startDate!);
 
       await this.dbService.db.insert(businessLicenses).values({
         userId,
@@ -195,11 +295,7 @@ export class BusinessLicensesService {
 
       return { result: this.mapBusinessStatus(row.b_stt_cd), checkedAt, raw: row };
     } catch (error) {
-      return {
-        result: 'lookup_failed',
-        checkedAt,
-        error: error instanceof Error ? error.message : 'request_failed',
-      };
+      return { result: 'lookup_failed', checkedAt, ...describeNtsFailure(error) };
     }
   }
 
@@ -216,9 +312,16 @@ export class BusinessLicensesService {
         );
         return data;
       } catch (error) {
-        const status = (error as AxiosError).response?.status;
-        const retriable = status === undefined || status >= 500;
-        if (!retriable || attempt >= NTS_MAX_ATTEMPTS) throw error;
+        const { errorStatus, errorBody } = describeNtsFailure(error);
+        const retriable = errorStatus === undefined || errorStatus >= 500;
+        const giveUp = !retriable || attempt >= NTS_MAX_ATTEMPTS;
+
+        this.logger.warn(
+          `국세청 호출 실패 ${url} attempt=${attempt}/${NTS_MAX_ATTEMPTS} status=${errorStatus ?? 'none'} ` +
+            `giveUp=${giveUp} body=${errorBody ?? 'none'}`,
+        );
+
+        if (giveUp) throw error;
         await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
       }
     }
@@ -246,8 +349,7 @@ export class BusinessLicensesService {
     if (!isCorporateBusinessNumber(businessNumber)) return;
 
     throw new BusinessLicenseException({
-      message:
-        '법인사업자는 자동 인증을 지원하지 않습니다. 사업자등록증·명함 등 증빙 서류를 첨부해 등록해주세요.',
+      message: '법인사업자는 자동 인증을 지원하지 않습니다. 사업자등록증·명함 등 증빙 서류를 첨부해 등록해주세요.',
       errorCode: 'BUSINESS_LICENSE_CORPORATE_REQUIRES_FILE',
       httpStatus: HttpStatus.BAD_REQUEST,
     });
@@ -261,6 +363,15 @@ export class BusinessLicensesService {
    * 승인하지 않고 under_review 로 보내 사람이 보게 한다 (실패를 통과로 취급하지 않는다).
    */
   private async verifyWithNts(
+    businessNumber: string,
+    representativeName: string,
+    startDate: string,
+  ): Promise<NtsValidateResult> {
+    const result = await this.runNtsValidate(businessNumber, representativeName, startDate);
+    return { ...result, requested: { businessNumber, representativeName, startDate } };
+  }
+
+  private async runNtsValidate(
     businessNumber: string,
     representativeName: string,
     startDate: string,
@@ -304,12 +415,7 @@ export class BusinessLicensesService {
 
       return { valid: true, status, checkedAt, raw: row };
     } catch (error) {
-      return {
-        valid: false,
-        status: 'lookup_failed',
-        checkedAt,
-        error: error instanceof Error ? error.message : 'request_failed',
-      };
+      return { valid: false, status: 'lookup_failed', checkedAt, ...describeNtsFailure(error) };
     }
   }
 

--- a/apps/user-service/src/api/business-licenses/dto/business-license.dto.ts
+++ b/apps/user-service/src/api/business-licenses/dto/business-license.dto.ts
@@ -12,6 +12,10 @@ export interface NtsLookupResult {
   checkedAt: string;
   raw?: Record<string, unknown>;
   error?: string;
+  /** 실패 응답의 HTTP 상태. 응답 자체가 없으면(타임아웃 등) 비어 있다 */
+  errorStatus?: number;
+  /** 실패 응답의 본문. 라이브에서만 나는 5xx 의 정체를 사후에 볼 수 있는 유일한 흔적이다 */
+  errorBody?: string;
 }
 
 /**
@@ -24,6 +28,8 @@ export interface NtsLookupResult {
 export interface NtsValidateResult {
   /** 세 값의 조합이 국세청 기록과 일치하는가 */
   valid: boolean;
+  /** 신청자가 낸 입력값. 조회 실패로 raw 가 없을 때도 재검증할 수 있도록 우리가 직접 남긴다 */
+  requested?: { businessNumber: string; representativeName: string; startDate: string };
   /** 일치하지 않을 때 국세청이 준 사유 */
   invalidReason?: string;
   /** 진위확인과 함께 돌아오는 납세자 상태 (계속/휴업/폐업 등) */
@@ -31,6 +37,8 @@ export interface NtsValidateResult {
   checkedAt: string;
   raw?: Record<string, unknown>;
   error?: string;
+  errorStatus?: number;
+  errorBody?: string;
 }
 
 export interface BusinessMetadata {

--- a/package.json
+++ b/package.json
@@ -347,7 +347,7 @@
       "^@app/db(|/.*)$": "<rootDir>/libs/db/src/$1",
       "^@app/events(|/.*)$": "<rootDir>/libs/events/src/$1",
       "^@app/shared(|/.*)$": "<rootDir>/libs/shared/src/$1",
-      "^@packages/event-contracts/(.*)$": "<rootDir>/packages/event-contracts/$1",
+      "^@packages/event-contracts(|/.*)$": "<rootDir>/packages/event-contracts$1",
       "^@packages/domain-types(|/.*)$": "<rootDir>/packages/domain-types$1",
       "^@packages/product-description(|/.*)$": "<rootDir>/packages/product-description$1",
       "^@packages/web-observability(|/.*)$": "<rootDir>/packages/web-observability$1",


### PR DESCRIPTION
odcloud 5xx 는 요청 단위로 랜덤이라 즉시 3회 재시도로 못 뚫는 구간이 있고,
거기 걸린 정상 사업자가 `lookup_failed` 로 심사중에 갇혀 사람 손을 기다리며 쌓였다. 30분 크론이 최근 7일치 실패 건을 다시 확인해 통과하면 승인하고
BusinessLicenseApproved 를 발행한다. 여전히 안 되면 손대지 않고 넘긴다.

재검증에 필요한 개업일자가 실패 응답엔 없으므로 신청자 입력값을
`ntsValidate.requested` 로 직접 남긴다. 입력값 없이 접수된 옛 건은
건너뛰고 사람이 본다.

실패 흔적도 같이 남긴다 — 이 호출은 예외를 metadata 로 흡수해 앱 로그에
아무것도 안 남아서, "라이브에서만 5xx" 외에 팔 재료가 없었다.
상태코드·본문(1000자 컷)을 metadata 와 warn 로그 양쪽에 담는다.

jest moduleNameMapper 의 `@packages/event-contracts` 패턴이 서브경로만 받아 bare import 를 놓치던 것도 같이 고친다.