### PR TITLE
perf(channel-adapter): 카테고리 조상 재보장을 내용이 바뀔 때만 수행한다

### DIFF
--- a/apps/channel-adapter/scripts/backfill-v2.ts
+++ b/apps/channel-adapter/scripts/backfill-v2.ts
@@ -33,6 +33,7 @@ import { MigrationSessionService } from './lib/migration-session.service';
 import { syncWithRetry, classifyError } from './lib/error-classifier';
 import { PimMedusaSyncService } from '../src/adapters/medusa/pim-medusa-sync.service';
 import { StorefrontRevalidateService } from '../src/adapters/medusa/storefront-revalidate.service';
+import { CategoryEnsureMemoService } from '../src/adapters/medusa/category-ensure-memo.service';
 import { DeferredRevalidateService } from '../src/adapters/medusa/deferred-revalidate.service';
 import { MedusaClient } from '../src/adapters/medusa/medusa.client';
 import { PimMedusaMappingRepository } from '../src/adapters/medusa/pim-medusa-mapping.repository';
@@ -198,6 +199,7 @@ async function main() {
     mappingRepo,
     revalidateSvc,
     new DeferredRevalidateService(revalidateSvc, new ConfigService()),
+    new CategoryEnsureMemoService(new ConfigService()),
   );
 
   // 카테고리/태그/타입/세일즈채널 캐시를 미리 채워 product 당 list/verify HTTP 호출을

--- a/apps/channel-adapter/scripts/retry-failed.ts
+++ b/apps/channel-adapter/scripts/retry-failed.ts
@@ -24,6 +24,7 @@ import { MedusaClient } from '../src/adapters/medusa/medusa.client';
 import { PimMedusaMappingRepository } from '../src/adapters/medusa/pim-medusa-mapping.repository';
 import type { StorefrontRevalidateService } from '../src/adapters/medusa/storefront-revalidate.service';
 import type { DeferredRevalidateService } from '../src/adapters/medusa/deferred-revalidate.service';
+import { CategoryEnsureMemoService } from '../src/adapters/medusa/category-ensure-memo.service';
 import type { PimProductSnapshot } from '../src/types';
 import { eq, and } from 'drizzle-orm';
 
@@ -105,6 +106,7 @@ async function main() {
     mappingRepo,
     noopStorefrontRevalidate,
     noopDeferredRevalidate,
+    new CategoryEnsureMemoService(configService),
   );
 
   try {

--- a/apps/channel-adapter/src/adapter.module.ts
+++ b/apps/channel-adapter/src/adapter.module.ts
@@ -72,6 +72,7 @@ import { MedusaClient } from './adapters/medusa/medusa.client';
 import { PimMedusaSyncService } from './adapters/medusa/pim-medusa-sync.service';
 import { StorefrontRevalidateService } from './adapters/medusa/storefront-revalidate.service';
 import { DeferredRevalidateService } from './adapters/medusa/deferred-revalidate.service';
+import { CategoryEnsureMemoService } from './adapters/medusa/category-ensure-memo.service';
 import { MembershipMedusaSyncService } from './adapters/medusa/membership-medusa-sync.service';
 import { PimProductEventConsumer } from './consumers/pim-product-event.consumer';
 import { PimCategoryConsumer } from './consumers/pim-category.consumer';
@@ -265,6 +266,7 @@ const NO_KAFKA_PUBLISHER_STREAMS: StreamConfig[] = [
     MembershipEventConsumer,
     PimMedusaMappingRepository,
     DeferredRevalidateService,
+    CategoryEnsureMemoService,
     InboxWorkerService,
 
     // 주문 수집 (ADR-0031: source 는 채널 원어, 번역·식별·격리는 공용)

--- a/apps/channel-adapter/src/adapters/medusa/category-ensure-memo.service.spec.ts
+++ b/apps/channel-adapter/src/adapters/medusa/category-ensure-memo.service.spec.ts
@@ -1,0 +1,78 @@
+import { CategoryEnsureMemoService } from './category-ensure-memo.service';
+
+const config = (maxEntries?: number) => ({ get: () => maxEntries }) as never;
+
+describe('CategoryEnsureMemoService', () => {
+  let memo: CategoryEnsureMemoService;
+  let ensure: jest.Mock<Promise<void>, []>;
+
+  beforeEach(() => {
+    memo = new CategoryEnsureMemoService(config());
+    ensure = jest.fn().mockResolvedValue(undefined);
+  });
+
+  it('같은 카테고리를 같은 내용으로 다시 보장하면 건너뛴다', async () => {
+    await memo.ensureOnce('c1', { name: 'A' }, ensure);
+    await memo.ensureOnce('c1', { name: 'A' }, ensure);
+
+    expect(ensure).toHaveBeenCalledTimes(1);
+  });
+
+  it('내용이 바뀌면 다시 보장한다', async () => {
+    await memo.ensureOnce('c1', { name: 'A' }, ensure);
+    await memo.ensureOnce('c1', { name: 'B' }, ensure);
+
+    expect(ensure).toHaveBeenCalledTimes(2);
+  });
+
+  it('보장이 실패하면 기억하지 않는다 — 실패한 상태로 굳으면 다음 이벤트까지 안 고쳐진다', async () => {
+    ensure.mockRejectedValueOnce(new Error('medusa down'));
+
+    await expect(memo.ensureOnce('c1', { name: 'A' }, ensure)).rejects.toThrow('medusa down');
+    await memo.ensureOnce('c1', { name: 'A' }, ensure);
+
+    expect(ensure).toHaveBeenCalledTimes(2);
+  });
+
+  it('키 순서만 다른 같은 내용은 같은 것으로 본다 — 스냅샷 조립 순서에 판정이 흔들리면 안 된다', async () => {
+    await memo.ensureOnce('c1', { name: 'A', sortOrder: 1 }, ensure);
+    await memo.ensureOnce('c1', { sortOrder: 1, name: 'A' }, ensure);
+
+    expect(ensure).toHaveBeenCalledTimes(1);
+  });
+
+  it('중첩된 객체의 키 순서도 무시한다', async () => {
+    await memo.ensureOnce('c1', { meta: { a: 1, b: 2 } }, ensure);
+    await memo.ensureOnce('c1', { meta: { b: 2, a: 1 } }, ensure);
+
+    expect(ensure).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidate 한 카테고리는 다시 보장한다 — 삭제처럼 메모 밖에서 바뀐 경우가 있다', async () => {
+    await memo.ensureOnce('c1', { name: 'A' }, ensure);
+    memo.invalidate('c1');
+    await memo.ensureOnce('c1', { name: 'A' }, ensure);
+
+    expect(ensure).toHaveBeenCalledTimes(2);
+  });
+
+  it('상한을 넘기면 오래된 항목부터 버린다', async () => {
+    const capped = new CategoryEnsureMemoService(config(2));
+
+    await capped.ensureOnce('c1', { name: 'A' }, ensure);
+    await capped.ensureOnce('c2', { name: 'B' }, ensure);
+    await capped.ensureOnce('c3', { name: 'C' }, ensure);
+    await capped.ensureOnce('c1', { name: 'A' }, ensure);
+
+    expect(ensure).toHaveBeenCalledTimes(4);
+  });
+
+  it('상한이 0 이면 메모를 끈다 — 킬스위치', async () => {
+    const disabled = new CategoryEnsureMemoService(config(0));
+
+    await disabled.ensureOnce('c1', { name: 'A' }, ensure);
+    await disabled.ensureOnce('c1', { name: 'A' }, ensure);
+
+    expect(ensure).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/channel-adapter/src/adapters/medusa/category-ensure-memo.service.ts
+++ b/apps/channel-adapter/src/adapters/medusa/category-ensure-memo.service.ts
@@ -1,0 +1,94 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+const DEFAULT_MAX_ENTRIES = 5000;
+
+/**
+ * 키 순서에 흔들리지 않는 표준형. 스냅샷은 여러 자리에서 조립되므로 같은 내용이
+ * 다른 키 순서로 올 수 있고, 그때 재보장이 일어나면 이 메모가 무의미해진다.
+ */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const source = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(source)
+        .sort()
+        .map((key) => [key, canonicalize(source[key])]),
+    );
+  }
+
+  return value;
+}
+
+/**
+ * 카테고리 보장(ensure)을 내용이 바뀌었을 때만 실제로 수행한다.
+ *
+ * CategoryChanged 핸들러는 이벤트마다 조상 체인을 루트부터 다시 보장하는데, 한 부모의
+ * 자손 96건이 한꺼번에 들어오면 그 부모를 똑같은 내용으로 96번 다시 쓴다 (실측 2026-08-14:
+ * 이벤트당 Medusa 카테고리 호출 8.2회 중 약 64%가 조상 재보장, POST 갱신만 이벤트당 2.62회).
+ *
+ * TTL 이 없는 이유: Medusa admin 에서 카테고리를 직접 고치는 것은 내부적으로 금지돼 있어,
+ * "우리가 마지막으로 쓴 내용"이 곧 Medusa 의 상태다. 그 전제가 깨지는 경로(삭제)는
+ * invalidate 로 명시적으로 지운다. 프로세스 재시작이 메모를 통째로 비우는 것도 안전 밸브다.
+ *
+ * 락은 두지 않는다. 인박스 핸들러가 동시에 2개 돌므로 같은 조상을 두 핸들러가 함께 놓쳐
+ * 두 번 보장할 수 있는데, 같은 내용을 두 번 쓰는 것뿐이라 결과가 달라지지 않는다.
+ */
+@Injectable()
+export class CategoryEnsureMemoService {
+  /** categoryId → 마지막으로 성공적으로 보장한 스냅샷의 표준형 문자열. 삽입 순서 = 축출 순서. */
+  private readonly remembered = new Map<string, string>();
+  private readonly maxEntries: number;
+
+  constructor(configService: ConfigService) {
+    const raw = configService.get<string | number | undefined>('CATEGORY_ANCESTOR_MEMO_MAX_ENTRIES');
+    const parsed = Number(raw);
+    this.maxEntries =
+      raw === undefined || raw === null || raw === '' || !Number.isInteger(parsed) || parsed < 0
+        ? DEFAULT_MAX_ENTRIES
+        : parsed;
+  }
+
+  /**
+   * 내용이 직전 보장과 같으면 `ensure` 를 부르지 않는다.
+   *
+   * 기억은 `ensure` 가 성공한 뒤에만 남긴다 — 실패한 보장을 기억하면 그 카테고리가
+   * 다음 이벤트까지 잘못된 상태로 굳는다.
+   */
+  async ensureOnce(categoryId: string, snapshot: object, ensure: () => Promise<unknown>): Promise<void> {
+    if (this.maxEntries === 0) {
+      await ensure();
+      return;
+    }
+
+    const fingerprint = JSON.stringify(canonicalize(snapshot));
+
+    if (this.remembered.get(categoryId) === fingerprint) {
+      return;
+    }
+
+    await ensure();
+
+    this.remembered.set(categoryId, fingerprint);
+    this.evictOverflow();
+  }
+
+  /** 메모 밖에서 카테고리가 바뀐 경우(삭제 등) 다음 보장이 실제로 나가게 한다. */
+  invalidate(categoryId: string): void {
+    this.remembered.delete(categoryId);
+  }
+
+  private evictOverflow(): void {
+    while (this.remembered.size > this.maxEntries) {
+      const oldest = this.remembered.keys().next();
+      if (oldest.done) {
+        return;
+      }
+      this.remembered.delete(oldest.value);
+    }
+  }
+}

--- a/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts
+++ b/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.spec.ts
@@ -1,6 +1,7 @@
 import { PimMedusaSyncService } from './pim-medusa-sync.service';
 import type { ProductSellableQuantityChangedPayload } from '@packages/event-contracts/streams/inventory.stream';
 import type { PimProductSnapshot } from '../../types';
+import { CategoryEnsureMemoService } from './category-ensure-memo.service';
 
 describe('PimMedusaSyncService.handleProductSellableQuantityChanged', () => {
   const payload: ProductSellableQuantityChangedPayload = {
@@ -37,6 +38,7 @@ describe('PimMedusaSyncService.handleProductSellableQuantityChanged', () => {
       mappingRepo as any,
       storefrontRevalidate as any,
       deferredRevalidate as any,
+      new CategoryEnsureMemoService({ get: () => undefined } as never),
     );
 
     return { service, medusaClient, mappingRepo, storefrontRevalidate };
@@ -135,6 +137,7 @@ describe('PimMedusaSyncService.syncFromSnapshot 의 revalidate 분기', () => {
       mappingRepo as any,
       storefrontRevalidate as any,
       deferredRevalidate as any,
+      new CategoryEnsureMemoService({ get: () => undefined } as never),
     );
 
     return { service, storefrontRevalidate, deferredRevalidate };
@@ -177,6 +180,7 @@ describe('PimMedusaSyncService.handleProductMasterDeleted', () => {
       mappingRepo as any,
       storefrontRevalidate as any,
       deferredRevalidate as any,
+      new CategoryEnsureMemoService({ get: () => undefined } as never),
     );
 
     return { service, medusaClient, mappingRepo, storefrontRevalidate };
@@ -247,6 +251,7 @@ describe('PimMedusaSyncService.syncPriceLists (replace semantics)', () => {
       mappingRepo as any,
       storefrontRevalidate as any,
       deferredRevalidate as any,
+      new CategoryEnsureMemoService({ get: () => undefined } as never),
     );
     return { service, medusaClient, calls };
   }
@@ -327,6 +332,7 @@ describe('PimMedusaSyncService 카테고리 조상 처리', () => {
       medusaClient: { value: medusaClient },
       logger: { value: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
       storefrontRevalidate: { value: { revalidateCategory: jest.fn() } },
+      categoryEnsureMemo: { value: new CategoryEnsureMemoService({ get: () => undefined } as never) },
     });
     return { service, ensureCategoryFromSnapshot };
   };
@@ -416,5 +422,125 @@ describe('isBulkOrigin', () => {
 
   it('모르는 출처는 단건으로 판정한다 — 안전한 쪽이 즉시 반영이다', () => {
     expect(isBulkOrigin('admin_ui')).toBe(false);
+  });
+});
+
+describe('PimMedusaSyncService.handleCategoryChanged — 조상 재보장 메모', () => {
+  const snapshot = (id: string, parentId: string | null, overrides: Record<string, unknown> = {}) =>
+    ({
+      id,
+      name: `name-${id}`,
+      slug: `slug-${id}`,
+      description: null,
+      parentId,
+      level: parentId ? 1 : 0,
+      path: id,
+      sortOrder: 0,
+      isActive: true,
+      visibility: true,
+      thumbnail: null,
+      displaySettings: {},
+      seoConfig: null,
+      templateConfig: null,
+      createdAt: '2026-08-14T00:00:00.000Z',
+      updatedAt: '2026-08-14T00:00:00.000Z',
+      ...overrides,
+    }) as any;
+
+  const changed = (categoryId: string, category: unknown, ancestors: unknown[]) =>
+    ({
+      categoryId,
+      changeType: 'updated',
+      timestamp: '2026-08-14T00:00:00.000Z',
+      category,
+      ancestors,
+    }) as any;
+
+  function createService() {
+    const medusaClient = {
+      ensureCategoryFromSnapshot: jest.fn().mockResolvedValue('medusa-cat'),
+      findCategoryByPimRef: jest.fn().mockResolvedValue({ id: 'medusa-cat', handle: 'handle-p1' }),
+      softDeleteCategory: jest.fn().mockResolvedValue(undefined),
+      invalidateCategoryCacheByHandle: jest.fn(),
+    };
+    const storefrontRevalidate = { revalidateCategory: jest.fn().mockResolvedValue(undefined) };
+    const memo = new CategoryEnsureMemoService({ get: () => undefined } as never);
+    const service = new PimMedusaSyncService(
+      medusaClient as any,
+      {} as any,
+      storefrontRevalidate as any,
+      { enqueue: jest.fn() } as any,
+      memo,
+    );
+
+    const ensuredIds = () =>
+      medusaClient.ensureCategoryFromSnapshot.mock.calls.map(([arg]: [{ id: string }]) => arg.id);
+
+    return { service, medusaClient, ensuredIds };
+  }
+
+  it('같은 조상 체인이 연달아 오면 조상은 한 번만 보장한다', async () => {
+    const { service, ensuredIds } = createService();
+    const parent = snapshot('p1', null);
+
+    await service.handleCategoryChanged(changed('c1', snapshot('c1', 'p1'), [parent]));
+    await service.handleCategoryChanged(changed('c2', snapshot('c2', 'p1'), [parent]));
+
+    expect(ensuredIds()).toEqual(['p1', 'c1', 'c2']);
+  });
+
+  it('조상 내용이 바뀌면 다시 보장한다', async () => {
+    const { service, ensuredIds } = createService();
+
+    await service.handleCategoryChanged(changed('c1', snapshot('c1', 'p1'), [snapshot('p1', null)]));
+    await service.handleCategoryChanged(
+      changed('c2', snapshot('c2', 'p1'), [snapshot('p1', null, { name: '이름 바뀜' })]),
+    );
+
+    expect(ensuredIds()).toEqual(['p1', 'c1', 'p1', 'c2']);
+  });
+
+  it('조상의 멤버십 전용 상속이 켜지면 내용이 달라지므로 다시 보장한다', async () => {
+    const { service, ensuredIds } = createService();
+
+    await service.handleCategoryChanged(changed('c1', snapshot('c1', 'p1'), [snapshot('p1', null)]));
+    await service.handleCategoryChanged(
+      changed('c2', snapshot('c2', 'p1'), [
+        snapshot('p1', null, { displaySettings: { isVisibleToMembersOnly: true } }),
+      ]),
+    );
+
+    expect(ensuredIds()).toEqual(['p1', 'c1', 'p1', 'c2']);
+  });
+
+  it('조상 자신은 그대로여도 그 위에서 멤버십 전용이 켜지면 다시 보장한다 — 판정은 누적된 값으로 한다', async () => {
+    const { service, ensuredIds } = createService();
+    const parent = snapshot('p1', 'g1');
+
+    await service.handleCategoryChanged(changed('c1', snapshot('c1', 'p1'), [snapshot('g1', null), parent]));
+    await service.handleCategoryChanged(
+      changed('c2', snapshot('c2', 'p1'), [
+        snapshot('g1', null, { displaySettings: { isVisibleToMembersOnly: true } }),
+        parent,
+      ]),
+    );
+
+    expect(ensuredIds()).toEqual(['g1', 'p1', 'c1', 'g1', 'p1', 'c2']);
+  });
+
+  it('삭제된 카테고리는 메모에서 지운다 — 다시 조상으로 오면 실제로 보장해야 한다', async () => {
+    const { service, ensuredIds } = createService();
+    const parent = snapshot('p1', null);
+
+    await service.handleCategoryChanged(changed('c1', snapshot('c1', 'p1'), [parent]));
+    await service.handleCategoryChanged({
+      categoryId: 'p1',
+      changeType: 'deleted',
+      timestamp: '2026-08-14T00:00:00.000Z',
+      category: null,
+    } as any);
+    await service.handleCategoryChanged(changed('c2', snapshot('c2', 'p1'), [parent]));
+
+    expect(ensuredIds()).toEqual(['p1', 'c1', 'p1', 'c2']);
   });
 });

--- a/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts
+++ b/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts
@@ -5,6 +5,7 @@ import { MedusaClient } from './medusa.client';
 import { PimMedusaMappingRepository } from './pim-medusa-mapping.repository';
 import { StorefrontRevalidateService } from './storefront-revalidate.service';
 import { DeferredRevalidateService } from './deferred-revalidate.service';
+import { CategoryEnsureMemoService } from './category-ensure-memo.service';
 import { transformPimToMedusa, validatePimSnapshot } from './transformers/pim-to-medusa.transformer';
 import type { PimActiveVersionChangedEvent, PimProductSnapshot, MedusaProduct } from '../../types';
 // PIMCLIENT: Type import removed
@@ -45,6 +46,7 @@ export class PimMedusaSyncService {
     private readonly mappingRepo: PimMedusaMappingRepository,
     private readonly storefrontRevalidate: StorefrontRevalidateService,
     private readonly deferredRevalidate: DeferredRevalidateService,
+    private readonly categoryEnsureMemo: CategoryEnsureMemoService,
   ) {}
 
   // PIMCLIENT: This method is disabled because it calls PIM API (this.pimClient.getCategory)
@@ -702,10 +704,9 @@ export class PimMedusaSyncService {
       // 자손 이벤트가 조상을 자기 플래그(false)로 덮어써 상속이 풀린다.
       let ancestorMembersOnly = false;
       for (const ancestor of ancestors ?? []) {
-        ancestorMembersOnly =
-          ancestorMembersOnly || ancestor.displaySettings?.isVisibleToMembersOnly === true;
+        ancestorMembersOnly = ancestorMembersOnly || ancestor.displaySettings?.isVisibleToMembersOnly === true;
 
-        await this.medusaClient.ensureCategoryFromSnapshot({
+        const ancestorSnapshot = {
           id: ancestor.id,
           name: ancestor.name,
           slug: ancestor.slug,
@@ -719,26 +720,35 @@ export class PimMedusaSyncService {
           thumbnail: ancestor.thumbnail ?? undefined,
           sortOrder: ancestor.sortOrder,
           description: ancestor.description,
-        }, { refreshFields: true });
+        };
+
+        // 한 부모의 자손 96건이 한꺼번에 들어오면 그 부모를 똑같은 내용으로 96번 다시 쓴다.
+        // 내용이 바뀌었을 때만 실제로 보낸다 — 판정 대상은 여기서 조립한 스냅샷 그대로라
+        // 상속된 isVisibleToMembersOnly 변화도 그대로 잡힌다.
+        await this.categoryEnsureMemo.ensureOnce(ancestor.id, ancestorSnapshot, () =>
+          this.medusaClient.ensureCategoryFromSnapshot(ancestorSnapshot, { refreshFields: true }),
+        );
       }
 
       // Handle create/update/moved (all treated as upsert)
-      const medusaCategoryId = await this.medusaClient.ensureCategoryFromSnapshot({
-        id: category.id,
-        name: category.name,
-        slug: category.slug,
-        path: category.path,
-        parentId: category.parentId,
-        isActive: category.isActive,
-        visibility: category.visibility,
-        showOnMainCategory: category.displaySettings?.showOnMainCategory ?? false,
-        isVisibleToMembersOnly:
-          category.displaySettings?.isVisibleToMembersOnly === true || ancestorMembersOnly,
-        isBrand: category.displaySettings?.isBrand,
-        thumbnail: category.thumbnail ?? undefined,
-        sortOrder: category.sortOrder,
-        description: category.description,
-      }, { requireParent: true, refreshFields: true });
+      const medusaCategoryId = await this.medusaClient.ensureCategoryFromSnapshot(
+        {
+          id: category.id,
+          name: category.name,
+          slug: category.slug,
+          path: category.path,
+          parentId: category.parentId,
+          isActive: category.isActive,
+          visibility: category.visibility,
+          showOnMainCategory: category.displaySettings?.showOnMainCategory ?? false,
+          isVisibleToMembersOnly: category.displaySettings?.isVisibleToMembersOnly === true || ancestorMembersOnly,
+          isBrand: category.displaySettings?.isBrand,
+          thumbnail: category.thumbnail ?? undefined,
+          sortOrder: category.sortOrder,
+          description: category.description,
+        },
+        { requireParent: true, refreshFields: true },
+      );
 
       this.logger.log(`Category synced to Medusa: PIM=${categoryId} → Medusa=${medusaCategoryId}`);
 
@@ -760,6 +770,10 @@ export class PimMedusaSyncService {
    * Handle category deletion in Medusa
    */
   private async handleCategoryDelete(pimCategoryId: string): Promise<void> {
+    // 삭제는 메모 밖에서 Medusa 를 바꾸는 유일한 경로다 (softDeleteCategory).
+    // 지우지 않으면 이 카테고리가 다시 조상으로 등장할 때 보장을 건너뛴다.
+    this.categoryEnsureMemo.invalidate(pimCategoryId);
+
     try {
       // 생성 시 handle은 slug 우선(pimCategoryId는 fallback)이라, 삭제에서는
       // metadata.pimCategoryId + legacy handle 두 경로로 조회해야 한다.

--- a/apps/channel-adapter/src/config/env.validation.ts
+++ b/apps/channel-adapter/src/config/env.validation.ts
@@ -56,6 +56,8 @@ export const channelAdapterEnvSchema = z.object({
   INBOX_MAX_RETRIES: z.coerce.number().int().positive().optional(),
   INBOX_SLOW_MAX_RETRIES: z.coerce.number().int().positive().optional(),
   DEFERRED_REVALIDATE_FLUSH_MS: z.coerce.number().int().min(1000).optional(),
+  // 0 이면 조상 재보장 메모를 끈다 (킬스위치).
+  CATEGORY_ANCESTOR_MEMO_MAX_ENTRIES: z.coerce.number().int().nonnegative().optional(),
 
   // Firebase Membership Sync
   ALMOND_AUTH_URL: z.string().url().optional(),

--- a/deployments/lcnine/services/infra/services.ts
+++ b/deployments/lcnine/services/infra/services.ts
@@ -251,6 +251,8 @@ export function setup(infra: SharedInfra) {
     INBOX_PROCESSING_LEASE_MS: '900000',
     INBOX_SHUTDOWN_DRAIN_MS: '25000',
     DEFERRED_REVALIDATE_FLUSH_MS: '60000',
+    // 조상 재보장 메모의 항목 상한. 0 으로 두면 메모를 끈다 (킬스위치).
+    CATEGORY_ANCESTOR_MEMO_MAX_ENTRIES: '5000',
   });
   const membershipEnv = withPrefix('MEMBERSHIP', {
     DATABASE_URL: dbUrl('membership'),


### PR DESCRIPTION
## 왜

카테고리 하나에서 **멤버십 전용**을 켜면 core 가 `publishDescendantsChanged`(`apps/core/src/modules/catalog/core/categories/categories.service.ts:844`)로 **자손 전체**를 `CategoryChanged(updated)` 로 재발행한다. channel-adapter 는 이벤트마다 조상 체인을 루트부터 다시 보장하므로, 자손 96건이 같은 부모를 **똑같은 내용으로 96번** 다시 쓴다.

실측(Loki, 2026-08-14 03~04시) — `CategoryChanged` 325건을 처리하는 동안 Medusa 카테고리 호출:

| 호출 | 건수 | 이벤트당 |
|---|---:|---:|
| `GET /admin/product-categories` (목록/검색) | 901 | 2.77 |
| `GET /admin/product-categories/{id}` | 901 | 2.77 |
| `POST /admin/product-categories/{id}` (갱신) | 852 | 2.62 |
| **합** | 2,654 | **8.2** |

이벤트당 ensure 2.77회 = 자기 자신 1회 + **조상 1.77회**. 즉 호출의 약 64%가 조상 재보장이고, 읽기만이 아니라 이벤트당 2.62회의 **쓰기**다.

그날 그 시간대는 상품 동기화가 23건뿐인데 `/admin/product-categories` 가 2,676회였고, 마침 대량등록과 겹쳐 Medusa CPU 가 96% 였다.

## 무엇을

`CategoryEnsureMemoService` 를 새로 두고, `handleCategoryChanged` 의 조상 루프를 감쌌다. 조립된 조상 스냅샷의 표준형(키 정렬 후 직렬화)이 직전 보장과 같으면 Medusa 왕복을 건너뛴다.

설계에서 중요한 결정 세 가지:

- **판정 대상은 원본 조상이 아니라 조립된 스냅샷이다.** 조상 자신은 그대로여도 그 위에서 멤버십 전용이 켜지면 누적값(`ancestorMembersOnly`)이 달라져 다시 보장된다. 원본으로 판정하면 상속이 조용히 전파되지 않는다.
- **기억은 보장이 성공한 뒤에만 남긴다.** 실패를 기억하면 그 카테고리가 다음 이벤트까지 잘못된 상태로 굳는다.
- **TTL 이 없다.** Medusa admin 직접 편집이 내부적으로 금지돼 있어 "우리가 마지막으로 쓴 내용"이 곧 Medusa 의 상태다. 그 전제가 깨지는 유일한 경로인 삭제(`softDeleteCategory`)는 `invalidate` 로 지우고, 프로세스 재시작이 메모를 통째로 비우는 것도 안전 밸브다.

self ensure 와 상품 동기화 경로(`refreshFields: false`)는 건드리지 않았다 — 낭비가 전부 조상 루프에 있다.

락은 두지 않았다. 인박스 핸들러 2개가 같은 조상을 함께 놓쳐 두 번 보장할 수 있지만, 같은 내용을 두 번 쓰는 것뿐이라 결과가 달라지지 않는다.

## 테스트

즉시 통과한 테스트는 통과만으론 아무것도 증명하지 못하므로, 구현을 변이시켜 실제로 잡히는지 확인했다.

| 테스트 | 실패를 확인한 방법 |
|---|---|
| 같은 내용이면 건너뛴다 | 모듈 부재로 RED |
| 키 순서 무시 (평면·중첩) | `JSON.stringify` 순서 의존으로 RED |
| `invalidate` 후 재보장 | 메서드 부재로 RED |
| 상한 초과 축출 / 상한 0 = 킬스위치 | RED |
| 내용이 바뀌면 재보장 | 변이: `has(id)` 로 fingerprint 무시 → ✕ |
| 실패하면 기억 안 함 | 변이: `set()` 을 `ensure()` 앞으로 → ✕ |
| 조상 체인 1회만 보장 | 배선 전 RED |
| 누적된 멤버십 전용 변화 감지 | 변이: `ensureOnce(id, ancestor, …)` → ✕ |
| 삭제가 메모를 지운다 | 변이: `invalidate` 제거 → ✕ |

## 검증

- `npm run type-check` → 에러 **0**
- `npx jest --maxWorkers=2` → **440 suites / 3,734 tests 전부 통과**
- 브랜치 기점(`820b491ac`) 기준선은 439 suites / 3,721 tests → **+1 suite · +13 tests · 실패 0**
- `worker process has failed to exit gracefully` 경고는 기준선에도 그대로 있다 (이 PR 이 만든 게 아니다)
- lint: 새 파일 0건. `pim-medusa-sync.service.ts` 의 불가피 에러는 기준선과 같은 10건. `--fix` 가 self ensure 호출부를 prettier 형식으로 재정렬했는데, 수정한 함수 안이지만 의도한 변경은 아니다

## 배포

- 마이그레이션 **0** · 이벤트 계약 **0** · **channel-adapter 단독 배포**
- 새 env `CATEGORY_ANCESTOR_MEMO_MAX_ENTRIES` (기본 5000, `0` 이면 메모 비활성). `services.ts` 에 명시했다

## 배포 후 판정

다음 카테고리 저장 팬아웃 때 같은 Loki 쿼리로 이벤트당 호출을 다시 잰다. 목표는 `GET 목록 / GET 단건 / POST 갱신` **2.77 / 2.77 / 2.62 → 1.0 근처**.

```
sum(count_over_time({service_name="channel-adapter"} |= "Processing CategoryChanged" [1h]))
sum(count_over_time({service_name="medusa"} |~ "Authenticating route POST /admin/product-categories/[^/]+$" [1h]))
```

## 남은 것 (이 PR 범위 밖)

- **b1** — 같은 `categoryId` 의 pending 인박스 행 접기. 08-14 기준 이벤트의 32%가 같은 id 중복이다
- **(a)** — core 에서 자손 재발행을 한 이벤트로 합치기. 인박스 행 수와 클레임 유휴까지 줄지만 이벤트 계약 변경이 필요하다
- 이 카테고리 축은 `docs/superpowers/specs/2026-08-13-bulk-import-medusa-load-design.md` 의 부하 회계에 빠져 있다 — 후속 섹션으로 보강 필요
