### PR TITLE
fix(medusa): metadata 타입을 type alias 로 바꿔 빌드를 되살린다

### DIFF
--- a/apps/medusa/src/api/store/customers/me/default-shipping-memo/metadata.ts
+++ b/apps/medusa/src/api/store/customers/me/default-shipping-memo/metadata.ts
@@ -21,12 +21,16 @@ export interface DefaultShippingMemoInput {
   has_entrance?: boolean;
 }
 
-export interface DefaultShippingMemoMetadata {
+// `interface` 가 아니라 `type` 이어야 한다 — TypeScript 는 type alias 에만 암묵적 인덱스
+// 시그니처를 부여하므로, interface 로 두면 Medusa 의 `metadata: Record<string, unknown>` 에
+// 대입할 수 없다(TS2322). 루트 type-check 는 apps/medusa 를 제외하므로 이 오류는
+// `medusa build` 에서야 드러난다.
+export type DefaultShippingMemoMetadata = {
   default_shipping_memo_type: string;
   default_shipping_memo_custom: string;
   default_entrance_password: string;
   default_has_entrance: boolean;
-}
+};
 
 export function buildDefaultShippingMemoMetadata(
   input: DefaultShippingMemoInput,


### PR DESCRIPTION
## 문제

`medusa build` 가 실패해 **develop 배포가 막혀 있다**. #695 가 들여온 회귀다.

```
route.ts(52,56): error TS2322
  Type 'DefaultShippingMemoMetadata' is not assignable to type 'Record<string, unknown>'.
  Index signature for type 'string' is missing in type 'DefaultShippingMemoMetadata'.
```

TypeScript 는 **type alias 에만 암묵적 인덱스 시그니처를 부여한다.** `interface` 로 선언하면 Medusa 의 `metadata: Record<string, unknown>` 자리에 대입할 수 없다. `interface` → `type` 한 줄 변경.

## 왜 게이트를 전부 통과했나

이게 이 PR 의 본론이다. 커밋 전에 돌린 검증 넷 다 이 파일의 타입을 보지 않았다.

| 게이트 | 왜 못 잡았나 |
|---|---|
| `npm run type-check` | 루트 tsconfig 가 `apps/medusa` 를 **exclude** 한다 (프론트엔드 트리 잡음 제거 목적, 의도된 설정) |
| medusa `jest` | ts-jest transpile-only — 타입 미검사 |
| CI `gates` | 위 둘의 조합 |
| CI `unit` | 같은 jest |

즉 **`apps/medusa` 의 타입을 검사하는 CI 게이트가 없다.** `medusa build` 가 유일한 방어선이고 그건 배포 때 처음 돈다 — 가장 비싼 시점이다.

이 사실을 코드 주석으로 남겼다. 다음 사람이 medusa 파일을 고치고 "type-check 0" 을 근거로 안전하다고 판단하지 않도록.

## 검증

- `npx tsc --noEmit -p apps/medusa/tsconfig.json` — 이 파일 오류 0
- `npx medusa build` — **성공** (backend 5.23s / frontend 16.47s)
- `npx jest --maxWorkers=2 default-shipping-memo` — 7건 통과

남은 tsc 오류 3건(`admin/lib/sdk.ts` 의 `import.meta` 2건, `confirm-purchase.unit.spec.ts` 모듈 미해결)은 선행 존재이며 `medusa build` 를 막지 않는다 — admin 은 vite 가 따로 빌드하고 spec 은 빌드 대상이 아니다.

## 후속 제안

`apps/medusa` 타입 게이트를 CI 에 추가할 것을 권한다. 이번이 "빌드해야만 드러나는 오류"의 마지막일 이유가 없고, 배포 시점에 터지면 되돌리기 비싸다. `medusa build` 자체를 CI 에 태우거나, `tsc -p apps/medusa/tsconfig.json` 을 선행 오류 3건만 예외 처리해 붙이는 방법이 있다.