### PR TITLE
feat(channel-adapter,core,admin-web): 네이버 주문 수집을 개통하고 격리 큐 운영 화면을 붙인다 (#643, #640)

### DIFF
--- a/apps/admin-web/src/components/layout/mobile-nav.tsx
+++ b/apps/admin-web/src/components/layout/mobile-nav.tsx
@@ -20,6 +20,7 @@ import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils/ui';
 import { mainMenus, type MainMenu, type MenuItem } from '@/lib/utils/menu';
+import { QuarantineMenuBadge } from './quarantine-menu-badge';
 
 const iconMap: Record<string, React.ElementType> = {
   Users,
@@ -61,19 +62,23 @@ function NavSection({
         onClick={() => item.path && !item.isComingSoon && onNavigate(item.path)}
         disabled={!item.path || item.isComingSoon}
         className={cn(
-          'w-full text-left px-3 py-2 text-sm rounded-md transition-colors',
+          'w-full flex items-center gap-1.5 text-left px-3 py-2 text-sm rounded-md transition-colors',
           depth === 2 && 'pl-6',
           depth === 3 && 'pl-9',
           isActive
             ? 'bg-blue-50 text-blue-600 font-medium'
             : 'text-gray-700 hover:bg-gray-100',
-          (!item.path || item.isComingSoon) && 'opacity-40 cursor-not-allowed hover:bg-transparent',
+          (!item.path || item.isComingSoon) &&
+            'opacity-40 cursor-not-allowed hover:bg-transparent'
         )}
       >
-        {item.title}
-        {item.isComingSoon && (
-          <span className="ml-1.5 text-xs text-gray-400">(준비중)</span>
-        )}
+        <span>
+          {item.title}
+          {item.isComingSoon && (
+            <span className="ml-1.5 text-xs text-gray-400">(준비중)</span>
+          )}
+        </span>
+        {item.hasQuarantineBadge && <QuarantineMenuBadge />}
       </button>
     );
   }
@@ -86,14 +91,14 @@ function NavSection({
           'w-full flex items-center justify-between px-3 py-2 text-sm rounded-md transition-colors',
           depth === 2 && 'pl-6',
           depth === 3 && 'pl-9',
-          'text-gray-500 font-medium hover:bg-gray-50',
+          'text-gray-500 font-medium hover:bg-gray-50'
         )}
       >
         <span>{item.title}</span>
         <ChevronDown
           className={cn(
             'w-3.5 h-3.5 transition-transform shrink-0',
-            expanded && 'rotate-180',
+            expanded && 'rotate-180'
           )}
         />
       </button>
@@ -134,13 +139,18 @@ function TopMenuSection({
         onClick={() => setExpanded((v) => !v)}
         className={cn(
           'w-full flex items-center gap-3 px-4 py-3 text-sm font-semibold transition-colors',
-          isActive ? 'text-blue-600 bg-blue-50/60' : 'text-gray-800 hover:bg-gray-50',
+          isActive
+            ? 'text-blue-600 bg-blue-50/60'
+            : 'text-gray-800 hover:bg-gray-50'
         )}
       >
         {Icon && <Icon className="w-4 h-4 shrink-0" />}
         <span className="flex-1 text-left">{menu.title}</span>
         <ChevronDown
-          className={cn('w-4 h-4 transition-transform shrink-0', expanded && 'rotate-180')}
+          className={cn(
+            'w-4 h-4 transition-transform shrink-0',
+            expanded && 'rotate-180'
+          )}
         />
       </button>
       {expanded && (
@@ -160,7 +170,11 @@ function TopMenuSection({
   );
 }
 
-export function MobileNav({ activeMenu, activeItem, onMenuChange }: MobileNavProps) {
+export function MobileNav({
+  activeMenu,
+  activeItem,
+  onMenuChange,
+}: MobileNavProps) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
 
@@ -186,7 +200,9 @@ export function MobileNav({ activeMenu, activeItem, onMenuChange }: MobileNavPro
         <SheetContent side="left" className="w-72 p-0 flex flex-col">
           <SheetTitle className="sr-only">네비게이션 메뉴</SheetTitle>
           <div className="px-4 py-4 border-b border-gray-100">
-            <span className="text-lg font-bold text-blue-600 tracking-tight">LCNINE</span>
+            <span className="text-lg font-bold text-blue-600 tracking-tight">
+              LCNINE
+            </span>
           </div>
           <nav className="flex-1 overflow-y-auto">
             {mainMenus.map((menu) => (

--- a/apps/admin-web/src/components/layout/quarantine-menu-badge.tsx
+++ b/apps/admin-web/src/components/layout/quarantine-menu-badge.tsx
@@ -8,10 +8,14 @@
 
 import { Badge } from '@/components/ui/badge';
 import { useQuarantinedFailures } from '@/lib/services/channel/queries';
+import { formatQuarantineCount } from '@/lib/api/domains/channel/order-collection-failures.client';
 
 export function QuarantineMenuBadge() {
   const { data, isLoading } = useQuarantinedFailures();
   const count = data?.count ?? 0;
+  // 한 판의 상한에 닿았으면 "200" 이 아니라 "200+" 로 적는다 — 배지가 상한을 실제 건수처럼
+  // 보여주면 운영자가 큐를 다 봤다고 오해한다.
+  const label = data ? formatQuarantineCount(data) : String(count);
 
   if (isLoading || count === 0) return null;
 
@@ -19,9 +23,9 @@ export function QuarantineMenuBadge() {
     <Badge
       variant="destructive"
       className="ml-auto text-xs group-data-[collapsible=icon]:hidden"
-      aria-label={`격리 ${count}건`}
+      aria-label={`격리 ${label}건`}
     >
-      {count}
+      {label}
     </Badge>
   );
 }

--- a/apps/admin-web/src/components/layout/quarantine-menu-badge.tsx
+++ b/apps/admin-web/src/components/layout/quarantine-menu-badge.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+// src/components/layout/quarantine-menu-badge.tsx
+// 사이드바 "채널 노출 관리" 메뉴 항목 옆에 격리 큐 건수를 보여준다. `menu.ts` 의
+// `hasQuarantineBadge` 플래그가 붙은 항목에서만 마운트된다 — 모든 메뉴 항목마다 훅을
+// 호출하지 않기 위함이다. count 가 0 이거나 로딩 중이면 아무것도 그리지 않는다: 격리가
+// 없을 때도 배지가 보이면 운영자가 오해한다.
+
+import { Badge } from '@/components/ui/badge';
+import { useQuarantinedFailures } from '@/lib/services/channel/queries';
+
+export function QuarantineMenuBadge() {
+  const { data, isLoading } = useQuarantinedFailures();
+  const count = data?.count ?? 0;
+
+  if (isLoading || count === 0) return null;
+
+  return (
+    <Badge
+      variant="destructive"
+      className="ml-auto text-xs group-data-[collapsible=icon]:hidden"
+      aria-label={`격리 ${count}건`}
+    >
+      {count}
+    </Badge>
+  );
+}

--- a/apps/admin-web/src/components/layout/sidebar-menu-item.tsx
+++ b/apps/admin-web/src/components/layout/sidebar-menu-item.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { ChevronRight, Folder, FileText } from 'lucide-react';
 import { type MenuItem } from '@/lib/utils/menu';
 import { Badge } from '@/components/ui/badge';
+import { QuarantineMenuBadge } from './quarantine-menu-badge';
 import { IconComponent } from '@/lib/utils/icons';
 import {
   Collapsible,
@@ -76,7 +77,10 @@ export function SidebarMenuItemRecursive({
                 </span>
                 <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90 group-data-[collapsible=icon]:hidden" />
                 {isComingSoon && (
-                  <Badge variant="secondary" className="ml-auto text-xs group-data-[collapsible=icon]:hidden">
+                  <Badge
+                    variant="secondary"
+                    className="ml-auto text-xs group-data-[collapsible=icon]:hidden"
+                  >
                     준비중
                   </Badge>
                 )}
@@ -119,10 +123,14 @@ export function SidebarMenuItemRecursive({
                 {item.title}
               </span>
               {isComingSoon && (
-                <Badge variant="secondary" className="ml-auto text-xs group-data-[collapsible=icon]:hidden">
+                <Badge
+                  variant="secondary"
+                  className="ml-auto text-xs group-data-[collapsible=icon]:hidden"
+                >
                   준비중
                 </Badge>
               )}
+              {item.hasQuarantineBadge && <QuarantineMenuBadge />}
             </Link>
           </SidebarMenuButton>
         ) : (
@@ -138,10 +146,14 @@ export function SidebarMenuItemRecursive({
               {item.title}
             </span>
             {isComingSoon && (
-              <Badge variant="secondary" className="ml-auto text-xs group-data-[collapsible=icon]:hidden">
+              <Badge
+                variant="secondary"
+                className="ml-auto text-xs group-data-[collapsible=icon]:hidden"
+              >
                 준비중
               </Badge>
             )}
+            {item.hasQuarantineBadge && <QuarantineMenuBadge />}
           </SidebarMenuButton>
         )}
       </SidebarMenuItem>

--- a/apps/admin-web/src/features/mall/channel-listings/components/channel-listing-form-dialog/index.tsx
+++ b/apps/admin-web/src/features/mall/channel-listings/components/channel-listing-form-dialog/index.tsx
@@ -12,26 +12,51 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
-import { useCreateChannelListing, useUpdateChannelListing } from '@/lib/services/products';
-import type { ChannelListingDto, CreateChannelListingDto } from '@/lib/types/dto/products';
+import {
+  useCreateChannelListing,
+  useUpdateChannelListing,
+} from '@/lib/services/products';
+import { siteLabel } from '@/lib/api/domains/sales-channel/vocabulary';
+import type {
+  ChannelListingDto,
+  CreateChannelListingDto,
+} from '@/lib/types/dto/products';
 
 type Props = {
-  variantId: string;
+  /**
+   * 검색으로 이미 확정된 variant 에서 여는 경우 필수로 넘어온다(기존 channel-listings 화면).
+   * 격리 큐 화면처럼 variant 를 아직 모르는 채로 여는 경우 생략하면, 폼이 직접 입력 필드를 보여준다.
+   */
+  variantId?: string;
   listing?: ChannelListingDto | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** 격리 큐의 "매핑 생성" 프리필. `channelItemId` 는 채워주지만 `salesChannelId`(UUID)는 대신 채울 수 없다 — 안내 문구만 보탠다. */
+  defaultChannelCode?: string;
+  defaultChannelItemId?: string;
+  /** 신규 등록이 성공했을 때만 호출된다(수정은 호출 안 함) — 격리 큐가 이어서 재처리를 트리거하는 데 쓴다. */
+  onCreated?: () => void;
 };
 
-export function ChannelListingFormDialog({ variantId, listing, open, onOpenChange }: Props) {
+export function ChannelListingFormDialog({
+  variantId,
+  listing,
+  open,
+  onOpenChange,
+  defaultChannelCode,
+  defaultChannelItemId,
+  onCreated,
+}: Props) {
   const createMutation = useCreateChannelListing();
   const updateMutation = useUpdateChannelListing();
 
   const isEdit = !!listing;
+  const variantIdKnown = !!variantId;
 
   const [form, setForm] = useState<CreateChannelListingDto>({
-    variantId,
+    variantId: variantId ?? '',
     salesChannelId: '',
-    channelItemId: '',
+    channelItemId: defaultChannelItemId ?? '',
     channelItemName: '',
     channelOptionName: '',
     channelPrice: undefined,
@@ -41,7 +66,7 @@ export function ChannelListingFormDialog({ variantId, listing, open, onOpenChang
   useEffect(() => {
     if (listing) {
       setForm({
-        variantId,
+        variantId: variantId ?? '',
         salesChannelId: listing.salesChannelId,
         channelItemId: listing.channelItemId,
         channelItemName: listing.channelItemName ?? '',
@@ -49,13 +74,29 @@ export function ChannelListingFormDialog({ variantId, listing, open, onOpenChang
         channelPrice: listing.channelPrice ?? undefined,
         channelProductUrl: listing.channelProductUrl ?? '',
       });
+    } else {
+      setForm({
+        variantId: variantId ?? '',
+        salesChannelId: '',
+        channelItemId: defaultChannelItemId ?? '',
+        channelItemName: '',
+        channelOptionName: '',
+        channelPrice: undefined,
+        channelProductUrl: '',
+      });
     }
-  }, [listing, variantId]);
+  }, [listing, variantId, defaultChannelItemId]);
 
-  const update = (key: keyof CreateChannelListingDto, value: string | number | undefined) =>
-    setForm((prev) => ({ ...prev, [key]: value }));
+  const update = (
+    key: keyof CreateChannelListingDto,
+    value: string | number | undefined
+  ) => setForm((prev) => ({ ...prev, [key]: value }));
 
   const handleSubmit = async () => {
+    if (!isEdit && !form.variantId.trim()) {
+      toast.error('Variant ID를 입력해주세요.');
+      return;
+    }
     if (!form.salesChannelId.trim()) {
       toast.error('판매 채널 ID를 입력해주세요.');
       return;
@@ -80,6 +121,7 @@ export function ChannelListingFormDialog({ variantId, listing, open, onOpenChang
       } else {
         await createMutation.mutateAsync(form);
         toast.success('채널 리스팅이 등록되었습니다.');
+        onCreated?.();
       }
       onOpenChange(false);
     } catch (e: any) {
@@ -98,13 +140,31 @@ export function ChannelListingFormDialog({ variantId, listing, open, onOpenChang
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>{isEdit ? '채널 리스팅 수정' : '채널 리스팅 등록'}</DialogTitle>
+          <DialogTitle>
+            {isEdit ? '채널 리스팅 수정' : '채널 리스팅 등록'}
+          </DialogTitle>
         </DialogHeader>
 
         <div className="space-y-3">
+          {!isEdit && !variantIdKnown && (
+            <div className="space-y-1">
+              <Label>Variant ID</Label>
+              <Input
+                placeholder="매핑할 판매상품 Variant UUID"
+                value={form.variantId}
+                onChange={(e) => update('variantId', e.target.value)}
+              />
+            </div>
+          )}
           {!isEdit && (
             <div className="space-y-1">
               <Label>판매 채널 ID</Label>
+              {defaultChannelCode && (
+                <p className="text-xs text-muted-foreground">
+                  채널: {siteLabel(defaultChannelCode)} ({defaultChannelCode}) —
+                  해당 판매채널의 UUID를 입력하세요.
+                </p>
+              )}
               <Input
                 placeholder="Sales Channel UUID"
                 value={form.salesChannelId}
@@ -143,7 +203,10 @@ export function ChannelListingFormDialog({ variantId, listing, open, onOpenChang
               placeholder="원 단위"
               value={form.channelPrice ?? ''}
               onChange={(e) =>
-                update('channelPrice', e.target.value ? Number(e.target.value) : undefined)
+                update(
+                  'channelPrice',
+                  e.target.value ? Number(e.target.value) : undefined
+                )
               }
             />
           </div>
@@ -158,7 +221,9 @@ export function ChannelListingFormDialog({ variantId, listing, open, onOpenChang
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>취소</Button>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            취소
+          </Button>
           <Button onClick={handleSubmit} disabled={isPending}>
             {isPending ? '저장 중…' : isEdit ? '수정' : '등록'}
           </Button>

--- a/apps/admin-web/src/features/mall/channel-listings/components/channel-listing-form-dialog/index.tsx
+++ b/apps/admin-web/src/features/mall/channel-listings/components/channel-listing-form-dialog/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -13,10 +13,14 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
 import {
+  useActiveChannels,
   useCreateChannelListing,
   useUpdateChannelListing,
 } from '@/lib/services/products';
-import { siteLabel } from '@/lib/api/domains/sales-channel/vocabulary';
+import {
+  resolveActiveChannelId,
+  channelResolutionMessage,
+} from './resolve-channel-id';
 import type {
   ChannelListingDto,
   CreateChannelListingDto,
@@ -49,9 +53,24 @@ export function ChannelListingFormDialog({
 }: Props) {
   const createMutation = useCreateChannelListing();
   const updateMutation = useUpdateChannelListing();
+  const activeChannelsQuery = useActiveChannels();
 
   const isEdit = !!listing;
   const variantIdKnown = !!variantId;
+
+  const channelResolution = resolveActiveChannelId(
+    defaultChannelCode,
+    activeChannelsQuery.data,
+    activeChannelsQuery.isLoading
+  );
+  const channelHint = channelResolutionMessage(
+    channelResolution,
+    defaultChannelCode
+  );
+  const resolvedSalesChannelId =
+    channelResolution.status === 'resolved'
+      ? channelResolution.salesChannelId
+      : null;
 
   const [form, setForm] = useState<CreateChannelListingDto>({
     variantId: variantId ?? '',
@@ -62,6 +81,9 @@ export function ChannelListingFormDialog({
     channelPrice: undefined,
     channelProductUrl: '',
   });
+
+  // salesChannelId 를 운영자가 직접 고쳤으면 뒤늦게 해석이 끝나도 덮어쓰지 않는다.
+  const salesChannelIdTouchedRef = useRef(false);
 
   useEffect(() => {
     if (listing) {
@@ -75,6 +97,7 @@ export function ChannelListingFormDialog({
         channelProductUrl: listing.channelProductUrl ?? '',
       });
     } else {
+      salesChannelIdTouchedRef.current = false;
       setForm({
         variantId: variantId ?? '',
         salesChannelId: '',
@@ -87,10 +110,20 @@ export function ChannelListingFormDialog({
     }
   }, [listing, variantId, defaultChannelItemId]);
 
+  // 채널 목록 조회가 폼이 이미 열린 뒤에 끝나는 경우(캐시 미스)를 위한 뒤늦은 프리필.
+  useEffect(() => {
+    if (isEdit || !resolvedSalesChannelId || salesChannelIdTouchedRef.current)
+      return;
+    setForm((prev) => ({ ...prev, salesChannelId: resolvedSalesChannelId }));
+  }, [isEdit, resolvedSalesChannelId]);
+
   const update = (
     key: keyof CreateChannelListingDto,
     value: string | number | undefined
-  ) => setForm((prev) => ({ ...prev, [key]: value }));
+  ) => {
+    if (key === 'salesChannelId') salesChannelIdTouchedRef.current = true;
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
 
   const handleSubmit = async () => {
     if (!isEdit && !form.variantId.trim()) {
@@ -159,10 +192,15 @@ export function ChannelListingFormDialog({
           {!isEdit && (
             <div className="space-y-1">
               <Label>판매 채널 ID</Label>
-              {defaultChannelCode && (
-                <p className="text-xs text-muted-foreground">
-                  채널: {siteLabel(defaultChannelCode)} ({defaultChannelCode}) —
-                  해당 판매채널의 UUID를 입력하세요.
+              {channelHint && (
+                <p
+                  className={
+                    channelResolution.status === 'unresolved'
+                      ? 'text-xs text-amber-600'
+                      : 'text-xs text-muted-foreground'
+                  }
+                >
+                  {channelHint}
                 </p>
               )}
               <Input

--- a/apps/admin-web/src/features/mall/channel-listings/components/channel-listing-form-dialog/resolve-channel-id.spec.ts
+++ b/apps/admin-web/src/features/mall/channel-listings/components/channel-listing-form-dialog/resolve-channel-id.spec.ts
@@ -1,0 +1,81 @@
+import {
+  resolveActiveChannelId,
+  channelResolutionMessage,
+} from './resolve-channel-id';
+import type { ChannelDto } from '@/lib/types/dto/products';
+
+const channel = (overrides: Partial<ChannelDto> = {}): ChannelDto => ({
+  id: 'channel-uuid-1',
+  type: 'MARKETPLACE',
+  site: 'naver',
+  name: '네이버 스마트스토어',
+  isActive: true,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
+
+describe('resolveActiveChannelId', () => {
+  it('code 가 없으면 해석할 것이 없다(일반 검색 플로우)', () => {
+    expect(resolveActiveChannelId(undefined, [channel()], false)).toEqual({
+      status: 'unresolved',
+    });
+  });
+
+  it('채널 목록이 아직 로딩 중이면 loading', () => {
+    expect(resolveActiveChannelId('naver', undefined, true)).toEqual({
+      status: 'loading',
+    });
+  });
+
+  it('site 가 일치하는 활성 채널을 찾으면 UUID 로 해석한다', () => {
+    expect(
+      resolveActiveChannelId('naver', [channel({ id: 'abc-123' })], false)
+    ).toEqual({
+      status: 'resolved',
+      salesChannelId: 'abc-123',
+    });
+  });
+
+  it('site 는 같지만 비활성이면 찾지 못한 것으로 취급한다', () => {
+    expect(
+      resolveActiveChannelId('naver', [channel({ isActive: false })], false)
+    ).toEqual({ status: 'unresolved' });
+  });
+
+  it('일치하는 site 자체가 없으면 unresolved', () => {
+    expect(
+      resolveActiveChannelId('coupang', [channel({ site: 'naver' })], false)
+    ).toEqual({
+      status: 'unresolved',
+    });
+  });
+});
+
+describe('channelResolutionMessage', () => {
+  it('code 가 없으면 아무 말도 하지 않는다', () => {
+    expect(
+      channelResolutionMessage({ status: 'unresolved' }, undefined)
+    ).toBeNull();
+  });
+
+  it('해석되면 자동으로 채워졌다고 말한다', () => {
+    const message = channelResolutionMessage(
+      { status: 'resolved', salesChannelId: 'abc-123' },
+      'naver'
+    );
+    expect(message).toContain('자동으로 채워졌습니다');
+  });
+
+  it('로딩 중이면 로딩 중이라고 말한다', () => {
+    expect(channelResolutionMessage({ status: 'loading' }, 'naver')).toContain(
+      '불러오는 중'
+    );
+  });
+
+  it('찾지 못하면 비활성/미등록 가능성과 수동 입력 안내를 말한다 (channel_inactive 와 같은 결)', () => {
+    const message = channelResolutionMessage({ status: 'unresolved' }, 'naver');
+    expect(message).toContain('찾지 못했습니다');
+    expect(message).toContain('직접');
+  });
+});

--- a/apps/admin-web/src/features/mall/channel-listings/components/channel-listing-form-dialog/resolve-channel-id.ts
+++ b/apps/admin-web/src/features/mall/channel-listings/components/channel-listing-form-dialog/resolve-channel-id.ts
@@ -1,0 +1,56 @@
+// src/features/mall/channel-listings/components/channel-listing-form-dialog/resolve-channel-id.ts
+//
+// 격리 큐가 아는 것은 채널 코드(`site`, 예: 'naver')뿐이고, 리스팅 생성 폼이 실제로 저장하는
+// 것은 판매채널 UUID(`salesChannelId`)다. `useActiveChannels()`(products 도메인, `/channels/active`)
+// 가 이미 두 값을 다 가진 `ChannelDto[]` 를 돌려주므로 그걸로 코드→UUID를 해석한다.
+//
+// 실패 갈래를 "로딩 중"과 "찾지 못함"으로 나누는 이유: 후자는 그 자체로 운영 신호다 —
+// 격리 사유 어휘(`ListingResolutionCause`)에 `channel_inactive` 가 있는 것과 같은 결이다.
+// 채널이 비활성이거나 아예 없는 상태를 조용히 빈 칸으로 넘기면 운영자가 "왜 안 채워지지"를
+// 스스로 조사해야 한다.
+
+import { siteLabel } from '@/lib/api/domains/sales-channel/vocabulary';
+import type { ChannelDto } from '@/lib/types/dto/products';
+
+export type ChannelResolution =
+  | { status: 'resolved'; salesChannelId: string }
+  | { status: 'loading' }
+  | { status: 'unresolved' };
+
+/**
+ * `code`(채널 사이트 코드)를 활성 판매채널 목록에서 찾아 UUID로 해석한다.
+ * `code` 가 없으면(격리 큐가 아닌 일반 검색 플로우) 애초에 해석할 것이 없으므로 `unresolved`.
+ */
+export function resolveActiveChannelId(
+  code: string | undefined,
+  channels: ChannelDto[] | undefined,
+  isLoadingChannels: boolean
+): ChannelResolution {
+  if (!code) return { status: 'unresolved' };
+  if (isLoadingChannels) return { status: 'loading' };
+
+  const match = (channels ?? []).find((c) => c.site === code && c.isActive);
+  return match
+    ? { status: 'resolved', salesChannelId: match.id }
+    : { status: 'unresolved' };
+}
+
+/**
+ * 판매채널 ID 입력칸 위에 보여줄 안내 문구. `code` 가 없으면(일반 검색 플로우) 아무 말도
+ * 하지 않는다 — 이 문구는 격리 큐에서 열렸을 때만 의미가 있다.
+ */
+export function channelResolutionMessage(
+  resolution: ChannelResolution,
+  code: string | undefined
+): string | null {
+  if (!code) return null;
+
+  switch (resolution.status) {
+    case 'resolved':
+      return `채널: ${siteLabel(code)} (${code}) — 자동으로 채워졌습니다.`;
+    case 'loading':
+      return '채널 목록을 불러오는 중입니다…';
+    case 'unresolved':
+      return `활성 상태인 '${siteLabel(code)}(${code})' 채널을 찾지 못했습니다 — 채널이 비활성이거나 아직 등록되지 않았을 수 있습니다. 직접 UUID를 입력하세요.`;
+  }
+}

--- a/apps/admin-web/src/features/mall/channel-listings/template/index.tsx
+++ b/apps/admin-web/src/features/mall/channel-listings/template/index.tsx
@@ -6,10 +6,15 @@ import { Header } from '@/components/admin-ui-experimental/common/header/header'
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils/ui';
 import { ChannelListingsTable } from '../components/channel-listings-table';
 import { ChannelListingFormDialog } from '../components/channel-listing-form-dialog';
+import { QuarantineTable } from '@/features/mall/quarantine/components/quarantine-table';
+
+type Tab = 'listings' | 'quarantine';
 
 export default function ChannelListingsTemplate() {
+  const [tab, setTab] = useState<Tab>('listings');
   const [variantId, setVariantId] = useState('');
   const [searchedVariantId, setSearchedVariantId] = useState('');
   const [createOpen, setCreateOpen] = useState(false);
@@ -25,44 +30,79 @@ export default function ChannelListingsTemplate() {
         subtitle="Variant와 판매 채널 간 매핑을 관리합니다. GET /lookup은 Channel Adapter 전용 경로입니다."
       />
 
-      <div className="px-6 py-4 space-y-3">
-        <div className="flex gap-2 items-end">
-          <div className="space-y-1 flex-1 max-w-md">
-            <Label>Variant ID</Label>
-            <Input
-              placeholder="Variant UUID로 검색"
-              value={variantId}
-              onChange={(e) => setVariantId(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') handleSearch();
-              }}
-            />
-          </div>
-          <Button onClick={handleSearch}>조회</Button>
-          {searchedVariantId && (
-            <Button onClick={() => setCreateOpen(true)} variant="outline">
-              리스팅 등록
-            </Button>
+      <nav className="flex gap-1 px-6 pt-4 border-b">
+        <button
+          type="button"
+          aria-pressed={tab === 'listings'}
+          onClick={() => setTab('listings')}
+          className={cn(
+            'px-3 py-2 text-sm font-medium border-b-2 -mb-px',
+            tab === 'listings'
+              ? 'border-blue-600 text-blue-600'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
           )}
-        </div>
+        >
+          채널 리스팅
+        </button>
+        <button
+          type="button"
+          aria-pressed={tab === 'quarantine'}
+          onClick={() => setTab('quarantine')}
+          className={cn(
+            'px-3 py-2 text-sm font-medium border-b-2 -mb-px',
+            tab === 'quarantine'
+              ? 'border-blue-600 text-blue-600'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
+          )}
+        >
+          미매핑 주문
+        </button>
+      </nav>
 
-        {searchedVariantId && (
-          <ChannelListingsTable variantId={searchedVariantId} />
-        )}
+      {tab === 'listings' ? (
+        <>
+          <div className="px-6 py-4 space-y-3">
+            <div className="flex gap-2 items-end">
+              <div className="space-y-1 flex-1 max-w-md">
+                <Label>Variant ID</Label>
+                <Input
+                  placeholder="Variant UUID로 검색"
+                  value={variantId}
+                  onChange={(e) => setVariantId(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleSearch();
+                  }}
+                />
+              </div>
+              <Button onClick={handleSearch}>조회</Button>
+              {searchedVariantId && (
+                <Button onClick={() => setCreateOpen(true)} variant="outline">
+                  리스팅 등록
+                </Button>
+              )}
+            </div>
 
-        {!searchedVariantId && (
-          <p className="text-sm text-muted-foreground py-8 text-center">
-            Variant ID를 입력하고 조회하세요.
-          </p>
-        )}
-      </div>
+            {searchedVariantId && (
+              <ChannelListingsTable variantId={searchedVariantId} />
+            )}
 
-      {searchedVariantId && (
-        <ChannelListingFormDialog
-          variantId={searchedVariantId}
-          open={createOpen}
-          onOpenChange={setCreateOpen}
-        />
+            {!searchedVariantId && (
+              <p className="text-sm text-muted-foreground py-8 text-center">
+                Variant ID를 입력하고 조회하세요.
+              </p>
+            )}
+          </div>
+
+          {searchedVariantId && (
+            <ChannelListingFormDialog
+              variantId={searchedVariantId}
+              open={createOpen}
+              onOpenChange={setCreateOpen}
+            />
+          )}
+        </>
+      ) : (
+        <QuarantineTable />
       )}
     </Container>
   );

--- a/apps/admin-web/src/features/mall/quarantine/components/quarantine-detail-dialog/index.tsx
+++ b/apps/admin-web/src/features/mall/quarantine/components/quarantine-detail-dialog/index.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+// src/features/mall/quarantine/components/quarantine-detail-dialog/index.tsx
+// 격리 건 하나의 상세 — 라인별 사유/조치 안내, 매핑 생성(채널 리스팅 다이얼로그 재사용),
+// 재처리. "격리 확인 → 매핑 생성 → 재처리" 한 바퀴가 이 다이얼로그 안에서 끝나야 한다.
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+import { actionForCause, replayResultMessage } from '../../guidance';
+import { useReplayFailure } from '@/lib/services/channel/mutations';
+import { ChannelListingFormDialog } from '@/features/mall/channel-listings/components/channel-listing-form-dialog';
+import type { OrderCollectionFailureDto } from '@/lib/api/domains/channel/order-collection-failures.client';
+
+type Props = {
+  failure: OrderCollectionFailureDto | null;
+  onClose: () => void;
+};
+
+export function QuarantineDetailDialog({ failure, onClose }: Props) {
+  const replay = useReplayFailure();
+  // 매핑 생성 중인 라인의 channelItemId 프리필. 라인마다 값이 다를 수 있으므로 라인 단위로 연다.
+  const [createListingItemId, setCreateListingItemId] = useState<string | null>(
+    null
+  );
+
+  const lines = failure?.affectedLines;
+
+  const handleResolved = async () => {
+    if (!failure) return;
+    try {
+      const result = await replay.mutateAsync(failure.id);
+      toast(replayResultMessage(result.status));
+      onClose();
+    } catch {
+      toast.error('재처리 요청에 실패했습니다. 잠시 후 다시 시도하세요.');
+    }
+  };
+
+  return (
+    <>
+      <Dialog
+        open={!!failure}
+        onOpenChange={(open) => {
+          if (!open) onClose();
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          {failure && (
+            <>
+              <DialogHeader>
+                <DialogTitle>{failure.externalOrderId}</DialogTitle>
+              </DialogHeader>
+
+              <div className="space-y-3 text-sm">
+                {/* 옛 행에는 라인별 사유가 없다. 이건 정상 상태이므로 빈 화면이 아니라 설명을 렌더한다. */}
+                {!lines || lines.length === 0 ? (
+                  <p className="text-muted-foreground">
+                    사유 정보가 없는 옛 격리입니다. 원본을 확인해 직접
+                    매핑하세요.
+                  </p>
+                ) : (
+                  <ul className="space-y-3">
+                    {lines.map((line) => {
+                      const guidance = actionForCause(line.cause);
+                      return (
+                        <li
+                          key={line.lineId}
+                          className="border-b pb-3 last:border-0 last:pb-0"
+                        >
+                          <div className="font-medium">
+                            {line.lineId} — {guidance.label}
+                          </div>
+                          <p className="text-muted-foreground">
+                            {guidance.description}
+                          </p>
+                          {guidance.action === 'create-listing' && (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="mt-2"
+                              onClick={() =>
+                                setCreateListingItemId(
+                                  line.channelProductId ?? ''
+                                )
+                              }
+                            >
+                              매핑 생성
+                            </Button>
+                          )}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </div>
+
+              <DialogFooter>
+                <Button variant="outline" onClick={onClose}>
+                  닫기
+                </Button>
+                <Button onClick={handleResolved} disabled={replay.isPending}>
+                  {replay.isPending ? '재처리 중…' : '조치 완료 — 재처리'}
+                </Button>
+              </DialogFooter>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {failure && (
+        <ChannelListingFormDialog
+          open={createListingItemId !== null}
+          onOpenChange={(open) => {
+            if (!open) setCreateListingItemId(null);
+          }}
+          defaultChannelCode={failure.channel}
+          defaultChannelItemId={createListingItemId ?? ''}
+          onCreated={() => {
+            // 저장 → 자동 재처리. 매핑이 생겼으니 굳이 다시 "조치 완료" 버튼을 누르게 하지 않는다.
+            setCreateListingItemId(null);
+            void handleResolved();
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/admin-web/src/features/mall/quarantine/components/quarantine-detail-dialog/index.tsx
+++ b/apps/admin-web/src/features/mall/quarantine/components/quarantine-detail-dialog/index.tsx
@@ -37,7 +37,9 @@ export function QuarantineDetailDialog({ failure, onClose }: Props) {
     if (!failure) return;
     try {
       const result = await replay.mutateAsync(failure.id);
-      toast(replayResultMessage(result.status));
+      // 응답 모양이 예상과 다르면 `result` 가 null 이다 — 그때도 문구는 나가야 한다
+      // (`replayResultMessage` 가 모르는 값에 폴백을 준다).
+      toast(replayResultMessage(result?.status ?? ''));
       onClose();
     } catch {
       toast.error('재처리 요청에 실패했습니다. 잠시 후 다시 시도하세요.');

--- a/apps/admin-web/src/features/mall/quarantine/components/quarantine-table/index.tsx
+++ b/apps/admin-web/src/features/mall/quarantine/components/quarantine-table/index.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+// src/features/mall/quarantine/components/quarantine-table/index.tsx
+// 미매핑 주문(채널 수집 실패 격리) 목록. 운영 전략이 "격리되면 그때 등록해서 푼다" 이므로
+// 이 표가 그 전제조건이다 — 빈 목록·옛 행(라인별 사유 없음)·재처리 불가 행을 모두 다뤄야 한다.
+
+import { useState } from 'react';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table';
+import { useQuarantinedFailures } from '@/lib/services/channel/queries';
+import { canReplay, reasonLabel } from '../../guidance';
+import { QuarantineDetailDialog } from '../quarantine-detail-dialog';
+import type { OrderCollectionFailureDto } from '@/lib/api/domains/channel/order-collection-failures.client';
+
+export function QuarantineTable() {
+  const { data, isLoading, isFetching } = useQuarantinedFailures();
+  const [selected, setSelected] = useState<OrderCollectionFailureDto | null>(
+    null
+  );
+
+  const rows = data?.data ?? [];
+
+  return (
+    <>
+      <div className="px-4 pb-4">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>채널</TableHead>
+              <TableHead>외부주문번호</TableHead>
+              <TableHead>사유</TableHead>
+              <TableHead className="text-right">라인</TableHead>
+              <TableHead>변경시각</TableHead>
+              <TableHead className="text-right">조치</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading || isFetching ? (
+              <TableRow>
+                <TableCell
+                  colSpan={6}
+                  className="py-12 text-center text-sm text-muted-foreground"
+                >
+                  불러오는 중…
+                </TableCell>
+              </TableRow>
+            ) : rows.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={6}
+                  className="py-12 text-center text-sm text-muted-foreground"
+                >
+                  격리된 주문이 없습니다.
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((row) => {
+                const lineCount =
+                  row.affectedLines?.length ?? row.affectedLineIds.length;
+                const replayable = canReplay(row.status, row.reason);
+                return (
+                  <TableRow key={row.id}>
+                    <TableCell>{row.channel}</TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {row.externalOrderId}
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {reasonLabel(row.reason)}
+                    </TableCell>
+                    <TableCell className="text-right">{lineCount}</TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {new Date(row.updatedAt).toLocaleString('ko-KR')}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {replayable ? (
+                        <button
+                          type="button"
+                          className="text-sm text-blue-600 hover:underline"
+                          onClick={() => setSelected(row)}
+                        >
+                          해소하기
+                        </button>
+                      ) : (
+                        <span
+                          className="text-xs text-muted-foreground"
+                          title="수집 후 채널에서 변경된 건입니다"
+                        >
+                          CS 처리 필요
+                        </span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <QuarantineDetailDialog
+        failure={selected}
+        onClose={() => setSelected(null)}
+      />
+    </>
+  );
+}

--- a/apps/admin-web/src/features/mall/quarantine/components/quarantine-table/index.tsx
+++ b/apps/admin-web/src/features/mall/quarantine/components/quarantine-table/index.tsx
@@ -19,7 +19,9 @@ import { QuarantineDetailDialog } from '../quarantine-detail-dialog';
 import type { OrderCollectionFailureDto } from '@/lib/api/domains/channel/order-collection-failures.client';
 
 export function QuarantineTable() {
-  const { data, isLoading, isFetching } = useQuarantinedFailures();
+  // isFetching 은 뺀다 — 배경 재조회마다 스켈레톤을 다시 씌우면 운영자가 읽던 행 위로
+  // "불러오는 중…" 이 매번 깜빡인다. 최초 로딩(isLoading)에만 스켈레톤을 보여준다.
+  const { data, isLoading } = useQuarantinedFailures();
   const [selected, setSelected] = useState<OrderCollectionFailureDto | null>(
     null
   );
@@ -41,7 +43,7 @@ export function QuarantineTable() {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {isLoading || isFetching ? (
+            {isLoading ? (
               <TableRow>
                 <TableCell
                   colSpan={6}

--- a/apps/admin-web/src/features/mall/quarantine/components/quarantine-table/index.tsx
+++ b/apps/admin-web/src/features/mall/quarantine/components/quarantine-table/index.tsx
@@ -31,6 +31,17 @@ export function QuarantineTable() {
   return (
     <>
       <div className="px-4 pb-4">
+        {/* 한 판의 상한에 닿았다 — 잘린 목록을 전부인 것처럼 보여주면, 안 보이는 주문의 출고가
+            멈춘 채 방치된다(lazy 매핑 전략의 급소). 잘렸다는 사실 자체를 표 위에 올린다. */}
+        {data?.truncated && (
+          <p
+            role="status"
+            className="mb-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900"
+          >
+            상위 {data.limit}건만 표시했습니다. 이 목록이 전부가 아닙니다 — 먼저 보이는 건들을
+            해소한 뒤 다시 불러오세요.
+          </p>
+        )}
         <Table>
           <TableHeader>
             <TableRow>

--- a/apps/admin-web/src/features/mall/quarantine/guidance.spec.ts
+++ b/apps/admin-web/src/features/mall/quarantine/guidance.spec.ts
@@ -1,4 +1,9 @@
-import { actionForCause, canReplay, replayResultMessage } from './guidance';
+import {
+  actionForCause,
+  canReplay,
+  reasonLabel,
+  replayResultMessage,
+} from './guidance';
 
 describe('actionForCause', () => {
   it('리스팅이 없으면 매핑 생성으로 안내한다', () => {
@@ -45,17 +50,47 @@ describe('canReplay', () => {
 });
 
 describe('replayResultMessage', () => {
-  it('여섯 가지 결과를 모두 사람 말로 옮긴다', () => {
+  it('일곱 가지 결과를 모두 사람 말로 옮긴다 (OrderPollerOrchestrator.replayFailure 의 전체 어휘)', () => {
     const statuses = [
       'replayed',
       'already_processed',
       'still_quarantined',
       'closed_terminal',
       'closed_already_collected',
+      'not_found_or_not_payment_accepted',
       'not_replayable',
     ] as const;
     for (const status of statuses) {
       expect(replayResultMessage(status).length).toBeGreaterThan(0);
     }
+  });
+
+  it('채널에서 주문을 찾지 못하거나 결제완료가 아니면 그 사실을 그대로 말한다', () => {
+    const message = replayResultMessage('not_found_or_not_payment_accepted');
+    expect(message).toContain('찾을 수 없');
+  });
+
+  it('모르는 값이 와도 폴백 문구를 준다', () => {
+    expect(replayResultMessage('some_unknown_status')).toBe(
+      '알 수 없는 결과입니다.'
+    );
+  });
+});
+
+describe('reasonLabel', () => {
+  it('식별 실패 사유를 사람 말로 옮긴다', () => {
+    expect(reasonLabel('channel_product_identification_failed')).toBe(
+      '채널상품 식별 실패'
+    );
+  });
+
+  it('수집 후 변경 사유를 사람 말로 옮긴다', () => {
+    expect(reasonLabel('collected_order_modification_not_accepted')).toBe(
+      '수집 후 변경(재처리 불가)'
+    );
+  });
+
+  it('모르는 값은 원본을 그대로 보여준다', () => {
+    expect(reasonLabel('weird_new_reason')).toBe('weird_new_reason');
   });
 });

--- a/apps/admin-web/src/features/mall/quarantine/guidance.spec.ts
+++ b/apps/admin-web/src/features/mall/quarantine/guidance.spec.ts
@@ -1,0 +1,61 @@
+import { actionForCause, canReplay, replayResultMessage } from './guidance';
+
+describe('actionForCause', () => {
+  it('리스팅이 없으면 매핑 생성으로 안내한다', () => {
+    expect(actionForCause('listing_not_found')).toEqual({
+      label: '매핑 생성',
+      action: 'create-listing',
+      description: '이 채널상품에 대응하는 채널 리스팅을 만드세요.',
+    });
+  });
+
+  it('활성 버전이 없으면 두 갈래를 다 알린다 — 판매중지를 publish 로 오도하지 않는다', () => {
+    const guidance = actionForCause('no_active_version');
+    expect(guidance.action).toBe('none');
+    expect(guidance.description).toContain('publish');
+    expect(guidance.description).toContain('내리세요');
+  });
+
+  it('모르는 값이 와도 렌더 가능한 안내를 준다', () => {
+    expect(actionForCause('unknown').action).toBe('none');
+  });
+});
+
+describe('canReplay', () => {
+  it('격리 상태이고 식별 실패면 재처리할 수 있다', () => {
+    expect(
+      canReplay('quarantined', 'channel_product_identification_failed')
+    ).toBe(true);
+  });
+
+  it('수집 후 변경은 재처리 대상이 아니다', () => {
+    expect(
+      canReplay('quarantined', 'collected_order_modification_not_accepted')
+    ).toBe(false);
+  });
+
+  it('닫힌 건은 재처리하지 않는다', () => {
+    expect(
+      canReplay(
+        'closed_already_collected',
+        'channel_product_identification_failed'
+      )
+    ).toBe(false);
+  });
+});
+
+describe('replayResultMessage', () => {
+  it('여섯 가지 결과를 모두 사람 말로 옮긴다', () => {
+    const statuses = [
+      'replayed',
+      'already_processed',
+      'still_quarantined',
+      'closed_terminal',
+      'closed_already_collected',
+      'not_replayable',
+    ] as const;
+    for (const status of statuses) {
+      expect(replayResultMessage(status).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/admin-web/src/features/mall/quarantine/guidance.ts
+++ b/apps/admin-web/src/features/mall/quarantine/guidance.ts
@@ -16,6 +16,7 @@ export type ReplayStatus =
   | 'still_quarantined'
   | 'closed_terminal'
   | 'closed_already_collected'
+  | 'not_found_or_not_payment_accepted'
   | 'not_replayable';
 
 export interface CauseGuidance {
@@ -96,6 +97,8 @@ const REPLAY_MESSAGES: Record<ReplayStatus, string> = {
   closed_terminal:
     '채널에서 취소·환불되어 더 이상 수집할 수 없습니다. 격리를 닫았습니다.',
   closed_already_collected: '이미 판매주문이 있어 격리를 닫았습니다.',
+  not_found_or_not_payment_accepted:
+    '채널에서 주문을 찾을 수 없거나 결제완료 상태가 아닙니다. 수집할 것이 없습니다.',
   not_replayable:
     '수집 후 변경 건이라 재처리할 수 없습니다. CS/주문정정으로 처리하세요.',
 };
@@ -106,4 +109,18 @@ const REPLAY_MESSAGES: Record<ReplayStatus, string> = {
  */
 export function replayResultMessage(status: string): string {
   return REPLAY_MESSAGES[status as ReplayStatus] ?? '알 수 없는 결과입니다.';
+}
+
+const REASON_LABELS: Record<QuarantineReason, string> = {
+  channel_product_identification_failed: '채널상품 식별 실패',
+  collected_order_modification_not_accepted: '수집 후 변경(재처리 불가)',
+};
+
+/**
+ * 격리 목록의 "사유" 컬럼 표시용 라벨. 서버 코드값을 그대로 렌더하면 운영자가 못 읽으므로
+ * 여기서 옮긴다 — `replayResultMessage` 와 같은 이유로 `string` 을 그대로 받고 모르는 값은
+ * 원본을 그대로 보여준다(격리를 조사할 단서를 잃지 않기 위함).
+ */
+export function reasonLabel(reason: string): string {
+  return REASON_LABELS[reason as QuarantineReason] ?? reason;
 }

--- a/apps/admin-web/src/features/mall/quarantine/guidance.ts
+++ b/apps/admin-web/src/features/mall/quarantine/guidance.ts
@@ -1,0 +1,109 @@
+import type { ListingResolutionCause } from '@packages/domain-types';
+
+export type QuarantineStatus =
+  | 'quarantined'
+  | 'replayed'
+  | 'closed_lifecycle'
+  | 'closed_already_collected';
+
+export type QuarantineReason =
+  | 'channel_product_identification_failed'
+  | 'collected_order_modification_not_accepted';
+
+export type ReplayStatus =
+  | 'replayed'
+  | 'already_processed'
+  | 'still_quarantined'
+  | 'closed_terminal'
+  | 'closed_already_collected'
+  | 'not_replayable';
+
+export interface CauseGuidance {
+  label: string;
+  action: 'create-listing' | 'activate-listing' | 'activate-channel' | 'none';
+  description: string;
+}
+
+const GUIDANCE: Record<ListingResolutionCause, CauseGuidance> = {
+  listing_not_found: {
+    label: '매핑 생성',
+    action: 'create-listing',
+    description: '이 채널상품에 대응하는 채널 리스팅을 만드세요.',
+  },
+  listing_inactive: {
+    label: '리스팅 활성화',
+    action: 'activate-listing',
+    description: '리스팅이 비활성 상태입니다. 활성화하세요.',
+  },
+  channel_inactive: {
+    label: '채널 활성화',
+    action: 'activate-channel',
+    description: '판매채널이 비활성 상태입니다. 활성화하세요.',
+  },
+  variant_inactive: {
+    label: '품목 확인',
+    action: 'none',
+    description:
+      '연결된 품목이 판매중지 상태입니다. 상품 화면에서 품목을 활성화하세요.',
+  },
+  no_active_version: {
+    label: '버전 확인',
+    action: 'none',
+    description:
+      '활성 버전이 없습니다. 판매를 재개하려면 publish 하고, 판매중지가 맞다면 네이버에서 해당 상품을 내리세요.',
+  },
+  product_deleted: {
+    label: '재매핑',
+    action: 'create-listing',
+    description: '연결된 상품이 삭제됐습니다. 다른 상품으로 다시 매핑하세요.',
+  },
+  no_embedded_ids: {
+    label: '상품 재생성',
+    action: 'none',
+    description:
+      '채널에 우리 식별자가 없습니다. Core 를 통해 상품을 다시 만드세요.',
+  },
+  no_lookup_key: {
+    label: '채널 데이터 확인',
+    action: 'none',
+    description:
+      '주문 라인에 조회 키가 없습니다. 채널 원본 데이터를 확인하세요.',
+  },
+  unknown: {
+    label: '판정 불가',
+    action: 'none',
+    description: '사유를 알 수 없는 격리입니다. 원본을 확인하세요.',
+  },
+};
+
+export function actionForCause(cause: ListingResolutionCause): CauseGuidance {
+  return GUIDANCE[cause] ?? GUIDANCE.unknown;
+}
+
+/**
+ * 재처리 가능 여부. **상태를 먼저 본다** — 닫힌 행에 버튼을 주면 운영자가 헛수고를 반복한다.
+ * `collected_order_modification_not_accepted` 는 서버가 `not_replayable` 로 응답하는 사유다.
+ */
+export function canReplay(status: string, reason: string): boolean {
+  if (status !== 'quarantined') return false;
+  return reason !== 'collected_order_modification_not_accepted';
+}
+
+const REPLAY_MESSAGES: Record<ReplayStatus, string> = {
+  replayed: '재처리했습니다. 판매주문이 생성됐습니다.',
+  already_processed: '이미 처리된 주문이라 새로 발행할 것이 없었습니다.',
+  still_quarantined: '아직 해소되지 않았습니다. 조치가 반영됐는지 확인하세요.',
+  closed_terminal:
+    '채널에서 취소·환불되어 더 이상 수집할 수 없습니다. 격리를 닫았습니다.',
+  closed_already_collected: '이미 판매주문이 있어 격리를 닫았습니다.',
+  not_replayable:
+    '수집 후 변경 건이라 재처리할 수 없습니다. CS/주문정정으로 처리하세요.',
+};
+
+/**
+ * 서버 응답 문자열을 그대로 받는다. `ReplayStatus` 로 좁혀 받으면 클라이언트 DTO 의 `status: string`
+ * 과 어긋나 호출부에 캐스팅이 생긴다 — 모르는 값이 오면 폴백 문구를 준다.
+ */
+export function replayResultMessage(status: string): string {
+  return REPLAY_MESSAGES[status as ReplayStatus] ?? '알 수 없는 결과입니다.';
+}

--- a/apps/admin-web/src/lib/api/domains/channel/order-collection-failures.client.ts
+++ b/apps/admin-web/src/lib/api/domains/channel/order-collection-failures.client.ts
@@ -1,0 +1,101 @@
+'use client';
+
+// src/lib/api/domains/channel/order-collection-failures.client.ts
+// 네이버 주문 수집 실패(미매핑 주문) 격리 큐 API 클라이언트
+//
+// 응답 envelope 은 channel-adapter 의
+// apps/channel-adapter/src/controllers/order-collection-failures.controller.ts 를 그대로 따른다:
+//   GET  /adapter/order-collection-failures       -> { success, count, data, timestamp }
+//   GET  /adapter/order-collection-failures/:id   -> { success, data, replayPath, timestamp }
+//   POST /adapter/order-collection-failures/:id/replay -> { success, result, timestamp }
+// `success`/`timestamp` 는 이 화면이 쓰지 않으므로 DTO 에서 생략한다.
+
+import { CHANNEL_ADAPTER_SERVICE_BASE_URL } from '@/const';
+import { client } from '../../client';
+import type { AffectedLine } from '@packages/domain-types';
+
+/**
+ * `order_collection_failures` 행 하나 (apps/channel-adapter/src/schema.ts).
+ * `sourceUpdatedAt`/`replayedAt`/`replayedWmsOrderId`/`errorMessage` 도 실제 응답에 실려
+ * 온다 — 특히 `errorMessage` 는 종결(closed_*) 사유를 담으므로 격리 큐 화면에서 "왜 닫혔는지"를
+ * 보여주는 데 필요하다.
+ */
+export interface OrderCollectionFailureDto {
+  id: string;
+  channel: string;
+  externalOrderId: string;
+  reason: string;
+  status: string;
+  affectedLineIds: string[];
+  affectedLines: AffectedLine[] | null;
+  rawOrder: Record<string, unknown>;
+  sourceUpdatedAt: string;
+  replayedAt: string | null;
+  replayedWmsOrderId: string | null;
+  errorMessage: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * `OrderPollerOrchestrator.replayFailure` 가 반환하는 정확한 status 어휘
+ * (apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.ts).
+ */
+export type ReplayResultStatus =
+  | 'replayed'
+  | 'already_processed'
+  | 'still_quarantined'
+  | 'closed_terminal'
+  | 'closed_already_collected'
+  | 'not_found_or_not_payment_accepted'
+  | 'not_replayable';
+
+export interface ReplayResultDto {
+  status: ReplayResultStatus;
+  failureId: string;
+  externalOrderId: string;
+  emitted: number;
+  dedupedUnchanged: number;
+}
+
+/** 상세 조회가 함께 주는 "다음 행동" 안내 (컨트롤러의 `buildReplayPath`). */
+export interface ReplayPathDto {
+  fix: string;
+  endpoint: string | null;
+}
+
+export const orderCollectionFailuresClient = {
+  list: async (params: {
+    channel?: string;
+    reason?: string;
+    status?: string;
+    limit?: number;
+    offset?: number;
+  }) => {
+    const response = await client.get<{
+      count: number;
+      data: OrderCollectionFailureDto[];
+    }>(
+      `${CHANNEL_ADAPTER_SERVICE_BASE_URL}/adapter/order-collection-failures`,
+      { params }
+    );
+    return response.data;
+  },
+
+  get: async (id: string) => {
+    const response = await client.get<{
+      data: OrderCollectionFailureDto;
+      replayPath: ReplayPathDto;
+    }>(
+      `${CHANNEL_ADAPTER_SERVICE_BASE_URL}/adapter/order-collection-failures/${encodeURIComponent(id)}`
+    );
+    return response.data;
+  },
+
+  replay: async (id: string) => {
+    const response = await client.post<{ result: ReplayResultDto }>(
+      `${CHANNEL_ADAPTER_SERVICE_BASE_URL}/adapter/order-collection-failures/${encodeURIComponent(id)}/replay`
+    );
+    return response.data.result;
+  },
+};

--- a/apps/admin-web/src/lib/api/domains/channel/order-collection-failures.client.ts
+++ b/apps/admin-web/src/lib/api/domains/channel/order-collection-failures.client.ts
@@ -3,66 +3,37 @@
 // src/lib/api/domains/channel/order-collection-failures.client.ts
 // 네이버 주문 수집 실패(미매핑 주문) 격리 큐 API 클라이언트
 //
-// 응답 envelope 은 channel-adapter 의
-// apps/channel-adapter/src/controllers/order-collection-failures.controller.ts 를 그대로 따른다:
+// 🔴 **여기서 envelope 를 벗기지 않는다.** 공용 axios 인스턴스(`lib/api/client.ts`)의 응답
+// 인터셉터가 `{ success: true, data, … }` 를 이미 한 번 벗긴다. 두 번 벗기면 런타임 값과 타입이
+// 어긋나 표가 영구히 비고 배지가 영구히 0 이 된다 — 타입이 거짓말을 하므로 컴파일도 통과한다.
+// 모양 맞추기는 전부 `./order-collection-failures.shape` 의 순수 함수가 하고, 그 함수들만
+// 스펙으로 검증된다(admin-web 은 컴포넌트 테스트가 불가능하다).
+//
+// 서버 응답 원형은 apps/channel-adapter/src/controllers/order-collection-failures.controller.ts:
 //   GET  /adapter/order-collection-failures       -> { success, count, data, timestamp }
 //   GET  /adapter/order-collection-failures/:id   -> { success, data, replayPath, timestamp }
 //   POST /adapter/order-collection-failures/:id/replay -> { success, result, timestamp }
-// `success`/`timestamp` 는 이 화면이 쓰지 않으므로 DTO 에서 생략한다.
+//
+// `replayPath` 는 인터셉터가 버리며 되살리지 않는다 — 서버 문구는 Medusa 전용 영어 안내이고,
+// 화면은 `features/mall/quarantine/guidance.ts` 가 사유별 한국어 안내를 이미 갖고 있다.
 
 import { CHANNEL_ADAPTER_SERVICE_BASE_URL } from '@/const';
 import { client } from '../../client';
-import type { AffectedLine } from '@packages/domain-types';
+import {
+  QUARANTINE_LIST_LIMIT,
+  toFailureDetail,
+  toFailureListResult,
+  toReplayResult,
+} from './order-collection-failures.shape';
+import type { FailureListResult, OrderCollectionFailureDto, ReplayResultDto } from './order-collection-failures.shape';
 
-/**
- * `order_collection_failures` 행 하나 (apps/channel-adapter/src/schema.ts).
- * `sourceUpdatedAt`/`replayedAt`/`replayedWmsOrderId`/`errorMessage` 도 실제 응답에 실려
- * 온다 — 특히 `errorMessage` 는 종결(closed_*) 사유를 담으므로 격리 큐 화면에서 "왜 닫혔는지"를
- * 보여주는 데 필요하다.
- */
-export interface OrderCollectionFailureDto {
-  id: string;
-  channel: string;
-  externalOrderId: string;
-  reason: string;
-  status: string;
-  affectedLineIds: string[];
-  affectedLines: AffectedLine[] | null;
-  rawOrder: Record<string, unknown>;
-  sourceUpdatedAt: string;
-  replayedAt: string | null;
-  replayedWmsOrderId: string | null;
-  errorMessage: string | null;
-  createdAt: string;
-  updatedAt: string;
-}
-
-/**
- * `OrderPollerOrchestrator.replayFailure` 가 반환하는 정확한 status 어휘
- * (apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.ts).
- */
-export type ReplayResultStatus =
-  | 'replayed'
-  | 'already_processed'
-  | 'still_quarantined'
-  | 'closed_terminal'
-  | 'closed_already_collected'
-  | 'not_found_or_not_payment_accepted'
-  | 'not_replayable';
-
-export interface ReplayResultDto {
-  status: ReplayResultStatus;
-  failureId: string;
-  externalOrderId: string;
-  emitted: number;
-  dedupedUnchanged: number;
-}
-
-/** 상세 조회가 함께 주는 "다음 행동" 안내 (컨트롤러의 `buildReplayPath`). */
-export interface ReplayPathDto {
-  fix: string;
-  endpoint: string | null;
-}
+export type {
+  FailureListResult,
+  OrderCollectionFailureDto,
+  ReplayResultDto,
+  ReplayResultStatus,
+} from './order-collection-failures.shape';
+export { QUARANTINE_LIST_LIMIT, formatQuarantineCount } from './order-collection-failures.shape';
 
 export const orderCollectionFailuresClient = {
   list: async (params: {
@@ -71,31 +42,27 @@ export const orderCollectionFailuresClient = {
     status?: string;
     limit?: number;
     offset?: number;
-  }) => {
-    const response = await client.get<{
-      count: number;
-      data: OrderCollectionFailureDto[];
-    }>(
-      `${CHANNEL_ADAPTER_SERVICE_BASE_URL}/adapter/order-collection-failures`,
-      { params }
-    );
-    return response.data;
+  }): Promise<FailureListResult> => {
+    // 서버 기본값은 50 이다. 개통 직후엔 수백 건이 격리될 수 있으므로 명시적으로 올려 보내고,
+    // 그래도 상한에 닿으면 `truncated` 로 화면에 알린다.
+    const limit = params.limit ?? QUARANTINE_LIST_LIMIT;
+    const response = await client.get(`${CHANNEL_ADAPTER_SERVICE_BASE_URL}/adapter/order-collection-failures`, {
+      params: { ...params, limit },
+    });
+    return toFailureListResult(response.data, limit);
   },
 
-  get: async (id: string) => {
-    const response = await client.get<{
-      data: OrderCollectionFailureDto;
-      replayPath: ReplayPathDto;
-    }>(
+  get: async (id: string): Promise<OrderCollectionFailureDto | null> => {
+    const response = await client.get(
       `${CHANNEL_ADAPTER_SERVICE_BASE_URL}/adapter/order-collection-failures/${encodeURIComponent(id)}`
     );
-    return response.data;
+    return toFailureDetail(response.data);
   },
 
-  replay: async (id: string) => {
-    const response = await client.post<{ result: ReplayResultDto }>(
+  replay: async (id: string): Promise<ReplayResultDto | null> => {
+    const response = await client.post(
       `${CHANNEL_ADAPTER_SERVICE_BASE_URL}/adapter/order-collection-failures/${encodeURIComponent(id)}/replay`
     );
-    return response.data.result;
+    return toReplayResult(response.data);
   },
 };

--- a/apps/admin-web/src/lib/api/domains/channel/order-collection-failures.shape.spec.ts
+++ b/apps/admin-web/src/lib/api/domains/channel/order-collection-failures.shape.spec.ts
@@ -1,0 +1,126 @@
+import {
+  QUARANTINE_LIST_LIMIT,
+  formatQuarantineCount,
+  toFailureDetail,
+  toFailureListResult,
+  toReplayResult,
+} from './order-collection-failures.shape';
+
+const ROW = {
+  id: 'f-1',
+  channel: 'naver',
+  externalOrderId: 'ord-1',
+  reason: 'channel_product_identification_failed',
+  status: 'quarantined',
+  affectedLineIds: ['po-1'],
+  affectedLines: [{ lineId: 'po-1', cause: 'listing_not_found' as const }],
+  rawOrder: {},
+  sourceUpdatedAt: '2026-08-19T00:00:00.000Z',
+  replayedAt: null,
+  replayedWmsOrderId: null,
+  errorMessage: null,
+  createdAt: '2026-08-19T00:00:00.000Z',
+  updatedAt: '2026-08-19T00:00:00.000Z',
+};
+
+describe('toFailureListResult', () => {
+  /**
+   * 공용 인터셉터(`lib/api/client.ts`)가 `{ success, count, data }` 를 이미 벗겨 **배열**을
+   * 남긴다. 이것이 실제 런타임 모양이고, 여기서 한 번 더 `.data` 를 읽던 것이 표를 영구히
+   * 비게 만든 버그였다.
+   */
+  it('인터셉터가 벗긴 배열을 받아 count 를 길이에서 되살린다', () => {
+    const result = toFailureListResult([ROW, { ...ROW, id: 'f-2' }]);
+
+    expect(result.data).toHaveLength(2);
+    expect(result.count).toBe(2);
+    expect(result.data[0].id).toBe('f-1');
+  });
+
+  it('인터셉터를 통과하지 않은 { count, data } 모양도 받는다', () => {
+    const result = toFailureListResult({ success: true, count: 1, data: [ROW] });
+
+    expect(result.count).toBe(1);
+    expect(result.data[0].id).toBe('f-1');
+  });
+
+  it('모양이 어긋나면 빈 판을 준다 — 화면이 터지는 대신 "없습니다" 를 그린다', () => {
+    expect(toFailureListResult(null).count).toBe(0);
+    expect(toFailureListResult(undefined).data).toEqual([]);
+    expect(toFailureListResult('nope').data).toEqual([]);
+    expect(toFailureListResult({ success: true }).data).toEqual([]);
+  });
+
+  it('상한에 닿으면 truncated 가 선다 — 잘린 목록을 전부로 보여주지 않기 위함', () => {
+    const rows = Array.from({ length: 3 }, (_, i) => ({ ...ROW, id: `f-${i}` }));
+
+    expect(toFailureListResult(rows, 3).truncated).toBe(true);
+    expect(toFailureListResult(rows, 4).truncated).toBe(false);
+    expect(toFailureListResult(rows, 3).limit).toBe(3);
+  });
+
+  it('기본 상한은 서버 기본값 50 보다 크다 — 개통 직후 수백 건이 조용히 잘리던 자리', () => {
+    expect(QUARANTINE_LIST_LIMIT).toBeGreaterThan(50);
+    expect(toFailureListResult([]).limit).toBe(QUARANTINE_LIST_LIMIT);
+  });
+});
+
+describe('toFailureDetail', () => {
+  it('인터셉터가 벗긴 행을 그대로 받는다', () => {
+    expect(toFailureDetail(ROW)?.id).toBe('f-1');
+  });
+
+  it('{ data: row } 로 싸여 있으면 벗긴다', () => {
+    expect(toFailureDetail({ success: true, data: ROW, replayPath: { fix: 'x', endpoint: null } })?.id).toBe('f-1');
+  });
+
+  it('행이 아니면 null 을 준다', () => {
+    expect(toFailureDetail(null)).toBeNull();
+    expect(toFailureDetail([ROW])).toBeNull();
+    expect(toFailureDetail({ success: true })).toBeNull();
+  });
+});
+
+describe('toReplayResult', () => {
+  /**
+   * 재처리 응답만 인터셉터를 통과하지 못한다 — 본문에 `data` 키가 없어 envelope 술어
+   * (`success === true && 'data' in body`)에 걸리지 않기 때문이다. 그래서 `result` 를 여기서 벗긴다.
+   */
+  it('{ success, result } 에서 result 를 벗긴다', () => {
+    const result = toReplayResult({
+      success: true,
+      result: { status: 'replayed', failureId: 'f-1', externalOrderId: 'ord-1', emitted: 1, dedupedUnchanged: 0 },
+      timestamp: 'x',
+    });
+
+    expect(result?.status).toBe('replayed');
+    expect(result?.emitted).toBe(1);
+  });
+
+  it('이미 벗겨진 결과도 그대로 받는다', () => {
+    expect(
+      toReplayResult({
+        status: 'not_replayable',
+        failureId: 'f-1',
+        externalOrderId: 'ord-1',
+        emitted: 0,
+        dedupedUnchanged: 0,
+      })?.status
+    ).toBe('not_replayable');
+  });
+
+  it('모양이 어긋나면 null 을 준다', () => {
+    expect(toReplayResult(null)).toBeNull();
+    expect(toReplayResult({ success: true })).toBeNull();
+  });
+});
+
+describe('formatQuarantineCount', () => {
+  it('상한에 닿았으면 "더 있다" 를 숫자에 싣는다', () => {
+    expect(formatQuarantineCount({ count: 200, truncated: true })).toBe('200+');
+  });
+
+  it('상한 미만이면 숫자를 그대로 적는다', () => {
+    expect(formatQuarantineCount({ count: 7, truncated: false })).toBe('7');
+  });
+});

--- a/apps/admin-web/src/lib/api/domains/channel/order-collection-failures.shape.ts
+++ b/apps/admin-web/src/lib/api/domains/channel/order-collection-failures.shape.ts
@@ -1,0 +1,149 @@
+// src/lib/api/domains/channel/order-collection-failures.shape.ts
+//
+// 격리 큐 응답의 **순수 정형화 함수**들. axios 나 react-query 를 import 하지 않는다 —
+// admin-web 은 컴포넌트 테스트가 불가능하므로(렌더러 없음 + `.tsx` transform 밖), 검증 가능한
+// 판정을 `.ts` 순수 함수로 뽑아 두는 것이 유일한 자동 방어선이다.
+//
+// ## 왜 이 파일이 필요한가 (#640 회귀)
+//
+// 공용 axios 인스턴스(`lib/api/client.ts`)의 응답 인터셉터가 `{ success: true, data, … }` 를
+// **이미 한 번 벗긴다**. 도메인 client 가 `response.data.data` 로 한 번 더 벗기면 런타임 값과
+// 타입이 어긋난다 — 실제로 `list()` 는 배열을 돌려주는데 타입은 `{ count, data }` 라고 말했고,
+// 그래서 표는 `data.data`(=undefined)를 읽어 **영구히 빈 목록**, 배지는 `data.count`(=undefined)
+// 를 읽어 **영구히 0** 이었다. 타입이 맞으니 컴파일도 통과했다.
+//
+// 컨트롤러(`apps/channel-adapter/src/controllers/order-collection-failures.controller.ts`)의
+// 응답 본문과 인터셉터 통과 후의 값:
+//
+// | 호출 | 서버 본문 | 인터셉터 통과 후 (`response.data`) |
+// |---|---|---|
+// | `GET /`      | `{ success, count, data, timestamp }`      | `data` (배열) — `count` 는 유실 |
+// | `GET /:id`   | `{ success, data, replayPath, timestamp }` | `data` (행) — `replayPath` 는 유실 |
+// | `POST /:id/replay` | `{ success, result, timestamp }`    | 그대로 (`data` 키가 없어 벗겨지지 않는다) |
+//
+// 그래서 `count` 는 **배열 길이에서 되살리고**, `replayPath` 는 되살리지 않는다 — 그 안내문은
+// 서버가 영어로 주는 Medusa 전용 문구였고, 화면은 `features/mall/quarantine/guidance.ts` 가
+// 사유별로 더 정확한 한국어 안내를 이미 갖고 있다.
+//
+// 아래 함수들은 **인터셉터가 벗긴 모양과 안 벗긴 모양을 모두** 받는다. 인터셉터의 술어
+// (`success === true && 'data' in body`)가 바뀌어도 화면이 조용히 비지 않게 하기 위함이다.
+
+import type { AffectedLine } from '@packages/domain-types';
+
+/**
+ * `order_collection_failures` 행 하나 (apps/channel-adapter/src/schema.ts).
+ * `sourceUpdatedAt`/`replayedAt`/`replayedWmsOrderId`/`errorMessage` 도 실제 응답에 실려
+ * 온다 — 특히 `errorMessage` 는 종결(closed_*) 사유를 담으므로 격리 큐 화면에서 "왜 닫혔는지"를
+ * 보여주는 데 필요하다.
+ */
+export interface OrderCollectionFailureDto {
+  id: string;
+  channel: string;
+  externalOrderId: string;
+  reason: string;
+  status: string;
+  affectedLineIds: string[];
+  affectedLines: AffectedLine[] | null;
+  rawOrder: Record<string, unknown>;
+  sourceUpdatedAt: string;
+  replayedAt: string | null;
+  replayedWmsOrderId: string | null;
+  errorMessage: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * `OrderPollerOrchestrator.replayFailure` 가 반환하는 정확한 status 어휘
+ * (apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.ts).
+ */
+export type ReplayResultStatus =
+  | 'replayed'
+  | 'already_processed'
+  | 'still_quarantined'
+  | 'closed_terminal'
+  | 'closed_already_collected'
+  | 'not_found_or_not_payment_accepted'
+  | 'not_replayable';
+
+export interface ReplayResultDto {
+  status: ReplayResultStatus;
+  failureId: string;
+  externalOrderId: string;
+  emitted: number;
+  dedupedUnchanged: number;
+}
+
+/**
+ * 목록 한 판의 상한. 서버 기본값이 50 인데 클라이언트가 아무것도 보내지 않아, 개통 직후 수백
+ * 건이 격리되는 구간에서 **말없이 50건만** 보이고 있었다. 명시적으로 보내고, 상한에 닿았다는
+ * 사실을 `truncated` 로 화면에 올린다 — 운영자가 "이게 전부" 라고 오해하면 남은 주문의 출고가
+ * 멈춘 채 방치된다 (lazy 매핑 전략의 급소).
+ */
+export const QUARANTINE_LIST_LIMIT = 200;
+
+export interface FailureListResult {
+  data: OrderCollectionFailureDto[];
+  /** 이 판에 담긴 행 수. 서버가 주는 `count` 도 `data.length` 다. */
+  count: number;
+  limit: number;
+  /** 상한에 닿았다 — 뒤에 더 있을 수 있다. */
+  truncated: boolean;
+}
+
+function asRecord(body: unknown): Record<string, unknown> | null {
+  return body && typeof body === 'object' && !Array.isArray(body) ? (body as Record<string, unknown>) : null;
+}
+
+/**
+ * 목록 응답 → `{ count, data, limit, truncated }`.
+ *
+ * 배열(인터셉터 통과 후)과 `{ count, data }`(안 벗겨진 경우) 양쪽을 받는다. 그 외에는 빈 판을
+ * 돌려준다 — 화면이 터지는 대신 "격리된 주문이 없습니다" 를 그리게 하기 위함이다.
+ */
+export function toFailureListResult(body: unknown, limit: number = QUARANTINE_LIST_LIMIT): FailureListResult {
+  const rows = Array.isArray(body)
+    ? (body as OrderCollectionFailureDto[])
+    : Array.isArray(asRecord(body)?.data)
+      ? (asRecord(body)!.data as OrderCollectionFailureDto[])
+      : [];
+
+  return {
+    data: rows,
+    // 서버의 `count` 는 인터셉터가 버렸으므로 길이에서 되살린다. 서버도 `data.length` 를 넣는다.
+    count: rows.length,
+    limit,
+    truncated: rows.length >= limit,
+  };
+}
+
+/**
+ * 상세 응답 → 행 하나. 배열이 아닌 객체이되 `{ data: … }` 로 한 겹 더 싸여 있으면 벗긴다.
+ * 행 자체에는 `data` 키가 없으므로 두 모양이 섞이지 않는다.
+ */
+export function toFailureDetail(body: unknown): OrderCollectionFailureDto | null {
+  const record = asRecord(body);
+  if (!record) return null;
+  const inner = asRecord(record.data);
+  if (inner) return inner as unknown as OrderCollectionFailureDto;
+  return typeof record.id === 'string' ? (record as unknown as OrderCollectionFailureDto) : null;
+}
+
+/**
+ * 재처리 응답 → 결과.
+ *
+ * 이 응답만 인터셉터를 통과하지 못한다(`data` 키가 없다). 그래서 `result` 를 여기서 벗기지만,
+ * 서버가 언젠가 `data` 로 감싸도 화면이 조용히 죽지 않도록 벗겨진 모양도 함께 받는다.
+ */
+export function toReplayResult(body: unknown): ReplayResultDto | null {
+  const record = asRecord(body);
+  if (!record) return null;
+  const inner = asRecord(record.result);
+  if (inner) return inner as unknown as ReplayResultDto;
+  return typeof record.status === 'string' ? (record as unknown as ReplayResultDto) : null;
+}
+
+/** 배지·헤더에 쓸 건수 표기. 상한에 닿았으면 "더 있다" 는 사실을 숫자에 실어 보낸다. */
+export function formatQuarantineCount(result: Pick<FailureListResult, 'count' | 'truncated'>): string {
+  return result.truncated ? `${result.count}+` : String(result.count);
+}

--- a/apps/admin-web/src/lib/services/channel/mutations.ts
+++ b/apps/admin-web/src/lib/services/channel/mutations.ts
@@ -1,0 +1,20 @@
+'use client';
+
+// src/lib/services/channel/mutations.ts
+// 주문 수집 실패(미매핑 주문) 격리 큐 뮤테이션 훅
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { channelQueryKeys } from './query-keys';
+import { orderCollectionFailuresClient } from '@/lib/api/domains/channel/order-collection-failures.client';
+
+export function useReplayFailure() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => orderCollectionFailuresClient.replay(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: channelQueryKeys.failures,
+      });
+    },
+  });
+}

--- a/apps/admin-web/src/lib/services/channel/queries.ts
+++ b/apps/admin-web/src/lib/services/channel/queries.ts
@@ -1,0 +1,28 @@
+'use client';
+
+// src/lib/services/channel/queries.ts
+// 주문 수집 실패(미매핑 주문) 격리 큐 쿼리 훅
+
+import { useQuery } from '@tanstack/react-query';
+import { channelQueryKeys } from './query-keys';
+import { orderCollectionFailuresClient } from '@/lib/api/domains/channel/order-collection-failures.client';
+
+export function useQuarantinedFailures(
+  params: { channel?: string; status?: string } = {}
+) {
+  const query = { status: 'quarantined', ...params };
+  return useQuery({
+    queryKey: channelQueryKeys.failuresList(query),
+    queryFn: () => orderCollectionFailuresClient.list(query),
+  });
+}
+
+export function useFailureDetail(id: string | null) {
+  return useQuery({
+    queryKey: channelQueryKeys.failure(id ?? ''),
+    // non-null assertion: `enabled` 이 id 를 가드하므로 queryFn 은 id 가 있을 때만 호출된다.
+    // 이 codebase 의 동일 패턴(useGetCampaign/useGetCoupon/useCouponEvent)이 전부 이 방식이다.
+    queryFn: () => orderCollectionFailuresClient.get(id!),
+    enabled: Boolean(id),
+  });
+}

--- a/apps/admin-web/src/lib/services/channel/queries.ts
+++ b/apps/admin-web/src/lib/services/channel/queries.ts
@@ -5,24 +5,27 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { channelQueryKeys } from './query-keys';
-import { orderCollectionFailuresClient } from '@/lib/api/domains/channel/order-collection-failures.client';
+import {
+  QUARANTINE_LIST_LIMIT,
+  orderCollectionFailuresClient,
+} from '@/lib/api/domains/channel/order-collection-failures.client';
 
+/**
+ * 격리 목록. 반환값은 `{ count, data, limit, truncated }` — 표와 배지가 같은 판을 공유한다.
+ *
+ * `limit` 을 명시해 보낸다: 서버 기본값 50 을 그대로 쓰면 개통 직후 수백 건이 격리되는 구간에서
+ * 말없이 앞의 50건만 보인다. 상한에 닿으면 `truncated` 가 서고, 화면이 그 사실을 그린다.
+ */
 export function useQuarantinedFailures(
-  params: { channel?: string; status?: string } = {}
+  params: { channel?: string; status?: string; limit?: number } = {}
 ) {
-  const query = { status: 'quarantined', ...params };
+  const query = { status: 'quarantined', limit: QUARANTINE_LIST_LIMIT, ...params };
   return useQuery({
     queryKey: channelQueryKeys.failuresList(query),
     queryFn: () => orderCollectionFailuresClient.list(query),
   });
 }
 
-export function useFailureDetail(id: string | null) {
-  return useQuery({
-    queryKey: channelQueryKeys.failure(id ?? ''),
-    // non-null assertion: `enabled` 이 id 를 가드하므로 queryFn 은 id 가 있을 때만 호출된다.
-    // 이 codebase 의 동일 패턴(useGetCampaign/useGetCoupon/useCouponEvent)이 전부 이 방식이다.
-    queryFn: () => orderCollectionFailuresClient.get(id!),
-    enabled: Boolean(id),
-  });
-}
+// `useFailureDetail` 은 삭제했다. 호출부가 한 곳도 없었고(상세 다이얼로그는 목록 행을 그대로
+// 받는다), 목록과 같은 이중 unwrap 버그를 안고 있어 되살아나면 같은 사고를 다시 낸다.
+// 상세 단건 조회가 필요해지면 `orderCollectionFailuresClient.get` 위에 새로 쓰면 된다.

--- a/apps/admin-web/src/lib/services/channel/query-keys.ts
+++ b/apps/admin-web/src/lib/services/channel/query-keys.ts
@@ -1,0 +1,9 @@
+// src/lib/services/channel/query-keys.ts
+// 주문 수집 실패(미매핑 주문) 격리 큐 쿼리 키 팩토리
+
+export const channelQueryKeys = {
+  failures: ['order-collection-failures'] as const,
+  failuresList: (query: Record<string, unknown>) =>
+    [...channelQueryKeys.failures, 'list', query] as const,
+  failure: (id: string) => [...channelQueryKeys.failures, id] as const,
+};

--- a/apps/admin-web/src/lib/utils/menu.ts
+++ b/apps/admin-web/src/lib/utils/menu.ts
@@ -9,6 +9,12 @@ export interface MenuItem {
   isComingSoon?: boolean;
   path?: string;
   requireRole?: string[];
+  /**
+   * 미매핑 주문(채널 수집 실패 격리) 건수를 메뉴 라벨 옆에 배지로 그린다.
+   * 실제 카운트 조회는 렌더 컴포넌트(header.tsx/mobile-nav.tsx)의 몫이다 —
+   * 이 파일은 순수 데이터이고 훅을 가질 수 없다.
+   */
+  hasQuarantineBadge?: boolean;
 }
 
 export interface MainMenu {
@@ -235,6 +241,7 @@ export const mainMenus: MainMenu[] = [
         id: 'channel-listings',
         title: '채널 노출 관리',
         path: '/mall/channel-listings',
+        hasQuarantineBadge: true,
       },
       {
         id: 'channel-categories',

--- a/apps/admin-web/src/lib/utils/menu.ts
+++ b/apps/admin-web/src/lib/utils/menu.ts
@@ -11,8 +11,10 @@ export interface MenuItem {
   requireRole?: string[];
   /**
    * 미매핑 주문(채널 수집 실패 격리) 건수를 메뉴 라벨 옆에 배지로 그린다.
-   * 실제 카운트 조회는 렌더 컴포넌트(header.tsx/mobile-nav.tsx)의 몫이다 —
-   * 이 파일은 순수 데이터이고 훅을 가질 수 없다.
+   * 실제 카운트 조회는 렌더 컴포넌트(sidebar-menu-item.tsx의 데스크톱 사이드바,
+   * mobile-nav.tsx의 모바일 시트 내비)의 `<QuarantineMenuBadge />` 가 담당한다 —
+   * 이 파일은 순수 데이터이고 훅을 가질 수 없다. header.tsx 의 상단 호버 드롭다운은
+   * 의도적으로 범위 밖이다(사이드바가 이미 같은 신호를 보여준다).
    */
   hasQuarantineBadge?: boolean;
 }

--- a/apps/admin-web/tsconfig.json
+++ b/apps/admin-web/tsconfig.json
@@ -25,7 +25,9 @@
       "@packages/product-description": ["../../packages/product-description"],
       "@packages/product-description/*": ["../../packages/product-description/*"],
       "@packages/event-contracts": ["../../packages/event-contracts"],
-      "@packages/event-contracts/*": ["../../packages/event-contracts/*"]
+      "@packages/event-contracts/*": ["../../packages/event-contracts/*"],
+      "@packages/domain-types": ["../../packages/domain-types"],
+      "@packages/domain-types/*": ["../../packages/domain-types/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/apps/channel-adapter/src/adapter.module.ts
+++ b/apps/channel-adapter/src/adapter.module.ts
@@ -90,6 +90,7 @@ import { OrderCollectionFailuresController } from './controllers/order-collectio
 import { ChannelDispatchOperationsController } from './controllers/channel-dispatch-operations.controller';
 import { CHANNEL_ORDER_PROVIDER } from './services/order-collection/channel-order-provider.interface';
 import { MedusaOrderSource } from './services/order-collection/medusa-order.source';
+import { NaverOrderSource } from './services/order-collection/naver-order.source';
 import { ChannelOrderTranslator } from './services/order-collection/channel-order.translator';
 import { ChannelLineIdentityResolver } from './services/order-collection/channel-line-identity.resolver';
 import { createOrderProvider } from './services/order-collection/translating-order.provider';
@@ -270,13 +271,15 @@ const NO_KAFKA_PUBLISHER_STREAMS: StreamConfig[] = [
     ChannelLineIdentityResolver,
     ChannelOrderTranslator,
     MedusaOrderSource,
+    NaverOrderSource,
     {
       provide: CHANNEL_ORDER_PROVIDER,
       // 채널이 늘면 source 를 하나 더 만들어 이 배열에 더한다. 번역기는 공유한다.
-      useFactory: (translator: ChannelOrderTranslator, medusa: MedusaOrderSource) => [
+      useFactory: (translator: ChannelOrderTranslator, medusa: MedusaOrderSource, naver: NaverOrderSource) => [
         createOrderProvider(medusa, translator),
+        createOrderProvider(naver, translator),
       ],
-      inject: [ChannelOrderTranslator, MedusaOrderSource],
+      inject: [ChannelOrderTranslator, MedusaOrderSource, NaverOrderSource],
     },
     OrderPollerOrchestrator,
     OrderCollectionFailureService,

--- a/apps/channel-adapter/src/adapters/naver/clients/naver-order.client.spec.ts
+++ b/apps/channel-adapter/src/adapters/naver/clients/naver-order.client.spec.ts
@@ -1,0 +1,41 @@
+import { of } from 'rxjs';
+import { NaverOrderClient } from './naver-order.client';
+
+describe('NaverOrderClient.getLastChangedStatuses', () => {
+  const http = { get: jest.fn() } as any;
+  const auth = { getAccessToken: jest.fn().mockResolvedValue('token') } as any;
+  const client = new NaverOrderClient(http, auth);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    http.get.mockReturnValue(of({ data: { timestamp: '', traceId: 't', data: { count: 0, lastChangeStatuses: [] } } }));
+  });
+
+  it('조회 창의 끝을 명시해 보낸다', async () => {
+    await client.getLastChangedStatuses({
+      lastChangedFrom: '2026-08-19T00:00:00.000+09:00',
+      lastChangedTo: '2026-08-19T06:00:00.000+09:00',
+    });
+
+    const [, config] = http.get.mock.calls[0];
+    expect(config.params.lastChangedTo).toBe('2026-08-19T06:00:00.000+09:00');
+    expect(config.params.limitCount).toBe(300);
+  });
+
+  it('moreSequence 를 넘기면 그대로 실어 보낸다', async () => {
+    await client.getLastChangedStatuses({
+      lastChangedFrom: '2026-08-19T02:00:00.000+09:00',
+      moreSequence: '17',
+    });
+
+    const [, config] = http.get.mock.calls[0];
+    expect(config.params.moreSequence).toBe('17');
+  });
+
+  it('moreSequence 가 없으면 파라미터를 아예 넣지 않는다', async () => {
+    await client.getLastChangedStatuses({ lastChangedFrom: '2026-08-19T02:00:00.000+09:00' });
+
+    const [, config] = http.get.mock.calls[0];
+    expect('moreSequence' in config.params).toBe(false);
+  });
+});

--- a/apps/channel-adapter/src/adapters/naver/clients/naver-order.client.ts
+++ b/apps/channel-adapter/src/adapters/naver/clients/naver-order.client.ts
@@ -164,17 +164,31 @@ export class NaverOrderClient extends NaverBaseClient {
   // =================================================================
 
   /**
-   * 지정된 기간 내에 변경된 상품 주문 내역을 조회합니다.
-   * @param lastChangedFrom 조회 시작 시각 (ISO 8601 형식)
-   * @returns API 응답 데이터
+   * 지정한 창에서 변경된 상품 주문을 조회한다.
+   *
+   * `lastChangedTo` 를 생략하면 네이버가 **`lastChangedFrom` + 24시간**을 자동 적용한다.
+   * 즉 24시간은 "허용 과거" 가 아니라 **한 번에 볼 수 있는 창의 길이**다.
+   *
+   * 응답은 `limitCount` (최대·기본 300) 에서 잘리고, 남은 항목이 있으면 `data.more` 가 실린다.
+   * 이어받으려면 `more.moreFrom` 을 새 `lastChangedFrom` 으로, `more.moreSequence` 를
+   * `moreSequence` 로 **함께** 넘겨야 같은 일시의 항목이 중복되지 않는다.
    */
-  async getLastChangedStatuses(lastChangedFrom: string): Promise<NaverLastChangedStatusResponse> {
-    const token = await this.authService.getAccessToken(); // 🔑 인증 서비스 사용
+  async getLastChangedStatuses(params: {
+    lastChangedFrom: string;
+    lastChangedTo?: string;
+    moreSequence?: string;
+  }): Promise<NaverLastChangedStatusResponse> {
+    const token = await this.authService.getAccessToken();
     const url = `${this.apiBaseUrl}/pay-order/seller/product-orders/last-changed-statuses`;
     const response = await firstValueFrom(
       this.http.get<NaverLastChangedStatusResponse>(url, {
         headers: { Authorization: `Bearer ${token}` },
-        params: { lastChangedFrom, limitCount: 300 },
+        params: {
+          lastChangedFrom: params.lastChangedFrom,
+          ...(params.lastChangedTo ? { lastChangedTo: params.lastChangedTo } : {}),
+          ...(params.moreSequence ? { moreSequence: params.moreSequence } : {}),
+          limitCount: 300,
+        },
       }),
     );
     return response.data;

--- a/apps/channel-adapter/src/services/order-collection/channel-order-provider.interface.ts
+++ b/apps/channel-adapter/src/services/order-collection/channel-order-provider.interface.ts
@@ -79,6 +79,14 @@ export interface FetchOrdersResult {
   orders: OrderFetchItem[];
   failures: OrderCollectionFailureItem[];
   lifecycleEvents?: OrderLifecycleEventItem[];
+  /**
+   * 이번 폴이 **끝까지 훑은 닫힌 조회 창**의 끝 (`WindowedChannelOrderSource`).
+   *
+   * 항목이 하나도 없을 때만 쓰인다 — 그때 워터마크를 여기까지 전진시키지 않으면 같은 닫힌 창을
+   * 영원히 다시 묻는다. 열린 질의를 쓰는 source(Medusa)는 이 필드를 내지 않으며, 그 경로의
+   * 워터마크 계산은 이 필드가 없던 때와 완전히 같다.
+   */
+  completedWindowEnd?: Date | null;
 }
 
 export type OrderFetchOutcome =

--- a/apps/channel-adapter/src/services/order-collection/channel-order-source.interface.ts
+++ b/apps/channel-adapter/src/services/order-collection/channel-order-source.interface.ts
@@ -45,6 +45,12 @@ export interface ChannelOrderLineSnapshot {
   unitPrice: number;
   fulfillmentKind?: 'physical' | 'digital';
   requiresShipping?: boolean;
+  /**
+   * 채널에서 이미 취소된 라인. **스냅샷에서 빼지 않고 표시만 한다** — 빼면 변경 해시가 달라져
+   * 부분취소가 `collected_order_modification_not_accepted` 로 오격리되고, 그 사유는 replay 가
+   * 거부한다 (`order-poller.orchestrator.ts:271`).
+   */
+  cancelled?: boolean;
 }
 
 interface LifecycleObservationBase {

--- a/apps/channel-adapter/src/services/order-collection/channel-order-source.interface.ts
+++ b/apps/channel-adapter/src/services/order-collection/channel-order-source.interface.ts
@@ -83,6 +83,7 @@ export interface ChannelOrderSnapshot {
   walletIntentId?: string;
   lines: ChannelOrderLineSnapshot[];
   amounts: {
+    /** **계약 총액** — 살아있는 라인만. Core `OrderCreated.totalAmount` 가 이 값이다. */
     total: number;
     subtotal: number;
     shipping: number;
@@ -90,6 +91,18 @@ export interface ChannelOrderSnapshot {
     /** 포인트는 할인이 아니라 결제수단이라 `total` 에 포함돼 있다. */
     points?: number;
     currency: string;
+    /**
+     * **해시 총액** — 취소된 라인까지 포함한 전 라인 합계. 계약 총액과 목적이 다르다.
+     *
+     * `changes.totalAmount` 는 `polling_change_hashes` 의 입력이라 **취소로 값이 움직이면
+     * 안 된다** — 움직이면 부분취소가 `collected_order_modification_not_accepted` 로 오격리되고
+     * 그 사유는 replay 가 거부한다(`order-poller.orchestrator.ts` 의 `not_replayable`).
+     * `total` 은 반대로 취소분을 빼야 Core 합계가 부풀지 않는다. 그래서 두 값을 나눈다.
+     *
+     * **선택 필드인 것이 요점이다.** Medusa 는 `cancelled` 라인 개념이 없어 이 값을 세팅하지
+     * 않고, translator 가 `total` 로 폴백하므로 Medusa 의 해시 입력이 바이트 단위로 그대로다.
+     */
+    allLinesTotal?: number;
   };
   shippingAddress: ShippingAddress;
   createdAt: string;
@@ -110,4 +123,32 @@ export interface ReplayableChannelOrderSource extends ChannelOrderSource {
 
 export function isReplayableSource(source: ChannelOrderSource): source is ReplayableChannelOrderSource {
   return typeof (source as ReplayableChannelOrderSource).fetchOrder === 'function';
+}
+
+/**
+ * **닫힌 조회 창**을 쓰는 source. 워터마크가 항목 없이도 전진할 수 있게 창의 끝을 함께 보고한다.
+ *
+ * 왜 필요한가: 네이버 변경 피드는 `[since, since+24h]` 로 창이 닫힌다. 그 창 안에 아무 변경도
+ * 없으면 항목이 0건이고, 오케스트레이터의 워터마크는 `null` 로 남는다. `sync-status.service.ts`
+ * 의 `recordSyncComplete` 는 `watermark === null` 이면 `lastSyncAt` 을 **갱신하지 않으므로**
+ * 다음 주기가 같은 닫힌 창을 다시 묻는다 — 조용한 24시간이 수집을 영구히 정지시킨다.
+ *
+ * 창이 `now` 에서 끝났다면(아직 열려 있다면) `null` 을 보고한다. 그 경우는 창이 시간과 함께
+ * 자라므로 영구 정지가 아니고, 성급히 전진시키면 경계 근처 변경을 잃는다.
+ *
+ * Medusa 는 `since` 이후 전부를 훑는 열린 질의라 이 계약을 구현하지 않는다 — 즉 이 필드는
+ * Medusa 경로에 존재하지 않고, 오케스트레이터도 그 경로에서는 예전 그대로 동작한다.
+ */
+export interface WindowedFetchResult {
+  snapshots: ChannelOrderSnapshot[];
+  /** 방금 **끝까지 훑은** 닫힌 창의 끝. 창이 열려 있거나 페이징이 잘렸으면 `null`. */
+  completedWindowEnd: Date | null;
+}
+
+export interface WindowedChannelOrderSource extends ChannelOrderSource {
+  fetchOrdersInWindow(since: Date | null): Promise<WindowedFetchResult>;
+}
+
+export function isWindowedSource(source: ChannelOrderSource): source is WindowedChannelOrderSource {
+  return typeof (source as WindowedChannelOrderSource).fetchOrdersInWindow === 'function';
 }

--- a/apps/channel-adapter/src/services/order-collection/channel-order.translator.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/channel-order.translator.spec.ts
@@ -101,7 +101,34 @@ describe('ChannelOrderTranslator — lineIdentity: mapped (naver/coupang)', () =
     });
     // resolver 가 준 사유(#674)가 라인 ID 와 정확히 짝지어 실려야 한다 — 순서가 바뀌거나
     // 필드가 뒤바뀌면(lineId↔cause) 여기서 잡힌다.
-    expect(outcome.failure.affectedLines).toEqual([{ lineId: 'naver-product-order-1', cause: 'listing_not_found' }]);
+    expect(outcome.failure.affectedLines).toEqual([
+      { lineId: 'naver-product-order-1', cause: 'listing_not_found', channelProductId: 'naver-product-1' },
+    ]);
+  });
+
+  it('격리 행에 해석에 쓴 채널상품ID 를 함께 남긴다 — 화면 프리필의 정본이다', async () => {
+    const { translator } = makeTranslator(null);
+
+    const { outcome } = await translator.translate(
+      'naver',
+      makeSnapshot({
+        lines: [
+          {
+            channelOrderItemId: 'po-1',
+            channelProductId: '13700000002',
+            productName: '미매핑 상품',
+            quantity: 1,
+            unitPrice: 5000,
+          },
+        ],
+      }),
+    );
+
+    expect(outcome.kind).toBe('failure');
+    if (outcome.kind !== 'failure') return;
+    expect(outcome.failure.affectedLines).toEqual([
+      { lineId: 'po-1', cause: 'listing_not_found', channelProductId: '13700000002' },
+    ]);
   });
 
   it('여러 라인 중 일부만 미식별이면 그 라인의 사유만, Core 가 준 값 그대로 싣는다', async () => {
@@ -143,7 +170,9 @@ describe('ChannelOrderTranslator — lineIdentity: mapped (naver/coupang)', () =
     if (outcome.kind !== 'failure') throw new Error('unreachable');
     // 식별된 첫 라인은 빠지고, 미식별인 두 번째 라인만 — Core 가 준 cause 그대로 — 남아야 한다.
     expect(outcome.failure.affectedLineIds).toEqual(['naver-product-order-2']);
-    expect(outcome.failure.affectedLines).toEqual([{ lineId: 'naver-product-order-2', cause: 'variant_inactive' }]);
+    expect(outcome.failure.affectedLines).toEqual([
+      { lineId: 'naver-product-order-2', cause: 'variant_inactive', channelProductId: 'naver-product-2' },
+    ]);
   });
 
   it('이미 종결된 스냅샷은 매핑이 없어도 격리하지 않는다 — 판매주문을 만들지 않기 때문', async () => {

--- a/apps/channel-adapter/src/services/order-collection/channel-order.translator.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/channel-order.translator.spec.ts
@@ -333,4 +333,68 @@ describe('ChannelOrderTranslator — 변경 해시 입력의 모양', () => {
     expect(outcome.order.changes.shippingAddress).toEqual(SHIPPING_ADDRESS);
     expect(outcome.order.changes.totalAmount).toBe(10000);
   });
+
+  /**
+   * `allLinesTotal` 을 내지 않는 source 가 Medusa 다. 폴백이 사라지면 Medusa 의 해시 입력이
+   * 바뀌어 배포 직후 한 주기의 주문이 전부 `collected_order_modification_not_accepted` 로
+   * 격리된다 — replay 가 거부하는 사유라 운영자가 지울 수 없는 행이 남는다.
+   */
+  it('allLinesTotal 이 없으면 총액은 amounts.total 그대로다 (Medusa 해시 입력 불변)', async () => {
+    const { translator } = makeTranslator(LISTING);
+
+    // `MedusaOrderSource` 의 amounts 가 정확히 이 모양이다 — `allLinesTotal` 을 세팅하지 않는다.
+    const snapshot = makeSnapshot();
+    expect(snapshot.amounts.allLinesTotal).toBeUndefined();
+
+    const { outcome } = await translator.translate('naver', snapshot);
+    if (outcome.kind !== 'order') throw new Error('unreachable');
+
+    expect(outcome.order.changes.totalAmount).toBe(snapshot.amounts.total);
+    expect(outcome.order.changes.totalAmount).toBe(outcome.order.createPayload.totalAmount);
+  });
+
+  /**
+   * 부분취소가 `changes` 해시를 흔들면 그 주문은 다음 폴링에서 오격리된다. `items` 는 이미 전
+   * 라인을 담고 있었지만 총액은 계약 총액(살아있는 라인 합)을 재사용하고 있어 취소가 곧 값
+   * 변경이었다 — 해시 전용 총액을 따로 받아 그 축을 끊는다.
+   */
+  it('allLinesTotal 이 있으면 해시 총액으로 그것을 쓴다 — 계약 총액과 갈린다 (FIX C)', async () => {
+    const { translator } = makeTranslator(LISTING);
+
+    const { outcome } = await translator.translate(
+      'naver',
+      makeSnapshot({
+        lines: [
+          {
+            channelOrderItemId: 'po-1',
+            channelProductId: 'naver-product-1',
+            productName: '살아있는 라인',
+            quantity: 1,
+            unitPrice: 5000,
+          },
+          {
+            channelOrderItemId: 'po-2',
+            channelProductId: 'naver-product-1',
+            productName: '취소된 라인',
+            quantity: 1,
+            unitPrice: 3000,
+            cancelled: true,
+          },
+        ],
+        amounts: {
+          total: 5000,
+          subtotal: 5000,
+          shipping: 0,
+          discount: 0,
+          currency: 'KRW',
+          allLinesTotal: 8000,
+        },
+      }),
+    );
+    if (outcome.kind !== 'order') throw new Error('unreachable');
+
+    // 계약 총액은 실판매분(5000), 해시 총액은 전 라인(8000) — 취소 전과 같은 값이다.
+    expect(outcome.order.createPayload.totalAmount).toBe(5000);
+    expect(outcome.order.changes.totalAmount).toBe(8000);
+  });
 });

--- a/apps/channel-adapter/src/services/order-collection/channel-order.translator.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/channel-order.translator.spec.ts
@@ -211,6 +211,80 @@ describe('ChannelOrderTranslator — lineIdentity: mapped (naver/coupang)', () =
   });
 });
 
+describe('ChannelOrderTranslator — 취소된 라인', () => {
+  /**
+   * 네이버는 한 주문의 일부 상품주문만 취소되는 일이 흔하다. 취소된 라인을 스냅샷에서 빼버리면
+   * 변경 해시(`changes.items`)가 달라져 부분취소가 `collected_order_modification_not_accepted`
+   * 로 오격리된다 — 그 사유는 replay 가 거부한다. 그래서 취소 라인은 계약(`createPayload.items`)
+   * 에서만 빠지고 해시 입력(`changes.items`)에는 남아야 한다.
+   */
+  it('취소된 라인은 판매주문 계약에서 빠지지만 변경 해시에는 남는다', async () => {
+    const { translator } = makeTranslator(LISTING);
+
+    const { outcome } = await translator.translate(
+      'naver',
+      makeSnapshot({
+        lines: [
+          {
+            channelOrderItemId: 'po-1',
+            channelProductId: 'naver-product-1',
+            productName: '살아있는 라인',
+            quantity: 1,
+            unitPrice: 5000,
+          },
+          {
+            channelOrderItemId: 'po-2',
+            channelProductId: 'naver-product-2',
+            productName: '취소된 라인',
+            quantity: 1,
+            unitPrice: 3000,
+            cancelled: true,
+          },
+        ],
+      }),
+    );
+
+    expect(outcome.kind).toBe('order');
+    if (outcome.kind !== 'order') return;
+    expect(outcome.order.createPayload.items.map((i) => i.orderItemId)).toEqual(['po-1']);
+    expect(outcome.order.changes.items.map((i) => i.orderItemId)).toEqual(['po-1', 'po-2']);
+  });
+
+  it('취소된 라인의 미식별은 격리를 부르지 않는다', async () => {
+    const { translator, resolveByChannelCode } = makeTranslator(LISTING);
+    resolveByChannelCode.mockImplementation(async (_channelCode: string, channelItemId: string) =>
+      channelItemId === 'naver-product-2'
+        ? { found: false, cause: 'listing_not_found' }
+        : { found: true, listing: LISTING },
+    );
+
+    const { outcome } = await translator.translate(
+      'naver',
+      makeSnapshot({
+        lines: [
+          {
+            channelOrderItemId: 'po-1',
+            channelProductId: 'naver-product-1',
+            productName: '살아있는 라인',
+            quantity: 1,
+            unitPrice: 5000,
+          },
+          {
+            channelOrderItemId: 'po-2',
+            channelProductId: 'naver-product-2',
+            productName: '취소된 라인',
+            quantity: 1,
+            unitPrice: 3000,
+            cancelled: true,
+          },
+        ],
+      }),
+    );
+
+    expect(outcome.kind).toBe('order');
+  });
+});
+
 describe('ChannelOrderTranslator — 변경 해시 입력의 모양', () => {
   /**
    * `OrderFetchItem.changes` 는 저장된 `polling_change_hashes` 의 입력이다. 여기에 채널 원어를

--- a/apps/channel-adapter/src/services/order-collection/channel-order.translator.ts
+++ b/apps/channel-adapter/src/services/order-collection/channel-order.translator.ts
@@ -44,7 +44,14 @@ export class ChannelOrderTranslator {
     const unidentified = snapshot.lines.flatMap((line, index) => {
       if (line.cancelled) return [];
       const resolution = resolutions[index];
-      return resolution.identified ? [] : [{ lineId: line.channelOrderItemId, cause: resolution.cause }];
+      if (resolution.identified) return [];
+      return [
+        {
+          lineId: line.channelOrderItemId,
+          cause: resolution.cause,
+          ...(line.channelProductId ? { channelProductId: line.channelProductId } : {}),
+        },
+      ];
     });
 
     if (eligibleForOrderCreation && unidentified.length > 0) {

--- a/apps/channel-adapter/src/services/order-collection/channel-order.translator.ts
+++ b/apps/channel-adapter/src/services/order-collection/channel-order.translator.ts
@@ -40,7 +40,9 @@ export class ChannelOrderTranslator {
 
     // 유료 주문 라인이 미식별이면 조용히 넘기지 않고 격리한다 (CONTEXT §채널 상품 식별 실패).
     // 이미 종결된 스냅샷(취소/환불 관측)은 판매주문을 만들지 않으므로 식별을 요구하지 않는다.
+    // 취소된 라인은 판매주문을 만들지 않으므로 식별을 요구하지 않는다.
     const unidentified = snapshot.lines.flatMap((line, index) => {
+      if (line.cancelled) return [];
       const resolution = resolutions[index];
       return resolution.identified ? [] : [{ lineId: line.channelOrderItemId, cause: resolution.cause }];
     });
@@ -62,10 +64,16 @@ export class ChannelOrderTranslator {
       };
     }
 
-    const items = snapshot.lines.map((line, index) => {
+    const allItems = snapshot.lines.map((line, index) => {
       const resolution = resolutions[index];
-      return this.buildOrderItem(line, resolution.identified ? resolution.identity : null);
+      return {
+        item: this.buildOrderItem(line, resolution.identified ? resolution.identity : null),
+        cancelled: line.cancelled === true,
+      };
     });
+    // 계약에는 살아있는 라인만 넣는다. 해시는 전 라인으로 계산해 취소가 modification 으로 세지지 않게 한다.
+    const items = allItems.filter((entry) => !entry.cancelled).map((entry) => entry.item);
+    const changeItems = allItems.map((entry) => entry.item);
 
     const createPayload: OrderCreatedPayload = {
       orderId: uuidv4(),
@@ -93,7 +101,7 @@ export class ChannelOrderTranslator {
       eligibleForOrderCreation,
       createPayload,
       changes: {
-        items,
+        items: changeItems,
         shippingAddress: snapshot.shippingAddress,
         totalAmount: snapshot.amounts.total,
       },

--- a/apps/channel-adapter/src/services/order-collection/channel-order.translator.ts
+++ b/apps/channel-adapter/src/services/order-collection/channel-order.translator.ts
@@ -110,7 +110,12 @@ export class ChannelOrderTranslator {
       changes: {
         items: changeItems,
         shippingAddress: snapshot.shippingAddress,
-        totalAmount: snapshot.amounts.total,
+        // 취소가 modification 을 유발하지 않으려면 **금액도** 취소에 흔들리면 안 된다.
+        // `items` 만 전 라인으로 두고 총액을 계약 총액(살아있는 라인 합)으로 두면, 라인 하나가
+        // 취소되는 순간 해시가 바뀌어 `collected_order_modification_not_accepted` 로 오격리되고
+        // 그 사유는 replay 가 거부한다. `allLinesTotal` 을 내지 않는 source(Medusa)는 `total`
+        // 로 폴백하므로 해시 입력이 바이트 단위로 예전과 같다.
+        totalAmount: snapshot.amounts.allLinesTotal ?? snapshot.amounts.total,
       },
       modifiedAt: snapshot.sourceUpdatedAt,
     };

--- a/apps/channel-adapter/src/services/order-collection/medusa-order-collection.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/medusa-order-collection.spec.ts
@@ -89,6 +89,16 @@ describe('Medusa order collection (source + translator)', () => {
     expect(ORDER_STREAM.events.OrderCreated.schema!.parse(result.orders[0].createPayload)).toEqual(
       result.orders[0].createPayload,
     );
+    // 해시 입력 불변식 (#643 FIX C/D): Medusa 는 취소 라인 개념이 없어 `changes` 의 세 값이
+    // `createPayload` 의 세 값과 같다. 이것이 깨지면 배포 직후 한 주기의 Medusa 주문이 전부
+    // `collected_order_modification_not_accepted` 로 격리되고, 그 사유는 replay 가 거부한다.
+    expect(result.orders[0].changes).toEqual({
+      items: result.orders[0].createPayload.items,
+      shippingAddress: result.orders[0].createPayload.shippingAddress,
+      totalAmount: result.orders[0].createPayload.totalAmount,
+    });
+    // 닫힌 창 계약도 타지 않는다 — 워터마크 계산이 예전 그대로여야 한다 (FIX F).
+    expect(result.completedWindowEnd).toBeUndefined();
   });
 
   it('does not manufacture a Medusa channelProductId from the line item ID', async () => {

--- a/apps/channel-adapter/src/services/order-collection/naver-order-fields.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/naver-order-fields.spec.ts
@@ -42,4 +42,8 @@ describe('parseNaverProductOrderInfo', () => {
   it('필수 식별자가 없으면 throw 한다 — 조용히 넘기지 않는다', () => {
     expect(() => parseNaverProductOrderInfo({ ...raw, productOrder: { ...raw.productOrder, productOrderId: undefined } })).toThrow();
   });
+
+  it('unitPrice 누락 시 throw 한다 — 매출이 0 으로 조용히 기록되는 회복 불가 사태를 방지한다', () => {
+    expect(() => parseNaverProductOrderInfo({ ...raw, productOrder: { ...raw.productOrder, unitPrice: undefined } })).toThrow();
+  });
 });

--- a/apps/channel-adapter/src/services/order-collection/naver-order-fields.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/naver-order-fields.spec.ts
@@ -1,0 +1,45 @@
+import { parseNaverProductOrderInfo } from './naver-order-fields';
+
+const raw = {
+  order: {
+    orderId: '2026081900000',
+    paymentDate: '2026-08-19T00:00:00.000+09:00',
+    ordererName: '홍길동',
+    ordererTel: '010-0000-0000',
+  },
+  productOrder: {
+    productOrderId: '2026081900001',
+    productOrderStatus: 'PAYED',
+    productId: '13700000002',
+    productName: '아몬드영 세럼',
+    quantity: 2,
+    unitPrice: 12000,
+    totalPaymentAmount: 24000,
+    shippingAddress: {
+      name: '홍길동',
+      tel1: '010-0000-0000',
+      zipCode: '06236',
+      baseAddress: '서울 강남구 테헤란로 1',
+      detailedAddress: '10층',
+    },
+  },
+};
+
+describe('parseNaverProductOrderInfo', () => {
+  it('필요한 필드만 뽑아 좁힌 모양으로 돌려준다', () => {
+    const parsed = parseNaverProductOrderInfo(raw);
+    expect(parsed.orderId).toBe('2026081900000');
+    expect(parsed.productOrderId).toBe('2026081900001');
+    expect(parsed.channelProductId).toBe('13700000002');
+    expect(parsed.quantity).toBe(2);
+    expect(parsed.shippingAddress.postalCode).toBe('06236');
+  });
+
+  it('모르는 필드가 더 있어도 통과한다', () => {
+    expect(() => parseNaverProductOrderInfo({ ...raw, unknownTopLevel: 1 })).not.toThrow();
+  });
+
+  it('필수 식별자가 없으면 throw 한다 — 조용히 넘기지 않는다', () => {
+    expect(() => parseNaverProductOrderInfo({ ...raw, productOrder: { ...raw.productOrder, productOrderId: undefined } })).toThrow();
+  });
+});

--- a/apps/channel-adapter/src/services/order-collection/naver-order-fields.ts
+++ b/apps/channel-adapter/src/services/order-collection/naver-order-fields.ts
@@ -12,6 +12,18 @@ import { ClaimStatusSchema, ProductOrderStatusSchema } from '../../zods/naver/na
  *
  * `looseObject` 인 것이 요점이다: 모르는 필드는 통과시키고, **우리가 의존하는 필드가 없으면
  * throw** 한다. 삼키면 라인이 조용히 빠진 주문이 Core 로 들어간다.
+ *
+ * **Load-bearing 필드** (누락 시 throw):
+ * - `orderId` — 주문 식별 (필수)
+ * - `productOrderId` — 상품주문 식별 (필수)
+ * - `productOrderStatus` — 주문 상태 (필수)
+ * - `quantity` — 수량 (필수, 기본값 1 은 언더십핑 위험)
+ * - `unitPrice` — 단가 (필수, 누락 시 매출 0 으로 조용히 기록되어 회복 불가)
+ *
+ * **Display/Fallback 필드** (누락 가능):
+ * - `productName`, `shippingAddress` — 기본값으로 표시 목적 달성
+ * - `totalPaymentAmount` — `unitPrice * quantity` 로 유도 가능
+ * - `deliveryFeeAmount` — 누락 시 배송료 0 (수량 부문 아님)
  */
 const OrderSchema = z.looseObject({
   orderId: z.string().min(1),
@@ -34,8 +46,8 @@ const ProductOrderSchema = z.looseObject({
   claimStatus: ClaimStatusSchema.optional(),
   productId: z.union([z.string(), z.number()]).optional(),
   productName: z.string().optional(),
-  quantity: z.number().int().nonnegative().optional(),
-  unitPrice: z.number().nonnegative().optional(),
+  quantity: z.number().int().nonnegative(),
+  unitPrice: z.number().nonnegative(),
   totalPaymentAmount: z.number().nonnegative().optional(),
   deliveryFeeAmount: z.number().nonnegative().optional(),
   shippingAddress: ShippingAddressSchema.optional(),
@@ -66,8 +78,6 @@ export function parseNaverProductOrderInfo(raw: unknown): NaverProductOrderInfo 
   const parsed = ProductOrderInfoSchema.parse(raw);
   const { order, productOrder } = parsed;
   const address = productOrder.shippingAddress;
-  const quantity = productOrder.quantity ?? 1;
-  const unitPrice = productOrder.unitPrice ?? 0;
 
   return {
     orderId: order.orderId,
@@ -76,9 +86,9 @@ export function parseNaverProductOrderInfo(raw: unknown): NaverProductOrderInfo 
     ...(productOrder.claimStatus ? { claimStatus: productOrder.claimStatus } : {}),
     ...(productOrder.productId != null ? { channelProductId: String(productOrder.productId) } : {}),
     productName: productOrder.productName ?? productOrder.productOrderId,
-    quantity,
-    unitPrice,
-    lineTotal: productOrder.totalPaymentAmount ?? unitPrice * quantity,
+    quantity: productOrder.quantity,
+    unitPrice: productOrder.unitPrice,
+    lineTotal: productOrder.totalPaymentAmount ?? productOrder.unitPrice * productOrder.quantity,
     shippingFee: productOrder.deliveryFeeAmount ?? 0,
     ...(order.paymentDate ? { paymentDate: order.paymentDate } : {}),
     shippingAddress: {

--- a/apps/channel-adapter/src/services/order-collection/naver-order-fields.ts
+++ b/apps/channel-adapter/src/services/order-collection/naver-order-fields.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod';
+import type { ShippingAddress } from '@packages/event-contracts/streams';
+import { ClaimStatusSchema, ProductOrderStatusSchema } from '../../zods/naver/naver-core.zod';
+
+/**
+ * 네이버 상품주문 상세의 **우리가 읽는 부분만** 좁힌 모양.
+ *
+ * 커머스API 의 공개 문서(`llms/*.md`)는 `order`·`productOrder` 의 하위 구조를 "OAS 참조" 로
+ * 생략한다. 그래서 **이 파일이 필드명 확정의 단일 지점**이다 — shadow 점검(계획 Task 8)에서
+ * 실 응답을 보고 여기만 고친다. 아래 이름은 옛 어댑터가 실제로 읽던 값이다
+ * (`naver-smartstore.adapter.ts:727-745`).
+ *
+ * `looseObject` 인 것이 요점이다: 모르는 필드는 통과시키고, **우리가 의존하는 필드가 없으면
+ * throw** 한다. 삼키면 라인이 조용히 빠진 주문이 Core 로 들어간다.
+ */
+const OrderSchema = z.looseObject({
+  orderId: z.string().min(1),
+  paymentDate: z.string().optional(),
+  ordererName: z.string().optional(),
+  ordererTel: z.string().optional(),
+});
+
+const ShippingAddressSchema = z.looseObject({
+  name: z.string().optional(),
+  tel1: z.string().optional(),
+  zipCode: z.string().optional(),
+  baseAddress: z.string().optional(),
+  detailedAddress: z.string().optional(),
+});
+
+const ProductOrderSchema = z.looseObject({
+  productOrderId: z.string().min(1),
+  productOrderStatus: ProductOrderStatusSchema,
+  claimStatus: ClaimStatusSchema.optional(),
+  productId: z.union([z.string(), z.number()]).optional(),
+  productName: z.string().optional(),
+  quantity: z.number().int().nonnegative().optional(),
+  unitPrice: z.number().nonnegative().optional(),
+  totalPaymentAmount: z.number().nonnegative().optional(),
+  deliveryFeeAmount: z.number().nonnegative().optional(),
+  shippingAddress: ShippingAddressSchema.optional(),
+});
+
+const ProductOrderInfoSchema = z.looseObject({
+  order: OrderSchema,
+  productOrder: ProductOrderSchema,
+});
+
+export interface NaverProductOrderInfo {
+  orderId: string;
+  productOrderId: string;
+  productOrderStatus: z.infer<typeof ProductOrderStatusSchema>;
+  claimStatus?: z.infer<typeof ClaimStatusSchema>;
+  /** 리스팅 조회 키. 종류(원상품번호 vs 채널상품번호)는 shadow 로 확정한다. */
+  channelProductId?: string;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  lineTotal: number;
+  shippingFee: number;
+  paymentDate?: string;
+  shippingAddress: ShippingAddress;
+}
+
+export function parseNaverProductOrderInfo(raw: unknown): NaverProductOrderInfo {
+  const parsed = ProductOrderInfoSchema.parse(raw);
+  const { order, productOrder } = parsed;
+  const address = productOrder.shippingAddress;
+  const quantity = productOrder.quantity ?? 1;
+  const unitPrice = productOrder.unitPrice ?? 0;
+
+  return {
+    orderId: order.orderId,
+    productOrderId: productOrder.productOrderId,
+    productOrderStatus: productOrder.productOrderStatus,
+    ...(productOrder.claimStatus ? { claimStatus: productOrder.claimStatus } : {}),
+    ...(productOrder.productId != null ? { channelProductId: String(productOrder.productId) } : {}),
+    productName: productOrder.productName ?? productOrder.productOrderId,
+    quantity,
+    unitPrice,
+    lineTotal: productOrder.totalPaymentAmount ?? unitPrice * quantity,
+    shippingFee: productOrder.deliveryFeeAmount ?? 0,
+    ...(order.paymentDate ? { paymentDate: order.paymentDate } : {}),
+    shippingAddress: {
+      recipientName: address?.name ?? order.ordererName ?? 'Unknown',
+      phone: address?.tel1 ?? order.ordererTel ?? '',
+      postalCode: address?.zipCode ?? '',
+      roadAddress: address?.baseAddress ?? '',
+      detailAddress: address?.detailedAddress ?? '',
+    },
+  };
+}

--- a/apps/channel-adapter/src/services/order-collection/naver-order.source.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/naver-order.source.spec.ts
@@ -1,0 +1,175 @@
+import { NaverOrderSource } from './naver-order.source';
+
+const changed = (productOrderId: string, orderId: string) => ({
+  orderId,
+  productOrderId,
+  lastChangedType: 'PAYED' as const,
+  lastChangedDate: '2026-08-19T01:00:00.000+09:00',
+  productOrderStatus: 'PAYED' as const,
+});
+
+const detail = (productOrderId: string, orderId: string, overrides: Record<string, unknown> = {}) => ({
+  order: { orderId, paymentDate: '2026-08-19T00:00:00.000+09:00', ordererName: '홍길동' },
+  productOrder: {
+    productOrderId,
+    productOrderStatus: 'PAYED',
+    productId: '13700000002',
+    productName: '세럼',
+    quantity: 1,
+    unitPrice: 10000,
+    totalPaymentAmount: 10000,
+    shippingAddress: { name: '홍길동', tel1: '010', zipCode: '06236', baseAddress: '서울', detailedAddress: '1층' },
+    ...overrides,
+  },
+});
+
+describe('NaverOrderSource', () => {
+  let client: any;
+  let source: NaverOrderSource;
+
+  beforeEach(() => {
+    client = {
+      getLastChangedStatuses: jest.fn(),
+      getProductOrderIdsByOrderId: jest.fn(),
+      getOrderDetails: jest.fn(),
+    };
+    source = new NaverOrderSource(client);
+  });
+
+  it('한 라인만 변경돼도 형제 라인을 복원해 주문 전체를 조립한다', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-2', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2', 'po-3'] });
+    client.getOrderDetails.mockResolvedValue({
+      data: [detail('po-1', 'ord-1'), detail('po-2', 'ord-1'), detail('po-3', 'ord-1')],
+    });
+
+    const snapshots = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0].lines.map((l) => l.channelOrderItemId)).toEqual(['po-1', 'po-2', 'po-3']);
+    expect(snapshots[0].paymentState).toBe('accepted');
+  });
+
+  it('상세 응답이 요청보다 적으면 throw 한다 — 라인이 빠진 주문을 만들지 않는다', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-1', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2'] });
+    client.getOrderDetails.mockResolvedValue({ data: [detail('po-1', 'ord-1')] });
+
+    await expect(source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'))).rejects.toThrow(/누락/);
+  });
+
+  it('more 를 따라 다음 페이지를 이어 받는다', async () => {
+    client.getLastChangedStatuses
+      .mockResolvedValueOnce({
+        data: {
+          count: 300,
+          lastChangeStatuses: [changed('po-1', 'ord-1')],
+          more: { moreFrom: '2026-08-19T02:00:00.000+09:00', moreSequence: '17' },
+        },
+      })
+      .mockResolvedValueOnce({ data: { count: 1, lastChangeStatuses: [changed('po-2', 'ord-2')] } });
+    client.getProductOrderIdsByOrderId.mockImplementation(async (orderId: string) => ({
+      data: [orderId === 'ord-1' ? 'po-1' : 'po-2'],
+    }));
+    client.getOrderDetails.mockImplementation(async (ids: string[]) => ({
+      data: ids.map((id) => detail(id, id === 'po-1' ? 'ord-1' : 'ord-2')),
+    }));
+
+    const snapshots = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    expect(client.getLastChangedStatuses).toHaveBeenCalledTimes(2);
+    expect(client.getLastChangedStatuses.mock.calls[1][0]).toMatchObject({
+      lastChangedFrom: '2026-08-19T02:00:00.000+09:00',
+      moreSequence: '17',
+    });
+    expect(snapshots.map((s) => s.externalOrderId).sort()).toEqual(['ord-1', 'ord-2']);
+  });
+
+  it('취소 요청 중이면 accepted 로 보지 않는다', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-1', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1'] });
+    client.getOrderDetails.mockResolvedValue({
+      data: [detail('po-1', 'ord-1', { claimStatus: 'CANCEL_REQUEST' })],
+    });
+
+    const [snapshot] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+    expect(snapshot.paymentState).toBe('pending');
+  });
+
+  it('일부 라인만 취소면 라인 단위 부분취소 관측을 낸다', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-2', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2'] });
+    client.getOrderDetails.mockResolvedValue({
+      data: [detail('po-1', 'ord-1'), detail('po-2', 'ord-1', { productOrderStatus: 'CANCELED' })],
+    });
+
+    const [snapshot] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    expect(snapshot.paymentState).toBe('accepted');
+    expect(snapshot.lines.find((l) => l.channelOrderItemId === 'po-2')?.cancelled).toBe(true);
+    expect(snapshot.lifecycle).toHaveLength(1);
+    expect(snapshot.lifecycle[0].eventKey).toBe('cancelled:po-2');
+    expect(snapshot.lifecycle[0].payload).toMatchObject({
+      cancelledLines: [{ channelOrderItemId: 'po-2', quantity: 1 }],
+    });
+  });
+
+  it('전 라인 취소면 전체 취소 1건이고 terminal 이다', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-1', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1'] });
+    client.getOrderDetails.mockResolvedValue({
+      data: [detail('po-1', 'ord-1', { productOrderStatus: 'CANCELED' })],
+    });
+
+    const [snapshot] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    expect(snapshot.paymentState).toBe('terminal');
+    expect(snapshot.lifecycle).toHaveLength(1);
+    expect(snapshot.lifecycle[0].eventKey).toBe('cancelled');
+    expect((snapshot.lifecycle[0].payload as Record<string, unknown>).cancelledLines).toBeUndefined();
+  });
+
+  it('sourceUpdatedAt 은 채널이 말한 변경 시각이다 — 현재 시각을 쓰면 워터마크가 창을 건너뛴다', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: {
+        count: 1,
+        lastChangeStatuses: [
+          { ...changed('po-1', 'ord-1'), lastChangedDate: '2026-08-19T01:00:00.000+09:00' },
+          { ...changed('po-2', 'ord-1'), lastChangedDate: '2026-08-19T03:00:00.000+09:00' },
+        ],
+      },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2'] });
+    client.getOrderDetails.mockResolvedValue({ data: [detail('po-1', 'ord-1'), detail('po-2', 'ord-1')] });
+
+    const [snapshot] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    // 한 주문의 여러 라인이 바뀌면 가장 늦은 시각을 취한다.
+    expect(snapshot.sourceUpdatedAt).toBe('2026-08-19T03:00:00.000+09:00');
+  });
+
+  it('워터마크가 없으면 최근 1시간을, 오래됐으면 24시간 창을 조회한다', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({ data: { count: 0, lastChangeStatuses: [] } });
+
+    await source.fetchOrders(null);
+    const firstCall = client.getLastChangedStatuses.mock.calls[0][0];
+    expect(firstCall.lastChangedTo).toBeUndefined();
+
+    const old = new Date(Date.now() - 72 * 60 * 60 * 1000);
+    await source.fetchOrders(old);
+    const secondCall = client.getLastChangedStatuses.mock.calls[1][0];
+    const from = new Date(secondCall.lastChangedFrom).getTime();
+    const to = new Date(secondCall.lastChangedTo).getTime();
+    expect(to - from).toBe(24 * 60 * 60 * 1000);
+  });
+});

--- a/apps/channel-adapter/src/services/order-collection/naver-order.source.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/naver-order.source.spec.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import { NaverOrderSource } from './naver-order.source';
 
 const changed = (productOrderId: string, orderId: string) => ({
@@ -52,14 +53,48 @@ describe('NaverOrderSource', () => {
     expect(snapshots[0].paymentState).toBe('accepted');
   });
 
-  it('상세 응답이 요청보다 적으면 throw 한다 — 라인이 빠진 주문을 만들지 않는다', async () => {
-    client.getLastChangedStatuses.mockResolvedValue({
-      data: { count: 1, lastChangeStatuses: [changed('po-1', 'ord-1')] },
-    });
+  // FIX 2 이후 `fetchOrders` 는 개별 주문 실패를 삼키고 건너뛴다(throw 하지 않는다) — 그래서
+  // 이 throw 자체를 검증하려면 워터마크 경로가 아닌 replay 전용 `fetchOrder` 를 직접 불러야
+  // 한다. `fetchOrder` 는 사람이 트리거하는 replay 라 여전히 그대로 throw 한다.
+  it('상세 응답이 요청보다 적으면 throw 한다 — 라인이 빠진 주문을 만들지 않는다 (replay 경로 fetchOrder 로 검증)', async () => {
     client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2'] });
     client.getOrderDetails.mockResolvedValue({ data: [detail('po-1', 'ord-1')] });
 
-    await expect(source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'))).rejects.toThrow(/누락/);
+    await expect(source.fetchOrder('ord-1')).rejects.toThrow(/누락/);
+  });
+
+  it('상세 응답 개수는 맞아도 요청하지 않은 productOrderId 가 섞여 있으면 throw 한다 (개수 대신 신원을 본다, FIX 5)', async () => {
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2'] });
+    // 개수는 요청과 같은 2건이지만, 요청한 po-2 대신 엉뚱한 po-9 가 섞여 있다.
+    client.getOrderDetails.mockResolvedValue({
+      data: [detail('po-1', 'ord-1'), detail('po-9', 'ord-1')],
+    });
+
+    await expect(source.fetchOrder('ord-1')).rejects.toThrow(/누락/);
+  });
+
+  it('세 주문 중 하나의 상세가 깨져도 나머지는 계속 수집하고 throw 하지 않는다 (한 주문 실패가 주기 전체를 막지 않는다, FIX 2)', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: {
+        count: 3,
+        lastChangeStatuses: [changed('po-1', 'ord-1'), changed('po-2', 'ord-2'), changed('po-3', 'ord-3')],
+      },
+    });
+    client.getProductOrderIdsByOrderId.mockImplementation(async (orderId: string) => ({
+      data: [orderId === 'ord-1' ? 'po-1' : orderId === 'ord-2' ? 'po-2' : 'po-3'],
+    }));
+    client.getOrderDetails.mockImplementation(async (ids: string[]) => {
+      const id = ids[0];
+      if (id === 'po-2') {
+        // 필수 필드(quantity) 가 없어 parseNaverProductOrderInfo 가 throw 하는 응답.
+        return { data: [detail('po-2', 'ord-2', { quantity: undefined })] };
+      }
+      return { data: [detail(id, id === 'po-1' ? 'ord-1' : 'ord-3')] };
+    });
+
+    const snapshots = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    expect(snapshots.map((s) => s.externalOrderId).sort()).toEqual(['ord-1', 'ord-3']);
   });
 
   it('more 를 따라 다음 페이지를 이어 받는다', async () => {
@@ -122,6 +157,68 @@ describe('NaverOrderSource', () => {
     });
   });
 
+  it('부분취소면 금액 합계가 취소된 라인을 빼고 산출된다 — 안 그러면 Core 총액이 부풀려진다 (FIX 3)', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-2', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2'] });
+    client.getOrderDetails.mockResolvedValue({
+      data: [detail('po-1', 'ord-1'), detail('po-2', 'ord-1', { productOrderStatus: 'CANCELED' })],
+    });
+
+    const [snapshot] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    // 두 라인 다 포함하면 20000/20000 이 나온다 — 취소된 po-2 를 빼고 po-1 몫만 남아야 한다.
+    expect(snapshot.amounts.total).toBe(10000);
+    expect(snapshot.amounts.subtotal).toBe(10000);
+    expect(snapshot.amounts.shipping).toBe(0);
+  });
+
+  it('ADMIN_CANCELING(관리자 취소 진행중) claim 도 취소요청과 같이 accepted 로 보지 않는다 (FIX 6)', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-1', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1'] });
+    client.getOrderDetails.mockResolvedValue({
+      data: [detail('po-1', 'ord-1', { claimStatus: 'ADMIN_CANCELING' })],
+    });
+
+    const [snapshot] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+    expect(snapshot.paymentState).toBe('pending');
+  });
+
+  it('라인별 배송지가 서로 다르면 경고 로그를 남기고 첫 라인 배송지를 대표값으로 쓴다 (FIX 7)', async () => {
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    try {
+      client.getLastChangedStatuses.mockResolvedValue({
+        data: { count: 1, lastChangeStatuses: [changed('po-2', 'ord-1')] },
+      });
+      client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2'] });
+      client.getOrderDetails.mockResolvedValue({
+        data: [
+          detail('po-1', 'ord-1'),
+          detail('po-2', 'ord-1', {
+            shippingAddress: {
+              name: '김철수',
+              tel1: '011',
+              zipCode: '12345',
+              baseAddress: '부산',
+              detailedAddress: '2층',
+            },
+          }),
+        ],
+      });
+
+      const [snapshot] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+      // Core 계약은 주문당 배송지 하나 — infos[0](po-1) 이 대표값으로 유지된다.
+      expect(snapshot.shippingAddress.roadAddress).toBe('서울');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('배송지가 서로 다르다'));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('전 라인 취소면 전체 취소 1건이고 terminal 이다', async () => {
     client.getLastChangedStatuses.mockResolvedValue({
       data: { count: 1, lastChangeStatuses: [changed('po-1', 'ord-1')] },
@@ -168,6 +265,10 @@ describe('NaverOrderSource', () => {
     const old = new Date(Date.now() - 72 * 60 * 60 * 1000);
     await source.fetchOrders(old);
     const secondCall = client.getLastChangedStatuses.mock.calls[1][0];
+    // 24시간은 한 창의 "길이" 이지 "허용 과거" 가 아니다 — `since` 를 `now - 24h` 로 앞당기면
+    // 안 되고, 실제로 넘긴 워터마크 값 그대로에서 창을 시작해야 한다 (FIX 4). 창 길이만 보면
+    // `since` 를 `now - 24h` 로 클램프하는 회귀도 통과해버린다 — 시작점 자체를 값으로 고정한다.
+    expect(secondCall.lastChangedFrom).toBe(old.toISOString());
     const from = new Date(secondCall.lastChangedFrom).getTime();
     const to = new Date(secondCall.lastChangedTo).getTime();
     expect(to - from).toBe(24 * 60 * 60 * 1000);

--- a/apps/channel-adapter/src/services/order-collection/naver-order.source.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/naver-order.source.spec.ts
@@ -63,14 +63,29 @@ describe('NaverOrderSource', () => {
     await expect(source.fetchOrder('ord-1')).rejects.toThrow(/누락/);
   });
 
-  it('상세 응답 개수는 맞아도 요청하지 않은 productOrderId 가 섞여 있으면 throw 한다 (개수 대신 신원을 본다, FIX 5)', async () => {
+  // 개수는 요청과 같지만(2건) 요청한 po-2 자리에 엉뚱한 po-9 가 대신 왔다 — 결손 쪽(po-2 없음)
+  // 만으로도 throw 는 되지만, 이 케이스는 "신원 불일치" 를 대표하기보다 결손의 한 변형이다.
+  // 개수는 같은데 응답이 요청보다 **많아지는**(초과분) 케이스는 별도 테스트가 따로 막는다.
+  it('상세 응답 개수는 맞아도 요청한 id 대신 엉뚱한 id 가 왔으면(결손+치환) throw 하고 누락/예상외 id 를 메시지에 남긴다', async () => {
     client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2'] });
     // 개수는 요청과 같은 2건이지만, 요청한 po-2 대신 엉뚱한 po-9 가 섞여 있다.
     client.getOrderDetails.mockResolvedValue({
       data: [detail('po-1', 'ord-1'), detail('po-9', 'ord-1')],
     });
 
-    await expect(source.fetchOrder('ord-1')).rejects.toThrow(/누락/);
+    await expect(source.fetchOrder('ord-1')).rejects.toThrow(/누락.*\[po-2\].*예상외.*\[po-9\]/s);
+  });
+
+  // FIX 5 재보강: 신원(집합 포함) 검사만으로는 "요청한 id 가 응답에 다 있는가" 밖에 못 본다 —
+  // 응답이 요청 전부 + 엉뚱한 id 하나(상위집합)여도 그 조건은 그대로 통과해, 요청하지 않은
+  // 라인이 주문에 섞여 들어간다. 개수 비교를 다시 더해야 이 방향도 막힌다.
+  it('상세 응답이 요청한 id 를 전부 포함하면서 엉뚱한 id 까지 더 얹혀 오면(초과분) throw 한다', async () => {
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2'] });
+    client.getOrderDetails.mockResolvedValue({
+      data: [detail('po-1', 'ord-1'), detail('po-2', 'ord-1'), detail('po-9', 'ord-1')],
+    });
+
+    await expect(source.fetchOrder('ord-1')).rejects.toThrow(/누락.*예상외.*\[po-9\]/s);
   });
 
   it('세 주문 중 하나의 상세가 깨져도 나머지는 계속 수집하고 throw 하지 않는다 (한 주문 실패가 주기 전체를 막지 않는다, FIX 2)', async () => {

--- a/apps/channel-adapter/src/services/order-collection/naver-order.source.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/naver-order.source.spec.ts
@@ -270,6 +270,204 @@ describe('NaverOrderSource', () => {
     expect(snapshot.sourceUpdatedAt).toBe('2026-08-19T03:00:00.000+09:00');
   });
 
+  // FIX B: 반품/교환은 취소가 아니다. `OrderCancelled` 로 내보내면 Core 의 출고 증거 가드가
+  // BadRequestException 을 던지고, non-retryable 이라 DLQ 로 사라진다 — 신호가 소멸한다.
+  it('반품/교환 라인은 계약에서 빠지지만 취소 관측을 내지 않는다 (FIX B)', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-2', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2', 'po-3'] });
+    client.getOrderDetails.mockResolvedValue({
+      data: [
+        detail('po-1', 'ord-1'),
+        detail('po-2', 'ord-1', { productOrderStatus: 'RETURNED' }),
+        detail('po-3', 'ord-1', { productOrderStatus: 'EXCHANGED' }),
+      ],
+    });
+
+    const [snapshot] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    // 계약에서는 빠진다(살아있는 라인은 po-1 뿐).
+    expect(snapshot.lines.find((l) => l.channelOrderItemId === 'po-2')?.cancelled).toBe(true);
+    expect(snapshot.lines.find((l) => l.channelOrderItemId === 'po-3')?.cancelled).toBe(true);
+    expect(snapshot.amounts.total).toBe(10000);
+    // 하지만 취소 관측은 하나도 나가지 않는다.
+    expect(snapshot.lifecycle).toEqual([]);
+  });
+
+  it('전 라인이 반품이면 terminal 이되 취소 이벤트는 없다 (FIX B)', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-1', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1'] });
+    client.getOrderDetails.mockResolvedValue({
+      data: [detail('po-1', 'ord-1', { productOrderStatus: 'RETURNED' })],
+    });
+
+    const [snapshot] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    expect(snapshot.paymentState).toBe('terminal');
+    expect(snapshot.lifecycle).toEqual([]);
+  });
+
+  it('취소와 반품이 섞이면 취소된 라인만 라인 단위 관측을 낸다 (FIX B)', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-1', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2'] });
+    client.getOrderDetails.mockResolvedValue({
+      data: [
+        detail('po-1', 'ord-1', { productOrderStatus: 'CANCELED' }),
+        detail('po-2', 'ord-1', { productOrderStatus: 'RETURNED' }),
+      ],
+    });
+
+    const [snapshot] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    // 전 라인이 계약에서 빠졌으므로 terminal 이지만, 전체취소 1건으로 접으면 반품 라인까지
+    // 취소하는 셈이 된다 — 취소로 관측된 라인만 부분취소로 낸다.
+    expect(snapshot.paymentState).toBe('terminal');
+    expect(snapshot.lifecycle).toHaveLength(1);
+    expect(snapshot.lifecycle[0].eventKey).toBe('cancelled:po-1');
+  });
+
+  // FIX C: `changes.totalAmount` 는 해시 입력이라 취소로 흔들리면 안 된다.
+  it('allLinesTotal 은 취소 라인을 포함해 취소 전후로 값이 같다 (FIX C)', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-2', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2'] });
+
+    client.getOrderDetails.mockResolvedValueOnce({
+      data: [detail('po-1', 'ord-1'), detail('po-2', 'ord-1')],
+    });
+    const [before] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    client.getOrderDetails.mockResolvedValueOnce({
+      data: [detail('po-1', 'ord-1'), detail('po-2', 'ord-1', { productOrderStatus: 'CANCELED' })],
+    });
+    const [after] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    expect(before.amounts.allLinesTotal).toBe(20000);
+    expect(after.amounts.allLinesTotal).toBe(20000);
+    // 계약 총액은 반대로 취소분을 뺀다 — 두 값의 목적이 다르다는 것이 요점이다.
+    expect(after.amounts.total).toBe(10000);
+  });
+
+  // FIX G: 조용한 null 은 그 주문을 영영 잃는다 — 같은 폴의 다른 항목이 워터마크를 밀기 때문.
+  it('상품주문 id 목록이 비면 경고를 남기고 throw 한다 (FIX G)', async () => {
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    try {
+      client.getProductOrderIdsByOrderId.mockResolvedValue({ data: [] });
+
+      await expect(source.fetchOrder('ord-1')).rejects.toThrow(/id 목록이 비었다/);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('상품주문 id 목록이 비어 있다'));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('id 목록이 빈 주문은 주기를 멈추지 않고 건너뛴다 — 워터마크는 그 주문 뒤로 가지 않는다 (FIX G)', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 2, lastChangeStatuses: [changed('po-1', 'ord-1'), changed('po-2', 'ord-2')] },
+    });
+    client.getProductOrderIdsByOrderId.mockImplementation(async (orderId: string) => ({
+      data: orderId === 'ord-1' ? [] : ['po-2'],
+    }));
+    client.getOrderDetails.mockImplementation(async (ids: string[]) => ({
+      data: ids.map((id) => detail(id, 'ord-2')),
+    }));
+
+    const snapshots = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    expect(snapshots.map((s) => s.externalOrderId)).toEqual(['ord-2']);
+  });
+
+  // FIX H: shadow 점검이 `raw_order` 로 네이버 실제 필드명을 확정한다 — 파싱 결과를 넣으면
+  // 우리가 이미 안다고 가정한 이름만 되비쳐 그 점검이 성립하지 않는다.
+  it('raw 에는 파싱 결과가 아니라 채널 원본 응답이 담긴다 (FIX H)', async () => {
+    const rawDetail = detail('po-1', 'ord-1', { 옵션단위식별자후보: 'opt-9', 알수없는필드: { a: 1 } });
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-1', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1'] });
+    client.getOrderDetails.mockResolvedValue({ data: [rawDetail] });
+
+    const [snapshot] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    const raw = snapshot.raw as { productOrders: unknown[] };
+    expect(raw.productOrders).toEqual([rawDetail]);
+    // 파서가 만들어내는 평면 필드(channelProductId 등)가 raw 에 섞이면 안 된다.
+    expect(raw.productOrders[0]).not.toHaveProperty('channelProductId');
+    expect((raw.productOrders[0] as Record<string, any>).productOrder).toHaveProperty('옵션단위식별자후보', 'opt-9');
+  });
+
+  // FIX I: `OrderCancelledSchema.cancelledLines[].quantity` 는 양수를 요구한다.
+  it('수량이 0 인 취소 라인은 취소 관측을 내지 않는다 (FIX I)', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-2', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2'] });
+    client.getOrderDetails.mockResolvedValue({
+      data: [detail('po-1', 'ord-1'), detail('po-2', 'ord-1', { productOrderStatus: 'CANCELED', quantity: 0 })],
+    });
+
+    const [snapshot] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    expect(snapshot.lines.find((l) => l.channelOrderItemId === 'po-2')?.cancelled).toBe(true);
+    expect(snapshot.lifecycle).toEqual([]);
+  });
+
+  // FIX F: 닫힌 창에 변경이 0건이면 워터마크가 영원히 그 창에 묶인다.
+  it('닫힌 창을 끝까지 훑었으면 항목이 없어도 창의 끝을 보고한다 (FIX F)', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({ data: { count: 0, lastChangeStatuses: [] } });
+
+    const since = new Date(Date.now() - 72 * 60 * 60 * 1000);
+    const { snapshots, completedWindowEnd } = await source.fetchOrdersInWindow(since);
+
+    expect(snapshots).toEqual([]);
+    expect(completedWindowEnd?.getTime()).toBe(since.getTime() + 24 * 60 * 60 * 1000);
+  });
+
+  it('창이 아직 열려 있으면(now 에서 끝나면) 창의 끝을 보고하지 않는다 (FIX F)', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({ data: { count: 0, lastChangeStatuses: [] } });
+
+    const { completedWindowEnd } = await source.fetchOrdersInWindow(new Date(Date.now() - 10 * 60 * 1000));
+
+    expect(completedWindowEnd).toBeNull();
+  });
+
+  // FIX F × FIX G 의 접점: 창의 주문이 전부 실패하면 스냅샷이 0건이라 오케스트레이터가
+  // "변경 없음" 갈래로 들어간다. 거기서 창의 끝까지 워터마크를 밀면 실패한 주문이 조회 범위
+  // 밖으로 빠져 영영 사라진다 — FIX G 가 막으려던 손실이 다른 문으로 되돌아온다.
+  it('주문 수집이 실패한 주기에는 창을 다 봤다고 말하지 않는다 (FIX F × FIX G)', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-1', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: [] });
+
+    const { snapshots, completedWindowEnd } = await source.fetchOrdersInWindow(
+      new Date(Date.now() - 72 * 60 * 60 * 1000),
+    );
+
+    expect(snapshots).toEqual([]);
+    expect(completedWindowEnd).toBeNull();
+  });
+
+  it('페이징이 상한에서 잘리면 창을 다 봤다고 말하지 않는다 (FIX F)', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: {
+        count: 300,
+        lastChangeStatuses: [],
+        more: { moreFrom: '2026-08-19T02:00:00.000+09:00', moreSequence: '17' },
+      },
+    });
+
+    const { completedWindowEnd } = await source.fetchOrdersInWindow(new Date(Date.now() - 72 * 60 * 60 * 1000));
+
+    expect(completedWindowEnd).toBeNull();
+  });
+
   it('워터마크가 없으면 최근 1시간을, 오래됐으면 24시간 창을 조회한다', async () => {
     client.getLastChangedStatuses.mockResolvedValue({ data: { count: 0, lastChangeStatuses: [] } });
 

--- a/apps/channel-adapter/src/services/order-collection/naver-order.source.ts
+++ b/apps/channel-adapter/src/services/order-collection/naver-order.source.ts
@@ -19,8 +19,12 @@ const MAX_PAGES = 20;
 
 const ACCEPTED_STATUSES = new Set(['PAYED', 'DELIVERING', 'DELIVERED', 'PURCHASE_DECIDED']);
 const TERMINAL_STATUSES = new Set(['CANCELED', 'CANCELED_BY_NOPAYMENT', 'RETURNED', 'EXCHANGED']);
-/** 취소 요청 중에도 productOrderStatus 는 PAYED 다 — 그대로 두면 출고로 흘러간다. */
-const CANCEL_IN_FLIGHT_CLAIMS = new Set(['CANCEL_REQUEST', 'CANCELING']);
+/**
+ * 취소 요청 중에도 productOrderStatus 는 PAYED 다 — 그대로 두면 출고로 흘러간다.
+ * `ADMIN_CANCELING` 은 판매자(관리자)가 취소를 개시한 경로다 (FIX 6) — 고객 신청과 상태 축은
+ * 다르지만 결과는 같다: 아직 확정 취소가 아니면서 출고해서는 안 되는 구간.
+ */
+const CANCEL_IN_FLIGHT_CLAIMS = new Set(['CANCEL_REQUEST', 'CANCELING', 'ADMIN_CANCELING']);
 
 @Injectable()
 export class NaverOrderSource implements ReplayableChannelOrderSource {
@@ -32,11 +36,27 @@ export class NaverOrderSource implements ReplayableChannelOrderSource {
   async fetchOrders(since: Date | null): Promise<ChannelOrderSnapshot[]> {
     const changedAtByOrderId = await this.collectChangedOrderIds(since);
     const snapshots: ChannelOrderSnapshot[] = [];
+    let failedCount = 0;
     for (const [orderId, changedAt] of changedAtByOrderId) {
-      // 🔴 채널이 말한 변경 시각을 그대로 싣는다. `now` 를 쓰면 워터마크가 조회 창을 건너뛰어
-      // 그 사이 변경이 영영 조회 범위 밖으로 빠진다 (창 걷기가 무력화된다).
-      const snapshot = await this.fetchSnapshot(orderId, changedAt);
-      if (snapshot) snapshots.push(snapshot);
+      try {
+        // 🔴 채널이 말한 변경 시각을 그대로 싣는다. `now` 를 쓰면 워터마크가 조회 창을 건너뛰어
+        // 그 사이 변경이 영영 조회 범위 밖으로 빠진다 (창 걷기가 무력화된다).
+        const snapshot = await this.fetchSnapshot(orderId, changedAt);
+        if (snapshot) snapshots.push(snapshot);
+      } catch (error) {
+        // 실패 단위는 주문 하나다, 사이클 전체가 아니다 (FIX 2). 여기서 throw 하면 오케스트레이터가
+        // 사이클 전체를 실패로 기록하고 워터마크를 멈춘다 — 그러면 이 한 주문 뒤에 있는(맵 순서상)
+        // 나머지 정상 주문들도 다음 폴링에서 똑같이 막혀, 잘못된 응답 하나가 수집 전체를 영구히
+        // 정지시킨다. 개별 주문 실패는 로그로 표면화하고 나머지는 계속 처리한다.
+        failedCount += 1;
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.error(`[naver] 주문 ${orderId} 수집 실패, 건너뛴다: ${message}`);
+      }
+    }
+    if (failedCount > 0) {
+      this.logger.error(
+        `[naver] 이번 주기 ${changedAtByOrderId.size}건 중 ${failedCount}건 수집 실패 — 개별 사유는 위 로그 참고.`,
+      );
     }
     return snapshots;
   }
@@ -59,8 +79,12 @@ export class NaverOrderSource implements ReplayableChannelOrderSource {
     const infos = (detailsResponse.data ?? []).map((raw) => parseNaverProductOrderInfo(raw));
 
     // 문서가 "식별자 단위로 일부만 조회 실패할 수 있다" 고 경고한다. 조용히 빠지면 §6.1 이
-    // 막으려던 사고가 그대로 난다.
-    if (infos.length !== productOrderIds.length) {
+    // 막으려던 사고가 그대로 난다. 개수만 비교하면 응답에 요청하지 않은 id 가 섞여 개수가
+    // 우연히 맞아떨어지는 경우를 놓친다 — 요청한 id 전체가 실제로 응답에 있는지 신원으로
+    // 확인한다 (FIX 5).
+    const returnedProductOrderIds = new Set(infos.map((info) => info.productOrderId));
+    const hasMissingProductOrderId = productOrderIds.some((id) => !returnedProductOrderIds.has(id));
+    if (hasMissingProductOrderId) {
       throw new Error(
         `네이버 상세 조회 누락: 주문 ${externalOrderId} 요청 ${productOrderIds.length}건, 응답 ${infos.length}건`,
       );
@@ -115,7 +139,9 @@ export class NaverOrderSource implements ReplayableChannelOrderSource {
   ): ChannelOrderSnapshot {
     const lines = infos.map((info) => this.buildLine(info));
     const cancelled = infos.filter((info) => TERMINAL_STATUSES.has(info.productOrderStatus));
+    const live = infos.filter((info) => !TERMINAL_STATUSES.has(info.productOrderStatus));
     const allCancelled = cancelled.length === infos.length;
+    this.warnIfShippingAddressesDiffer(externalOrderId, infos);
 
     return {
       externalOrderId,
@@ -124,9 +150,12 @@ export class NaverOrderSource implements ReplayableChannelOrderSource {
       customerId: null,
       lines,
       amounts: {
-        total: infos.reduce((sum, info) => sum + info.lineTotal, 0),
-        subtotal: infos.reduce((sum, info) => sum + info.unitPrice * info.quantity, 0),
-        shipping: infos.reduce((sum, info) => sum + info.shippingFee, 0),
+        // 취소된 라인은 `lines` 에는 남기지만(변경 해시 보존), Core `items` 계약에는 실리지 않는다
+        // — 금액도 그 라인을 뺀 실판매분만 합산한다. 안 그러면 부분취소 주문의 Core 합계가
+        // 부풀려진 채로 들어간다 (FIX 3).
+        total: live.reduce((sum, info) => sum + info.lineTotal, 0),
+        subtotal: live.reduce((sum, info) => sum + info.unitPrice * info.quantity, 0),
+        shipping: live.reduce((sum, info) => sum + info.shippingFee, 0),
         discount: 0,
         currency: 'KRW',
       },
@@ -135,6 +164,22 @@ export class NaverOrderSource implements ReplayableChannelOrderSource {
       lifecycle: this.buildLifecycle(infos, cancelled, allCancelled, sourceUpdatedAt),
       raw: { externalOrderId, productOrders: infos },
     };
+  }
+
+  /**
+   * Core 계약은 주문당 배송지 하나만 나른다 — `infos[0]` 을 대표값으로 쓰는 결정은 유지한다.
+   * 네이버는 상품주문(라인) 단위로 배송지를 들고 있어 이론상 라인마다 다를 수 있는데, 그 경우를
+   * 조용히 넘기면 나머지 라인의 실제 배송지가 소리 없이 버려진다 — 눈에 띄게 로그만 남긴다
+   * (FIX 7).
+   */
+  private warnIfShippingAddressesDiffer(externalOrderId: string, infos: NaverProductOrderInfo[]): void {
+    const first = JSON.stringify(infos[0].shippingAddress);
+    const differs = infos.some((info) => JSON.stringify(info.shippingAddress) !== first);
+    if (differs) {
+      this.logger.warn(
+        `[naver] 주문 ${externalOrderId} 의 라인별 배송지가 서로 다르다 — 첫 라인 배송지를 주문 대표값으로 쓴다.`,
+      );
+    }
   }
 
   private buildLine(info: NaverProductOrderInfo): ChannelOrderLineSnapshot {

--- a/apps/channel-adapter/src/services/order-collection/naver-order.source.ts
+++ b/apps/channel-adapter/src/services/order-collection/naver-order.source.ts
@@ -1,0 +1,204 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { SalesChannel } from '@packages/event-contracts/streams';
+import { NaverOrderClient } from '../../adapters/naver/clients/naver-order.client';
+import {
+  ChannelOrderLineSnapshot,
+  ChannelOrderSnapshot,
+  ChannelPaymentState,
+  LifecycleObservation,
+  ReplayableChannelOrderSource,
+} from './channel-order-source.interface';
+import { NaverProductOrderInfo, parseNaverProductOrderInfo } from './naver-order-fields';
+
+/** 최초 수집 바닥값. 과거를 소급하면 이미 수기 처리된 주문이 중복 유입된다. */
+const FIRST_RUN_LOOKBACK_MS = 60 * 60 * 1000;
+/** 변경 피드가 한 번에 볼 수 있는 창. `lastChangedTo` 생략 시 네이버가 자동 적용하는 값과 같다. */
+const MAX_WINDOW_MS = 24 * 60 * 60 * 1000;
+/** 무한 페이징 방어. 한 창 × 300건이면 6000건으로, 우리 주문량에서 도달할 수 없다. */
+const MAX_PAGES = 20;
+
+const ACCEPTED_STATUSES = new Set(['PAYED', 'DELIVERING', 'DELIVERED', 'PURCHASE_DECIDED']);
+const TERMINAL_STATUSES = new Set(['CANCELED', 'CANCELED_BY_NOPAYMENT', 'RETURNED', 'EXCHANGED']);
+/** 취소 요청 중에도 productOrderStatus 는 PAYED 다 — 그대로 두면 출고로 흘러간다. */
+const CANCEL_IN_FLIGHT_CLAIMS = new Set(['CANCEL_REQUEST', 'CANCELING']);
+
+@Injectable()
+export class NaverOrderSource implements ReplayableChannelOrderSource {
+  readonly channel: SalesChannel = 'naver';
+  private readonly logger = new Logger(NaverOrderSource.name);
+
+  constructor(private readonly client: NaverOrderClient) {}
+
+  async fetchOrders(since: Date | null): Promise<ChannelOrderSnapshot[]> {
+    const changedAtByOrderId = await this.collectChangedOrderIds(since);
+    const snapshots: ChannelOrderSnapshot[] = [];
+    for (const [orderId, changedAt] of changedAtByOrderId) {
+      // 🔴 채널이 말한 변경 시각을 그대로 싣는다. `now` 를 쓰면 워터마크가 조회 창을 건너뛰어
+      // 그 사이 변경이 영영 조회 범위 밖으로 빠진다 (창 걷기가 무력화된다).
+      const snapshot = await this.fetchSnapshot(orderId, changedAt);
+      if (snapshot) snapshots.push(snapshot);
+    }
+    return snapshots;
+  }
+
+  /**
+   * replay 전용 단건. 워터마크 경로가 아니므로(`replayFailure` 는 `processOrderItem` 을 직접 부른다)
+   * 변경 시각을 알 수 없어 현재 시각을 쓴다.
+   */
+  async fetchOrder(externalOrderId: string): Promise<ChannelOrderSnapshot | null> {
+    return this.fetchSnapshot(externalOrderId, new Date().toISOString());
+  }
+
+  private async fetchSnapshot(externalOrderId: string, sourceUpdatedAt: string): Promise<ChannelOrderSnapshot | null> {
+    // 형제 라인을 복원한다. 변경 피드는 바뀐 라인만 주므로 이걸 건너뛰면 라인이 빠진 주문이 생긴다.
+    const idsResponse = await this.client.getProductOrderIdsByOrderId(externalOrderId);
+    const productOrderIds = idsResponse.data ?? [];
+    if (productOrderIds.length === 0) return null;
+
+    const detailsResponse = await this.client.getOrderDetails(productOrderIds);
+    const infos = (detailsResponse.data ?? []).map((raw) => parseNaverProductOrderInfo(raw));
+
+    // 문서가 "식별자 단위로 일부만 조회 실패할 수 있다" 고 경고한다. 조용히 빠지면 §6.1 이
+    // 막으려던 사고가 그대로 난다.
+    if (infos.length !== productOrderIds.length) {
+      throw new Error(
+        `네이버 상세 조회 누락: 주문 ${externalOrderId} 요청 ${productOrderIds.length}건, 응답 ${infos.length}건`,
+      );
+    }
+
+    return this.buildSnapshot(externalOrderId, infos, sourceUpdatedAt);
+  }
+
+  /**
+   * `more` 를 따라 창 전체를 훑고, **주문번호 → 그 주문의 최신 변경 시각**을 모은다.
+   * 한 주문의 여러 라인이 바뀌었으면 가장 늦은 시각을 취한다 — 워터마크의 근거다.
+   */
+  private async collectChangedOrderIds(since: Date | null): Promise<Map<string, string>> {
+    const now = new Date();
+    const from = since ?? new Date(now.getTime() - FIRST_RUN_LOOKBACK_MS);
+    // 창을 앞으로 점프시키지 않는다 — 그러면 그 사이 주문이 영영 조회 범위 밖으로 빠진다.
+    const windowEnd = new Date(Math.min(from.getTime() + MAX_WINDOW_MS, now.getTime()));
+    const explicitTo = windowEnd.getTime() < now.getTime() ? windowEnd.toISOString() : undefined;
+
+    const changedAtByOrderId = new Map<string, string>();
+    let lastChangedFrom = from.toISOString();
+    let moreSequence: string | undefined;
+
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const response = await this.client.getLastChangedStatuses({
+        lastChangedFrom,
+        ...(explicitTo ? { lastChangedTo: explicitTo } : {}),
+        ...(moreSequence ? { moreSequence } : {}),
+      });
+
+      for (const status of response.data?.lastChangeStatuses ?? []) {
+        const previous = changedAtByOrderId.get(status.orderId);
+        if (!previous || status.lastChangedDate > previous) {
+          changedAtByOrderId.set(status.orderId, status.lastChangedDate);
+        }
+      }
+
+      const more = response.data?.more;
+      if (!more) return changedAtByOrderId;
+      lastChangedFrom = more.moreFrom;
+      moreSequence = more.moreSequence;
+    }
+
+    this.logger.warn(`[naver] 변경 피드 페이징이 ${MAX_PAGES}쪽에서 끊겼다 — 다음 주기가 이어받는다.`);
+    return changedAtByOrderId;
+  }
+
+  private buildSnapshot(
+    externalOrderId: string,
+    infos: NaverProductOrderInfo[],
+    sourceUpdatedAt: string,
+  ): ChannelOrderSnapshot {
+    const lines = infos.map((info) => this.buildLine(info));
+    const cancelled = infos.filter((info) => TERMINAL_STATUSES.has(info.productOrderStatus));
+    const allCancelled = cancelled.length === infos.length;
+
+    return {
+      externalOrderId,
+      sourceUpdatedAt,
+      paymentState: this.resolvePaymentState(infos, allCancelled),
+      customerId: null,
+      lines,
+      amounts: {
+        total: infos.reduce((sum, info) => sum + info.lineTotal, 0),
+        subtotal: infos.reduce((sum, info) => sum + info.unitPrice * info.quantity, 0),
+        shipping: infos.reduce((sum, info) => sum + info.shippingFee, 0),
+        discount: 0,
+        currency: 'KRW',
+      },
+      shippingAddress: infos[0].shippingAddress,
+      createdAt: infos[0].paymentDate ?? sourceUpdatedAt,
+      lifecycle: this.buildLifecycle(infos, cancelled, allCancelled, sourceUpdatedAt),
+      raw: { externalOrderId, productOrders: infos },
+    };
+  }
+
+  private buildLine(info: NaverProductOrderInfo): ChannelOrderLineSnapshot {
+    return {
+      channelOrderItemId: info.productOrderId,
+      ...(info.channelProductId ? { channelProductId: info.channelProductId } : {}),
+      productName: info.productName,
+      quantity: info.quantity,
+      unitPrice: info.unitPrice,
+      ...(TERMINAL_STATUSES.has(info.productOrderStatus) ? { cancelled: true } : {}),
+    };
+  }
+
+  private resolvePaymentState(infos: NaverProductOrderInfo[], allCancelled: boolean): ChannelPaymentState {
+    if (allCancelled) return 'terminal';
+
+    const live = infos.filter((info) => !TERMINAL_STATUSES.has(info.productOrderStatus));
+    // 고객이 취소를 원하는 주문을 출고 파이프라인에 태우지 않는다 (Medusa 의 refund-requested 방어와 대칭).
+    if (live.some((info) => info.claimStatus && CANCEL_IN_FLIGHT_CLAIMS.has(info.claimStatus))) return 'pending';
+    if (live.every((info) => ACCEPTED_STATUSES.has(info.productOrderStatus))) return 'accepted';
+    return 'pending';
+  }
+
+  /**
+   * **전 라인 취소는 full 1건, 일부 취소는 라인마다 partial 1건.**
+   * Core 는 `lines` 유무로 전체/부분을 가르고, 부분취소가 누적돼 전량이 돼도 주문을 닫지 않는다.
+   */
+  private buildLifecycle(
+    infos: NaverProductOrderInfo[],
+    cancelled: NaverProductOrderInfo[],
+    allCancelled: boolean,
+    cancelledAt: string,
+  ): LifecycleObservation[] {
+    if (cancelled.length === 0) return [];
+
+    if (allCancelled) {
+      return [
+        {
+          eventType: 'OrderCancelled',
+          eventKey: 'cancelled',
+          payload: {
+            reason: 'CUSTOMER_REQUEST',
+            reasonDetail: '네이버 주문 취소 수집',
+            cancelledBy: 'naver',
+            cancelledAt,
+            refundRequired: false,
+          },
+          rawEvent: { productOrderIds: cancelled.map((info) => info.productOrderId) },
+        },
+      ];
+    }
+
+    return cancelled.map((info) => ({
+      eventType: 'OrderCancelled' as const,
+      eventKey: `cancelled:${info.productOrderId}`,
+      payload: {
+        reason: 'CUSTOMER_REQUEST' as const,
+        reasonDetail: '네이버 상품주문 부분 취소 수집',
+        cancelledBy: 'naver',
+        cancelledAt,
+        refundRequired: false,
+        cancelledLines: [{ channelOrderItemId: info.productOrderId, quantity: info.quantity }],
+      },
+      rawEvent: { productOrderId: info.productOrderId },
+    }));
+  }
+}

--- a/apps/channel-adapter/src/services/order-collection/naver-order.source.ts
+++ b/apps/channel-adapter/src/services/order-collection/naver-order.source.ts
@@ -16,6 +16,8 @@ const FIRST_RUN_LOOKBACK_MS = 60 * 60 * 1000;
 const MAX_WINDOW_MS = 24 * 60 * 60 * 1000;
 /** 무한 페이징 방어. 한 창 × 300건이면 6000건으로, 우리 주문량에서 도달할 수 없다. */
 const MAX_PAGES = 20;
+/** 상세 조회 불일치 메시지에 나열할 id 개수 상한. 병적인 응답이 메시지를 무한정 늘리지 못하게 막는다. */
+const MAX_LISTED_MISMATCHED_IDS = 20;
 
 const ACCEPTED_STATUSES = new Set(['PAYED', 'DELIVERING', 'DELIVERED', 'PURCHASE_DECIDED']);
 const TERMINAL_STATUSES = new Set(['CANCELED', 'CANCELED_BY_NOPAYMENT', 'RETURNED', 'EXCHANGED']);
@@ -79,18 +81,36 @@ export class NaverOrderSource implements ReplayableChannelOrderSource {
     const infos = (detailsResponse.data ?? []).map((raw) => parseNaverProductOrderInfo(raw));
 
     // 문서가 "식별자 단위로 일부만 조회 실패할 수 있다" 고 경고한다. 조용히 빠지면 §6.1 이
-    // 막으려던 사고가 그대로 난다. 개수만 비교하면 응답에 요청하지 않은 id 가 섞여 개수가
-    // 우연히 맞아떨어지는 경우를 놓친다 — 요청한 id 전체가 실제로 응답에 있는지 신원으로
-    // 확인한다 (FIX 5).
+    // 막으려던 사고가 그대로 난다. 신원(집합 포함) 검사만으로는 한쪽만 막는다 — 응답이
+    // 요청보다 많아서(요청 전부 + 엉뚱한 id 하나 더) 상위집합이 되는 경우는 "요청 id 가
+    // 다 있다" 는 조건을 그대로 통과해 엉뚱한 라인이 주문에 섞여 들어간다. 그래서 개수
+    // 일치까지 **같이** 요구한다 — 응답은 요청 집합과 정확히 같아야 한다 (FIX 5 재보강).
+    const requestedProductOrderIds = new Set(productOrderIds);
     const returnedProductOrderIds = new Set(infos.map((info) => info.productOrderId));
-    const hasMissingProductOrderId = productOrderIds.some((id) => !returnedProductOrderIds.has(id));
-    if (hasMissingProductOrderId) {
+    const missingProductOrderIds = productOrderIds.filter((id) => !returnedProductOrderIds.has(id));
+    const unexpectedProductOrderIds = infos
+      .map((info) => info.productOrderId)
+      .filter((id) => !requestedProductOrderIds.has(id));
+    const hasCountMismatch = infos.length !== productOrderIds.length;
+
+    if (missingProductOrderIds.length > 0 || unexpectedProductOrderIds.length > 0 || hasCountMismatch) {
+      const missingPart =
+        missingProductOrderIds.length > 0 ? `, 누락 [${this.formatIdSample(missingProductOrderIds)}]` : '';
+      const unexpectedPart =
+        unexpectedProductOrderIds.length > 0 ? `, 예상외 [${this.formatIdSample(unexpectedProductOrderIds)}]` : '';
       throw new Error(
-        `네이버 상세 조회 누락: 주문 ${externalOrderId} 요청 ${productOrderIds.length}건, 응답 ${infos.length}건`,
+        `네이버 상세 조회 누락: 주문 ${externalOrderId} 요청 ${productOrderIds.length}건, 응답 ${infos.length}건${missingPart}${unexpectedPart}`,
       );
     }
 
     return this.buildSnapshot(externalOrderId, infos, sourceUpdatedAt);
+  }
+
+  /** 불일치 메시지에 나열할 id 목록을 상한으로 자른다 — 병적인 응답이 메시지를 무한정 늘리지 못하게. */
+  private formatIdSample(ids: string[]): string {
+    if (ids.length <= MAX_LISTED_MISMATCHED_IDS) return ids.join(', ');
+    const shown = ids.slice(0, MAX_LISTED_MISMATCHED_IDS).join(', ');
+    return `${shown} 외 ${ids.length - MAX_LISTED_MISMATCHED_IDS}건`;
   }
 
   /**

--- a/apps/channel-adapter/src/services/order-collection/naver-order.source.ts
+++ b/apps/channel-adapter/src/services/order-collection/naver-order.source.ts
@@ -7,6 +7,8 @@ import {
   ChannelPaymentState,
   LifecycleObservation,
   ReplayableChannelOrderSource,
+  WindowedChannelOrderSource,
+  WindowedFetchResult,
 } from './channel-order-source.interface';
 import { NaverProductOrderInfo, parseNaverProductOrderInfo } from './naver-order-fields';
 
@@ -20,7 +22,23 @@ const MAX_PAGES = 20;
 const MAX_LISTED_MISMATCHED_IDS = 20;
 
 const ACCEPTED_STATUSES = new Set(['PAYED', 'DELIVERING', 'DELIVERED', 'PURCHASE_DECIDED']);
-const TERMINAL_STATUSES = new Set(['CANCELED', 'CANCELED_BY_NOPAYMENT', 'RETURNED', 'EXCHANGED']);
+/**
+ * **계약에서 빠지는 라인** — 이 상태의 라인은 판매주문 `items` 에 싣지 않고, 실판매 금액에서도
+ * 빼며, 전 라인이 이 상태면 주문 전체가 `terminal` 이다.
+ *
+ * `RETURNED`/`EXCHANGED` 가 여기 있고 아래 취소 관측 집합에는 **없다**는 것이 요점이다.
+ */
+const OUT_OF_CONTRACT_STATUSES = new Set(['CANCELED', 'CANCELED_BY_NOPAYMENT', 'RETURNED', 'EXCHANGED']);
+/**
+ * **취소 관측을 내는 라인**. 반품/교환은 여기 들어가지 않는다.
+ *
+ * 🔴 왜 나눴나: 반품/교환은 이미 **출고가 끝난 뒤**의 생애주기다. 그것을 `OrderCancelled` 로
+ * 내보내면 Core 의 출고 증거 가드(`sales-orders.service.ts` 의 shipped/completed FO 검사)가
+ * `BadRequestException` 을 던지고, 그것은 non-retryable 이라 DLQ 로 직행한다 — 신호는 사라지고
+ * 운영자가 볼 행도 남지 않는다. 반품/교환 생애주기는 이 브랜치가 의도적으로 모델링하지 않는다
+ * (설계 §9 판정 4: "취소 포함, 환불 제외" — 클레임 19종 해석은 별건).
+ */
+const CANCELLATION_OBSERVED_STATUSES = new Set(['CANCELED', 'CANCELED_BY_NOPAYMENT']);
 /**
  * 취소 요청 중에도 productOrderStatus 는 PAYED 다 — 그대로 두면 출고로 흘러간다.
  * `ADMIN_CANCELING` 은 판매자(관리자)가 취소를 개시한 경로다 (FIX 6) — 고객 신청과 상태 축은
@@ -29,14 +47,29 @@ const TERMINAL_STATUSES = new Set(['CANCELED', 'CANCELED_BY_NOPAYMENT', 'RETURNE
 const CANCEL_IN_FLIGHT_CLAIMS = new Set(['CANCEL_REQUEST', 'CANCELING', 'ADMIN_CANCELING']);
 
 @Injectable()
-export class NaverOrderSource implements ReplayableChannelOrderSource {
+export class NaverOrderSource implements ReplayableChannelOrderSource, WindowedChannelOrderSource {
   readonly channel: SalesChannel = 'naver';
   private readonly logger = new Logger(NaverOrderSource.name);
 
   constructor(private readonly client: NaverOrderClient) {}
 
   async fetchOrders(since: Date | null): Promise<ChannelOrderSnapshot[]> {
-    const changedAtByOrderId = await this.collectChangedOrderIds(since);
+    const { snapshots } = await this.fetchOrdersInWindow(since);
+    return snapshots;
+  }
+
+  /**
+   * `fetchOrders` 와 같은 일을 하되 **끝까지 훑은 닫힌 창의 끝**을 함께 돌려준다.
+   *
+   * 🔴 이게 없으면 조용한 24시간이 수집을 영구히 정지시킨다: 닫힌 창 `[since, since+24h]` 에
+   * 변경이 하나도 없으면 항목이 0건 → 오케스트레이터 워터마크 `null` → `recordSyncComplete` 가
+   * `lastSyncAt` 을 건드리지 않음 → 다음 주기가 **같은 닫힌 창**을 다시 묻는다. 영원히.
+   *
+   * 반환값은 상태로 들고 있지 않고 그 자리에서 함께 넘긴다 — 겹쳐 도는 두 폴이 인스턴스
+   * 필드를 서로 덮어쓰는 경합을 만들지 않기 위함이다.
+   */
+  async fetchOrdersInWindow(since: Date | null): Promise<WindowedFetchResult> {
+    const { changedAtByOrderId, completedWindowEnd } = await this.collectChangedOrderIds(since);
     const snapshots: ChannelOrderSnapshot[] = [];
     let failedCount = 0;
     for (const [orderId, changedAt] of changedAtByOrderId) {
@@ -60,7 +93,11 @@ export class NaverOrderSource implements ReplayableChannelOrderSource {
         `[naver] 이번 주기 ${changedAtByOrderId.size}건 중 ${failedCount}건 수집 실패 — 개별 사유는 위 로그 참고.`,
       );
     }
-    return snapshots;
+    // 🔴 실패한 주문이 하나라도 있으면 창을 다 봤다고 말하지 않는다. 그 창의 주문이 **전부**
+    // 실패했다면 스냅샷이 0건이라 오케스트레이터가 "변경 없음" 갈래로 들어가는데, 거기서
+    // 창의 끝까지 워터마크를 밀면 실패한 주문들이 조회 범위 밖으로 빠져 영영 사라진다 —
+    // FIX G 가 없애려던 손실 모드가 다른 문으로 되돌아온다.
+    return { snapshots, completedWindowEnd: failedCount > 0 ? null : completedWindowEnd };
   }
 
   /**
@@ -75,10 +112,22 @@ export class NaverOrderSource implements ReplayableChannelOrderSource {
     // 형제 라인을 복원한다. 변경 피드는 바뀐 라인만 주므로 이걸 건너뛰면 라인이 빠진 주문이 생긴다.
     const idsResponse = await this.client.getProductOrderIdsByOrderId(externalOrderId);
     const productOrderIds = idsResponse.data ?? [];
-    if (productOrderIds.length === 0) return null;
+    if (productOrderIds.length === 0) {
+      // 🔴 조용히 `null` 을 내면 그 주문은 **영영 사라진다**: 같은 폴의 다른 항목들이 워터마크를
+      // 이 주문 너머로 밀어버리므로 다음 주기의 조회 창에 다시 들어오지 못한다. 변경 피드가
+      // 준 주문번호에 상품주문이 하나도 없다는 것은 정상 응답이 아니므로 시끄럽게 실패시킨다 —
+      // `fetchOrders` 의 주문 단위 try/catch 가 다른 주문처럼 잡아 건너뛰고, 워터마크는
+      // 그 주문 시각 아래에 머문 채 다음 주기가 다시 시도한다(무손실).
+      this.logger.warn(`[naver] 주문 ${externalOrderId} 의 상품주문 id 목록이 비어 있다 — 수집을 실패로 처리한다.`);
+      throw new Error(`네이버 상품주문 id 목록이 비었다: 주문 ${externalOrderId}`);
+    }
 
     const detailsResponse = await this.client.getOrderDetails(productOrderIds);
-    const infos = (detailsResponse.data ?? []).map((raw) => parseNaverProductOrderInfo(raw));
+    // 🔴 채널 원본을 그대로 들고 간다. 격리 행의 `raw_order` 는 shadow 점검에서 **네이버의 실제
+    // 필드명을 확정하는 유일한 창**이라(설계 §7), 여기에 파싱 결과를 넣으면 우리가 이미 안다고
+    // 가정한 이름만 되비치고 확정이 불가능해진다.
+    const rawProductOrders = detailsResponse.data ?? [];
+    const infos = rawProductOrders.map((raw) => parseNaverProductOrderInfo(raw));
 
     // 문서가 "식별자 단위로 일부만 조회 실패할 수 있다" 고 경고한다. 조용히 빠지면 §6.1 이
     // 막으려던 사고가 그대로 난다. 신원(집합 포함) 검사만으로는 한쪽만 막는다 — 응답이
@@ -103,7 +152,7 @@ export class NaverOrderSource implements ReplayableChannelOrderSource {
       );
     }
 
-    return this.buildSnapshot(externalOrderId, infos, sourceUpdatedAt);
+    return this.buildSnapshot(externalOrderId, infos, rawProductOrders, sourceUpdatedAt);
   }
 
   /** 불일치 메시지에 나열할 id 목록을 상한으로 자른다 — 병적인 응답이 메시지를 무한정 늘리지 못하게. */
@@ -116,8 +165,16 @@ export class NaverOrderSource implements ReplayableChannelOrderSource {
   /**
    * `more` 를 따라 창 전체를 훑고, **주문번호 → 그 주문의 최신 변경 시각**을 모은다.
    * 한 주문의 여러 라인이 바뀌었으면 가장 늦은 시각을 취한다 — 워터마크의 근거다.
+   *
+   * 창을 **끝까지** 훑었고 그 창이 닫혀 있었으면(`lastChangedTo` 를 명시했으면) 창의 끝을 함께
+   * 돌려준다. 항목이 0건일 때 워터마크를 여기까지 밀어야 조용한 24시간에 갇히지 않는다.
+   * 창이 `now` 에서 끝났다면(열린 창) `null` — 그 창은 시간과 함께 자라므로 영구 정지가 아니고,
+   * 성급히 밀면 경계 근처 변경을 잃는다. 페이징이 `MAX_PAGES` 에서 잘렸을 때도 `null` 이다:
+   * 창을 끝까지 못 봤으므로 다 봤다고 말할 수 없다.
    */
-  private async collectChangedOrderIds(since: Date | null): Promise<Map<string, string>> {
+  private async collectChangedOrderIds(
+    since: Date | null,
+  ): Promise<{ changedAtByOrderId: Map<string, string>; completedWindowEnd: Date | null }> {
     const now = new Date();
     const from = since ?? new Date(now.getTime() - FIRST_RUN_LOOKBACK_MS);
     // 창을 앞으로 점프시키지 않는다 — 그러면 그 사이 주문이 영영 조회 범위 밖으로 빠진다.
@@ -143,30 +200,32 @@ export class NaverOrderSource implements ReplayableChannelOrderSource {
       }
 
       const more = response.data?.more;
-      if (!more) return changedAtByOrderId;
+      if (!more) {
+        return { changedAtByOrderId, completedWindowEnd: explicitTo ? windowEnd : null };
+      }
       lastChangedFrom = more.moreFrom;
       moreSequence = more.moreSequence;
     }
 
     this.logger.warn(`[naver] 변경 피드 페이징이 ${MAX_PAGES}쪽에서 끊겼다 — 다음 주기가 이어받는다.`);
-    return changedAtByOrderId;
+    return { changedAtByOrderId, completedWindowEnd: null };
   }
 
   private buildSnapshot(
     externalOrderId: string,
     infos: NaverProductOrderInfo[],
+    rawProductOrders: unknown[],
     sourceUpdatedAt: string,
   ): ChannelOrderSnapshot {
     const lines = infos.map((info) => this.buildLine(info));
-    const cancelled = infos.filter((info) => TERMINAL_STATUSES.has(info.productOrderStatus));
-    const live = infos.filter((info) => !TERMINAL_STATUSES.has(info.productOrderStatus));
-    const allCancelled = cancelled.length === infos.length;
+    const live = infos.filter((info) => !OUT_OF_CONTRACT_STATUSES.has(info.productOrderStatus));
+    const allOutOfContract = live.length === 0;
     this.warnIfShippingAddressesDiffer(externalOrderId, infos);
 
     return {
       externalOrderId,
       sourceUpdatedAt,
-      paymentState: this.resolvePaymentState(infos, allCancelled),
+      paymentState: this.resolvePaymentState(live, allOutOfContract),
       customerId: null,
       lines,
       amounts: {
@@ -178,11 +237,15 @@ export class NaverOrderSource implements ReplayableChannelOrderSource {
         shipping: live.reduce((sum, info) => sum + info.shippingFee, 0),
         discount: 0,
         currency: 'KRW',
+        // 🔴 해시 전용 총액 — **전 라인** 기준이라 취소로 움직이지 않는다. `total` 을 해시에
+        // 쓰면 라인 하나 취소가 곧 "수집 후 변경" 으로 읽혀 replay 가 거부하는 격리가 쌓인다.
+        allLinesTotal: infos.reduce((sum, info) => sum + info.lineTotal, 0),
       },
       shippingAddress: infos[0].shippingAddress,
       createdAt: infos[0].paymentDate ?? sourceUpdatedAt,
-      lifecycle: this.buildLifecycle(infos, cancelled, allCancelled, sourceUpdatedAt),
-      raw: { externalOrderId, productOrders: infos },
+      lifecycle: this.buildLifecycle(infos, sourceUpdatedAt),
+      // 채널 원본 그대로. 파싱 결과를 넣으면 shadow 점검이 필드명을 확정할 수 없다 (설계 §7).
+      raw: { externalOrderId, productOrders: rawProductOrders },
     };
   }
 
@@ -209,14 +272,16 @@ export class NaverOrderSource implements ReplayableChannelOrderSource {
       productName: info.productName,
       quantity: info.quantity,
       unitPrice: info.unitPrice,
-      ...(TERMINAL_STATUSES.has(info.productOrderStatus) ? { cancelled: true } : {}),
+      // 반품/교환도 "계약에서 빠진 라인" 이라는 점은 취소와 같다 — 표시는 같은 플래그로 한다.
+      // 다른 것은 **취소 관측을 내느냐**이고, 그 갈래는 `buildLifecycle` 이 가른다.
+      ...(OUT_OF_CONTRACT_STATUSES.has(info.productOrderStatus) ? { cancelled: true } : {}),
     };
   }
 
-  private resolvePaymentState(infos: NaverProductOrderInfo[], allCancelled: boolean): ChannelPaymentState {
-    if (allCancelled) return 'terminal';
+  /** `live` 는 계약에 남은 라인만. 전 라인이 빠졌으면 `terminal`. */
+  private resolvePaymentState(live: NaverProductOrderInfo[], allOutOfContract: boolean): ChannelPaymentState {
+    if (allOutOfContract) return 'terminal';
 
-    const live = infos.filter((info) => !TERMINAL_STATUSES.has(info.productOrderStatus));
     // 고객이 취소를 원하는 주문을 출고 파이프라인에 태우지 않는다 (Medusa 의 refund-requested 방어와 대칭).
     if (live.some((info) => info.claimStatus && CANCEL_IN_FLIGHT_CLAIMS.has(info.claimStatus))) return 'pending';
     if (live.every((info) => ACCEPTED_STATUSES.has(info.productOrderStatus))) return 'accepted';
@@ -226,15 +291,15 @@ export class NaverOrderSource implements ReplayableChannelOrderSource {
   /**
    * **전 라인 취소는 full 1건, 일부 취소는 라인마다 partial 1건.**
    * Core 는 `lines` 유무로 전체/부분을 가르고, 부분취소가 누적돼 전량이 돼도 주문을 닫지 않는다.
+   *
+   * 반품/교환(`RETURNED`/`EXCHANGED`)은 여기서 **관측을 내지 않는다** — 출고 후 생애주기라
+   * `OrderCancelled` 로 보내면 Core 의 출고 증거 가드에 막혀 DLQ 로 사라진다.
    */
-  private buildLifecycle(
-    infos: NaverProductOrderInfo[],
-    cancelled: NaverProductOrderInfo[],
-    allCancelled: boolean,
-    cancelledAt: string,
-  ): LifecycleObservation[] {
+  private buildLifecycle(infos: NaverProductOrderInfo[], cancelledAt: string): LifecycleObservation[] {
+    const cancelled = infos.filter((info) => CANCELLATION_OBSERVED_STATUSES.has(info.productOrderStatus));
     if (cancelled.length === 0) return [];
 
+    const allCancelled = cancelled.length === infos.length;
     if (allCancelled) {
       return [
         {
@@ -252,7 +317,16 @@ export class NaverOrderSource implements ReplayableChannelOrderSource {
       ];
     }
 
-    return cancelled.map((info) => ({
+    // 계약(`OrderCancelledSchema.cancelledLines[].quantity`)이 **양수**를 요구한다. 파서는
+    // 0 도 통과시키므로(수량 0 라인이 실재한다는 보고는 없지만 스키마상 가능) 여기서 거른다 —
+    // 안 거르면 zod 검증에서 터져 그 관측이 통째로 사라진다.
+    const emittable = cancelled.filter((info) => info.quantity > 0);
+    const skipped = cancelled.length - emittable.length;
+    if (skipped > 0) {
+      this.logger.warn(`[naver] 수량이 양수가 아닌 취소 라인 ${skipped}건은 취소 관측에서 제외한다 (계약 위반 방지).`);
+    }
+
+    return emittable.map((info) => ({
       eventType: 'OrderCancelled' as const,
       eventKey: `cancelled:${info.productOrderId}`,
       payload: {

--- a/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.spec.ts
+++ b/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.spec.ts
@@ -1355,6 +1355,226 @@ describe('OrderPollerOrchestrator — 채널 활성 게이트 (#654)', () => {
 
     expect(client.getActiveSites).toHaveBeenCalledTimes(1);
   });
+
+  // FIX D: 최초 수집 때 저장하는 해시는 `createPayload` 에서 세 값을 다시 조립해 만들었다.
+  // 그것은 "createPayload.items 와 changes.items 가 항상 같다" 는 가정이었고, 취소된 라인이
+  // 이미 있는 주문에서 깨진다 — 계약에는 살아있는 라인만, 해시에는 전 라인이 들어가기 때문.
+  // 그러면 두 번째 폴링이 구조적으로 다른 입력을 보고 오격리한다.
+  it('최초 수집 때 이미 취소된 라인이 있어도 두 번째 폴링이 오격리하지 않는다 (FIX D)', async () => {
+    const db = makeDb();
+    const order = makeOrderWithCancelledLine('2026-05-26T01:00:00.000Z');
+    const provider: ChannelOrderProvider = {
+      channel: 'naver',
+      fetchOrders: jest
+        .fn()
+        .mockResolvedValueOnce({ orders: [order], failures: [] })
+        .mockResolvedValueOnce({ orders: [makeOrderWithCancelledLine('2026-05-26T01:10:00.000Z')], failures: [] }),
+    };
+    const failures = makeFailureService();
+
+    const orchestrator = new OrderPollerOrchestrator(
+      [provider],
+      makeSyncStatus() as any,
+      { enqueue: jest.fn().mockResolvedValue(undefined) } as any,
+      makeHashService() as any,
+      failures as any,
+      db as any,
+      makeSalesChannelClient(['medusa', 'naver']) as any,
+    );
+
+    await orchestrator.poll();
+    await orchestrator.poll();
+
+    expect(failures.recordFailure).not.toHaveBeenCalled();
+  });
+
+  // 같은 FIX D 의 Medusa 쪽 대칭 근거: Medusa 는 취소 라인이 없어 두 입력이 같은 값이므로
+  // 저장되는 해시가 바이트 단위로 바뀌지 않는다. 그 사실을 직접 못 박는다.
+  it('Medusa 주문에서는 createPayload 유래 해시와 changes 유래 해시가 같은 값이다 (FIX D 무영향 근거)', async () => {
+    const db = makeDb();
+    const item = makeOrder('2026-05-26T01:00:00.000Z');
+    const hashes = makeHashService();
+
+    const orchestrator = new OrderPollerOrchestrator(
+      [{ channel: 'medusa', fetchOrders: jest.fn().mockResolvedValue({ orders: [item], failures: [] }) }],
+      makeSyncStatus() as any,
+      { enqueue: jest.fn().mockResolvedValue(undefined) } as any,
+      hashes as any,
+      makeFailureService() as any,
+      db as any,
+      makeSalesChannelClient(['medusa', 'naver']) as any,
+    );
+
+    await orchestrator.poll();
+
+    const legacyInput = {
+      items: item.createPayload.items,
+      shippingAddress: item.createPayload.shippingAddress,
+      totalAmount: item.createPayload.totalAmount,
+    };
+    expect(hashes.stored('medusa', 'order', 'medusa_order_1')).toBe(hashes.computeHash(legacyInput));
+  });
+
+  // FIX E: 관측의 정체성은 payload 가 아니라 `eventKey` 다. 네이버 부분취소는 형제 라인이 바뀔
+  // 때마다 `cancelledAt` 이 따라 움직여, payload 해시로 판정하면 같은 취소가 매 주기 재발행되고
+  // Core 는 `remaining = 0` 으로 BadRequestException → DLQ 를 만든다.
+  it('payload 가 흔들려도 같은 eventKey 의 관측은 한 번만 발행한다 (FIX E)', async () => {
+    const db = makeDb();
+    db.mappings.set('naver:medusa_order_1', {
+      salesChannel: 'naver',
+      channelOrderId: 'medusa_order_1',
+      wmsOrderId: '11111111-1111-4111-8111-111111111111',
+    });
+    const first = makeLifecycleEvent('OrderCancelled', 'cancelled:po-1', '2026-05-26T01:00:00.000Z');
+    // 형제 라인이 바뀌어 sourceUpdatedAt(=cancelledAt) 만 움직인 같은 취소.
+    const second = makeLifecycleEvent('OrderCancelled', 'cancelled:po-1', '2026-05-26T01:05:00.000Z');
+    const provider: ChannelOrderProvider = {
+      channel: 'naver',
+      fetchOrders: jest
+        .fn()
+        .mockResolvedValueOnce({ orders: [], failures: [], lifecycleEvents: [first] })
+        .mockResolvedValueOnce({ orders: [], failures: [], lifecycleEvents: [second] }),
+    };
+    const outbox = { enqueue: jest.fn().mockResolvedValue(undefined) };
+
+    const orchestrator = new OrderPollerOrchestrator(
+      [provider],
+      makeSyncStatus() as any,
+      outbox as any,
+      makeHashService() as any,
+      makeFailureService() as any,
+      db as any,
+      makeSalesChannelClient(['medusa', 'naver']) as any,
+    );
+
+    await orchestrator.poll();
+    await orchestrator.poll();
+
+    const cancellations = outbox.enqueue.mock.calls.filter(
+      ([event]: [{ eventType: string }, unknown]) => event.eventType === 'OrderCancelled',
+    );
+    expect(cancellations).toHaveLength(1);
+  });
+
+  it('eventKey 가 다르면 별개의 관측으로 각각 발행한다 (FIX E — 라인 단위 취소가 뭉개지지 않는다)', async () => {
+    const db = makeDb();
+    db.mappings.set('naver:medusa_order_1', {
+      salesChannel: 'naver',
+      channelOrderId: 'medusa_order_1',
+      wmsOrderId: '11111111-1111-4111-8111-111111111111',
+    });
+    const provider: ChannelOrderProvider = {
+      channel: 'naver',
+      fetchOrders: jest.fn().mockResolvedValue({
+        orders: [],
+        failures: [],
+        lifecycleEvents: [
+          makeLifecycleEvent('OrderCancelled', 'cancelled:po-1', '2026-05-26T01:00:00.000Z'),
+          makeLifecycleEvent('OrderCancelled', 'cancelled:po-2', '2026-05-26T01:00:00.000Z'),
+        ],
+      }),
+    };
+    const outbox = { enqueue: jest.fn().mockResolvedValue(undefined) };
+
+    const orchestrator = new OrderPollerOrchestrator(
+      [provider],
+      makeSyncStatus() as any,
+      outbox as any,
+      makeHashService() as any,
+      makeFailureService() as any,
+      db as any,
+      makeSalesChannelClient(['medusa', 'naver']) as any,
+    );
+
+    await orchestrator.poll();
+
+    expect(
+      outbox.enqueue.mock.calls.filter(([event]: [{ eventType: string }, unknown]) => event.eventType === 'OrderCancelled'),
+    ).toHaveLength(2);
+  });
+
+  // FIX F: 닫힌 창(`[since, since+24h]`)에 변경이 하나도 없으면 워터마크가 `null` 로 남고
+  // `recordSyncComplete` 가 `lastSyncAt` 을 건드리지 않는다 — 다음 주기가 같은 창을 다시 묻는다.
+  // 조용한 24시간 하나가 수집을 영구히 정지시킨다.
+  it('변경 0건이어도 완료한 닫힌 창의 끝까지 워터마크를 전진시킨다 (FIX F)', async () => {
+    const windowEnd = new Date('2026-05-27T00:00:00.000Z');
+    const syncStatus = makeSyncStatus(new Date('2026-05-26T00:00:00.000Z'));
+    const provider: ChannelOrderProvider = {
+      channel: 'naver',
+      fetchOrders: jest.fn().mockResolvedValue({
+        orders: [],
+        failures: [],
+        lifecycleEvents: [],
+        completedWindowEnd: windowEnd,
+      }),
+    };
+
+    const orchestrator = new OrderPollerOrchestrator(
+      [provider],
+      syncStatus as any,
+      { enqueue: jest.fn().mockResolvedValue(undefined) } as any,
+      makeHashService() as any,
+      makeFailureService() as any,
+      makeDb() as any,
+      makeSalesChannelClient(['medusa', 'naver']) as any,
+    );
+
+    await orchestrator.poll();
+    await orchestrator.poll();
+
+    expect(syncStatus.lastSyncAt()).toEqual(windowEnd);
+    // 두 번째 폴은 같은 닫힌 창이 아니라 그 뒤에서 다시 시작해야 한다 (2분 되감기 포함).
+    expect(provider.fetchOrders).toHaveBeenLastCalledWith(new Date('2026-05-26T23:58:00.000Z'));
+  });
+
+  it('창의 끝을 보고하지 않는 source(Medusa)는 변경 0건에서 워터마크가 그대로다 (FIX F 무영향 근거)', async () => {
+    const before = new Date('2026-05-26T00:00:00.000Z');
+    const syncStatus = makeSyncStatus(before);
+    const provider: ChannelOrderProvider = {
+      channel: 'medusa',
+      fetchOrders: jest.fn().mockResolvedValue({ orders: [], failures: [] }),
+    };
+
+    const orchestrator = new OrderPollerOrchestrator(
+      [provider],
+      syncStatus as any,
+      { enqueue: jest.fn().mockResolvedValue(undefined) } as any,
+      makeHashService() as any,
+      makeFailureService() as any,
+      makeDb() as any,
+      makeSalesChannelClient(['medusa', 'naver']) as any,
+    );
+
+    await orchestrator.poll();
+
+    expect(syncStatus.lastSyncAt()).toEqual(before);
+  });
+
+  it('항목이 있으면 창의 끝이 아니라 항목의 시각이 워터마크다 (FIX F 가 항목 경로를 건드리지 않는다)', async () => {
+    const syncStatus = makeSyncStatus(new Date('2026-05-26T00:00:00.000Z'));
+    const provider: ChannelOrderProvider = {
+      channel: 'naver',
+      fetchOrders: jest.fn().mockResolvedValue({
+        orders: [makeOrder('2026-05-26T01:00:00.000Z')],
+        failures: [],
+        completedWindowEnd: new Date('2026-05-27T00:00:00.000Z'),
+      }),
+    };
+
+    const orchestrator = new OrderPollerOrchestrator(
+      [provider],
+      syncStatus as any,
+      { enqueue: jest.fn().mockResolvedValue(undefined) } as any,
+      makeHashService() as any,
+      makeFailureService() as any,
+      makeDb() as any,
+      makeSalesChannelClient(['medusa', 'naver']) as any,
+    );
+
+    await orchestrator.poll();
+
+    expect(syncStatus.lastSyncAt()).toEqual(new Date('2026-05-26T01:00:00.000Z'));
+  });
 });
 
 /** 활성 사이트 목록을 주는 Core 클라이언트의 목. Error 를 주면 조회 실패를 흉내낸다. */
@@ -1415,6 +1635,62 @@ function makeOrder(
       items: [item],
       shippingAddress,
       totalAmount,
+    },
+    modifiedAt: sourceUpdatedAt,
+  };
+}
+
+/**
+ * 최초 수집 시점에 **이미 취소된 라인이 있는** 주문 (네이버 부분취소). 계약(`createPayload.items`)
+ * 에는 살아있는 라인만, 해시 입력(`changes.items`)에는 전 라인이 들어간다 — 두 값이 다르다는
+ * 것이 요점이고, 그 차이를 무시한 채 `createPayload` 로 최초 해시를 만들면 다음 폴링이
+ * 오격리한다. 총액도 마찬가지로 계약은 실판매분, 해시는 전 라인이다.
+ */
+function makeOrderWithCancelledLine(sourceUpdatedAt: string): OrderFetchItem {
+  const shippingAddress = {
+    recipientName: 'Jane Kim',
+    phone: '010-0000-0000',
+    postalCode: '12345',
+    roadAddress: 'Seoul',
+    detailAddress: '101',
+  };
+  const live = {
+    orderItemId: 'po-1',
+    skuId: 'pim_variant_1',
+    masterId: 'master_1',
+    versionId: 'version_1',
+    variantId: 'pim_variant_1',
+    productName: 'Product',
+    channelProductId: 'naver_product_1',
+    quantity: 1,
+    unitPrice: 10000,
+    totalPrice: 10000,
+  };
+  const cancelled = { ...live, orderItemId: 'po-2', quantity: 1, unitPrice: 3000, totalPrice: 3000 };
+
+  return {
+    externalOrderId: 'medusa_order_1',
+    sourceUpdatedAt,
+    eligibleForOrderCreation: true,
+    createPayload: {
+      orderId: '11111111-1111-4111-8111-111111111111',
+      externalOrderId: 'medusa_order_1',
+      salesChannel: 'naver',
+      customerId: null,
+      items: [live],
+      totalAmount: 10000,
+      subtotalAmount: 10000,
+      shippingAmount: 0,
+      discountAmount: 0,
+      currency: 'KRW',
+      shippingAddress,
+      status: 'confirmed',
+      createdAt: '2026-05-26T00:00:00.000Z',
+    },
+    changes: {
+      items: [live, cancelled],
+      shippingAddress,
+      totalAmount: 13000,
     },
     modifiedAt: sourceUpdatedAt,
   };
@@ -1526,6 +1802,16 @@ function makeHashService() {
       hashes.set(k, hash);
       return true;
     }),
+    // 처음 본 자원일 때만 선점하는 목 (`INSERT … ON CONFLICT DO NOTHING RETURNING`).
+    // 위와 마찬가지로 **검사와 기록 사이에 await 가 없다** — 그것이 원자성의 근거다.
+    claimFirstSeen: jest.fn(async (source: string, resourceType: string, resourceId: string, hash: string) => {
+      const k = key(source, resourceType, resourceId);
+      if (hashes.has(k)) return false;
+      hashes.set(k, hash);
+      return true;
+    }),
+    stored: (source: string, resourceType: string, resourceId: string) =>
+      hashes.get(key(source, resourceType, resourceId)) ?? null,
   };
 }
 

--- a/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.ts
+++ b/apps/channel-adapter/src/services/order-collection/order-poller.orchestrator.ts
@@ -93,7 +93,7 @@ export class OrderPollerOrchestrator {
         await this.syncStatusService.recordSyncStart(channelType, 'orders');
 
         const startTime = Date.now();
-        const { orders, failures, lifecycleEvents = [] } = await provider.fetchOrders(since);
+        const { orders, failures, lifecycleEvents = [], completedWindowEnd } = await provider.fetchOrders(since);
         const orderedItems: OrderedPollItem[] = [
           ...orders.map((item) => ({ kind: 'order' as const, item })),
           ...failures.map((item) => ({ kind: 'failure' as const, item })),
@@ -210,6 +210,21 @@ export class OrderPollerOrchestrator {
           emitted += result.emitted;
           dedupedUnchanged += result.dedupedUnchanged;
           advanceWatermark(orderedItem.item.sourceUpdatedAt);
+        }
+
+        // 🔴 조용한 창은 워터마크를 영원히 묶는다. 닫힌 조회 창(`[since, since+24h]`)을 쓰는
+        // source 는 그 창에 변경이 하나도 없으면 항목 0건을 낸다 — 그러면 워터마크가 `null` 로
+        // 남고 `recordSyncComplete` 는 `lastSyncAt` 을 건드리지 않으므로 다음 주기가 **같은 닫힌
+        // 창**을 다시 묻는다. 조용한 24시간 하나가 수집을 영구히 정지시키는 것이다.
+        //
+        // 항목이 하나라도 있었으면 그 항목들의 시각이 워터마크의 근거이므로 여기 오지 않는다.
+        // 즉 이 갈래는 "아무것도 없었다" 는 사실만 다루며, 그때 `watermarkHeldAt` 도 정의상 없다.
+        // 열린 질의를 쓰는 source(Medusa)는 `completedWindowEnd` 를 내지 않으므로 무영향이다.
+        if (orderedItems.length === 0 && completedWindowEnd) {
+          watermark = completedWindowEnd;
+          this.logger.log(
+            `[${provider.channel}] 변경 0건 — 완료한 조회 창 끝(${completedWindowEnd.toISOString()})으로 워터마크를 전진시킨다.`,
+          );
         }
 
         if (skippedAlreadyCollected > 0) {
@@ -430,16 +445,21 @@ export class OrderPollerOrchestrator {
 
         // 첫 폴링 직후의 후속 폴링이 동일 페이로드로 OrderModified를 오발행하지 않도록
         // 생성 시점의 변경-기준 콘텐츠 해시를 함께 기록해둔다.
-        const initialChangeContent = {
-          items: payload.items,
-          shippingAddress: payload.shippingAddress,
-          totalAmount: payload.totalAmount,
-        };
+        //
+        // 🔴 입력은 **`item.changes` 그 자체**여야 한다. 예전엔 `createPayload` 에서 같은 세 값을
+        // 다시 조립했는데, 그것은 두 값이 항상 같다는 가정 위에 서 있었다. 취소된 라인이 있는
+        // 주문에서 그 가정이 깨진다 — `createPayload.items` 는 살아있는 라인만, `changes.items`
+        // 는 전 라인이라 최초 수집 때 이미 취소된 라인이 있으면 저장 해시와 다음 폴링의 해시가
+        // 구조적으로 어긋나, 그 주문은 두 번째 폴링에서 `collected_order_modification_not_accepted`
+        // 로 오격리된다(그 사유는 replay 가 거부한다).
+        //
+        // Medusa 는 취소 라인 개념이 없어 두 값이 같은 항목·같은 주소·같은 총액이고,
+        // `computeHash` 의 직렬화가 키를 정렬하므로 **저장되는 해시가 바이트 단위로 동일**하다.
         await this.pollingHashService.upsert(
           provider.channel,
           POLLING_RESOURCE_TYPE_ORDER,
           payload.externalOrderId ?? payload.orderId,
-          this.pollingHashService.computeHash(initialChangeContent),
+          this.pollingHashService.computeHash(item.changes),
           tx,
         );
         return true;
@@ -529,6 +549,15 @@ export class OrderPollerOrchestrator {
       orderId: mapping[0].wmsOrderId,
       ...item.payload,
     };
+    // 🔴 관측의 정체성은 **`eventKey`** 다 (`LifecycleObservation.eventKey`: "같은 관측을 두 번
+    // 세지 않기 위한 채널 내 안정 키"). 그래서 자원 키에 그 값을 넣고, 중복 판정도 payload 가
+    // 아니라 **이 자원이 처음인가**로 한다. payload 로 판정하면 네이버 부분취소처럼 형제 라인이
+    // 바뀔 때마다 `cancelledAt` 이 따라 움직이는 관측이 매 주기 재발행되고, Core 는 이미 취소된
+    // 라인에 `remaining = 0` 으로 `BadRequestException` 을 던져 DLQ 에 쌓인다.
+    //
+    // Medusa 의 키(`cancelled`, `refund:<id>`)는 이미 안정적이라 payload 도 키마다 고정이었다 —
+    // 즉 "해시가 바뀌면 재발행" 과 "처음이면 발행" 이 Medusa 에서는 같은 판정을 낸다. 해시 값
+    // 자체도 계속 같은 입력으로 계산해 기록하므로 기존 행의 저장 바이트가 달라지지 않는다.
     const lifecycleResourceId = `${item.externalOrderId}:${item.eventKey}`;
     const newHash = this.pollingHashService.computeHash({
       eventType: item.eventType,
@@ -537,10 +566,10 @@ export class OrderPollerOrchestrator {
     });
     const wmsOrderId = mapping[0].wmsOrderId;
 
-    // 해시 확인이 **트랜잭션 안**이고, 검사와 기록이 한 문장이다 (#599). 밖에서 읽고 안에서
-    // 쓰면 겹쳐 도는 두 폴이 같은 옛 해시를 보고 둘 다 발행한다 — 라이브에서 실제로 발생했다.
+    // 선점이 **트랜잭션 안**이고, 검사와 기록이 한 문장이다 (#599). 밖에서 읽고 안에서
+    // 쓰면 겹쳐 도는 두 폴이 같은 옛 상태를 보고 둘 다 발행한다 — 라이브에서 실제로 발생했다.
     const claimed = await this.db.db.transaction(async (tx) => {
-      const won = await this.pollingHashService.claimChanged(
+      const won = await this.pollingHashService.claimFirstSeen(
         provider.channel,
         POLLING_RESOURCE_TYPE_ORDER_LIFECYCLE,
         lifecycleResourceId,
@@ -576,7 +605,7 @@ export class OrderPollerOrchestrator {
         await this.ordersPublisher.enqueue({ eventType: 'OrderRefundCreated', payload: refunded, ...common }, tx);
       }
 
-      // 해시 기록은 `claimChanged` 가 이미 같은 트랜잭션에서 끝냈다 — 여기서 또 쓰지 않는다.
+      // 기록은 `claimFirstSeen` 이 이미 같은 트랜잭션에서 끝냈다 — 여기서 또 쓰지 않는다.
       return true;
     });
 

--- a/apps/channel-adapter/src/services/order-collection/translating-order.provider.ts
+++ b/apps/channel-adapter/src/services/order-collection/translating-order.provider.ts
@@ -5,6 +5,7 @@ import {
   ChannelOrderSnapshot,
   ReplayableChannelOrderSource,
   isReplayableSource,
+  isWindowedSource,
 } from './channel-order-source.interface';
 import {
   ChannelOrderProvider,
@@ -34,7 +35,11 @@ export class TranslatingOrderProvider implements ChannelOrderProvider {
   }
 
   async fetchOrders(since: Date | null): Promise<FetchOrdersResult> {
-    const snapshots = await this.source.fetchOrders(since);
+    // 닫힌 창을 쓰는 source 만 창의 끝을 보고한다. 열린 질의(Medusa)는 이 갈래를 타지 않으므로
+    // `completedWindowEnd` 가 `undefined` 로 남고, 오케스트레이터의 워터마크 계산이 전과 같다.
+    const { snapshots, completedWindowEnd } = isWindowedSource(this.source)
+      ? await this.source.fetchOrdersInWindow(since)
+      : { snapshots: await this.source.fetchOrders(since), completedWindowEnd: undefined };
 
     const orders: OrderFetchItem[] = [];
     const failures: OrderCollectionFailureItem[] = [];
@@ -50,7 +55,12 @@ export class TranslatingOrderProvider implements ChannelOrderProvider {
       }
     }
 
-    return { orders, failures, lifecycleEvents };
+    return {
+      orders,
+      failures,
+      lifecycleEvents,
+      ...(completedWindowEnd !== undefined ? { completedWindowEnd } : {}),
+    };
   }
 
   protected async translateOne(snapshot: ChannelOrderSnapshot): Promise<OrderFetchOutcome> {

--- a/apps/channel-adapter/src/services/polling-change-hash.service.ts
+++ b/apps/channel-adapter/src/services/polling-change-hash.service.ts
@@ -88,6 +88,53 @@ export class PollingChangeHashService {
     return rows.length > 0;
   }
 
+  /**
+   * **처음 본 자원일 때만** 선점한다 — 내용 해시를 비교하지 않는다 (#643).
+   *
+   * `claimChanged` 는 "내용이 바뀌었나" 를 묻는다. 그것이 맞는 질문인 자원(주문 스냅샷)도 있지만,
+   * **관측(observation)** 은 다르다. 관측의 정체성은 채널이 준 안정 키(`eventKey`)이고, 그 키가
+   * 같으면 payload 가 흔들려도 **같은 사건**이다. 네이버 부분취소가 그 반례였다: 형제 라인이
+   * 바뀔 때마다 `cancelledAt` 이 따라 움직여 해시가 달라지고, 같은 취소가 매 주기 재발행돼
+   * Core 에서 `remaining = 0` → `BadRequestException` → DLQ 로 쌓였다.
+   *
+   * `resourceId` 에 이미 `eventKey` 가 들어 있으므로, 여기서는 **행의 존재 자체**가 "이 관측은
+   * 이미 셌다" 는 사실이다:
+   *
+   * ```sql
+   * INSERT … ON CONFLICT (source, resource_type, resource_id) DO NOTHING RETURNING resource_id
+   * ```
+   *
+   * - 행이 없으면 INSERT 성공 → 반환 행 있음 → 선점
+   * - 행이 있으면 DO NOTHING → 반환 행 없음 → 이미 처리된 사실
+   *
+   * 동시 실행에서 뒤늦은 쪽은 유니크 인덱스의 행 잠금에서 대기하다 커밋 후 충돌을 보고 물러난다.
+   * 정확히 한 쪽만 선점한다 — `claimChanged` 와 같은 성질이다.
+   *
+   * `hash` 는 **판단에 쓰이지 않고 기록으로만 남는다**. 그래서 기존 행의 해시 값도 건드리지
+   * 않으며, 이미 관측된 자원의 저장 바이트가 이 변경으로 달라지지 않는다.
+   *
+   * 호출자는 **반드시 발행과 같은 트랜잭션**에서 부를 것.
+   */
+  async claimFirstSeen(
+    source: string,
+    resourceType: string,
+    resourceId: string,
+    hash: string,
+    tx?: DbTx,
+  ): Promise<boolean> {
+    const now = new Date();
+    const exec = (trx: DbTx | DbService<typeof channelAdapterSchema>['db']) =>
+      trx
+        .insert(pollingChangeHashes)
+        .values({ source, resourceType, resourceId, hash, lastSeenAt: now })
+        .onConflictDoNothing({
+          target: [pollingChangeHashes.source, pollingChangeHashes.resourceType, pollingChangeHashes.resourceId],
+        })
+        .returning({ resourceId: pollingChangeHashes.resourceId });
+    const rows = await exec(tx ?? this.db.db);
+    return rows.length > 0;
+  }
+
   async upsert(source: string, resourceType: string, resourceId: string, hash: string, tx?: DbTx): Promise<void> {
     const now = new Date();
     const exec = (trx: DbTx | DbService<typeof channelAdapterSchema>['db']) =>

--- a/apps/channel-adapter/src/zods/naver/naver-core.zod.ts
+++ b/apps/channel-adapter/src/zods/naver/naver-core.zod.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
  */
 export function createNaverApiResponseSchema<T extends z.ZodTypeAny>(dataSchema: T) {
   return z.object({
-    timestamp: z.string().datetime(),
+    timestamp: z.string().datetime({ offset: true }),
     traceId: z.string(),
     data: dataSchema,
   });
@@ -20,7 +20,7 @@ export function createNaverApiResponseSchema<T extends z.ZodTypeAny>(dataSchema:
  */
 export function createNaverApiResponseSchemaOptional<T extends z.ZodTypeAny>(dataSchema: T) {
   return z.object({
-    timestamp: z.string().datetime(),
+    timestamp: z.string().datetime({ offset: true }),
     traceId: z.string(),
     data: dataSchema.optional(),
   });
@@ -218,6 +218,24 @@ export const ProductOrderStatusSchema = z.enum([
   'CANCELED_BY_NOPAYMENT',
 ]);
 export type ProductOrderStatus = z.infer<typeof ProductOrderStatusSchema>;
+
+/**
+ * 최종 변경 구분 (변경 피드 전용).
+ *
+ * **`productOrderStatus` 와 다른 축이다.** 발송 완료 시 `productOrderStatus` 는 `DELIVERING`,
+ * `lastChangedType` 이 `DISPATCHED` 다. 옛 `mapNaverStatusToInternal` 이 둘을 한 표에 섞었다.
+ */
+export const LastChangedTypeSchema = z.enum([
+  'PAY_WAITING',
+  'PAYED',
+  'DISPATCHED',
+  'CANCEL_REQUESTED',
+  'CLAIM_REQUESTED',
+  'CLAIM_REJECTED',
+  'CLAIM_COMPLETED',
+  'PURCHASE_DECIDED',
+]);
+export type LastChangedType = z.infer<typeof LastChangedTypeSchema>;
 
 /**
  * 클레임 상태 코드

--- a/apps/channel-adapter/src/zods/naver/naver.order.zod.spec.ts
+++ b/apps/channel-adapter/src/zods/naver/naver.order.zod.spec.ts
@@ -1,0 +1,44 @@
+import { NaverLastChangedStatusResponseSchema } from './naver.order.zod';
+import { LastChangedTypeSchema, ProductOrderStatusSchema } from './naver-core.zod';
+
+describe('네이버 변경 피드 스키마', () => {
+  it('DISPATCHED 는 lastChangedType 값이지 productOrderStatus 값이 아니다', () => {
+    expect(LastChangedTypeSchema.safeParse('DISPATCHED').success).toBe(true);
+    expect(ProductOrderStatusSchema.safeParse('DISPATCHED').success).toBe(false);
+  });
+
+  it('발송 완료 항목을 파싱한다', () => {
+    const parsed = NaverLastChangedStatusResponseSchema.safeParse({
+      timestamp: '2026-08-19T00:00:00.000+09:00',
+      traceId: 'trace-1',
+      data: {
+        count: 1,
+        lastChangeStatuses: [
+          {
+            orderId: '2026081900000',
+            productOrderId: '2026081900001',
+            lastChangedType: 'DISPATCHED',
+            paymentDate: '2026-08-19T00:00:00.000+09:00',
+            lastChangedDate: '2026-08-19T01:00:00.000+09:00',
+            productOrderStatus: 'DELIVERING',
+            receiverAddressChanged: false,
+          },
+        ],
+      },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('more 객체를 파싱한다 — 페이징 입력이다', () => {
+    const parsed = NaverLastChangedStatusResponseSchema.safeParse({
+      timestamp: '2026-08-19T00:00:00.000+09:00',
+      traceId: 'trace-2',
+      data: {
+        count: 300,
+        lastChangeStatuses: [],
+        more: { moreFrom: '2026-08-19T02:00:00.000+09:00', moreSequence: '17' },
+      },
+    });
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/apps/channel-adapter/src/zods/naver/naver.order.zod.ts
+++ b/apps/channel-adapter/src/zods/naver/naver.order.zod.ts
@@ -7,6 +7,7 @@ import {
   ProductOrderStatusSchema,
   ClaimStatusSchema,
   PlaceOrderStatusTypeSchema,
+  LastChangedTypeSchema,
 } from './naver-core.zod';
 
 // =================================================================
@@ -136,17 +137,18 @@ export type QueryProductOrdersParams = z.infer<typeof QueryProductOrdersParamsSc
  * (from naver-api.zod.ts)
  */
 const NaverLastChangedStatusesDataSchema = z.object({
+  count: z.number().int().nonnegative(),
   lastChangeStatuses: z.array(
     z.object({
       orderId: z.string(),
       productOrderId: z.string(),
-      lastChangedType: z.string(),
-      paymentDate: z.iso.datetime(),
-      lastChangedDate: z.iso.datetime(),
+      lastChangedType: LastChangedTypeSchema,
+      paymentDate: z.string().optional(),
+      lastChangedDate: z.string(),
       productOrderStatus: ProductOrderStatusSchema,
       claimType: z.string().optional(), // TODO: Enum화 가능
       claimStatus: ClaimStatusSchema.optional(),
-      receiverAddressChanged: z.boolean(),
+      receiverAddressChanged: z.boolean().optional(),
     }),
   ),
   more: z

--- a/apps/core/src/modules/sales-order/consumers/order-events.consumer.spec.ts
+++ b/apps/core/src/modules/sales-order/consumers/order-events.consumer.spec.ts
@@ -25,7 +25,15 @@ import { RETRY_POLICY_METADATA } from '@app/events';
 describe('OrderEventsConsumer', () => {
   type Mocks = {
     salesOrders: jest.Mocked<
-      Pick<SalesOrdersService, 'findByChannelOrderId' | 'createFromEvent' | 'getOne' | 'cancel' | 'updateFromEvent'>
+      Pick<
+        SalesOrdersService,
+        | 'findByChannelOrderId'
+        | 'createFromEvent'
+        | 'getOne'
+        | 'cancel'
+        | 'updateFromEvent'
+        | 'findLineIdsByChannelOrderItemIds'
+      >
     >;
     library: jest.Mocked<Pick<LibraryService, 'grantOwnershipsForOrder' | 'revokeOwnershipsForOrder'>>;
     backlog: jest.Mocked<
@@ -73,6 +81,7 @@ describe('OrderEventsConsumer', () => {
         getOne: jest.fn(),
         cancel: jest.fn(),
         updateFromEvent: jest.fn(),
+        findLineIdsByChannelOrderItemIds: jest.fn(),
       } as any,
       library: {
         grantOwnershipsForOrder: jest.fn().mockResolvedValue(0),
@@ -350,6 +359,80 @@ describe('OrderEventsConsumer', () => {
 
     expect(mocks.salesOrders.cancel).not.toHaveBeenCalled();
     expect(mocks.txInserts).toHaveLength(0);
+  });
+
+  it('cancelledLines 가 있으면 채널 라인 ID 를 salesOrderLineId 로 바꿔 부분취소로 넘긴다', async () => {
+    const mocks = makeMocks();
+    const consumer = makeConsumer(mocks);
+    mocks.salesOrders.findByChannelOrderId.mockResolvedValue({ id: 'so-1' } as any);
+    mocks.salesOrders.findLineIdsByChannelOrderItemIds.mockResolvedValue(
+      new Map([['2026081900001', 'sol-1']]),
+    );
+
+    await consumer.handleOrderCancelled(
+      {
+        orderId: 'ord-1',
+        salesChannel: 'naver',
+        externalOrderId: '2026081900000',
+        reason: 'CUSTOMER_REQUEST',
+        cancelledBy: 'naver',
+        cancelledAt: '2026-08-19T00:00:00.000Z',
+        refundRequired: true,
+        cancelledLines: [{ channelOrderItemId: '2026081900001', quantity: 2 }],
+      } as any,
+      { messageId: 'msg-1', correlationId: 'corr-1' } as any,
+    );
+
+    expect(mocks.salesOrders.cancel).toHaveBeenCalledWith(
+      'so-1',
+      expect.objectContaining({ lines: [{ salesOrderLineId: 'sol-1', quantity: 2 }] }),
+      expect.anything(),
+    );
+  });
+
+  it('cancelledLines 가 없으면 lines 를 넘기지 않는다 (전체 취소)', async () => {
+    const mocks = makeMocks();
+    const consumer = makeConsumer(mocks);
+    mocks.salesOrders.findByChannelOrderId.mockResolvedValue({ id: 'so-1' } as any);
+
+    await consumer.handleOrderCancelled(
+      {
+        orderId: 'ord-1',
+        salesChannel: 'naver',
+        externalOrderId: '2026081900000',
+        reason: 'CUSTOMER_REQUEST',
+        cancelledBy: 'naver',
+        cancelledAt: '2026-08-19T00:00:00.000Z',
+        refundRequired: true,
+      } as any,
+      { messageId: 'msg-2', correlationId: 'corr-2' } as any,
+    );
+
+    const [, options] = mocks.salesOrders.cancel.mock.calls[0];
+    expect((options as any).lines).toBeUndefined();
+  });
+
+  it('해석되지 않는 채널 라인이 있으면 NotFoundException 을 던진다', async () => {
+    const mocks = makeMocks();
+    const consumer = makeConsumer(mocks);
+    mocks.salesOrders.findByChannelOrderId.mockResolvedValue({ id: 'so-1' } as any);
+    mocks.salesOrders.findLineIdsByChannelOrderItemIds.mockResolvedValue(new Map());
+
+    await expect(
+      consumer.handleOrderCancelled(
+        {
+          orderId: 'ord-1',
+          salesChannel: 'naver',
+          externalOrderId: '2026081900000',
+          reason: 'CUSTOMER_REQUEST',
+          cancelledBy: 'naver',
+          cancelledAt: '2026-08-19T00:00:00.000Z',
+          refundRequired: true,
+          cancelledLines: [{ channelOrderItemId: 'unknown', quantity: 1 }],
+        } as any,
+        { messageId: 'msg-3', correlationId: 'corr-3' } as any,
+      ),
+    ).rejects.toThrow(NotFoundException);
   });
 
   it('OrderModified 는 수락된 판매주문 계약 데이터를 업데이트하지 않고 처리 이력만 남긴다', async () => {

--- a/apps/core/src/modules/sales-order/consumers/order-events.consumer.spec.ts
+++ b/apps/core/src/modules/sales-order/consumers/order-events.consumer.spec.ts
@@ -412,7 +412,11 @@ describe('OrderEventsConsumer', () => {
     expect((options as any).lines).toBeUndefined();
   });
 
-  it('해석되지 않는 채널 라인이 있으면 NotFoundException 을 던진다', async () => {
+  // 판매주문 계약은 수락 이후 불변이다 — 채널이 지목한 라인이 그 주문에 없다면 애초 수락된
+  // 적이 없는 라인이므로 취소할 대상 자체가 없다. throw 하면 non-retryable 이라 DLQ 로 가고
+  // 재시도해도 영원히 같은 결과이므로, 조용히 넘기고 no-op 으로 처리한다 (FIX 1, 최초 수집
+  // 시점에 이미 취소된 라인을 번역기가 `items` 에서 빼는 경로가 대표 재현 시나리오다).
+  it('cancelledLines 전부 해석되지 않으면 cancel 을 부르지 않고 no-op 으로 넘긴다 (throw 하지 않는다)', async () => {
     const mocks = makeMocks();
     const consumer = makeConsumer(mocks);
     mocks.salesOrders.findByChannelOrderId.mockResolvedValue({ id: 'so-1' } as any);
@@ -432,7 +436,41 @@ describe('OrderEventsConsumer', () => {
         } as any,
         { messageId: 'msg-3', correlationId: 'corr-3' } as any,
       ),
-    ).rejects.toThrow(NotFoundException);
+    ).resolves.toBeUndefined();
+
+    expect(mocks.salesOrders.cancel).not.toHaveBeenCalled();
+  });
+
+  it('cancelledLines 중 일부만 해석되지 않으면 해석된 라인만으로 cancel 을 부른다 (해석 안 된 라인은 skip)', async () => {
+    const mocks = makeMocks();
+    const consumer = makeConsumer(mocks);
+    mocks.salesOrders.findByChannelOrderId.mockResolvedValue({ id: 'so-1' } as any);
+    mocks.salesOrders.findLineIdsByChannelOrderItemIds.mockResolvedValue(
+      new Map([['known-1', 'sol-1']]),
+    );
+
+    await consumer.handleOrderCancelled(
+      {
+        orderId: 'ord-1',
+        salesChannel: 'naver',
+        externalOrderId: '2026081900000',
+        reason: 'CUSTOMER_REQUEST',
+        cancelledBy: 'naver',
+        cancelledAt: '2026-08-19T00:00:00.000Z',
+        refundRequired: true,
+        cancelledLines: [
+          { channelOrderItemId: 'known-1', quantity: 1 },
+          { channelOrderItemId: 'unknown-1', quantity: 2 },
+        ],
+      } as any,
+      { messageId: 'msg-4', correlationId: 'corr-4' } as any,
+    );
+
+    expect(mocks.salesOrders.cancel).toHaveBeenCalledWith(
+      'so-1',
+      expect.objectContaining({ lines: [{ salesOrderLineId: 'sol-1', quantity: 1 }] }),
+      expect.anything(),
+    );
   });
 
   it('OrderModified 는 수락된 판매주문 계약 데이터를 업데이트하지 않고 처리 이력만 남긴다', async () => {

--- a/apps/core/src/modules/sales-order/consumers/order-events.consumer.ts
+++ b/apps/core/src/modules/sales-order/consumers/order-events.consumer.ts
@@ -95,12 +95,23 @@ export class OrderEventsConsumer {
    *
    * **없으면 `undefined` 를 돌려준다** — Core 는 `lines` 유무로 전체/부분을 가르므로
    * 빈 배열을 넘기면 `BadRequestException` 이 된다 (`sales-orders.service.ts:436`).
+   *
+   * **해석되지 않는 라인은 skip 하지 throw 하지 않는다.** 판매주문의 계약은 수락(accept) 이후
+   * 불변이라, 그 주문에 라인이 없다는 것은 애초 수락된 적이 없다는 뜻이다 — 취소할 대상 자체가
+   * 없다. 대표 사례: 최초 수집 시점에 이미 취소된 라인은 번역기가 `items` 에서 빼버려 Core 가
+   * 그 라인을 만든 적이 없는데, source 는 그 라인을 지목하는 부분취소 관측을 그대로 낸다.
+   * 여기서 NotFound 로 throw 하면 non-retryable 이라 즉시 DLQ 로 가고, 재시도해도 영원히
+   * 같은 결과다 — 조용히 넘기는 것이 맞다.
+   *
+   * `cancelledLines` 가 있는데 **단 하나도 해석되지 않으면** `null` 을 돌려준다 — 이걸
+   * `undefined`(= 필드 자체가 없어 전체취소) 로 착각하면 안 되므로 구분한다. 호출부는 `null` 을
+   * "취소할 것이 없는 no-op" 으로 다뤄야 하고, 이때 전체취소로 대체 처리해서는 안 된다.
    */
   private async resolveCancelledLines(
     salesOrderId: string,
     cancelledLines: Array<{ channelOrderItemId: string; quantity: number }> | undefined,
     tx: DbTx,
-  ): Promise<Array<{ salesOrderLineId: string; quantity: number }> | undefined> {
+  ): Promise<Array<{ salesOrderLineId: string; quantity: number }> | undefined | null> {
     if (!cancelledLines || cancelledLines.length === 0) return undefined;
 
     const channelOrderItemIds = cancelledLines.map((line) => line.channelOrderItemId);
@@ -110,16 +121,25 @@ export class OrderEventsConsumer {
       tx,
     );
 
-    return cancelledLines.map((line) => {
+    const resolvedLines: Array<{ salesOrderLineId: string; quantity: number }> = [];
+    const unresolved: string[] = [];
+    for (const line of cancelledLines) {
       const salesOrderLineId = idByChannelItem.get(line.channelOrderItemId);
       if (!salesOrderLineId) {
-        // 재시도해도 결과가 같다. NotFound 는 이 핸들러의 nonRetryableErrors 라 DLQ 로 간다.
-        throw new NotFoundException(
-          `Sales order line not found for channelOrderItemId=${line.channelOrderItemId} (salesOrder=${salesOrderId})`,
-        );
+        unresolved.push(line.channelOrderItemId);
+        continue;
       }
-      return { salesOrderLineId, quantity: line.quantity };
-    });
+      resolvedLines.push({ salesOrderLineId, quantity: line.quantity });
+    }
+
+    if (unresolved.length > 0) {
+      this.logger.warn(
+        `[OrderCancelled] Skipping unresolved cancelled lines for salesOrder=${salesOrderId}: ${unresolved.join(', ')}`,
+      );
+    }
+
+    if (resolvedLines.length === 0) return null;
+    return resolvedLines;
   }
 
   @On(ORDER_STREAM, 'OrderCreated')
@@ -203,6 +223,12 @@ export class OrderEventsConsumer {
         if (alreadyProcessed) return;
 
         const lines = await this.resolveCancelledLines(salesOrderId, payload.cancelledLines, tx);
+        if (lines === null) {
+          this.logger.log(
+            `[OrderCancelled] No resolvable cancelled lines for salesOrder=${salesOrderId}, skipping as no-op`,
+          );
+          return;
+        }
 
         await this.salesOrdersService.cancel(
           salesOrderId,

--- a/apps/core/src/modules/sales-order/consumers/order-events.consumer.ts
+++ b/apps/core/src/modules/sales-order/consumers/order-events.consumer.ts
@@ -90,6 +90,38 @@ export class OrderEventsConsumer {
     return byPrimaryKey?.id ?? null;
   }
 
+  /**
+   * 채널 라인 범위를 Core 라인 범위로 옮긴다.
+   *
+   * **없으면 `undefined` 를 돌려준다** — Core 는 `lines` 유무로 전체/부분을 가르므로
+   * 빈 배열을 넘기면 `BadRequestException` 이 된다 (`sales-orders.service.ts:436`).
+   */
+  private async resolveCancelledLines(
+    salesOrderId: string,
+    cancelledLines: Array<{ channelOrderItemId: string; quantity: number }> | undefined,
+    tx: DbTx,
+  ): Promise<Array<{ salesOrderLineId: string; quantity: number }> | undefined> {
+    if (!cancelledLines || cancelledLines.length === 0) return undefined;
+
+    const channelOrderItemIds = cancelledLines.map((line) => line.channelOrderItemId);
+    const idByChannelItem = await this.salesOrdersService.findLineIdsByChannelOrderItemIds(
+      salesOrderId,
+      channelOrderItemIds,
+      tx,
+    );
+
+    return cancelledLines.map((line) => {
+      const salesOrderLineId = idByChannelItem.get(line.channelOrderItemId);
+      if (!salesOrderLineId) {
+        // 재시도해도 결과가 같다. NotFound 는 이 핸들러의 nonRetryableErrors 라 DLQ 로 간다.
+        throw new NotFoundException(
+          `Sales order line not found for channelOrderItemId=${line.channelOrderItemId} (salesOrder=${salesOrderId})`,
+        );
+      }
+      return { salesOrderLineId, quantity: line.quantity };
+    });
+  }
+
   @On(ORDER_STREAM, 'OrderCreated')
   @RetryPolicy({ maxRetries: 5, backoff: 'exponential', initialDelayMs: 1000, maxDelayMs: 15000 })
   async handleOrderCreated(
@@ -170,6 +202,8 @@ export class OrderEventsConsumer {
         );
         if (alreadyProcessed) return;
 
+        const lines = await this.resolveCancelledLines(salesOrderId, payload.cancelledLines, tx);
+
         await this.salesOrdersService.cancel(
           salesOrderId,
           {
@@ -177,6 +211,7 @@ export class OrderEventsConsumer {
             reasonDetail: payload.reasonDetail,
             cancelledBy: payload.cancelledBy,
             occurredAt: payload.cancelledAt,
+            ...(lines ? { lines } : {}),
             metadata: {
               refundRequired: payload.refundRequired,
               refundAmount: payload.refundAmount,

--- a/apps/core/src/modules/sales-order/services/sales-orders.service.ts
+++ b/apps/core/src/modules/sales-order/services/sales-orders.service.ts
@@ -784,6 +784,41 @@ export class SalesOrdersService {
     });
   }
 
+  /**
+   * 채널이 소유한 라인 식별자 → 우리 `sales_order_lines.id`.
+   *
+   * `(salesOrderId, channelOrderItemId)` 부분 unique 인덱스가 있으므로
+   * (`inventory.schema.ts:1343`) 주문 안에서 단건 확정이다.
+   */
+  async findLineIdsByChannelOrderItemIds(
+    salesOrderId: string,
+    channelOrderItemIds: string[],
+    tx?: DbTx,
+  ): Promise<Map<string, string>> {
+    if (channelOrderItemIds.length === 0) return new Map();
+
+    return this.db.run(async (trx) => {
+      const rows = await trx
+        .select({
+          id: wmsTables.salesOrderLines.id,
+          channelOrderItemId: wmsTables.salesOrderLines.channelOrderItemId,
+        })
+        .from(wmsTables.salesOrderLines)
+        .where(
+          and(
+            eq(wmsTables.salesOrderLines.salesOrderId, salesOrderId),
+            inArray(wmsTables.salesOrderLines.channelOrderItemId, channelOrderItemIds),
+          ),
+        );
+
+      return new Map(
+        rows
+          .filter((row): row is { id: string; channelOrderItemId: string } => row.channelOrderItemId !== null)
+          .map((row) => [row.channelOrderItemId, row.id]),
+      );
+    }, tx);
+  }
+
   async list(params: SalesOrderFilterDto, tx?: DbTx) {
     return this.db.run(async (trx) => {
       const S = wmsTables;

--- a/docs/superpowers/plans/2026-08-19-naver-order-collection-activation.md
+++ b/docs/superpowers/plans/2026-08-19-naver-order-collection-activation.md
@@ -1,0 +1,2080 @@
+# 네이버 주문 수집 개통 + 격리 큐 운영 화면 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 네이버 스마트스토어 주문을 Core 판매주문으로 수집하고, 매핑이 없어 격리된 주문을 운영자가 화면에서 등록·재처리할 수 있게 한다.
+
+**Architecture:** ADR-0031 의 `ChannelOrderSource` port 에 네이버 구현체를 채운다. 번역·식별·격리는 기존 공용 층(`ChannelOrderTranslator`, `OrderPollerOrchestrator`)이 그대로 처리한다. 취소는 `OrderCancelled` 계약에 라인 범위를 더해 Core 의 기존 부분취소 기구에 연결한다. 개통은 코드가 아니라 `sales_channels.is_active` 로 켠다.
+
+**Tech Stack:** NestJS 11 · Drizzle · zod 4 · Jest(ts-jest) · Next.js(admin-web) · @tanstack/react-query
+
+**Spec:** `docs/superpowers/specs/2026-08-19-naver-order-collection-activation-design.md`
+
+## Global Constraints
+
+- 계층 규칙: Controller → Service → Reader/Manager → Repository. Service 는 `HttpException`/drizzle 을 import 하지 않는다.
+- 도메인 예외는 `@app/shared` 의 `NotFoundError`/`BadRequestError`/`ConflictError` 를 쓴다.
+- `any`/`as` 캐스팅 금지 (문서화된 정당화 없이).
+- 검증 게이트는 **0 이 기준선**이다: `npm run type-check` → 0, `npx jest --maxWorkers=2` → 실패 0 (`--maxWorkers=2` 없이 돌리면 OOM), `npm run test:admin-web` → 실패 0.
+- 마이그레이션 **0건**. 이 계획의 어떤 태스크도 스키마를 바꾸지 않는다.
+- 배포 순서: **Task 1–2(Core) → Task 3–7(channel-adapter) → Task 8 shadow → Task 9 → Task 10–13(admin-web) → 개통**. Core 선배포를 어기면 부분취소가 전체 취소로 실행된다.
+- 커밋 메시지는 한국어 본문, 끝에 `Claude-Session:` 줄.
+- admin-web 은 컴포넌트 테스트가 불가능하다. 판정 로직은 반드시 `.ts` 순수 함수로 분리해 `.spec.ts` 로 덮는다.
+
+---
+
+## File Structure
+
+**Phase A — 취소 계약 (Core 선배포)**
+
+| 파일 | 책임 |
+|---|---|
+| `packages/event-contracts/streams/orders.stream.ts` (수정) | `OrderCancelledPayload.cancelledLines?` + zod |
+| `packages/event-contracts/streams/orders.stream.spec.ts` (신규) | 계약 zod 회귀 |
+| `apps/core/src/modules/sales-order/services/sales-orders.service.ts` (수정) | `findLineIdsByChannelOrderItemIds` 조회 |
+| `apps/core/src/modules/sales-order/consumers/order-events.consumer.ts` (수정) | 채널 라인 → `salesOrderLineId` 해석 후 부분취소 위임 |
+
+**Phase B — 네이버 source**
+
+| 파일 | 책임 |
+|---|---|
+| `apps/channel-adapter/src/services/order-collection/channel-order-source.interface.ts` (수정) | `ChannelOrderLineSnapshot.cancelled?` |
+| `apps/channel-adapter/src/services/order-collection/channel-order.translator.ts` (수정) | 살아있는 라인 vs 전 라인 분리 |
+| `apps/channel-adapter/src/zods/naver/naver-core.zod.ts` (수정) | `LastChangedTypeSchema` |
+| `apps/channel-adapter/src/zods/naver/naver.order.zod.ts` (수정) | 변경 피드 응답 + 상세 응답 스키마 |
+| `apps/channel-adapter/src/adapters/naver/clients/naver-order.client.ts` (수정) | 조회 창 파라미터 + `more` 페이징 |
+| `apps/channel-adapter/src/services/order-collection/naver-order-fields.ts` (신규) | **네이버 원어 필드 접근을 한 곳에 가둔다** (shadow 로 확정할 지점) |
+| `apps/channel-adapter/src/services/order-collection/naver-order.source.ts` (신규) | 스냅샷 조립 |
+| `apps/channel-adapter/src/adapter.module.ts` (수정) | provider 등록 |
+
+**Phase E — 격리 큐 화면**
+
+| 파일 | 책임 |
+|---|---|
+| `packages/domain-types/listing-resolution-cause.ts` (수정) | `AffectedLine.channelProductId?` |
+| `apps/admin-web/src/features/mall/quarantine/guidance.ts` (신규) | 사유→조치·상태→재처리가능·결과→문구 **순수 함수** |
+| `apps/admin-web/src/lib/api/domains/channel/order-collection-failures.client.ts` (신규) | REST 클라이언트 |
+| `apps/admin-web/src/lib/services/channel/{query-keys,queries,mutations}.ts` (신규) | react-query |
+| `apps/admin-web/src/features/mall/quarantine/components/*` (신규) | 목록·상세 UI |
+
+---
+
+## Phase A — 취소 계약 (Core 선배포)
+
+### Task 1: `OrderCancelled` 에 라인 범위를 더한다
+
+**Files:**
+- Modify: `packages/event-contracts/streams/orders.stream.ts:118-143` (interface), `:279-300` (zod)
+- Test: `packages/event-contracts/streams/orders.stream.spec.ts` (신규)
+
+**Interfaces:**
+- Produces: `OrderCancelledPayload.cancelledLines?: Array<{ channelOrderItemId: string; quantity: number }>`
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다**
+
+`packages/event-contracts/streams/orders.stream.spec.ts`:
+
+```ts
+import { ORDER_STREAM } from './orders.stream';
+
+const base = {
+  orderId: 'ord_1',
+  reason: 'CUSTOMER_REQUEST' as const,
+  cancelledBy: 'naver',
+  cancelledAt: '2026-08-19T00:00:00.000Z',
+  refundRequired: true,
+};
+
+describe('OrderCancelled 계약', () => {
+  const schema = ORDER_STREAM.events.OrderCancelled.schema;
+
+  it('cancelledLines 없이도 통과한다 (전체 취소)', () => {
+    expect(schema.safeParse(base).success).toBe(true);
+  });
+
+  it('cancelledLines 가 있으면 통과한다 (부분 취소)', () => {
+    const result = schema.safeParse({
+      ...base,
+      cancelledLines: [{ channelOrderItemId: '2026081900001', quantity: 2 }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('빈 배열은 거부한다 — 전체 취소는 필드를 생략해서 표현한다', () => {
+    expect(schema.safeParse({ ...base, cancelledLines: [] }).success).toBe(false);
+  });
+
+  it('수량 0 이하를 거부한다', () => {
+    const result = schema.safeParse({
+      ...base,
+      cancelledLines: [{ channelOrderItemId: '2026081900001', quantity: 0 }],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: 실패를 확인한다**
+
+Run: `npx jest --maxWorkers=2 packages/event-contracts/streams/orders.stream.spec.ts`
+Expected: FAIL — 빈 배열/수량 0 케이스가 통과해버린다 (스키마에 필드가 없어 무시되므로).
+
+- [ ] **Step 3: 계약을 고친다**
+
+`orders.stream.ts` 의 `OrderCancelledPayload` 에 추가 (`stockRestorationResults` 위):
+
+```ts
+  /**
+   * 부분 취소 범위 (네이버 개통). **생략 = 전체 취소** 이며, 이는 Core 의
+   * `CancelSalesOrderDto.lines` 유무 규칙과 같은 축이다 (`sales-orders.service.ts:440`).
+   * 값은 채널이 소유한 라인 식별자이고, Core 가 `sales_order_lines.channel_order_item_id`
+   * 로 자기 PK 를 찾는다. 선택 필드라 이 필드를 모르는 옛 메시지도 계속 통과한다.
+   */
+  cancelledLines?: Array<{ channelOrderItemId: string; quantity: number }>;
+```
+
+`OrderCancelledSchema` 에 추가 (`stockRestorationResults` 위):
+
+```ts
+  cancelledLines: z
+    .array(
+      z.object({
+        channelOrderItemId: z.string().min(1),
+        quantity: z.number().int().positive(),
+      }),
+    )
+    .min(1)
+    .optional(),
+```
+
+- [ ] **Step 4: 통과를 확인한다**
+
+Run: `npx jest --maxWorkers=2 packages/event-contracts/streams/orders.stream.spec.ts`
+Expected: PASS (4건)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add packages/event-contracts/streams/orders.stream.ts packages/event-contracts/streams/orders.stream.spec.ts
+git commit -m "feat(contracts): OrderCancelled 에 부분취소 라인 범위를 더한다"
+```
+
+---
+
+### Task 2: Core 소비자가 부분취소를 위임한다
+
+**Files:**
+- Modify: `apps/core/src/modules/sales-order/services/sales-orders.service.ts` (조회 메서드 추가)
+- Modify: `apps/core/src/modules/sales-order/consumers/order-events.consumer.ts:147-196`
+- Test: `apps/core/src/modules/sales-order/consumers/order-events.consumer.spec.ts`
+
+**Interfaces:**
+- Consumes: `OrderCancelledPayload.cancelledLines` (Task 1)
+- Produces: `SalesOrdersService.findLineIdsByChannelOrderItemIds(salesOrderId: string, channelOrderItemIds: string[], tx: DbTx): Promise<Map<string, string>>`
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다**
+
+`order-events.consumer.spec.ts` 의 `describe('handleOrderCancelled')` 안에 추가 (기존 mock 헬퍼를 그대로 쓴다):
+
+```ts
+  it('cancelledLines 가 있으면 채널 라인 ID 를 salesOrderLineId 로 바꿔 부분취소로 넘긴다', async () => {
+    salesOrdersService.findByChannelOrderId.mockResolvedValue({ id: 'so-1' });
+    salesOrdersService.findLineIdsByChannelOrderItemIds.mockResolvedValue(
+      new Map([['2026081900001', 'sol-1']]),
+    );
+
+    await consumer.handleOrderCancelled(
+      {
+        orderId: 'ord-1',
+        salesChannel: 'naver',
+        externalOrderId: '2026081900000',
+        reason: 'CUSTOMER_REQUEST',
+        cancelledBy: 'naver',
+        cancelledAt: '2026-08-19T00:00:00.000Z',
+        refundRequired: true,
+        cancelledLines: [{ channelOrderItemId: '2026081900001', quantity: 2 }],
+      } as any,
+      { messageId: 'msg-1', correlationId: 'corr-1' } as any,
+    );
+
+    expect(salesOrdersService.cancel).toHaveBeenCalledWith(
+      'so-1',
+      expect.objectContaining({ lines: [{ salesOrderLineId: 'sol-1', quantity: 2 }] }),
+      expect.anything(),
+    );
+  });
+
+  it('cancelledLines 가 없으면 lines 를 넘기지 않는다 (전체 취소)', async () => {
+    salesOrdersService.findByChannelOrderId.mockResolvedValue({ id: 'so-1' });
+
+    await consumer.handleOrderCancelled(
+      {
+        orderId: 'ord-1',
+        salesChannel: 'naver',
+        externalOrderId: '2026081900000',
+        reason: 'CUSTOMER_REQUEST',
+        cancelledBy: 'naver',
+        cancelledAt: '2026-08-19T00:00:00.000Z',
+        refundRequired: true,
+      } as any,
+      { messageId: 'msg-2', correlationId: 'corr-2' } as any,
+    );
+
+    const [, options] = salesOrdersService.cancel.mock.calls[0];
+    expect(options.lines).toBeUndefined();
+  });
+
+  it('해석되지 않는 채널 라인이 있으면 NotFoundException 을 던진다', async () => {
+    salesOrdersService.findByChannelOrderId.mockResolvedValue({ id: 'so-1' });
+    salesOrdersService.findLineIdsByChannelOrderItemIds.mockResolvedValue(new Map());
+
+    await expect(
+      consumer.handleOrderCancelled(
+        {
+          orderId: 'ord-1',
+          salesChannel: 'naver',
+          externalOrderId: '2026081900000',
+          reason: 'CUSTOMER_REQUEST',
+          cancelledBy: 'naver',
+          cancelledAt: '2026-08-19T00:00:00.000Z',
+          refundRequired: true,
+          cancelledLines: [{ channelOrderItemId: 'unknown', quantity: 1 }],
+        } as any,
+        { messageId: 'msg-3', correlationId: 'corr-3' } as any,
+      ),
+    ).rejects.toThrow(NotFoundException);
+  });
+```
+
+`salesOrdersService` mock 객체에 `findLineIdsByChannelOrderItemIds: jest.fn()` 를 더한다.
+
+- [ ] **Step 2: 실패를 확인한다**
+
+Run: `npx jest --maxWorkers=2 apps/core/src/modules/sales-order/consumers/order-events.consumer.spec.ts`
+Expected: FAIL — `salesOrdersService.findLineIdsByChannelOrderItemIds is not a function`
+
+- [ ] **Step 3: 조회 메서드를 만든다**
+
+`sales-orders.service.ts` 에 추가 (`findByChannelOrderId` 근처):
+
+```ts
+  /**
+   * 채널이 소유한 라인 식별자 → 우리 `sales_order_lines.id`.
+   *
+   * `(salesOrderId, channelOrderItemId)` 부분 unique 인덱스가 있으므로
+   * (`inventory.schema.ts:1343`) 주문 안에서 단건 확정이다.
+   */
+  async findLineIdsByChannelOrderItemIds(
+    salesOrderId: string,
+    channelOrderItemIds: string[],
+    tx?: DbTx,
+  ): Promise<Map<string, string>> {
+    if (channelOrderItemIds.length === 0) return new Map();
+
+    return this.dbService.run(async (trx) => {
+      const rows = await trx
+        .select({
+          id: wmsTables.salesOrderLines.id,
+          channelOrderItemId: wmsTables.salesOrderLines.channelOrderItemId,
+        })
+        .from(wmsTables.salesOrderLines)
+        .where(
+          and(
+            eq(wmsTables.salesOrderLines.salesOrderId, salesOrderId),
+            inArray(wmsTables.salesOrderLines.channelOrderItemId, channelOrderItemIds),
+          ),
+        );
+
+      return new Map(
+        rows
+          .filter((row): row is { id: string; channelOrderItemId: string } => row.channelOrderItemId !== null)
+          .map((row) => [row.channelOrderItemId, row.id]),
+      );
+    }, tx);
+  }
+```
+
+- [ ] **Step 4: 소비자를 고친다**
+
+`order-events.consumer.ts` 의 `handleOrderCancelled` 에서 `salesOrdersService.cancel` 호출 직전에 삽입하고, 옵션에 `lines` 를 조건부로 붙인다:
+
+```ts
+        const lines = await this.resolveCancelledLines(salesOrderId, payload.cancelledLines, tx);
+
+        await this.salesOrdersService.cancel(
+          salesOrderId,
+          {
+            reasonCode: payload.reason,
+            reasonDetail: payload.reasonDetail,
+            cancelledBy: payload.cancelledBy,
+            occurredAt: payload.cancelledAt,
+            ...(lines ? { lines } : {}),
+            metadata: {
+              refundRequired: payload.refundRequired,
+              refundAmount: payload.refundAmount,
+              stockRestorationResults: payload.stockRestorationResults ?? [],
+              sourceEventId: envelope.messageId,
+            },
+          },
+          tx,
+        );
+```
+
+같은 클래스에 private 헬퍼를 더한다:
+
+```ts
+  /**
+   * 채널 라인 범위를 Core 라인 범위로 옮긴다.
+   *
+   * **없으면 `undefined` 를 돌려준다** — Core 는 `lines` 유무로 전체/부분을 가르므로
+   * 빈 배열을 넘기면 `BadRequestException` 이 된다 (`sales-orders.service.ts:436`).
+   */
+  private async resolveCancelledLines(
+    salesOrderId: string,
+    cancelledLines: Array<{ channelOrderItemId: string; quantity: number }> | undefined,
+    tx: DbTx,
+  ): Promise<Array<{ salesOrderLineId: string; quantity: number }> | undefined> {
+    if (!cancelledLines || cancelledLines.length === 0) return undefined;
+
+    const channelOrderItemIds = cancelledLines.map((line) => line.channelOrderItemId);
+    const idByChannelItem = await this.salesOrdersService.findLineIdsByChannelOrderItemIds(
+      salesOrderId,
+      channelOrderItemIds,
+      tx,
+    );
+
+    return cancelledLines.map((line) => {
+      const salesOrderLineId = idByChannelItem.get(line.channelOrderItemId);
+      if (!salesOrderLineId) {
+        // 재시도해도 결과가 같다. NotFound 는 이 핸들러의 nonRetryableErrors 라 DLQ 로 간다.
+        throw new NotFoundException(
+          `Sales order line not found for channelOrderItemId=${line.channelOrderItemId} (salesOrder=${salesOrderId})`,
+        );
+      }
+      return { salesOrderLineId, quantity: line.quantity };
+    });
+  }
+```
+
+- [ ] **Step 5: 통과를 확인한다**
+
+Run: `npx jest --maxWorkers=2 apps/core/src/modules/sales-order/consumers/order-events.consumer.spec.ts`
+Expected: PASS
+
+- [ ] **Step 6: 게이트를 돌린다**
+
+Run: `npm run type-check`
+Expected: 0
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add apps/core/src/modules/sales-order
+git commit -m "feat(core): 채널 부분취소를 판매주문 부분취소로 위임한다"
+```
+
+---
+
+## Phase B — 네이버 source
+
+### Task 3: 취소된 라인을 계약에서 분리한다
+
+**Files:**
+- Modify: `apps/channel-adapter/src/services/order-collection/channel-order-source.interface.ts:31-48`
+- Modify: `apps/channel-adapter/src/services/order-collection/channel-order.translator.ts:36-102`
+- Test: `apps/channel-adapter/src/services/order-collection/channel-order.translator.spec.ts`
+
+**Interfaces:**
+- Produces: `ChannelOrderLineSnapshot.cancelled?: boolean`
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다**
+
+`channel-order.translator.spec.ts` 에 추가 (기존 헬퍼·mock resolver 를 재사용한다):
+
+```ts
+  it('취소된 라인은 판매주문 계약에서 빠지지만 변경 해시에는 남는다', async () => {
+    resolver.resolve.mockResolvedValue({
+      identified: true,
+      identity: { variantId: 'v1', masterId: 'm1', versionId: 'ver1' },
+    });
+
+    const { outcome } = await translator.translate('naver', {
+      ...snapshotFixture,
+      lines: [
+        { ...lineFixture, channelOrderItemId: 'po-1' },
+        { ...lineFixture, channelOrderItemId: 'po-2', cancelled: true },
+      ],
+    });
+
+    expect(outcome.kind).toBe('order');
+    if (outcome.kind !== 'order') return;
+    expect(outcome.order.createPayload.items.map((i) => i.orderItemId)).toEqual(['po-1']);
+    expect(outcome.order.changes.items?.map((i) => i.orderItemId)).toEqual(['po-1', 'po-2']);
+  });
+
+  it('취소된 라인의 미식별은 격리를 부르지 않는다', async () => {
+    resolver.resolve.mockImplementation(async (_channel, line) =>
+      line.channelOrderItemId === 'po-2'
+        ? { identified: false, cause: 'listing_not_found' }
+        : { identified: true, identity: { variantId: 'v1', masterId: 'm1', versionId: 'ver1' } },
+    );
+
+    const { outcome } = await translator.translate('naver', {
+      ...snapshotFixture,
+      lines: [
+        { ...lineFixture, channelOrderItemId: 'po-1' },
+        { ...lineFixture, channelOrderItemId: 'po-2', cancelled: true },
+      ],
+    });
+
+    expect(outcome.kind).toBe('order');
+  });
+```
+
+- [ ] **Step 2: 실패를 확인한다**
+
+Run: `npx jest --maxWorkers=2 apps/channel-adapter/src/services/order-collection/channel-order.translator.spec.ts`
+Expected: FAIL — 첫 테스트는 `items` 가 2건, 둘째는 `kind === 'failure'`
+
+- [ ] **Step 3: 스냅샷 계약에 플래그를 더한다**
+
+`channel-order-source.interface.ts` 의 `ChannelOrderLineSnapshot` 에:
+
+```ts
+  /**
+   * 채널에서 이미 취소된 라인. **스냅샷에서 빼지 않고 표시만 한다** — 빼면 변경 해시가 달라져
+   * 부분취소가 `collected_order_modification_not_accepted` 로 오격리되고, 그 사유는 replay 가
+   * 거부한다 (`order-poller.orchestrator.ts:271`).
+   */
+  cancelled?: boolean;
+```
+
+- [ ] **Step 4: translator 를 고친다**
+
+`translate` 안에서 미식별 판정과 items 조립을 이렇게 바꾼다:
+
+```ts
+    // 취소된 라인은 판매주문을 만들지 않으므로 식별을 요구하지 않는다.
+    const unidentified = snapshot.lines.flatMap((line, index) => {
+      if (line.cancelled) return [];
+      const resolution = resolutions[index];
+      return resolution.identified ? [] : [{ lineId: line.channelOrderItemId, cause: resolution.cause }];
+    });
+```
+
+```ts
+    const allItems = snapshot.lines.map((line, index) => {
+      const resolution = resolutions[index];
+      return {
+        item: this.buildOrderItem(line, resolution.identified ? resolution.identity : null),
+        cancelled: line.cancelled === true,
+      };
+    });
+    // 계약에는 살아있는 라인만 넣는다. 해시는 전 라인으로 계산해 취소가 modification 으로 세지지 않게 한다.
+    const items = allItems.filter((entry) => !entry.cancelled).map((entry) => entry.item);
+    const changeItems = allItems.map((entry) => entry.item);
+```
+
+`createPayload.items` 는 `items` 를, `order.changes.items` 는 `changeItems` 를 쓴다.
+
+- [ ] **Step 5: 통과를 확인한다**
+
+Run: `npx jest --maxWorkers=2 apps/channel-adapter/src/services/order-collection/channel-order.translator.spec.ts`
+Expected: PASS — 기존 Medusa 스펙도 전부 통과해야 한다 (Medusa 는 `cancelled` 를 쓰지 않아 `items === changeItems`).
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add apps/channel-adapter/src/services/order-collection
+git commit -m "feat(channel-adapter): 취소된 라인을 계약에서 빼되 변경 해시에는 남긴다"
+```
+
+---
+
+### Task 4: 네이버 변경 피드 zod 를 정확히 만든다
+
+**Files:**
+- Modify: `apps/channel-adapter/src/zods/naver/naver-core.zod.ts:209-219`
+- Modify: `apps/channel-adapter/src/zods/naver/naver.order.zod.ts:135-160`
+- Test: `apps/channel-adapter/src/zods/naver/naver.order.zod.spec.ts` (신규)
+
+**Interfaces:**
+- Produces: `LastChangedTypeSchema`, `NaverLastChangedStatusResponseSchema` (기존 이름 유지)
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다**
+
+`naver.order.zod.spec.ts`:
+
+```ts
+import { NaverLastChangedStatusResponseSchema } from './naver.order.zod';
+import { LastChangedTypeSchema, ProductOrderStatusSchema } from './naver-core.zod';
+
+describe('네이버 변경 피드 스키마', () => {
+  it('DISPATCHED 는 lastChangedType 값이지 productOrderStatus 값이 아니다', () => {
+    expect(LastChangedTypeSchema.safeParse('DISPATCHED').success).toBe(true);
+    expect(ProductOrderStatusSchema.safeParse('DISPATCHED').success).toBe(false);
+  });
+
+  it('발송 완료 항목을 파싱한다', () => {
+    const parsed = NaverLastChangedStatusResponseSchema.safeParse({
+      timestamp: '2026-08-19T00:00:00.000+09:00',
+      traceId: 'trace-1',
+      data: {
+        count: 1,
+        lastChangeStatuses: [
+          {
+            orderId: '2026081900000',
+            productOrderId: '2026081900001',
+            lastChangedType: 'DISPATCHED',
+            paymentDate: '2026-08-19T00:00:00.000+09:00',
+            lastChangedDate: '2026-08-19T01:00:00.000+09:00',
+            productOrderStatus: 'DELIVERING',
+            receiverAddressChanged: false,
+          },
+        ],
+      },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('more 객체를 파싱한다 — 페이징 입력이다', () => {
+    const parsed = NaverLastChangedStatusResponseSchema.safeParse({
+      timestamp: '2026-08-19T00:00:00.000+09:00',
+      traceId: 'trace-2',
+      data: {
+        count: 300,
+        lastChangeStatuses: [],
+        more: { moreFrom: '2026-08-19T02:00:00.000+09:00', moreSequence: '17' },
+      },
+    });
+    expect(parsed.success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: 실패를 확인한다**
+
+Run: `npx jest --maxWorkers=2 apps/channel-adapter/src/zods/naver/naver.order.zod.spec.ts`
+Expected: FAIL — `LastChangedTypeSchema` 없음, `data.count` 필수 아님
+
+- [ ] **Step 3: 스키마를 고친다**
+
+`naver-core.zod.ts` 에 추가:
+
+```ts
+/**
+ * 최종 변경 구분 (변경 피드 전용).
+ *
+ * **`productOrderStatus` 와 다른 축이다.** 발송 완료 시 `productOrderStatus` 는 `DELIVERING`,
+ * `lastChangedType` 이 `DISPATCHED` 다. 옛 `mapNaverStatusToInternal` 이 둘을 한 표에 섞었다.
+ */
+export const LastChangedTypeSchema = z.enum([
+  'PAY_WAITING',
+  'PAYED',
+  'DISPATCHED',
+  'CANCEL_REQUESTED',
+  'CLAIM_REQUESTED',
+  'CLAIM_REJECTED',
+  'CLAIM_COMPLETED',
+  'PURCHASE_DECIDED',
+]);
+export type LastChangedType = z.infer<typeof LastChangedTypeSchema>;
+```
+
+`naver.order.zod.ts` 의 `NaverLastChangedStatusesDataSchema` 를 교체:
+
+```ts
+const NaverLastChangedStatusesDataSchema = z.object({
+  count: z.number().int().nonnegative(),
+  lastChangeStatuses: z.array(
+    z.object({
+      orderId: z.string(),
+      productOrderId: z.string(),
+      lastChangedType: LastChangedTypeSchema,
+      paymentDate: z.string().optional(),
+      lastChangedDate: z.string(),
+      productOrderStatus: ProductOrderStatusSchema,
+      claimType: z.string().optional(),
+      claimStatus: ClaimStatusSchema.optional(),
+      receiverAddressChanged: z.boolean().optional(),
+    }),
+  ),
+  more: z.object({ moreFrom: z.string(), moreSequence: z.string() }).optional(),
+});
+```
+
+`LastChangedTypeSchema` 를 import 목록에 더한다. 날짜는 `z.iso.datetime()` 대신 `z.string()` 이다 — 네이버는 `+09:00` 오프셋을 붙여 내려주므로 엄격한 datetime 검증이 실패한다.
+
+- [ ] **Step 4: 통과를 확인한다**
+
+Run: `npx jest --maxWorkers=2 apps/channel-adapter/src/zods/naver/naver.order.zod.spec.ts`
+Expected: PASS (3건)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add apps/channel-adapter/src/zods/naver
+git commit -m "fix(channel-adapter): lastChangedType 을 productOrderStatus 와 분리한다"
+```
+
+---
+
+### Task 5: 조회 창과 `more` 페이징을 클라이언트에 넣는다
+
+**Files:**
+- Modify: `apps/channel-adapter/src/adapters/naver/clients/naver-order.client.ts:171-181`
+- Test: `apps/channel-adapter/src/adapters/naver/clients/naver-order.client.spec.ts` (신규)
+
+**Interfaces:**
+- Produces: `NaverOrderClient.getLastChangedStatuses(params: { lastChangedFrom: string; lastChangedTo?: string; moreSequence?: string }): Promise<NaverLastChangedStatusResponse>`
+
+기존 시그니처(`lastChangedFrom: string`)를 바꾼다. **호출자가 없음을 확인했다** (`grep -rn 'getLastChangedStatuses' apps/` → 정의 1곳).
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다**
+
+`naver-order.client.spec.ts`:
+
+```ts
+import { of } from 'rxjs';
+import { NaverOrderClient } from './naver-order.client';
+
+describe('NaverOrderClient.getLastChangedStatuses', () => {
+  const http = { get: jest.fn() } as any;
+  const auth = { getAccessToken: jest.fn().mockResolvedValue('token') } as any;
+  const client = new NaverOrderClient(http, auth);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    http.get.mockReturnValue(of({ data: { timestamp: '', traceId: 't', data: { count: 0, lastChangeStatuses: [] } } }));
+  });
+
+  it('조회 창의 끝을 명시해 보낸다', async () => {
+    await client.getLastChangedStatuses({
+      lastChangedFrom: '2026-08-19T00:00:00.000+09:00',
+      lastChangedTo: '2026-08-19T06:00:00.000+09:00',
+    });
+
+    const [, config] = http.get.mock.calls[0];
+    expect(config.params.lastChangedTo).toBe('2026-08-19T06:00:00.000+09:00');
+    expect(config.params.limitCount).toBe(300);
+  });
+
+  it('moreSequence 를 넘기면 그대로 실어 보낸다', async () => {
+    await client.getLastChangedStatuses({
+      lastChangedFrom: '2026-08-19T02:00:00.000+09:00',
+      moreSequence: '17',
+    });
+
+    const [, config] = http.get.mock.calls[0];
+    expect(config.params.moreSequence).toBe('17');
+  });
+
+  it('moreSequence 가 없으면 파라미터를 아예 넣지 않는다', async () => {
+    await client.getLastChangedStatuses({ lastChangedFrom: '2026-08-19T02:00:00.000+09:00' });
+
+    const [, config] = http.get.mock.calls[0];
+    expect('moreSequence' in config.params).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: 실패를 확인한다**
+
+Run: `npx jest --maxWorkers=2 apps/channel-adapter/src/adapters/naver/clients/naver-order.client.spec.ts`
+Expected: FAIL — 현재 시그니처가 문자열이라 `config.params.lastChangedFrom` 이 `[object Object]`
+
+- [ ] **Step 3: 클라이언트를 고친다**
+
+```ts
+  /**
+   * 지정한 창에서 변경된 상품 주문을 조회한다.
+   *
+   * `lastChangedTo` 를 생략하면 네이버가 **`lastChangedFrom` + 24시간**을 자동 적용한다.
+   * 즉 24시간은 "허용 과거" 가 아니라 **한 번에 볼 수 있는 창의 길이**다.
+   *
+   * 응답은 `limitCount` (최대·기본 300) 에서 잘리고, 남은 항목이 있으면 `data.more` 가 실린다.
+   * 이어받으려면 `more.moreFrom` 을 새 `lastChangedFrom` 으로, `more.moreSequence` 를
+   * `moreSequence` 로 **함께** 넘겨야 같은 일시의 항목이 중복되지 않는다.
+   */
+  async getLastChangedStatuses(params: {
+    lastChangedFrom: string;
+    lastChangedTo?: string;
+    moreSequence?: string;
+  }): Promise<NaverLastChangedStatusResponse> {
+    const token = await this.authService.getAccessToken();
+    const url = `${this.apiBaseUrl}/pay-order/seller/product-orders/last-changed-statuses`;
+    const response = await firstValueFrom(
+      this.http.get<NaverLastChangedStatusResponse>(url, {
+        headers: { Authorization: `Bearer ${token}` },
+        params: {
+          lastChangedFrom: params.lastChangedFrom,
+          ...(params.lastChangedTo ? { lastChangedTo: params.lastChangedTo } : {}),
+          ...(params.moreSequence ? { moreSequence: params.moreSequence } : {}),
+          limitCount: 300,
+        },
+      }),
+    );
+    return response.data;
+  }
+```
+
+- [ ] **Step 4: 통과를 확인한다**
+
+Run: `npx jest --maxWorkers=2 apps/channel-adapter/src/adapters/naver/clients/naver-order.client.spec.ts`
+Expected: PASS (3건)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add apps/channel-adapter/src/adapters/naver/clients
+git commit -m "feat(channel-adapter): 네이버 변경 피드에 조회 창과 more 페이징을 넣는다"
+```
+
+---
+
+### Task 6: 네이버 원어 필드 접근을 한 파일에 가둔다
+
+**Files:**
+- Create: `apps/channel-adapter/src/services/order-collection/naver-order-fields.ts`
+- Test: `apps/channel-adapter/src/services/order-collection/naver-order-fields.spec.ts`
+
+**Interfaces:**
+- Produces: `parseNaverProductOrderInfo(raw: unknown): NaverProductOrderInfo`, `NaverProductOrderInfo`
+
+**왜 별도 파일인가**: 커머스API 문서가 `productOrder`·`order` 의 하위 구조를 생략하므로 필드명이 **아직 미확정**이다 (스펙 §6.7). shadow(Task 8)에서 실 응답을 보고 고칠 지점을 **한 파일로 모아** 나머지 코드가 흔들리지 않게 한다. 아래 이름들은 추측이 아니라 옛 어댑터가 실제로 읽던 값이다 (`naver-smartstore.adapter.ts:727-745`).
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다**
+
+```ts
+import { parseNaverProductOrderInfo } from './naver-order-fields';
+
+const raw = {
+  order: {
+    orderId: '2026081900000',
+    paymentDate: '2026-08-19T00:00:00.000+09:00',
+    ordererName: '홍길동',
+    ordererTel: '010-0000-0000',
+  },
+  productOrder: {
+    productOrderId: '2026081900001',
+    productOrderStatus: 'PAYED',
+    productId: '13700000002',
+    productName: '아몬드영 세럼',
+    quantity: 2,
+    unitPrice: 12000,
+    totalPaymentAmount: 24000,
+    shippingAddress: {
+      name: '홍길동',
+      tel1: '010-0000-0000',
+      zipCode: '06236',
+      baseAddress: '서울 강남구 테헤란로 1',
+      detailedAddress: '10층',
+    },
+  },
+};
+
+describe('parseNaverProductOrderInfo', () => {
+  it('필요한 필드만 뽑아 좁힌 모양으로 돌려준다', () => {
+    const parsed = parseNaverProductOrderInfo(raw);
+    expect(parsed.orderId).toBe('2026081900000');
+    expect(parsed.productOrderId).toBe('2026081900001');
+    expect(parsed.channelProductId).toBe('13700000002');
+    expect(parsed.quantity).toBe(2);
+    expect(parsed.shippingAddress.postalCode).toBe('06236');
+  });
+
+  it('모르는 필드가 더 있어도 통과한다', () => {
+    expect(() => parseNaverProductOrderInfo({ ...raw, unknownTopLevel: 1 })).not.toThrow();
+  });
+
+  it('필수 식별자가 없으면 throw 한다 — 조용히 넘기지 않는다', () => {
+    expect(() => parseNaverProductOrderInfo({ ...raw, productOrder: { ...raw.productOrder, productOrderId: undefined } })).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: 실패를 확인한다**
+
+Run: `npx jest --maxWorkers=2 apps/channel-adapter/src/services/order-collection/naver-order-fields.spec.ts`
+Expected: FAIL — 모듈 없음
+
+- [ ] **Step 3: 구현한다**
+
+```ts
+import { z } from 'zod';
+import type { ShippingAddress } from '@packages/event-contracts/streams';
+import { ClaimStatusSchema, ProductOrderStatusSchema } from '../../zods/naver/naver-core.zod';
+
+/**
+ * 네이버 상품주문 상세의 **우리가 읽는 부분만** 좁힌 모양.
+ *
+ * 커머스API 의 공개 문서(`llms/*.md`)는 `order`·`productOrder` 의 하위 구조를 "OAS 참조" 로
+ * 생략한다. 그래서 **이 파일이 필드명 확정의 단일 지점**이다 — shadow 점검(계획 Task 8)에서
+ * 실 응답을 보고 여기만 고친다. 아래 이름은 옛 어댑터가 실제로 읽던 값이다
+ * (`naver-smartstore.adapter.ts:727-745`).
+ *
+ * `looseObject` 인 것이 요점이다: 모르는 필드는 통과시키고, **우리가 의존하는 필드가 없으면
+ * throw** 한다. 삼키면 라인이 조용히 빠진 주문이 Core 로 들어간다.
+ */
+const OrderSchema = z.looseObject({
+  orderId: z.string().min(1),
+  paymentDate: z.string().optional(),
+  ordererName: z.string().optional(),
+  ordererTel: z.string().optional(),
+});
+
+const ShippingAddressSchema = z.looseObject({
+  name: z.string().optional(),
+  tel1: z.string().optional(),
+  zipCode: z.string().optional(),
+  baseAddress: z.string().optional(),
+  detailedAddress: z.string().optional(),
+});
+
+const ProductOrderSchema = z.looseObject({
+  productOrderId: z.string().min(1),
+  productOrderStatus: ProductOrderStatusSchema,
+  claimStatus: ClaimStatusSchema.optional(),
+  productId: z.union([z.string(), z.number()]).optional(),
+  productName: z.string().optional(),
+  quantity: z.number().int().nonnegative().optional(),
+  unitPrice: z.number().nonnegative().optional(),
+  totalPaymentAmount: z.number().nonnegative().optional(),
+  deliveryFeeAmount: z.number().nonnegative().optional(),
+  shippingAddress: ShippingAddressSchema.optional(),
+});
+
+const ProductOrderInfoSchema = z.looseObject({
+  order: OrderSchema,
+  productOrder: ProductOrderSchema,
+});
+
+export interface NaverProductOrderInfo {
+  orderId: string;
+  productOrderId: string;
+  productOrderStatus: z.infer<typeof ProductOrderStatusSchema>;
+  claimStatus?: z.infer<typeof ClaimStatusSchema>;
+  /** 리스팅 조회 키. 종류(원상품번호 vs 채널상품번호)는 shadow 로 확정한다. */
+  channelProductId?: string;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  lineTotal: number;
+  shippingFee: number;
+  paymentDate?: string;
+  shippingAddress: ShippingAddress;
+}
+
+export function parseNaverProductOrderInfo(raw: unknown): NaverProductOrderInfo {
+  const parsed = ProductOrderInfoSchema.parse(raw);
+  const { order, productOrder } = parsed;
+  const address = productOrder.shippingAddress;
+  const quantity = productOrder.quantity ?? 1;
+  const unitPrice = productOrder.unitPrice ?? 0;
+
+  return {
+    orderId: order.orderId,
+    productOrderId: productOrder.productOrderId,
+    productOrderStatus: productOrder.productOrderStatus,
+    ...(productOrder.claimStatus ? { claimStatus: productOrder.claimStatus } : {}),
+    ...(productOrder.productId != null ? { channelProductId: String(productOrder.productId) } : {}),
+    productName: productOrder.productName ?? productOrder.productOrderId,
+    quantity,
+    unitPrice,
+    lineTotal: productOrder.totalPaymentAmount ?? unitPrice * quantity,
+    shippingFee: productOrder.deliveryFeeAmount ?? 0,
+    ...(order.paymentDate ? { paymentDate: order.paymentDate } : {}),
+    shippingAddress: {
+      recipientName: address?.name ?? order.ordererName ?? 'Unknown',
+      phone: address?.tel1 ?? order.ordererTel ?? '',
+      postalCode: address?.zipCode ?? '',
+      roadAddress: address?.baseAddress ?? '',
+      detailAddress: address?.detailedAddress ?? '',
+    },
+  };
+}
+```
+
+- [ ] **Step 4: 통과를 확인한다**
+
+Run: `npx jest --maxWorkers=2 apps/channel-adapter/src/services/order-collection/naver-order-fields.spec.ts`
+Expected: PASS (3건)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add apps/channel-adapter/src/services/order-collection/naver-order-fields.ts apps/channel-adapter/src/services/order-collection/naver-order-fields.spec.ts
+git commit -m "feat(channel-adapter): 네이버 원어 필드 접근을 한 파일에 가둔다"
+```
+
+---
+
+### Task 7: `NaverOrderSource` 를 만들고 등록한다
+
+**Files:**
+- Create: `apps/channel-adapter/src/services/order-collection/naver-order.source.ts`
+- Test: `apps/channel-adapter/src/services/order-collection/naver-order.source.spec.ts`
+- Modify: `apps/channel-adapter/src/adapter.module.ts:269-276`
+
+**Interfaces:**
+- Consumes: `parseNaverProductOrderInfo` (Task 6), `NaverOrderClient.getLastChangedStatuses` (Task 5), `ChannelOrderLineSnapshot.cancelled` (Task 3)
+- Produces: `NaverOrderSource implements ReplayableChannelOrderSource`
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다**
+
+`naver-order.source.spec.ts`:
+
+```ts
+import { NaverOrderSource } from './naver-order.source';
+
+const changed = (productOrderId: string, orderId: string) => ({
+  orderId,
+  productOrderId,
+  lastChangedType: 'PAYED' as const,
+  lastChangedDate: '2026-08-19T01:00:00.000+09:00',
+  productOrderStatus: 'PAYED' as const,
+});
+
+const detail = (productOrderId: string, orderId: string, overrides: Record<string, unknown> = {}) => ({
+  order: { orderId, paymentDate: '2026-08-19T00:00:00.000+09:00', ordererName: '홍길동' },
+  productOrder: {
+    productOrderId,
+    productOrderStatus: 'PAYED',
+    productId: '13700000002',
+    productName: '세럼',
+    quantity: 1,
+    unitPrice: 10000,
+    totalPaymentAmount: 10000,
+    shippingAddress: { name: '홍길동', tel1: '010', zipCode: '06236', baseAddress: '서울', detailedAddress: '1층' },
+    ...overrides,
+  },
+});
+
+describe('NaverOrderSource', () => {
+  let client: any;
+  let source: NaverOrderSource;
+
+  beforeEach(() => {
+    client = {
+      getLastChangedStatuses: jest.fn(),
+      getProductOrderIdsByOrderId: jest.fn(),
+      getOrderDetails: jest.fn(),
+    };
+    source = new NaverOrderSource(client);
+  });
+
+  it('한 라인만 변경돼도 형제 라인을 복원해 주문 전체를 조립한다', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-2', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2', 'po-3'] });
+    client.getOrderDetails.mockResolvedValue({
+      data: [detail('po-1', 'ord-1'), detail('po-2', 'ord-1'), detail('po-3', 'ord-1')],
+    });
+
+    const snapshots = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0].lines.map((l) => l.channelOrderItemId)).toEqual(['po-1', 'po-2', 'po-3']);
+    expect(snapshots[0].paymentState).toBe('accepted');
+  });
+
+  it('상세 응답이 요청보다 적으면 throw 한다 — 라인이 빠진 주문을 만들지 않는다', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-1', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2'] });
+    client.getOrderDetails.mockResolvedValue({ data: [detail('po-1', 'ord-1')] });
+
+    await expect(source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'))).rejects.toThrow(/누락/);
+  });
+
+  it('more 를 따라 다음 페이지를 이어 받는다', async () => {
+    client.getLastChangedStatuses
+      .mockResolvedValueOnce({
+        data: {
+          count: 300,
+          lastChangeStatuses: [changed('po-1', 'ord-1')],
+          more: { moreFrom: '2026-08-19T02:00:00.000+09:00', moreSequence: '17' },
+        },
+      })
+      .mockResolvedValueOnce({ data: { count: 1, lastChangeStatuses: [changed('po-2', 'ord-2')] } });
+    client.getProductOrderIdsByOrderId.mockImplementation(async (orderId: string) => ({
+      data: [orderId === 'ord-1' ? 'po-1' : 'po-2'],
+    }));
+    client.getOrderDetails.mockImplementation(async (ids: string[]) => ({
+      data: ids.map((id) => detail(id, id === 'po-1' ? 'ord-1' : 'ord-2')),
+    }));
+
+    const snapshots = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    expect(client.getLastChangedStatuses).toHaveBeenCalledTimes(2);
+    expect(client.getLastChangedStatuses.mock.calls[1][0]).toMatchObject({
+      lastChangedFrom: '2026-08-19T02:00:00.000+09:00',
+      moreSequence: '17',
+    });
+    expect(snapshots.map((s) => s.externalOrderId).sort()).toEqual(['ord-1', 'ord-2']);
+  });
+
+  it('취소 요청 중이면 accepted 로 보지 않는다', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-1', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1'] });
+    client.getOrderDetails.mockResolvedValue({
+      data: [detail('po-1', 'ord-1', { claimStatus: 'CANCEL_REQUEST' })],
+    });
+
+    const [snapshot] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+    expect(snapshot.paymentState).toBe('pending');
+  });
+
+  it('일부 라인만 취소면 라인 단위 부분취소 관측을 낸다', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-2', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2'] });
+    client.getOrderDetails.mockResolvedValue({
+      data: [detail('po-1', 'ord-1'), detail('po-2', 'ord-1', { productOrderStatus: 'CANCELED' })],
+    });
+
+    const [snapshot] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    expect(snapshot.paymentState).toBe('accepted');
+    expect(snapshot.lines.find((l) => l.channelOrderItemId === 'po-2')?.cancelled).toBe(true);
+    expect(snapshot.lifecycle).toHaveLength(1);
+    expect(snapshot.lifecycle[0].eventKey).toBe('cancelled:po-2');
+    expect(snapshot.lifecycle[0].payload).toMatchObject({
+      cancelledLines: [{ channelOrderItemId: 'po-2', quantity: 1 }],
+    });
+  });
+
+  it('전 라인 취소면 전체 취소 1건이고 terminal 이다', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: { count: 1, lastChangeStatuses: [changed('po-1', 'ord-1')] },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1'] });
+    client.getOrderDetails.mockResolvedValue({
+      data: [detail('po-1', 'ord-1', { productOrderStatus: 'CANCELED' })],
+    });
+
+    const [snapshot] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    expect(snapshot.paymentState).toBe('terminal');
+    expect(snapshot.lifecycle).toHaveLength(1);
+    expect(snapshot.lifecycle[0].eventKey).toBe('cancelled');
+    expect((snapshot.lifecycle[0].payload as Record<string, unknown>).cancelledLines).toBeUndefined();
+  });
+
+  it('sourceUpdatedAt 은 채널이 말한 변경 시각이다 — 현재 시각을 쓰면 워터마크가 창을 건너뛴다', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({
+      data: {
+        count: 1,
+        lastChangeStatuses: [
+          { ...changed('po-1', 'ord-1'), lastChangedDate: '2026-08-19T01:00:00.000+09:00' },
+          { ...changed('po-2', 'ord-1'), lastChangedDate: '2026-08-19T03:00:00.000+09:00' },
+        ],
+      },
+    });
+    client.getProductOrderIdsByOrderId.mockResolvedValue({ data: ['po-1', 'po-2'] });
+    client.getOrderDetails.mockResolvedValue({ data: [detail('po-1', 'ord-1'), detail('po-2', 'ord-1')] });
+
+    const [snapshot] = await source.fetchOrders(new Date('2026-08-19T00:00:00.000Z'));
+
+    // 한 주문의 여러 라인이 바뀌면 가장 늦은 시각을 취한다.
+    expect(snapshot.sourceUpdatedAt).toBe('2026-08-19T03:00:00.000+09:00');
+  });
+
+  it('워터마크가 없으면 최근 1시간을, 오래됐으면 24시간 창을 조회한다', async () => {
+    client.getLastChangedStatuses.mockResolvedValue({ data: { count: 0, lastChangeStatuses: [] } });
+
+    await source.fetchOrders(null);
+    const firstCall = client.getLastChangedStatuses.mock.calls[0][0];
+    expect(firstCall.lastChangedTo).toBeUndefined();
+
+    const old = new Date(Date.now() - 72 * 60 * 60 * 1000);
+    await source.fetchOrders(old);
+    const secondCall = client.getLastChangedStatuses.mock.calls[1][0];
+    const from = new Date(secondCall.lastChangedFrom).getTime();
+    const to = new Date(secondCall.lastChangedTo).getTime();
+    expect(to - from).toBe(24 * 60 * 60 * 1000);
+  });
+});
+```
+
+- [ ] **Step 2: 실패를 확인한다**
+
+Run: `npx jest --maxWorkers=2 apps/channel-adapter/src/services/order-collection/naver-order.source.spec.ts`
+Expected: FAIL — 모듈 없음
+
+- [ ] **Step 3: source 를 구현한다**
+
+```ts
+import { Injectable, Logger } from '@nestjs/common';
+import type { SalesChannel } from '@packages/event-contracts/streams';
+import { NaverOrderClient } from '../../adapters/naver/clients/naver-order.client';
+import {
+  ChannelOrderLineSnapshot,
+  ChannelOrderSnapshot,
+  ChannelPaymentState,
+  LifecycleObservation,
+  ReplayableChannelOrderSource,
+} from './channel-order-source.interface';
+import { NaverProductOrderInfo, parseNaverProductOrderInfo } from './naver-order-fields';
+
+/** 최초 수집 바닥값. 과거를 소급하면 이미 수기 처리된 주문이 중복 유입된다. */
+const FIRST_RUN_LOOKBACK_MS = 60 * 60 * 1000;
+/** 변경 피드가 한 번에 볼 수 있는 창. `lastChangedTo` 생략 시 네이버가 자동 적용하는 값과 같다. */
+const MAX_WINDOW_MS = 24 * 60 * 60 * 1000;
+/** 무한 페이징 방어. 한 창 × 300건이면 6000건으로, 우리 주문량에서 도달할 수 없다. */
+const MAX_PAGES = 20;
+
+const ACCEPTED_STATUSES = new Set(['PAYED', 'DELIVERING', 'DELIVERED', 'PURCHASE_DECIDED']);
+const TERMINAL_STATUSES = new Set(['CANCELED', 'CANCELED_BY_NOPAYMENT', 'RETURNED', 'EXCHANGED']);
+/** 취소 요청 중에도 productOrderStatus 는 PAYED 다 — 그대로 두면 출고로 흘러간다. */
+const CANCEL_IN_FLIGHT_CLAIMS = new Set(['CANCEL_REQUEST', 'CANCELING']);
+
+@Injectable()
+export class NaverOrderSource implements ReplayableChannelOrderSource {
+  readonly channel: SalesChannel = 'naver';
+  private readonly logger = new Logger(NaverOrderSource.name);
+
+  constructor(private readonly client: NaverOrderClient) {}
+
+  async fetchOrders(since: Date | null): Promise<ChannelOrderSnapshot[]> {
+    const changedAtByOrderId = await this.collectChangedOrderIds(since);
+    const snapshots: ChannelOrderSnapshot[] = [];
+    for (const [orderId, changedAt] of changedAtByOrderId) {
+      // 🔴 채널이 말한 변경 시각을 그대로 싣는다. `now` 를 쓰면 워터마크가 조회 창을 건너뛰어
+      // 그 사이 변경이 영영 조회 범위 밖으로 빠진다 (창 걷기가 무력화된다).
+      const snapshot = await this.fetchSnapshot(orderId, changedAt);
+      if (snapshot) snapshots.push(snapshot);
+    }
+    return snapshots;
+  }
+
+  /**
+   * replay 전용 단건. 워터마크 경로가 아니므로(`replayFailure` 는 `processOrderItem` 을 직접 부른다)
+   * 변경 시각을 알 수 없어 현재 시각을 쓴다.
+   */
+  async fetchOrder(externalOrderId: string): Promise<ChannelOrderSnapshot | null> {
+    return this.fetchSnapshot(externalOrderId, new Date().toISOString());
+  }
+
+  private async fetchSnapshot(externalOrderId: string, sourceUpdatedAt: string): Promise<ChannelOrderSnapshot | null> {
+    // 형제 라인을 복원한다. 변경 피드는 바뀐 라인만 주므로 이걸 건너뛰면 라인이 빠진 주문이 생긴다.
+    const idsResponse = await this.client.getProductOrderIdsByOrderId(externalOrderId);
+    const productOrderIds = idsResponse.data ?? [];
+    if (productOrderIds.length === 0) return null;
+
+    const detailsResponse = await this.client.getOrderDetails(productOrderIds);
+    const infos = (detailsResponse.data ?? []).map((raw) => parseNaverProductOrderInfo(raw));
+
+    // 문서가 "식별자 단위로 일부만 조회 실패할 수 있다" 고 경고한다. 조용히 빠지면 §6.1 이
+    // 막으려던 사고가 그대로 난다.
+    if (infos.length !== productOrderIds.length) {
+      throw new Error(
+        `네이버 상세 조회 누락: 주문 ${externalOrderId} 요청 ${productOrderIds.length}건, 응답 ${infos.length}건`,
+      );
+    }
+
+    return this.buildSnapshot(externalOrderId, infos, sourceUpdatedAt);
+  }
+
+  /**
+   * `more` 를 따라 창 전체를 훑고, **주문번호 → 그 주문의 최신 변경 시각**을 모은다.
+   * 한 주문의 여러 라인이 바뀌었으면 가장 늦은 시각을 취한다 — 워터마크의 근거다.
+   */
+  private async collectChangedOrderIds(since: Date | null): Promise<Map<string, string>> {
+    const now = new Date();
+    const from = since ?? new Date(now.getTime() - FIRST_RUN_LOOKBACK_MS);
+    // 창을 앞으로 점프시키지 않는다 — 그러면 그 사이 주문이 영영 조회 범위 밖으로 빠진다.
+    const windowEnd = new Date(Math.min(from.getTime() + MAX_WINDOW_MS, now.getTime()));
+    const explicitTo = windowEnd.getTime() < now.getTime() ? windowEnd.toISOString() : undefined;
+
+    const changedAtByOrderId = new Map<string, string>();
+    let lastChangedFrom = from.toISOString();
+    let moreSequence: string | undefined;
+
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const response = await this.client.getLastChangedStatuses({
+        lastChangedFrom,
+        ...(explicitTo ? { lastChangedTo: explicitTo } : {}),
+        ...(moreSequence ? { moreSequence } : {}),
+      });
+
+      for (const status of response.data?.lastChangeStatuses ?? []) {
+        const previous = changedAtByOrderId.get(status.orderId);
+        if (!previous || status.lastChangedDate > previous) {
+          changedAtByOrderId.set(status.orderId, status.lastChangedDate);
+        }
+      }
+
+      const more = response.data?.more;
+      if (!more) return changedAtByOrderId;
+      lastChangedFrom = more.moreFrom;
+      moreSequence = more.moreSequence;
+    }
+
+    this.logger.warn(`[naver] 변경 피드 페이징이 ${MAX_PAGES}쪽에서 끊겼다 — 다음 주기가 이어받는다.`);
+    return changedAtByOrderId;
+  }
+
+  private buildSnapshot(
+    externalOrderId: string,
+    infos: NaverProductOrderInfo[],
+    sourceUpdatedAt: string,
+  ): ChannelOrderSnapshot {
+    const lines = infos.map((info) => this.buildLine(info));
+    const cancelled = infos.filter((info) => TERMINAL_STATUSES.has(info.productOrderStatus));
+    const allCancelled = cancelled.length === infos.length;
+
+    return {
+      externalOrderId,
+      sourceUpdatedAt,
+      paymentState: this.resolvePaymentState(infos, allCancelled),
+      customerId: null,
+      lines,
+      amounts: {
+        total: infos.reduce((sum, info) => sum + info.lineTotal, 0),
+        subtotal: infos.reduce((sum, info) => sum + info.unitPrice * info.quantity, 0),
+        shipping: infos.reduce((sum, info) => sum + info.shippingFee, 0),
+        discount: 0,
+        currency: 'KRW',
+      },
+      shippingAddress: infos[0].shippingAddress,
+      createdAt: infos[0].paymentDate ?? sourceUpdatedAt,
+      lifecycle: this.buildLifecycle(infos, cancelled, allCancelled, sourceUpdatedAt),
+      raw: { externalOrderId, productOrders: infos },
+    };
+  }
+
+  private buildLine(info: NaverProductOrderInfo): ChannelOrderLineSnapshot {
+    return {
+      channelOrderItemId: info.productOrderId,
+      ...(info.channelProductId ? { channelProductId: info.channelProductId } : {}),
+      productName: info.productName,
+      quantity: info.quantity,
+      unitPrice: info.unitPrice,
+      ...(TERMINAL_STATUSES.has(info.productOrderStatus) ? { cancelled: true } : {}),
+    };
+  }
+
+  private resolvePaymentState(infos: NaverProductOrderInfo[], allCancelled: boolean): ChannelPaymentState {
+    if (allCancelled) return 'terminal';
+
+    const live = infos.filter((info) => !TERMINAL_STATUSES.has(info.productOrderStatus));
+    // 고객이 취소를 원하는 주문을 출고 파이프라인에 태우지 않는다 (Medusa 의 refund-requested 방어와 대칭).
+    if (live.some((info) => info.claimStatus && CANCEL_IN_FLIGHT_CLAIMS.has(info.claimStatus))) return 'pending';
+    if (live.every((info) => ACCEPTED_STATUSES.has(info.productOrderStatus))) return 'accepted';
+    return 'pending';
+  }
+
+  /**
+   * **전 라인 취소는 full 1건, 일부 취소는 라인마다 partial 1건.**
+   * Core 는 `lines` 유무로 전체/부분을 가르고, 부분취소가 누적돼 전량이 돼도 주문을 닫지 않는다.
+   */
+  private buildLifecycle(
+    infos: NaverProductOrderInfo[],
+    cancelled: NaverProductOrderInfo[],
+    allCancelled: boolean,
+    cancelledAt: string,
+  ): LifecycleObservation[] {
+    if (cancelled.length === 0) return [];
+
+    if (allCancelled) {
+      return [
+        {
+          eventType: 'OrderCancelled',
+          eventKey: 'cancelled',
+          payload: {
+            reason: 'CUSTOMER_REQUEST',
+            reasonDetail: '네이버 주문 취소 수집',
+            cancelledBy: 'naver',
+            cancelledAt,
+            refundRequired: false,
+          },
+          rawEvent: { productOrderIds: cancelled.map((info) => info.productOrderId) },
+        },
+      ];
+    }
+
+    return cancelled.map((info) => ({
+      eventType: 'OrderCancelled' as const,
+      eventKey: `cancelled:${info.productOrderId}`,
+      payload: {
+        reason: 'CUSTOMER_REQUEST' as const,
+        reasonDetail: '네이버 상품주문 부분 취소 수집',
+        cancelledBy: 'naver',
+        cancelledAt,
+        refundRequired: false,
+        cancelledLines: [{ channelOrderItemId: info.productOrderId, quantity: info.quantity }],
+      },
+      rawEvent: { productOrderId: info.productOrderId },
+    }));
+  }
+}
+```
+
+- [ ] **Step 4: 통과를 확인한다**
+
+Run: `npx jest --maxWorkers=2 apps/channel-adapter/src/services/order-collection/naver-order.source.spec.ts`
+Expected: PASS (8건)
+
+- [ ] **Step 5: 모듈에 등록한다**
+
+`adapter.module.ts` 의 provider 배열에서 `NaverOrderSource` 를 더하고 factory 를 고친다:
+
+```ts
+    MedusaOrderSource,
+    NaverOrderSource,
+    {
+      provide: CHANNEL_ORDER_PROVIDER,
+      // 채널이 늘면 source 를 하나 더 만들어 이 배열에 더한다. 번역기는 공유한다.
+      useFactory: (translator: ChannelOrderTranslator, medusa: MedusaOrderSource, naver: NaverOrderSource) => [
+        createOrderProvider(medusa, translator),
+        createOrderProvider(naver, translator),
+      ],
+      inject: [ChannelOrderTranslator, MedusaOrderSource, NaverOrderSource],
+    },
+```
+
+import 를 파일 상단에 더한다.
+
+- [ ] **Step 6: 게이트를 돌린다**
+
+Run: `npm run type-check && npx jest --maxWorkers=2 apps/channel-adapter`
+Expected: type-check 0, jest 실패 0
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add apps/channel-adapter/src
+git commit -m "feat(channel-adapter): 네이버 주문 수집 source 를 붙인다 (#643)"
+```
+
+---
+
+## Phase C — shadow 점검 (사람 작업)
+
+### Task 8: 실 응답으로 필드명을 확정한다
+
+**이 태스크는 코드를 쓰지 않는다.** Task 1–7 이 배포된 뒤 운영자가 수행한다.
+
+- [ ] **Step 1: 배포 전 채널을 내린다**
+
+Core DB 에서 확인하고 내린다. **이 단계를 건너뛰면 배포 즉시 수집이 시작된다** (현재 `is_active=true`).
+
+```sql
+SELECT id, name, site, is_active FROM sales_channels WHERE site = 'naver';
+UPDATE sales_channels SET is_active = false WHERE site = 'naver';
+```
+
+- [ ] **Step 2: 배포한다**
+
+Core(Task 1–2) → channel-adapter(Task 3–7) 순서. 마이그레이션 없음.
+
+- [ ] **Step 3: 한 주기만 켠다**
+
+```sql
+UPDATE sales_channels SET is_active = true WHERE site = 'naver';
+-- 6분 대기 (폴러는 5분 주기)
+UPDATE sales_channels SET is_active = false WHERE site = 'naver';
+```
+
+- [ ] **Step 4: 결과를 판정한다**
+
+channel-adapter DB 에서:
+
+```sql
+SELECT channel_type, last_sync_at, updated_at, error FROM sync_statuses WHERE channel_type = 'naver';
+SELECT external_order_id, reason, status, affected_lines FROM order_collection_failures WHERE channel = 'naver';
+SELECT raw_order FROM order_collection_failures WHERE channel = 'naver' LIMIT 1;
+SELECT count(*) FROM wms_order_mappings WHERE sales_channel = 'naver';  -- 0 이어야 정상
+```
+
+기대: `error` 없음 · 격리 행의 `cause` 가 전부 `listing_not_found` · 매핑 0행.
+
+- [ ] **Step 5: `raw_order` 에서 네 가지를 확정한다**
+
+① 상품 식별자 필드명과 **값의 종류** (원상품번호인가 채널상품번호인가 — 둘은 숫자가 겹칠 수 있다)
+② 옵션 상품이면 옵션 단위 식별자 필드가 있는가 (없으면 매핑 grain 판단이 별도로 필요)
+③ 금액·수량 필드명 (`totalPaymentAmount` / `unitPrice` / `deliveryFeeAmount` 가 맞는가)
+④ `claimStatus` 가 실리는 자리
+
+- [ ] **Step 6: 결과를 기록한다**
+
+확정값을 스펙 §6.5 에 적고 커밋한다. 어긋나면 Task 9 로 간다.
+
+⚠️ **shadow 와 개통 사이가 24시간을 넘으면**, 개통 전에 워터마크 행을 지워 최초 수집으로 되돌린다:
+`DELETE FROM sync_statuses WHERE channel_type = 'naver' AND data_type = 'orders';`
+
+---
+
+### Task 9: 확정된 필드명을 반영한다
+
+**Files:**
+- Modify: `apps/channel-adapter/src/services/order-collection/naver-order-fields.ts`
+- Modify: `apps/channel-adapter/src/services/order-collection/naver-order-fields.spec.ts`
+
+- [ ] **Step 1: 실 응답을 픽스처로 만든다**
+
+Task 8 에서 뜬 `raw_order` 를 그대로 `naver-order-fields.spec.ts` 의 `raw` 상수로 교체한다. 개인정보(수취인명·연락처·주소)는 더미로 치환한다.
+
+- [ ] **Step 2: 실패를 확인한다**
+
+Run: `npx jest --maxWorkers=2 apps/channel-adapter/src/services/order-collection/naver-order-fields.spec.ts`
+Expected: 필드명이 달랐다면 FAIL. 같았다면 PASS 이고 이 태스크는 픽스처 교체만으로 끝난다.
+
+- [ ] **Step 3: `naver-order-fields.ts` 만 고친다**
+
+스키마의 필드명·`channelProductId` 원천을 확정값으로 바꾼다. **다른 파일은 건드리지 않는다** — 그러라고 이 파일을 분리했다.
+
+- [ ] **Step 4: 전체 게이트**
+
+Run: `npm run type-check && npx jest --maxWorkers=2 apps/channel-adapter`
+Expected: 0 / 실패 0
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add apps/channel-adapter/src/services/order-collection
+git commit -m "fix(channel-adapter): shadow 실측으로 네이버 응답 필드를 확정한다"
+```
+
+---
+
+## Phase E — 격리 큐 운영 화면
+
+### Task 10: 격리 행에 채널상품ID 를 싣는다
+
+**Files:**
+- Modify: `packages/domain-types/listing-resolution-cause.ts:48-51`
+- Modify: `apps/channel-adapter/src/services/order-collection/channel-order.translator.ts` (`unidentified` 조립부)
+- Test: `apps/channel-adapter/src/services/order-collection/channel-order.translator.spec.ts`
+
+**Interfaces:**
+- Produces: `AffectedLine.channelProductId?: string`
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다**
+
+```ts
+  it('격리 행에 해석에 쓴 채널상품ID 를 함께 남긴다 — 화면 프리필의 정본이다', async () => {
+    resolver.resolve.mockResolvedValue({ identified: false, cause: 'listing_not_found' });
+
+    const { outcome } = await translator.translate('naver', {
+      ...snapshotFixture,
+      lines: [{ ...lineFixture, channelOrderItemId: 'po-1', channelProductId: '13700000002' }],
+    });
+
+    expect(outcome.kind).toBe('failure');
+    if (outcome.kind !== 'failure') return;
+    expect(outcome.failure.affectedLines).toEqual([
+      { lineId: 'po-1', cause: 'listing_not_found', channelProductId: '13700000002' },
+    ]);
+  });
+```
+
+- [ ] **Step 2: 실패를 확인한다**
+
+Run: `npx jest --maxWorkers=2 apps/channel-adapter/src/services/order-collection/channel-order.translator.spec.ts`
+Expected: FAIL — `channelProductId` 가 없다
+
+- [ ] **Step 3: 타입을 넓힌다**
+
+`listing-resolution-cause.ts`:
+
+```ts
+/** 격리된 주문에서 식별에 실패한 라인 하나. */
+export interface AffectedLine {
+  lineId: string;
+  cause: ListingResolutionCause;
+  /**
+   * 해석에 **실제로 쓴** 조회 키. 운영 화면의 "채널상품ID" 프리필이 이 값을 쓴다.
+   * 원본(`raw_order`)을 프런트가 파싱하지 않게 하려는 것이고, 그 덕에 "운영자가 등록하는 값"과
+   * "수집이 조회한 값"이 구조적으로 같아진다. 옛 행에는 없으므로 선택 필드다.
+   */
+  channelProductId?: string;
+}
+```
+
+- [ ] **Step 4: translator 가 채워 넣게 한다**
+
+`unidentified` 조립을 바꾼다:
+
+```ts
+    const unidentified = snapshot.lines.flatMap((line, index) => {
+      if (line.cancelled) return [];
+      const resolution = resolutions[index];
+      if (resolution.identified) return [];
+      return [
+        {
+          lineId: line.channelOrderItemId,
+          cause: resolution.cause,
+          ...(line.channelProductId ? { channelProductId: line.channelProductId } : {}),
+        },
+      ];
+    });
+```
+
+- [ ] **Step 5: 통과를 확인한다**
+
+Run: `npx jest --maxWorkers=2 apps/channel-adapter/src/services/order-collection && npm run type-check`
+Expected: PASS / 0
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add packages/domain-types apps/channel-adapter/src/services/order-collection
+git commit -m "feat: 격리 라인에 해석 키를 남겨 화면 프리필의 정본으로 쓴다"
+```
+
+---
+
+### Task 11: 화면 판정 로직을 순수 함수로 만든다
+
+**Files:**
+- Create: `apps/admin-web/src/features/mall/quarantine/guidance.ts`
+- Test: `apps/admin-web/src/features/mall/quarantine/guidance.spec.ts`
+
+**Interfaces:**
+- Produces: `actionForCause(cause)`, `canReplay(status, reason)`, `replayResultMessage(status)`
+
+**왜 순수 함수인가**: admin-web 은 렌더러가 없고 `.tsx` 가 transform 밖이라 컴포넌트 테스트가 불가능하다. `.tsx` 안에 인라인으로 두면 영구 미검증이다.
+
+- [ ] **Step 1: 실패하는 테스트를 쓴다**
+
+```ts
+import { actionForCause, canReplay, replayResultMessage } from './guidance';
+
+describe('actionForCause', () => {
+  it('리스팅이 없으면 매핑 생성으로 안내한다', () => {
+    expect(actionForCause('listing_not_found')).toEqual({
+      label: '매핑 생성',
+      action: 'create-listing',
+      description: '이 채널상품에 대응하는 채널 리스팅을 만드세요.',
+    });
+  });
+
+  it('활성 버전이 없으면 두 갈래를 다 알린다 — 판매중지를 publish 로 오도하지 않는다', () => {
+    const guidance = actionForCause('no_active_version');
+    expect(guidance.action).toBe('none');
+    expect(guidance.description).toContain('publish');
+    expect(guidance.description).toContain('내리세요');
+  });
+
+  it('모르는 값이 와도 렌더 가능한 안내를 준다', () => {
+    expect(actionForCause('unknown').action).toBe('none');
+  });
+});
+
+describe('canReplay', () => {
+  it('격리 상태이고 식별 실패면 재처리할 수 있다', () => {
+    expect(canReplay('quarantined', 'channel_product_identification_failed')).toBe(true);
+  });
+
+  it('수집 후 변경은 재처리 대상이 아니다', () => {
+    expect(canReplay('quarantined', 'collected_order_modification_not_accepted')).toBe(false);
+  });
+
+  it('닫힌 건은 재처리하지 않는다', () => {
+    expect(canReplay('closed_already_collected', 'channel_product_identification_failed')).toBe(false);
+  });
+});
+
+describe('replayResultMessage', () => {
+  it('여섯 가지 결과를 모두 사람 말로 옮긴다', () => {
+    const statuses = [
+      'replayed',
+      'already_processed',
+      'still_quarantined',
+      'closed_terminal',
+      'closed_already_collected',
+      'not_replayable',
+    ] as const;
+    for (const status of statuses) {
+      expect(replayResultMessage(status).length).toBeGreaterThan(0);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: 실패를 확인한다**
+
+Run: `npm run test:admin-web -- guidance`
+Expected: FAIL — 모듈 없음
+
+- [ ] **Step 3: 구현한다**
+
+```ts
+import type { ListingResolutionCause } from '@packages/domain-types';
+
+export type QuarantineStatus =
+  | 'quarantined'
+  | 'replayed'
+  | 'closed_lifecycle'
+  | 'closed_already_collected';
+
+export type QuarantineReason =
+  | 'channel_product_identification_failed'
+  | 'collected_order_modification_not_accepted';
+
+export type ReplayStatus =
+  | 'replayed'
+  | 'already_processed'
+  | 'still_quarantined'
+  | 'closed_terminal'
+  | 'closed_already_collected'
+  | 'not_replayable';
+
+export interface CauseGuidance {
+  label: string;
+  action: 'create-listing' | 'activate-listing' | 'activate-channel' | 'none';
+  description: string;
+}
+
+const GUIDANCE: Record<ListingResolutionCause, CauseGuidance> = {
+  listing_not_found: {
+    label: '매핑 생성',
+    action: 'create-listing',
+    description: '이 채널상품에 대응하는 채널 리스팅을 만드세요.',
+  },
+  listing_inactive: {
+    label: '리스팅 활성화',
+    action: 'activate-listing',
+    description: '리스팅이 비활성 상태입니다. 활성화하세요.',
+  },
+  channel_inactive: {
+    label: '채널 활성화',
+    action: 'activate-channel',
+    description: '판매채널이 비활성 상태입니다. 활성화하세요.',
+  },
+  variant_inactive: {
+    label: '품목 확인',
+    action: 'none',
+    description: '연결된 품목이 판매중지 상태입니다. 상품 화면에서 품목을 활성화하세요.',
+  },
+  no_active_version: {
+    label: '버전 확인',
+    action: 'none',
+    description:
+      '활성 버전이 없습니다. 판매를 재개하려면 publish 하고, 판매중지가 맞다면 네이버에서 해당 상품을 내리세요.',
+  },
+  product_deleted: {
+    label: '재매핑',
+    action: 'create-listing',
+    description: '연결된 상품이 삭제됐습니다. 다른 상품으로 다시 매핑하세요.',
+  },
+  no_embedded_ids: {
+    label: '상품 재생성',
+    action: 'none',
+    description: '채널에 우리 식별자가 없습니다. Core 를 통해 상품을 다시 만드세요.',
+  },
+  no_lookup_key: {
+    label: '채널 데이터 확인',
+    action: 'none',
+    description: '주문 라인에 조회 키가 없습니다. 채널 원본 데이터를 확인하세요.',
+  },
+  unknown: {
+    label: '판정 불가',
+    action: 'none',
+    description: '사유를 알 수 없는 격리입니다. 원본을 확인하세요.',
+  },
+};
+
+export function actionForCause(cause: ListingResolutionCause): CauseGuidance {
+  return GUIDANCE[cause] ?? GUIDANCE.unknown;
+}
+
+/**
+ * 재처리 가능 여부. **상태를 먼저 본다** — 닫힌 행에 버튼을 주면 운영자가 헛수고를 반복한다.
+ * `collected_order_modification_not_accepted` 는 서버가 `not_replayable` 로 응답하는 사유다.
+ */
+export function canReplay(status: string, reason: string): boolean {
+  if (status !== 'quarantined') return false;
+  return reason !== 'collected_order_modification_not_accepted';
+}
+
+const REPLAY_MESSAGES: Record<ReplayStatus, string> = {
+  replayed: '재처리했습니다. 판매주문이 생성됐습니다.',
+  already_processed: '이미 처리된 주문이라 새로 발행할 것이 없었습니다.',
+  still_quarantined: '아직 해소되지 않았습니다. 조치가 반영됐는지 확인하세요.',
+  closed_terminal: '채널에서 취소·환불되어 더 이상 수집할 수 없습니다. 격리를 닫았습니다.',
+  closed_already_collected: '이미 판매주문이 있어 격리를 닫았습니다.',
+  not_replayable: '수집 후 변경 건이라 재처리할 수 없습니다. CS/주문정정으로 처리하세요.',
+};
+
+/**
+ * 서버 응답 문자열을 그대로 받는다. `ReplayStatus` 로 좁혀 받으면 클라이언트 DTO 의 `status: string`
+ * 과 어긋나 호출부에 캐스팅이 생긴다 — 모르는 값이 오면 폴백 문구를 준다.
+ */
+export function replayResultMessage(status: string): string {
+  return REPLAY_MESSAGES[status as ReplayStatus] ?? '알 수 없는 결과입니다.';
+}
+```
+
+- [ ] **Step 4: 통과를 확인한다**
+
+Run: `npm run test:admin-web -- guidance`
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add apps/admin-web/src/features/mall/quarantine
+git commit -m "feat(admin-web): 격리 큐 판정 로직을 순수 함수로 분리한다"
+```
+
+---
+
+### Task 12: 격리 API 클라이언트와 쿼리 훅
+
+**Files:**
+- Create: `apps/admin-web/src/lib/api/domains/channel/order-collection-failures.client.ts`
+- Create: `apps/admin-web/src/lib/services/channel/query-keys.ts`
+- Create: `apps/admin-web/src/lib/services/channel/queries.ts`
+- Create: `apps/admin-web/src/lib/services/channel/mutations.ts`
+
+**Interfaces:**
+- Consumes: `CHANNEL_ADAPTER_SERVICE_BASE_URL` (`@/const`), `client` (`@/lib/api/client`)
+- Produces: `orderCollectionFailuresClient.list/get/replay`, `useQuarantinedFailures`, `useReplayFailure`
+
+- [ ] **Step 1: 클라이언트를 만든다**
+
+```ts
+'use client';
+
+import { CHANNEL_ADAPTER_SERVICE_BASE_URL } from '@/const';
+import { client } from '../../client';
+import type { AffectedLine } from '@packages/domain-types';
+
+export interface OrderCollectionFailureDto {
+  id: string;
+  channel: string;
+  externalOrderId: string;
+  reason: string;
+  status: string;
+  affectedLineIds: string[];
+  affectedLines: AffectedLine[] | null;
+  rawOrder: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ReplayResultDto {
+  status: string;
+  failureId: string;
+  externalOrderId: string;
+  emitted: number;
+  dedupedUnchanged: number;
+}
+
+export const orderCollectionFailuresClient = {
+  list: async (params: { channel?: string; reason?: string; status?: string; limit?: number; offset?: number }) => {
+    const response = await client.get<{ count: number; data: OrderCollectionFailureDto[] }>(
+      `${CHANNEL_ADAPTER_SERVICE_BASE_URL}/adapter/order-collection-failures`,
+      { params },
+    );
+    return response.data;
+  },
+
+  get: async (id: string) => {
+    const response = await client.get<{ data: OrderCollectionFailureDto; replayPath: unknown }>(
+      `${CHANNEL_ADAPTER_SERVICE_BASE_URL}/adapter/order-collection-failures/${encodeURIComponent(id)}`,
+    );
+    return response.data;
+  },
+
+  replay: async (id: string) => {
+    const response = await client.post<{ result: ReplayResultDto }>(
+      `${CHANNEL_ADAPTER_SERVICE_BASE_URL}/adapter/order-collection-failures/${encodeURIComponent(id)}/replay`,
+    );
+    return response.data.result;
+  },
+};
+```
+
+브라우저에서 `CHANNEL_ADAPTER_SERVICE_BASE_URL` 은 `/proxy/channel` 이고 axios `baseURL` 이 `/api` 라 최종 경로는 `/api/proxy/channel/adapter/...` — 기존 프록시 라우트가 그대로 받는다.
+
+- [ ] **Step 2: 쿼리 키와 훅을 만든다**
+
+`query-keys.ts`:
+
+```ts
+export const channelQueryKeys = {
+  failures: ['order-collection-failures'] as const,
+  failuresList: (query: Record<string, unknown>) => [...channelQueryKeys.failures, 'list', query] as const,
+  failure: (id: string) => [...channelQueryKeys.failures, id] as const,
+};
+```
+
+`queries.ts`:
+
+```ts
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { channelQueryKeys } from './query-keys';
+import { orderCollectionFailuresClient } from '@/lib/api/domains/channel/order-collection-failures.client';
+
+export function useQuarantinedFailures(params: { channel?: string; status?: string } = {}) {
+  const query = { status: 'quarantined', ...params };
+  return useQuery({
+    queryKey: channelQueryKeys.failuresList(query),
+    queryFn: () => orderCollectionFailuresClient.list(query),
+  });
+}
+
+export function useFailureDetail(id: string | null) {
+  return useQuery({
+    queryKey: channelQueryKeys.failure(id ?? ''),
+    queryFn: () => orderCollectionFailuresClient.get(id as string),
+    enabled: Boolean(id),
+  });
+}
+```
+
+`mutations.ts`:
+
+```ts
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { channelQueryKeys } from './query-keys';
+import { orderCollectionFailuresClient } from '@/lib/api/domains/channel/order-collection-failures.client';
+
+export function useReplayFailure() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => orderCollectionFailuresClient.replay(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: channelQueryKeys.failures });
+    },
+  });
+}
+```
+
+- [ ] **Step 3: 타입 게이트**
+
+Run: `npm run type-check`
+Expected: 0
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add apps/admin-web/src/lib
+git commit -m "feat(admin-web): 격리 큐 API 클라이언트와 쿼리 훅을 만든다"
+```
+
+---
+
+### Task 13: 미매핑 주문 탭을 붙인다
+
+**Files:**
+- Create: `apps/admin-web/src/features/mall/quarantine/components/quarantine-table/index.tsx`
+- Create: `apps/admin-web/src/features/mall/quarantine/components/quarantine-detail-dialog/index.tsx`
+- Modify: `apps/admin-web/src/features/mall/channel-listings/template/index.tsx`
+- Modify: `apps/admin-web/src/lib/utils/menu.ts` (배지)
+
+- [ ] **Step 1: 목록 컴포넌트를 만든다**
+
+`quarantine-table/index.tsx`. 테이블 primitive(`Table`/`TableHeader`/`TableRow`/`TableCell`)와 스타일은
+`features/mall/channel-listings/components/channel-listings-table/index.tsx` 에서 쓰는 것과 같은 것을 import 한다.
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useQuarantinedFailures } from '@/lib/services/channel/queries';
+import { canReplay } from '../../guidance';
+import { QuarantineDetailDialog } from '../quarantine-detail-dialog';
+import type { OrderCollectionFailureDto } from '@/lib/api/domains/channel/order-collection-failures.client';
+
+export function QuarantineTable() {
+  const { data, isLoading } = useQuarantinedFailures();
+  const [selected, setSelected] = useState<OrderCollectionFailureDto | null>(null);
+
+  if (isLoading) return <div className="p-6 text-sm text-muted-foreground">불러오는 중…</div>;
+
+  const rows = data?.data ?? [];
+  if (rows.length === 0) {
+    return <div className="p-6 text-sm text-muted-foreground">격리된 주문이 없습니다.</div>;
+  }
+
+  return (
+    <>
+      <table className="w-full text-sm">
+        <thead>
+          <tr>
+            <th className="text-left">채널</th>
+            <th className="text-left">외부주문번호</th>
+            <th className="text-left">사유</th>
+            <th className="text-right">라인</th>
+            <th className="text-left">변경시각</th>
+            <th className="text-right">조치</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.id}>
+              <td>{row.channel}</td>
+              <td>{row.externalOrderId}</td>
+              <td>{row.reason}</td>
+              <td className="text-right">{row.affectedLines?.length ?? row.affectedLineIds.length}</td>
+              <td>{new Date(row.updatedAt).toLocaleString('ko-KR')}</td>
+              <td className="text-right">
+                {canReplay(row.status, row.reason) ? (
+                  <button type="button" onClick={() => setSelected(row)}>
+                    해소하기
+                  </button>
+                ) : (
+                  <span title="수집 후 채널에서 변경된 건입니다">CS 처리 필요</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <QuarantineDetailDialog failure={selected} onClose={() => setSelected(null)} />
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: 상세 다이얼로그를 만든다**
+
+`quarantine-detail-dialog/index.tsx`. Dialog primitive 은 `channel-listing-form-dialog` 가 쓰는 것을 그대로 쓴다.
+
+```tsx
+'use client';
+
+import { actionForCause, replayResultMessage } from '../../guidance';
+import { useReplayFailure } from '@/lib/services/channel/mutations';
+import type { OrderCollectionFailureDto } from '@/lib/api/domains/channel/order-collection-failures.client';
+
+export function QuarantineDetailDialog({
+  failure,
+  onClose,
+}: {
+  failure: OrderCollectionFailureDto | null;
+  onClose: () => void;
+}) {
+  const replay = useReplayFailure();
+  if (!failure) return null;
+
+  const lines = failure.affectedLines;
+
+  const handleResolved = async () => {
+    const result = await replay.mutateAsync(failure.id);
+    window.alert(replayResultMessage(result.status));
+    onClose();
+  };
+
+  return (
+    <div role="dialog" aria-label="격리 주문 상세">
+      <h2>{failure.externalOrderId}</h2>
+
+      {/* 옛 행에는 라인별 사유가 없다. 이건 정상 상태이므로 빈 화면이 아니라 설명을 렌더한다. */}
+      {!lines || lines.length === 0 ? (
+        <p>사유 정보가 없는 옛 격리입니다. 원본을 확인해 직접 매핑하세요.</p>
+      ) : (
+        <ul>
+          {lines.map((line) => {
+            const guidance = actionForCause(line.cause);
+            return (
+              <li key={line.lineId}>
+                <strong>{line.lineId}</strong> — {guidance.label}
+                <p>{guidance.description}</p>
+                {guidance.action === 'create-listing' && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      openChannelListingForm({
+                        channelCode: failure.channel,
+                        channelItemId: line.channelProductId ?? '',
+                      })
+                    }
+                  >
+                    매핑 생성
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <button type="button" onClick={handleResolved} disabled={replay.isPending}>
+        조치 완료 — 재처리
+      </button>
+    </div>
+  );
+}
+```
+
+`openChannelListingForm` 은 기존 `channel-listing-form-dialog` 를 여는 함수다. 그 다이얼로그의 props 에
+`defaultChannelCode` / `defaultChannelItemId` 를 더해 프리필을 받게 한다 (없으면 빈 문자열).
+
+- [ ] **Step 3: 탭을 붙인다**
+
+`channel-listings/template/index.tsx` 의 최상단 반환을 탭으로 감싼다. 기존 테이블은 첫 탭에 그대로 둔다.
+
+```tsx
+const [tab, setTab] = useState<'listings' | 'quarantine'>('listings');
+
+return (
+  <div>
+    <nav>
+      <button type="button" onClick={() => setTab('listings')} aria-pressed={tab === 'listings'}>
+        채널 리스팅
+      </button>
+      <button type="button" onClick={() => setTab('quarantine')} aria-pressed={tab === 'quarantine'}>
+        미매핑 주문
+      </button>
+    </nav>
+    {tab === 'listings' ? <ChannelListingsTable /> : <QuarantineTable />}
+  </div>
+);
+```
+
+- [ ] **Step 4: 메뉴 배지**
+
+메뉴 항목 컴포넌트에서 `useQuarantinedFailures()` 의 `data?.count` 를 배지로 렌더한다.
+`count` 가 0 이거나 로딩 중이면 배지를 그리지 않는다.
+
+```tsx
+const { data } = useQuarantinedFailures();
+const quarantinedCount = data?.count ?? 0;
+// ...메뉴 라벨 옆
+{quarantinedCount > 0 && <span aria-label={`격리 ${quarantinedCount}건`}>{quarantinedCount}</span>}
+```
+
+- [ ] **Step 5: 게이트**
+
+Run: `npm run type-check && npm run test:admin-web`
+Expected: 0 / 실패 0
+
+- [ ] **Step 6: 브라우저 수동 확인 (유일한 방어선)**
+
+- 빈 목록이 깨지지 않는가
+- `affected_lines` 가 `null` 인 옛 행이 렌더되는가
+- 라인이 여러 개인 격리의 라인별 사유가 다 보이는가
+- `not_replayable` 건에 재처리 버튼이 없는가
+- 프리필된 매핑 생성 → 저장 → 자동 재처리 → 목록에서 사라지는가
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add apps/admin-web/src
+git commit -m "feat(admin-web): 미매핑 주문 격리 큐 화면을 붙인다 (#640)"
+```
+
+---
+
+## 개통 (Task 13 배포 후)
+
+- [ ] admin-web 배포 완료 확인
+- [ ] shadow 이후 24시간이 지났으면 워터마크 행 삭제 (Task 8 Step 6 주석)
+- [ ] `UPDATE sales_channels SET is_active = true WHERE site = 'naver';`
+- [ ] 첫 격리 건이 화면에 뜨는지 확인하고 한 바퀴(매핑 등록 → 재처리 → 판매주문 생성)를 끝까지 돌린다
+- [ ] 30분 뒤: `sync_statuses.updated_at` 이 갱신되는가 · `failed_syncs` +0 인가 · `wms_order_mappings` 에 naver 행이 생겼는가

--- a/docs/superpowers/specs/2026-08-19-naver-order-collection-activation-design.md
+++ b/docs/superpowers/specs/2026-08-19-naver-order-collection-activation-design.md
@@ -1,0 +1,290 @@
+# 네이버 주문 수집 개통과 격리 큐 운영 화면 (#643 · #640)
+
+- 날짜: 2026-08-19
+- 이슈: #643 (네이버 `ChannelOrderSource`) · #640 (미매핑 격리 큐 화면) · 신규 1건 (취소 계약)
+- 선행: #639 · #599 · #652 · #654 · #656 · #674 (전부 종결)
+- 관련: ADR-0031 · CONTEXT.md §채널 상품 식별 실패 · §Payment Accepted · §주문취소
+
+## 1. 문제
+
+ADR-0031 이 수집 경로를 `OrderPollerOrchestrator → ChannelOrderSource → ChannelOrderTranslator → 공용 아웃박스`
+하나로 좁혔고 source 구현체는 `MedusaOrderSource` 뿐이다. 네이버 자리는 비어 있다.
+
+코드 선행은 전부 해소됐고 남은 차단 요인은 데이터다 — `channel_variant_listings` 의 네이버 행이 **0행**이고,
+네이버는 `lineIdentity: 'mapped'` 라 전 라인이 수기 매핑에 의존한다. 매핑 없이 켜면 수집은 성공하고 전 라인이 격리된다.
+그런데 격리를 볼 화면이 없다 (`grep '/adapter/' apps/admin-web/src` → 0건).
+
+## 2. 착수 전 확정한 사실
+
+| 사실 | 근거 | 영향 |
+|---|---|---|
+| 개통 스위치는 코드가 아니라 DB 다 | `order-poller.orchestrator.ts:60-88` — 폴러가 매 주기 Core 에 활성 채널을 묻고 비활성 채널은 워터마크도 안 건드리고 건너뛴다 | 배포와 개통을 분리할 수 있다. shadow 점검이 공짜가 된다 |
+| naver 행이 이미 `is_active=true` | 2026-08-18 실측 | **배포 전에 내려두지 않으면 배포 즉시 수집이 시작된다** |
+| admin-web → channel-adapter 프록시가 이미 있다 | `apps/admin-web/src/app/api/proxy/channel/[...path]/route.ts`, auth 쿠키 전달 기본값 `true` | #640 "인증 경로" 판정 불필요 |
+| 조치에 필요한 Core API 가 다 있다 | `channel-listing.controller.ts` — `POST /`, `PUT /:id/activate`, `PUT /:id/deactivate` | 화면이 조치를 끝낼 수 있다 |
+| 네이버 주문 상세 zod 가 `z.any()` 다 | `naver.order.zod.ts:170-186` | 상세 스키마를 새로 써야 한다. 필드명이 저장소에 없다 |
+| `ProductOrderStatusSchema` 에 `DISPATCHED` 가 없다 | `naver-core.zod.ts:209-219` (옛 매핑 `naver-smartstore.adapter.ts:756` 에는 있다) | 발송 후 상태 변경이 parse 에서 깨진다 |
+| Core 는 부분취소를 이미 구현해뒀다 | `cancel-sales-order.dto.ts:16-25`, `partial-cancellation-refund-calculator.ts`, `fulfillments.service.ts:432` | 라인 개념을 새로 만들 필요가 없다 |
+| 라인의 채널 좌표도 이미 있다 | `inventory.schema.ts:1324,1343` (`channel_order_item_id` + 부분 unique), `channel-order.translator.ts:116` | 채널 라인 ID → `salesOrderLineId` 해석이 단건 확정이다 |
+| 옛 `/adapter` REST 는 읽기 전용이다 | `channel-adapter.controller.ts` 의 `queryOrders` 는 `channelReader.findOrders` 만 부른다 | 이중 수집 위험 없음 |
+
+## 3. 전략
+
+**운영 전략은 lazy 매핑이다** (사용자 결정). 사전 전량 매핑을 하지 않고, 미매핑 주문이 들어올 때마다 그 자리에서 등록한다.
+네이버 스토어는 실판매 중이고 주문량은 적다.
+
+그 결과:
+
+- 일괄 등록 도구는 **스코프 밖**이다 (YAGNI). Core 리스팅 API 는 단건 POST 뿐이고 그걸로 충분하다.
+- **개통의 유일한 전제는 #640 화면의 품질**이다. 개통 초기엔 사실상 모든 주문이 한 번씩 격리를 거치므로
+  "격리 → 매핑 등록 → 재수집" 한 바퀴가 몇 초 안에 끝나야 한다.
+- 재처리 트리거는 **화면이 조치 후 replay 를 호출**한다 (후보 A). Core 가 리스팅 생성 이벤트를 내고
+  channel-adapter 가 자가 재처리하는 안(후보 B)은 새 계약이 붙는 데 비해 원인 9종 중 `listing_not_found`
+  하나만 덮는다. replay 는 이미 멱등적이라(이미 수집됨 → `closed_already_collected`) 중복 클릭이 안전하다.
+- **shadow 점검을 개통 전에 한 번 끼운다** (§7). 문서만 보고 쓴 zod 의 정확성을 실 응답으로 바꾸는 유일한 수단이고,
+  킬스위치 덕분에 비용이 10분이다.
+
+## 4. 작업 단위와 배포 순서
+
+| # | 단위 | 앱 | 마이그레이션 |
+|---|---|---|---|
+| 1 | 취소 계약 + Core 소비자 (§5) | `@packages/event-contracts`, core | 0 |
+| 2 | `NaverOrderSource` (§6) | channel-adapter | 0 |
+| 3 | 격리 큐 화면 (§8) | admin-web (+ `@packages/domain-types`, channel-adapter 소폭) | 0 |
+
+**배포 순서: 1 → 2 → shadow(§7) → 3 → 개통.** 1이 2보다 먼저인 것은 안전 요건이다 (§5 마지막).
+개통은 코드가 아니라 `sales_channels.is_active` 를 올리는 운영 행위다.
+
+## 5. 취소 계약 + Core 소비자
+
+### 5.1 문제
+
+`OrderCancelledPayload` (`orders.stream.ts:118`) 에는 라인 범위가 없다. 그래서 소비자는 항상 전체 취소를 부른다
+(`order-events.consumer.ts:173`). 네이버는 `productOrder` 단위 부분취소가 흔하므로 그대로 두면 **멀쩡한 라인까지 취소**된다.
+
+Core 의 의미론은 이미 `lines` 유무로 갈린다 — `lines` 가 있으면 `cancelPartial`, 없으면 전체 취소
+(`sales-orders.service.ts:440,1211`). 그 축을 그대로 계약에 옮긴다.
+
+### 5.2 계약
+
+```ts
+// OrderCancelledPayload 에 선택 필드 추가
+cancelledLines?: Array<{ channelOrderItemId: string; quantity: number }>;
+```
+
+선택 필드 추가라 소비자 zod 런타임 검증에 걸리지 않는다 (값이 늘어나는 enum/literal 이 위험한 축이고, 이건 아니다).
+
+### 5.3 소비자
+
+`handleOrderCancelled` 가 `cancelledLines` 를 `sales_order_lines.channel_order_item_id` 로 조회해
+`salesOrderLineId` 로 바꾼 뒤 `cancel(id, { lines })` 로 넘긴다.
+`(salesOrderId, channelOrderItemId)` 부분 unique 인덱스가 있어 조회는 단건 확정이다.
+해석 실패는 `NotFoundException` — 이미 `nonRetryableErrors` 라 무한 재시도로 가지 않는다.
+
+### 5.4 배포 순서가 안전 요건인 이유
+
+**옛 Core 소비자는 `cancelledLines` 를 모르므로 부분취소를 전체 취소로 실행한다.** 조용한 데이터 사고다.
+따라서 `Core → channel-adapter` 순서가 강제이며, 네이버 개통은 그 뒤다.
+
+## 6. `NaverOrderSource` (#643)
+
+**파일**: `apps/channel-adapter/src/services/order-collection/naver-order.source.ts`,
+`implements ReplayableChannelOrderSource`, `readonly channel: SalesChannel = 'naver'`.
+등록은 `adapter.module.ts:269` provider 배열에 `createOrderProvider(naverSource, translator)` 한 줄.
+
+### 6.1 grain 이 어긋난다 — 조회가 3단계다
+
+네이버의 1급 단위는 `productOrderId`(라인)이고 `orderId`(주문)는 상위다. `getLastChangedStatuses` 는 **변경된 라인만** 준다.
+그대로 주문으로 접으면 3라인 주문 중 1라인만 바뀐 주기에 **라인이 하나뿐인 판매주문**이 Core 에 생긴다.
+
+```
+getLastChangedStatuses(since) → productOrderId[] → orderId 로 그룹핑
+  → orderId 마다 getProductOrderIdsByOrderId(orderId)   # 형제 라인 복원 (naver-order.client.ts:227)
+  → getOrderDetails(전체 productOrderIds)                # 상세 (naver-order.client.ts:187)
+```
+
+호출이 늘지만 주문량이 적으므로 완전성을 택한다.
+
+### 6.2 결제 상태
+
+CONTEXT.md:130 의 "결제 실패 위험을 벗어난 상태" 를 네이버에 대입한다.
+발주확인은 판매자의 수락 행위지 결제 위험이 아니므로 게이트로 쓰지 않는다.
+
+| 네이버 `productOrderStatus` | `ChannelPaymentState` |
+|---|---|
+| `PAYED` `DISPATCHED` `DELIVERING` `DELIVERED` `PURCHASE_DECIDED` | `accepted` |
+| `PAYMENT_WAITING` | `pending` |
+| `CANCELED` `CANCELED_BY_NOPAYMENT` `RETURNED` | `terminal` |
+
+`ProductOrderStatusSchema` 에 **`DISPATCHED` 를 추가**한다.
+
+### 6.3 취소 관측
+
+- 관측 시점에 **전 라인 취소** → full 1건 (`cancelledLines` 생략), `eventKey='cancelled'`.
+- **일부 취소** → 취소된 **라인마다** partial 1건, `eventKey='cancelled:<productOrderId>'`.
+  라인 단위 키라 중복 계수가 정확하다.
+- 환불(`OrderRefundCreated`)은 첫 판에서 제외한다. 네이버 클레임 상태 19종 해석은 별건이다.
+
+### 6.4 취소된 라인을 스냅샷에서 빼지 않는다
+
+**🔴 빼면 change hash 가 바뀌어 부분취소가 `collected_order_modification_not_accepted` 로 오격리되고,
+그 사유는 replay 가 거부한다** (`order-poller.orchestrator.ts:271`). 취소 이벤트와 이중 처리이기도 하다.
+
+따라서:
+
+- `ChannelOrderLineSnapshot` 에 `cancelled?: boolean` 을 더한다.
+- translator 의 `payload.items` 는 **살아있는 라인만** (최초 수집 시 죽은 라인을 계약에 넣지 않는다).
+- translator 의 `changes` 해시는 **전 라인 기준** — 취소가 modification 을 유발하지 않는다.
+
+Medusa 는 `cancelled` 를 쓰지 않아 값이 그대로다. 즉 기존 해시 계약이 깨지지 않으므로
+배포 직후 한 주기가 통째로 격리되는 사고가 없다 (`channel-order.translator.spec.ts` 가 그 계약을 못 박고 있다).
+
+### 6.5 라인 조립
+
+- `channelOrderItemId` = `productOrderId` — 발송처리 명령이 되돌려받는 값.
+- `channelProductId` = **옵션 단위 식별자 우선, 없으면 상품 식별자.** 정본 값은 §7 shadow 로 확정하고,
+  그때까지 후보를 상수 하나로 격리해 둔다. 운영자가 실제로 등록하는 값과 같아야 한다.
+- `productName` · `quantity` · `unitPrice` 는 채널 값을 싣는다 (금액은 채널이 SoT — CONTEXT.md:126).
+- `customerId` 는 `null` 고정. 네이버 구매자는 user-service 계정이 아니고, 이메일 링크는 오결합 위험 대비 이득이 없다.
+
+### 6.6 워터마크
+
+- `since=null`(최초) → `now - 1h`. 과거를 소급하면 이미 수기 처리된 주문이 중복 유입된다.
+- `since` 가 24시간보다 오래됐으면 `now - 24h` 로 clamp. 네이버 변경조회는 장기 구간을 거부한다.
+
+### 6.7 zod 전략과 실패 정책
+
+상세 스키마를 새로 쓴다. 저장소는 zod 4 이므로 `z.looseObject` 로 **우리가 읽는 필드만 검증하고 나머지는 통과**시킨다.
+
+문서 기반이라 필드명이 틀릴 수 있는데, 방어선은 **parse 실패를 삼키지 않는 것**이다.
+throw 하면 `recordSyncFailure` 가 남고 **워터마크가 그대로**라 5분 뒤 재시도된다 (무손실).
+격리 사유 union 을 늘리지 않는다 — 격리는 식별 실패의 어휘이지 파싱 실패의 어휘가 아니다.
+
+### 6.8 `fetchOrder(orderId)`
+
+같은 3단계의 단건 판. replay 가 이걸로 산다. 구현하지 않으면 `replayFailure` 가
+`No replayable order provider registered` 로 throw 하므로 **후처리 가능성 자체가 이 메서드에 달려 있다**.
+
+## 7. shadow 점검 (개통 전 1회, 10분)
+
+**목적**: 문서 기반 zod 를 실 응답으로 검증하고 `channelProductId` 정본 값을 확정한다.
+
+1. 배포 전 `sales_channels` 의 naver 행을 **`is_active=false`** 로 내린다.
+2. Core(§5) → channel-adapter(§6) 순으로 배포.
+3. naver 를 `is_active=true` 로 올리고 **한 주기(5분)만** 돌린 뒤 다시 내린다.
+4. 확인:
+   - `sync_statuses` naver/orders 행의 `last_sync_at` · `error` — parse 실패가 여기 남는다.
+   - `order_collection_failures where channel='naver'` — 행이 생겼는가, `affected_lines[].cause` 가 전부 `listing_not_found` 인가.
+   - 그 행의 **`raw_order`** 로 필드명·옵션 식별자 확인 → `channelProductId` 확정.
+   - `wms_order_mappings where sales_channel='naver'` 가 **0행**인가 (리스팅 0행이므로 판매주문은 안 생겨야 정상).
+
+넷 중 하나라도 어긋나면 §6 으로 돌아가 고치고 다시 shadow.
+
+**⚠️ shadow 와 개통 사이가 24시간을 넘으면 주문이 샌다.** shadow 가 워터마크를 남기는데 개통이 24시간 뒤면
+`now-24h` clamp 에 걸려 그 사이 주문이 조회 범위 밖으로 빠진다. 개통 직전에 하거나, 늦어지면 개통 전에
+naver/orders `sync_statuses` 행을 지워 최초 수집(`now-1h`)으로 되돌린다.
+shadow 에서 격리된 주문은 행이 남으므로 개통 후 화면에서 처리하면 된다.
+
+## 8. 격리 큐 운영 화면 (#640)
+
+**위치**: `/mall/channel-listings` 에 탭 2개 ("채널 리스팅" / "미매핑 주문").
+`page.tsx`(12줄) + `features/mall/channel-listings/template` 구조가 이미 있어 그 안에서 확장한다.
+
+**데이터 경로**: 기존 `/api/proxy/channel` 프록시 재사용.
+`lib/api/domains/` 에 `order-collection-failures.client.ts` 를 더하고 react-query 훅은 기존 패턴을 따른다.
+새 env · CORS · 게이트 없음.
+
+**목록**: 주문 단위 행 — 채널 / 외부주문번호 / 변경시각 / 사유 / 라인 수.
+기본 필터 `status=quarantined`, 나머지 3종(`replayed` `closed_lifecycle` `closed_already_collected`)은 "닫힘" 으로 접는다.
+`collected_order_modification_not_accepted` 행은 **재처리 버튼이 없는 별도 표시** —
+`replayFailure` 가 `not_replayable` 로 응답하는 사유라 버튼을 주면 헛수고다.
+
+**상세**: 라인별 `cause` → 조치 문구 + 조치 버튼.
+화면에서 바로 끝나는 것은 `listing_not_found`(매핑 생성) · `listing_inactive`(활성화) · `channel_inactive`(채널 활성화)이고,
+나머지는 문구로 안내만 한다. `affected_lines` 가 없는 옛 행은 "사유 없음" 을 정상 상태로 렌더한다.
+
+`no_active_version` 은 갈래를 판정하지 않고 둘 다 적는다 — Core `resolve` 는 "의도적 판매중지" 를 구분할 데이터를 주지 않는다:
+
+> 활성 버전이 없습니다. 판매를 재개하려면 publish, 판매중지가 맞다면 네이버에서 해당 상품을 내리세요.
+
+### 8.1 `AffectedLine` 에 `channelProductId` 를 더한다
+
+지금 `affected_lines` 는 `{ lineId, cause }` 뿐이고 `lineId` 는 주문 라인 ID(`productOrderId`)다.
+매핑 생성에 필요한 **채널상품ID 는 `raw_order` 안에만** 있어서, 프리필하려면 admin-web 이 채널별 원본 구조를 파싱해야 한다 —
+채널 지식이 프런트로 새는 결합이다.
+
+대신 `@packages/domain-types` 의 `AffectedLine` 에 선택 필드 `channelProductId?` 를 더한다.
+translator 는 해석에 실패한 바로 그 키를 손에 쥐고 있으므로 저장 비용이 0 이고,
+**"운영자가 등록하는 값 = 수집이 조회한 값" 이 구조적으로 보장된다** — #643 판정 1과 #640 프리필을
+한자리에서 맞추라는 요구가 이걸로 충족된다. 옛 행은 값이 없으므로 선택 필드다.
+
+### 8.2 조치 → 재처리
+
+조치 API 성공 후 `POST /adapter/order-collection-failures/:id/replay` 를 이어서 호출하고,
+응답 6종(`replayed` `already_processed` `still_quarantined` `closed_terminal` `closed_already_collected` `not_replayable`)을
+사람 말로 번역해 보여준다.
+
+### 8.3 격리 건수 배지
+
+lazy 매핑 전략이면 운영자가 큐를 놓치는 순간 그 주문의 출고가 멈춘다.
+사이드바 메뉴에 격리 건수 배지를 붙인다 (목록 API 의 `count` 재사용, 비용 0).
+알림·메일은 YAGNI 로 뺀다.
+
+## 9. 확정한 판정
+
+| # | 판정 | 결론 | 근거 |
+|---|---|---|---|
+| 1 | `channelProductId` 정본 값 | 옵션 단위 우선, **shadow 로 확정** | 옵션 상품이면 옵션 단위여야 variant 와 1:1 |
+| 2 | `paymentState` 경계 | `PAYED` 이후 accepted | CONTEXT.md:130 |
+| 3 | `customerId` | `null` 고정 | 네이버 구매자는 user-service 계정이 아니다 |
+| 4 | lifecycle 범위 | 취소 포함, 환불 제외 | 오출고 방지가 우선, 클레임 19종은 별건 |
+| 5 | 재처리 트리거 | 화면이 조치 후 replay 호출 | 원인 9종을 한 버튼으로 덮는다 |
+| 6 | 인증 경로 | 기존 `/api/proxy/channel` | 선례가 있고 auth 쿠키를 넘긴다 |
+| 7 | `no_active_version` 문구 | 두 갈래를 다 적는다 | 판정할 데이터가 없다 |
+| 8 | 개통 시퀀싱 | `is_active` 로 배포와 개통을 분리 | 폴러가 매 주기 활성 채널을 묻는다 |
+
+## 10. 함정
+
+- 🔴 **배포 전 naver `is_active` 를 내리지 않으면 배포 즉시 수집이 시작된다.**
+- 🔴 **Core 선배포를 어기면 부분취소가 전체 취소로 실행된다** (§5.4).
+- 🔴 **취소된 라인을 스냅샷에서 빼면 오격리 + 이중 처리** (§6.4).
+- 🔴 **`OrderFetchItem.changes` 에 네이버 원어를 넣지 말 것.** 해시 입력이라 모양이 바뀌면 한 주기 주문이 전부
+  `collected_order_modification_not_accepted` 로 격리되고 그 사유는 replay 가 거부한다.
+- ⚠️ shadow 와 개통 사이 24시간 (§7).
+- ⚠️ `sync_statuses.last_sync_at` 은 하트비트가 아니다. 폴링이 아무것도 못 잡으면 갱신되지 않는다 — 살아있는지는 `updated_at` 으로 본다.
+- ⚠️ 증분 수집은 워터마크에서 2분 되감아 조회한다. 중복은 `wms_order_mappings` + change hash 가 흡수한다.
+- ⚠️ `provider.channel as ChannelType` 캐스팅 때문에 `sync_statuses.channel_type` 에 `'naver'` 가 들어간다
+  (`ChannelType` union 은 `'naver_smartstore'`). 워터마크는 같은 값으로 읽고 쓰므로 동작은 맞지만,
+  옛 `naver_smartstore` 키로 보는 화면·대시보드에는 안 보인다.
+- ⚠️ admin-web 은 컴포넌트 테스트가 불가능하다 (렌더러 없음 + `.tsx` transform 밖).
+  **테스트가 초록이어도 배선이 살아있다는 근거가 되지 않는다.**
+
+## 11. 검증
+
+**자동**
+
+- `npm run type-check` → 0
+- `npx jest --maxWorkers=2` → 실패 0 (OOM 방지)
+- `npm run test:admin-web` → 실패 0
+- `naver-order.source.spec.ts` — 문서 기반 픽스처로:
+  ① 3라인 중 1라인만 변경돼도 3라인이 조립되는가 ② 부분취소 시 lifecycle 이 라인 단위로 나가는가
+  ③ 전체취소 시 terminal + full 취소 1건 ④ 미지 상태값에서 throw ⑤ `since=null` 바닥값과 24h clamp
+- translator 스펙 — 취소 라인이 `items` 에서 빠지고 `changes` 해시에는 남는가
+- Core 소비자 스펙 — `cancelledLines` → `salesOrderLineId` 해석, 해석 실패 시 `NotFoundException`
+- admin-web `.ts` 순수 함수 스펙 — 사유→조치 문구, 상태→재처리 가능 여부, replay 결과→문구, 필터 조립
+
+**수동 (유일한 방어선)**
+
+- 브라우저: 빈 목록 / `affected_lines` 없는 옛 행 / 라인 여러 개 / `not_replayable` 건 / 프리필 후 생성 → 자동 재처리
+- 개통 후: 폴러 `updated_at` age, `failed_syncs` +0, 신규 격리 건수, 첫 격리 건의 해소 한 바퀴
+
+## 12. 미결 / 후속
+
+- **부분취소 누적이 전량에 도달하는 경계.** `lines` 를 주면 항상 `cancelPartial` 이고, 누적이 전량이 돼도
+  주문 상태를 `cancelled` 로 닫지 않는다 (`sales-orders.service.ts:1217-`). 마지막 라인이 취소되는 순간
+  full cancel 이 오면 Core 가 "남은 수량만" 취소하는지 확인이 필요하다. 안전하지 않으면
+  "전량 취소 시 주문 종결" 은 채널과 무관한 Core 도메인 규칙으로 별건 처리한다 — admin 수기 부분취소에도 같은 구멍이다.
+- **환불 lifecycle** (`OrderRefundCreated`) — 네이버 클레임 상태 19종 해석과 함께 별건.
+- **`/channel-listings/lookup` 폴백 제거** — Core `/resolve` 배포가 안정된 뒤 후속 PR.
+- **#641** (`variantCode` notNull 승격 + 리스팅 키 이관) — 장기, 이 작업과 독립.
+- **#665** (publish 중 동시 `createListing` 레이스) — 개통 후 창이 넓어진다.

--- a/docs/superpowers/specs/2026-08-19-naver-order-collection-activation-design.md
+++ b/docs/superpowers/specs/2026-08-19-naver-order-collection-activation-design.md
@@ -28,6 +28,23 @@ ADR-0031 이 수집 경로를 `OrderPollerOrchestrator → ChannelOrderSource �
 | 라인의 채널 좌표도 이미 있다 | `inventory.schema.ts:1324,1343` (`channel_order_item_id` + 부분 unique), `channel-order.translator.ts:116` | 채널 라인 ID → `salesOrderLineId` 해석이 단건 확정이다 |
 | 옛 `/adapter` REST 는 읽기 전용이다 | `channel-adapter.controller.ts` 의 `queryOrders` 는 `channelReader.findOrders` 만 부른다 | 이중 수집 위험 없음 |
 
+### 2.1 커머스API 문서에서 확정한 제약
+
+`/home/pauseb/문서/naver_llms.txt` 인덱스와 그것이 가리키는 endpoint·위키 문서에서 확정한 것들이다.
+
+| 제약 | 출처 | 영향 |
+|---|---|---|
+| 변경 피드의 조회 창은 `lastChangedFrom` + 24시간 (`lastChangedTo` 생략 시 자동) | last-changed-statuses 문서 | 워터마크를 앞으로 clamp 하면 **데이터 손실**. 창을 이동시켜야 한다 (§6.6) |
+| `limitCount` 는 300 캡, 초과분은 `more{moreFrom,moreSequence}` 로 이어받는다 | 같은 문서 | 현재 클라이언트는 `more` 를 읽지 않아 **조용히 잘린다** (§6.6.1) |
+| 상세 조회는 식별자 단위로 일부만 실패할 수 있다 | product-orders/query 문서 | 요청/응답 개수 비교가 필수 (§6.7) |
+| `productOrderStatus` 와 `lastChangedType` 은 **다른 축**이다 | 주문 상태 변경 흐름도 | `DISPATCHED` 는 후자의 값 — 초안의 처방이 틀렸다 (§6.2) |
+| 취소 요청 중에도 `productOrderStatus` 는 `PAYED` 다 | 같은 문서, 분기 C | 취소 요청 중 주문이 출고로 흘러가는 것을 막아야 한다 (§6.2) |
+| 판매자관리코드는 고유성을 보장하지 않는다 | 스마트스토어 상품 가이드 | 식별자 후보에서 제외 (§6.5) |
+| 원상품번호와 채널상품번호는 숫자가 겹칠 수 있다 | 같은 문서 | 리스팅 키를 한 종류로 고정해야 한다 (§6.5) |
+| `productOrder`·`order`·`cancel` 의 하위 구조는 문서에 없다 (OAS 참조, OAS 는 비공개 경로) | 각 endpoint 문서 | **shadow 가 필드명 확정 단계로 승격** (§7) |
+
+`llms.txt` 인덱스는 2026-08-19 기준 원본과 동일함을 확인했다(`diff` 일치).
+
 ## 3. 전략
 
 **운영 전략은 lazy 매핑이다** (사용자 결정). 사전 전량 매핑을 하지 않고, 미매핑 주문이 들어올 때마다 그 자리에서 등록한다.
@@ -112,11 +129,22 @@ CONTEXT.md:130 의 "결제 실패 위험을 벗어난 상태" 를 네이버에 �
 
 | 네이버 `productOrderStatus` | `ChannelPaymentState` |
 |---|---|
-| `PAYED` `DISPATCHED` `DELIVERING` `DELIVERED` `PURCHASE_DECIDED` | `accepted` |
+| `PAYED` `DELIVERING` `DELIVERED` `PURCHASE_DECIDED` | `accepted` |
 | `PAYMENT_WAITING` | `pending` |
-| `CANCELED` `CANCELED_BY_NOPAYMENT` `RETURNED` | `terminal` |
+| `CANCELED` `CANCELED_BY_NOPAYMENT` `RETURNED` `EXCHANGED` | `terminal` |
 
-`ProductOrderStatusSchema` 에 **`DISPATCHED` 를 추가**한다.
+🔴 **`DISPATCHED` 를 `ProductOrderStatusSchema` 에 추가하면 안 된다** (초안의 오류).
+`DISPATCHED` 는 `productOrderStatus` 값이 아니라 **`lastChangedType` 값**이다 (상태 흐름도 §용어).
+두 축이 다르다 — 발송 완료 시 `productOrderStatus` 는 `DELIVERING` 이고 `lastChangedType` 이 `DISPATCHED` 다.
+옛 `mapNaverStatusToInternal`(`naver-smartstore.adapter.ts:756`)이 둘을 한 표에 섞은 것이 오해의 출처다.
+
+대신 **`lastChangedType` enum 을 새로 정의**한다 (변경 피드 응답용):
+`PAY_WAITING` `PAYED` `DISPATCHED` `CANCEL_REQUESTED` `CLAIM_REQUESTED` `CLAIM_REJECTED` `CLAIM_COMPLETED` `PURCHASE_DECIDED`.
+
+**취소 요청 중은 `accepted` 로 보지 않는다.** `claimStatus` 가 `CANCEL_REQUEST` 또는 `CANCELING` 이면
+`productOrderStatus` 는 아직 `PAYED` 다 (상태 흐름도 분기 C). 그대로 두면 고객이 취소를 원하는 주문이
+출고 파이프라인에 올라간다. `MedusaOrderSource.resolvePaymentState` 의 `isRefundRequested` 방어와 대칭으로
+이 경우 `pending` 으로 낮춘다. 이미 수집된 주문에는 영향이 없고, 첫 수집을 막는 것이 목적이다.
 
 ### 6.3 취소 관측
 
@@ -142,21 +170,53 @@ Medusa 는 `cancelled` 를 쓰지 않아 값이 그대로다. 즉 기존 해시 
 ### 6.5 라인 조립
 
 - `channelOrderItemId` = `productOrderId` — 발송처리 명령이 되돌려받는 값.
-- `channelProductId` = **옵션 단위 식별자 우선, 없으면 상품 식별자.** 정본 값은 §7 shadow 로 확정하고,
+- `channelProductId` = **옵션 단위 식별자 우선, 없으면 채널상품번호.** 정본 값은 §7 shadow 로 확정하고,
   그때까지 후보를 상수 하나로 격리해 둔다. 운영자가 실제로 등록하는 값과 같아야 한다.
+  상품 가이드에서 확정된 제약 둘이 후보를 좁힌다:
+  - 🔴 **판매자관리코드는 식별자로 쓸 수 없다.** 문서가 명시한다 — *"여러 상품에 동일한 판매자관리코드를
+    입력할 수 있으며 스마트스토어 상품번호와 달리 식별자로서의 고유성을 보장하지 않습니다."*
+    ADR-0031 이 네이버를 `embedded` 가 아니라 `mapped` 로 둔 선택이 이 사실로 뒷받침된다.
+  - 🔴 **원상품번호(`originProductNo`)와 채널상품번호(`channelProductNo`)는 숫자가 겹칠 수 있다.**
+    문서가 "서로 다른 상품을 가리킨다" 고 못 박는다. `channel_variant_listings` 는
+    `(salesChannelId, channelItemId)` unique 이므로 두 종류를 섞어 저장하면 충돌한다 —
+    **주문에 실리는 한 종류로 고정**하고 그 종류를 화면 프리필과 공유한다.
 - `productName` · `quantity` · `unitPrice` 는 채널 값을 싣는다 (금액은 채널이 SoT — CONTEXT.md:126).
 - `customerId` 는 `null` 고정. 네이버 구매자는 user-service 계정이 아니고, 이메일 링크는 오결합 위험 대비 이득이 없다.
 
-### 6.6 워터마크
+### 6.6 워터마크와 조회 창
 
 - `since=null`(최초) → `now - 1h`. 과거를 소급하면 이미 수기 처리된 주문이 중복 유입된다.
-- `since` 가 24시간보다 오래됐으면 `now - 24h` 로 clamp. 네이버 변경조회는 장기 구간을 거부한다.
+- 🔴 **초안의 "`now-24h` 로 clamp" 는 틀렸다 — 데이터 손실이다.** 변경 피드는 `lastChangedTo` 를 생략하면
+  **`lastChangedFrom` + 24시간**이 자동 적용된다. 즉 24시간은 "얼마나 과거까지 허용되는가" 가 아니라
+  **한 번에 볼 수 있는 창의 길이**다. 워터마크를 앞으로 점프시키면 그 사이 주문이 영영 조회 범위 밖으로 빠진다.
+- 올바른 처리: **창을 `[since, min(since + 24h, now)]` 로 잡고 워터마크가 걸어서 따라잡게 한다.**
+  폴러가 오래 죽어 있었어도 5분마다 24시간씩 전진하므로 자동 복구된다.
+
+### 6.6.1 `more` 페이징은 선택이 아니다
+
+`limitCount` 는 **300 에서 캡**되고, 남은 항목이 있으면 응답에 `more { moreFrom, moreSequence }` 가 실린다.
+**지금 클라이언트는 `limitCount: 300` 을 하드코딩하고 `more` 를 읽지 않는다**(`naver-order.client.ts:171-181`) —
+한 창에 300건이 넘으면 **조용히 잘린다**. source 가 `more` 를 따라 루프를 돌아야 한다.
+같은 일시에 묶인 항목을 중복 없이 이어받으려면 `moreFrom` 과 `moreSequence` 를 **함께** 넘겨야 한다.
 
 ### 6.7 zod 전략과 실패 정책
 
 상세 스키마를 새로 쓴다. 저장소는 zod 4 이므로 `z.looseObject` 로 **우리가 읽는 필드만 검증하고 나머지는 통과**시킨다.
 
-문서 기반이라 필드명이 틀릴 수 있는데, 방어선은 **parse 실패를 삼키지 않는 것**이다.
+**필드명은 문서로 확정할 수 없다.** 커머스API 의 `llms/*.md` 문서는 `productOrder`·`order`·`cancel` 의
+하위 구조를 "생략 (상세는 OAS 참조)" 로 처리하고, OAS 자체는 공개 경로에서 받을 수 없었다.
+따라서 **§7 shadow 가 필드명 확정 단계로 승격된다** — 초안처럼 "문서로 쓰고 shadow 로 검증" 이 아니라
+"뼈대만 문서로 쓰고 shadow 에서 필드를 확정" 이다.
+
+문서에서 새어 나온 확정 사실 하나: `productOrder.shippingAddress` 는 존재하며
+`pickupLocationType`(`FRONT_OF_DOOR` `MANAGEMENT_OFFICE` `DIRECT_RECEIVE` `OTHER`)와
+`entryMethod`(`LOBBY_PW` `MANAGEMENT_OFFICE` `FREE` `OTHER`)를 갖는다 (query endpoint 의 enum 카탈로그).
+
+**응답 누락을 검증한다.** 문서가 "한 요청에서 식별자 단위로 일부만 조회 실패할 수 있으므로 응답 길이와
+요청 길이를 비교해 누락 여부를 확인" 하라고 명시한다. 요청한 `productOrderIds` 수와 응답 수가 다르면
+그 주기를 실패로 처리한다 — 조용히 빠진 라인으로 주문을 조립하면 §6.1 이 막으려던 사고가 다시 난다.
+
+방어선은 **parse 실패를 삼키지 않는 것**이다.
 throw 하면 `recordSyncFailure` 가 남고 **워터마크가 그대로**라 5분 뒤 재시도된다 (무손실).
 격리 사유 union 을 늘리지 않는다 — 격리는 식별 실패의 어휘이지 파싱 실패의 어휘가 아니다.
 
@@ -167,7 +227,9 @@ throw 하면 `recordSyncFailure` 가 남고 **워터마크가 그대로**라 5�
 
 ## 7. shadow 점검 (개통 전 1회, 10분)
 
-**목적**: 문서 기반 zod 를 실 응답으로 검증하고 `channelProductId` 정본 값을 확정한다.
+**목적**: **응답 필드명을 확정하고** `channelProductId` 정본 값을 정한다.
+초안은 이 단계를 "검증" 으로 뒀지만, 커머스API 문서가 중첩 구조를 생략하므로(§6.7)
+이 단계 없이는 스키마를 완성할 수 없다. **선택이 아니라 필수 경로다.**
 
 1. 배포 전 `sales_channels` 의 naver 행을 **`is_active=false`** 로 내린다.
 2. Core(§5) → channel-adapter(§6) 순으로 배포.
@@ -175,7 +237,11 @@ throw 하면 `recordSyncFailure` 가 남고 **워터마크가 그대로**라 5�
 4. 확인:
    - `sync_statuses` naver/orders 행의 `last_sync_at` · `error` — parse 실패가 여기 남는다.
    - `order_collection_failures where channel='naver'` — 행이 생겼는가, `affected_lines[].cause` 가 전부 `listing_not_found` 인가.
-   - 그 행의 **`raw_order`** 로 필드명·옵션 식별자 확인 → `channelProductId` 확정.
+   - 그 행의 **`raw_order`** 를 떠서 확정한다:
+     ① `productOrder` 의 상품 식별자 필드명과 값의 종류(원상품번호인가 채널상품번호인가)
+     ② 옵션 상품이라면 옵션 단위 식별자 필드가 있는가 — 없으면 매핑 grain 이 상품 단위로 내려가고,
+        그때는 한 리스팅에 variant 가 여럿 붙는 문제를 어떻게 다룰지 별도 판단이 필요하다
+     ③ 금액·수량·배송지 필드명 ④ `claimStatus`/`claimType` 이 실리는 자리
    - `wms_order_mappings where sales_channel='naver'` 가 **0행**인가 (리스팅 0행이므로 판매주문은 안 생겨야 정상).
 
 넷 중 하나라도 어긋나면 §6 으로 돌아가 고치고 다시 shadow.
@@ -250,6 +316,8 @@ lazy 매핑 전략이면 운영자가 큐를 놓치는 순간 그 주문의 출�
 - 🔴 **취소된 라인을 스냅샷에서 빼면 오격리 + 이중 처리** (§6.4).
 - 🔴 **`OrderFetchItem.changes` 에 네이버 원어를 넣지 말 것.** 해시 입력이라 모양이 바뀌면 한 주기 주문이 전부
   `collected_order_modification_not_accepted` 로 격리되고 그 사유는 replay 가 거부한다.
+- 🔴 **워터마크를 `now-24h` 로 clamp 하지 말 것** — 24시간은 창 길이지 허용 과거가 아니다 (§6.6).
+- 🔴 **`more` 를 무시하면 한 창 300건 초과분이 조용히 사라진다** (§6.6.1).
 - ⚠️ shadow 와 개통 사이 24시간 (§7).
 - ⚠️ `sync_statuses.last_sync_at` 은 하트비트가 아니다. 폴링이 아무것도 못 잡으면 갱신되지 않는다 — 살아있는지는 `updated_at` 으로 본다.
 - ⚠️ 증분 수집은 워터마크에서 2분 되감아 조회한다. 중복은 `wms_order_mappings` + change hash 가 흡수한다.

--- a/packages/domain-types/listing-resolution-cause.ts
+++ b/packages/domain-types/listing-resolution-cause.ts
@@ -48,4 +48,10 @@ export function toListingResolutionCause(value: unknown): ListingResolutionCause
 export interface AffectedLine {
   lineId: string;
   cause: ListingResolutionCause;
+  /**
+   * 해석에 **실제로 쓴** 조회 키. 운영 화면의 "채널상품ID" 프리필이 이 값을 쓴다.
+   * 원본(`raw_order`)을 프런트가 파싱하지 않게 하려는 것이고, 그 덕에 "운영자가 등록하는 값"과
+   * "수집이 조회한 값"이 구조적으로 같아진다. 옛 행에는 없으므로 선택 필드다.
+   */
+  channelProductId?: string;
 }

--- a/packages/event-contracts/streams/orders.stream.spec.ts
+++ b/packages/event-contracts/streams/orders.stream.spec.ts
@@ -65,3 +65,39 @@ describe('ORDER_STREAM external line identity', () => {
     expect(() => schema.parse(payload([item]))).toThrow();
   });
 });
+
+describe('OrderCancelled 계약', () => {
+  const schema = ORDER_STREAM.events.OrderCancelled.schema!;
+
+  const base = {
+    orderId: 'ord_1',
+    reason: 'CUSTOMER_REQUEST' as const,
+    cancelledBy: 'naver',
+    cancelledAt: '2026-08-19T00:00:00.000Z',
+    refundRequired: true,
+  };
+
+  it('cancelledLines 없이도 통과한다 (전체 취소)', () => {
+    expect(schema.safeParse(base).success).toBe(true);
+  });
+
+  it('cancelledLines 가 있으면 통과한다 (부분 취소)', () => {
+    const result = schema.safeParse({
+      ...base,
+      cancelledLines: [{ channelOrderItemId: '2026081900001', quantity: 2 }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('빈 배열은 거부한다 — 전체 취소는 필드를 생략해서 표현한다', () => {
+    expect(schema.safeParse({ ...base, cancelledLines: [] }).success).toBe(false);
+  });
+
+  it('수량 0 이하를 거부한다', () => {
+    const result = schema.safeParse({
+      ...base,
+      cancelledLines: [{ channelOrderItemId: '2026081900001', quantity: 0 }],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/event-contracts/streams/orders.stream.ts
+++ b/packages/event-contracts/streams/orders.stream.ts
@@ -133,6 +133,14 @@ export interface OrderCancelledPayload {
   refundRequired: boolean;
   refundAmount?: number;
 
+  /**
+   * 부분 취소 범위 (네이버 개통). **생략 = 전체 취소** 이며, 이는 Core 의
+   * `CancelSalesOrderDto.lines` 유무 규칙과 같은 축이다 (`sales-orders.service.ts:440`).
+   * 값은 채널이 소유한 라인 식별자이고, Core 가 `sales_order_lines.channel_order_item_id`
+   * 로 자기 PK 를 찾는다. 선택 필드라 이 필드를 모르는 옛 메시지도 계속 통과한다.
+   */
+  cancelledLines?: Array<{ channelOrderItemId: string; quantity: number }>;
+
   // 재고 복원 정보
   stockRestorationResults?: Array<{
     orderItemId: string;
@@ -287,6 +295,15 @@ const OrderCancelledSchema = z.object({
   cancelledAt: z.string().datetime(),
   refundRequired: z.boolean(),
   refundAmount: z.number().nonnegative().optional(),
+  cancelledLines: z
+    .array(
+      z.object({
+        channelOrderItemId: z.string().min(1),
+        quantity: z.number().int().positive(),
+      }),
+    )
+    .min(1)
+    .optional(),
   stockRestorationResults: z
     .array(
       z.object({


### PR DESCRIPTION
ADR-0031 이 비워둔 네이버 `ChannelOrderSource` 자리를 채우고, 미매핑 주문 격리 큐에 운영 화면을 붙인다. 설계는 `docs/superpowers/specs/2026-08-19-naver-order-collection-activation-design.md`, 실행 계획은 `docs/superpowers/plans/2026-08-19-naver-order-collection-activation.md`.

Closes #643, #640.

## 무엇이 들어있나

**1. 취소 계약 + Core 소비자** (Core 선배포 대상)
- `OrderCancelledPayload` 에 선택 필드 `cancelledLines` 추가. Core 가 이미 `CancelSalesOrderDto.lines` 유무로 전체/부분을 가르므로 그 축을 그대로 이벤트에 옮겼다.
- 소비자가 채널 라인 ID 를 `sales_order_lines.channel_order_item_id` 로 해석해 부분취소로 위임한다. 해석되지 않는 라인은 건너뛰고(경고 로그), 하나도 해석되지 않으면 no-op — 판매주문 계약은 수락 후 불변이므로 "그 주문에 없는 라인" 은 애초에 수락된 적이 없다.

**2. `NaverOrderSource`**
- 변경 피드가 *라인* 단위라 주문 전체를 조립하려면 형제 라인 복원이 필요하다: `getLastChangedStatuses` → `orderId` 그룹핑 → `getProductOrderIdsByOrderId` → `getOrderDetails`. 상세 응답은 요청 id 집합과 **정확히** 일치해야 하며(결손·이물 모두 거부), 어긋나면 throw.
- 조회 창은 `[since, min(since+24h, now)]` 를 걸어가고 `more` 커서를 따라간다. **24시간은 창의 길이지 허용 과거가 아니다** — 앞으로 clamp 하면 그 사이 변경이 유실된다.
- 파싱 실패는 **주문 단위**로 격리한다. 사이클 단위로 던지면 불량 주문 1건이 채널 수집을 영구 정지시킨다.
- 취소: 전 라인 취소면 full 1건, 일부면 라인마다 partial 1건. 반품/교환 완료는 계약에서 빠지되 **취소 이벤트를 내지 않는다**(Core 가 출고완료 주문의 취소를 거부해 DLQ 가 된다).
- 필드명은 아직 실 응답으로 확정되지 않았고, `naver-order-fields.ts` **한 파일에 격리**돼 있다. 확정 작업은 후속.

**3. 격리 큐 운영 화면** (`/mall/channel-listings` 미매핑 주문 탭)
- 라인별 사유 → 조치 문구, 매핑 생성 다이얼로그 프리필(채널 UUID 해석 포함), 조치 후 자동 재처리, 사이드바 배지.
- 판정 로직은 전부 `.ts` 순수 함수다 — admin-web 은 렌더러가 없어 컴포넌트 테스트가 불가능하므로, `.tsx` 에 남은 판단은 영구 미검증이 된다.

## 배포

**순서: Core → channel-adapter → admin-web.** 어기면 옛 Core 소비자가 `cancelledLines` 를 모른 채 **부분취소를 전체취소로 실행**한다.

**마이그레이션 0건.** 개통은 코드가 아니라 `sales_channels.is_active` 다 — 배포해도 그 값이 false 면 아무 일도 일어나지 않는다.

## 리뷰가 잡은 것

태스크별 리뷰 12회 + 브랜치 전체 리뷰 1회. 전체 리뷰는 처음에 **병합 불가** 판정이었고 Critical 1 + Important 6 을 수정한 뒤 병합 권고로 바뀌었다.

가장 값진 지적은 **격리 화면이 항상 비어 있었다**는 것이다 — axios 인터셉터가 이미 벗기는 `{success,data}` 봉투를 클라이언트가 한 번 더 벗겨 목록이 영구 빈 배열이었다. 제네릭 단언이라 tsc 가 못 잡았고 admin-web 은 컴포넌트 테스트가 없어 **486개 테스트가 전부 초록인 채로 통과했다.**

변경 해시 관련 3건(`changes.totalAmount` 가 취소에 반응 / 생성 시점과 이후 폴의 해시 입력 불일치 / lifecycle 중복 판정이 payload 해시)도 같은 뿌리에서 나왔고, 셋 다 "운영자가 닫을 수 없는 격리" 를 만들고 있었다. **Medusa 의 해시 입력은 바이트 단위로 불변**임을 반증 실행으로 확인했다(구현을 되돌리면 새 테스트만 빨개지고 무영향 근거 스펙은 양쪽에서 통과).

## 검증

- `npm run type-check` → 0
- `npx jest --maxWorkers=2` → 439 suites / 3702 passed / 0 failed
- `npm run test:admin-web` → 71 suites / 499 passed
- `npx tsc -p apps/admin-web/tsconfig.json --noEmit` → 기존 `sanitize-html` 1건뿐 (이 브랜치 이전부터 존재)

## 병합 후 남는 일

1. 🔴 **라이브 네이버 크레덴셜이 자리표시자다.** `deployments/lcnine/services/infra/services.ts:242-244` 가 `NAVER_API_ENDPOINT: 'https://dummy.com'`, client id/secret 이 `'1'` 이다. 실측으로 확인했다 — 수집을 켜면 405 로 실패한다(사이클 단위 실패라 워터마크는 보존, 유실 없음). 엔드포인트는 `/external/v1` 까지 포함해야 하고, id/secret 은 인라인이 아니라 `sst secret` 으로 가야 한다.
2. **shadow 점검** — 실 응답으로 필드명 확정. `order_collection_failures.raw_order` 가 채널 원문을 담도록 되어 있어 그 확인이 가능하다. 확인 항목에 "취소된 상품주문의 `totalPaymentAmount` 가 0인지" 를 포함할 것 — 0이라면 해시 총액이 다시 흔들려 재처리 불가 격리가 재현된다(해소는 한 줄, `allLinesTotal` 을 `unitPrice*quantity` 로 도출).
3. **브라우저 수동 확인 10건** — admin-web 배선의 유일한 방어선.
4. 반품/교환 lifecycle 은 의도적으로 미모델링.

https://claude.ai/code/session_01XqTYCx48kkXkKVuvBhHRWD
