### PR TITLE
fix(wallet): 결제창에 PG사 이름 대신 결제수단 이름을 보여준다 (#684)

### DIFF
--- a/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
+++ b/apps/wallet-web/app/pay/[intentId]/pay-form.tsx
@@ -136,10 +136,9 @@ function isBankTransferPendingAction(value: unknown): value is BankTransferPendi
   return typeof value === 'object' && value !== null && (value as { type?: unknown }).type === 'BANK_TRANSFER_PENDING';
 }
 
-// 토스페이먼츠는 카드결제만 사용한다. (휴대폰/계좌이체/가상계좌 비노출)
-const TOSS_SUB_METHODS = [
-  { value: 'CARD' as const, label: '카드 / 간편결제', desc: '카드, 카카오페이, 네이버페이, 토스페이 등' },
-] as const;
+// PG(토스페이먼츠)에는 카드결제만 요청한다. (휴대폰/계좌이체/가상계좌 비노출)
+// 라벨은 상위 결제수단('카드 간편결제', provider-descriptors 정본)과 겹치지 않게 형제 수단 이름으로만 적는다.
+const TOSS_SUB_METHODS = [{ value: 'CARD' as const, label: '카드', desc: '신용·체크카드 및 간편결제' }] as const;
 type TossSubMethod = (typeof TOSS_SUB_METHODS)[number]['value'];
 
 export function PayForm({

--- a/apps/wallet/src/payment-config/dto/index.ts
+++ b/apps/wallet/src/payment-config/dto/index.ts
@@ -169,7 +169,7 @@ export class RegionMethodMatrixResponseDto {
 
 export class AvailablePaymentMethodDto {
   @ApiProperty({ description: 'provider 코드', example: 'TOSS' }) code!: string;
-  @ApiProperty({ example: '토스페이먼츠' }) displayName!: string;
+  @ApiProperty({ example: '카드 간편결제' }) displayName!: string;
   @ApiProperty({ nullable: true, type: String }) description!: string | null;
   @ApiProperty() sortOrder!: number;
 }

--- a/apps/wallet/src/payment-config/payment-config.service.spec.ts
+++ b/apps/wallet/src/payment-config/payment-config.service.spec.ts
@@ -35,7 +35,7 @@ const TEST_DESCRIPTORS: PaymentProviderDescriptor[] = [
   },
   {
     code: 'TOSS',
-    displayName: '토스페이먼츠',
+    displayName: '카드 간편결제',
     description: '토스 descriptor',
     defaultEnabled: true,
     defaultSortOrder: 20,
@@ -95,7 +95,7 @@ describe('PaymentConfigService', () => {
       expect(Object.keys(byCode)).toEqual(['TOSS', 'POINTS', 'BANK_TRANSFER', 'CMS_BATCH', 'NICEPAY']);
       expect(byCode.POINTS.isEnabled).toBe(true);
       expect(byCode.POINTS.supportStatus).toBe('supported');
-      expect(byCode.TOSS.displayName).toBe('토스페이먼츠');
+      expect(byCode.TOSS.displayName).toBe('카드 간편결제');
       expect(byCode.TOSS.description).toBe('토스 descriptor');
       expect(byCode.TOSS.isEnabled).toBe(false);
       expect(byCode.TOSS.sortOrder).toBe(5);
@@ -310,7 +310,7 @@ describe('PaymentConfigService', () => {
       expect(result).toEqual([
         {
           code: 'TOSS',
-          displayName: '토스페이먼츠',
+          displayName: '카드 간편결제',
           description: '토스 descriptor',
           sortOrder: 20,
         },

--- a/apps/wallet/src/providers/provider-descriptors.spec.ts
+++ b/apps/wallet/src/providers/provider-descriptors.spec.ts
@@ -1,0 +1,30 @@
+import { DEFAULT_PAYMENT_PROVIDER_DESCRIPTORS, PAYMENT_PROVIDER_DESCRIPTORS } from './provider-descriptors';
+
+/**
+ * 결제창(wallet-web)의 결제수단 라벨은 DB 가 아니라 이 descriptor 가 정본이다
+ * (payment-config.service 가 항상 descriptor 값을 쓰고, DB 행은 upsert 로 덮어쓴다).
+ * 고객은 PG사가 누구인지 모르고 알 필요도 없으므로 checkout 노출 수단에는 PG 브랜드명을 쓰지 않는다.
+ */
+describe('PAYMENT_PROVIDER_DESCRIPTORS', () => {
+  it('TOSS 는 고객에게 PG명이 아닌 결제수단 이름으로 보인다', () => {
+    expect(PAYMENT_PROVIDER_DESCRIPTORS.TOSS.displayName).toBe('카드 간편결제');
+    expect(PAYMENT_PROVIDER_DESCRIPTORS.TOSS.description).toBe('카드, 카카오페이, 네이버페이, 토스페이 등');
+  });
+
+  it('BANK_TRANSFER 설명에도 PG명을 쓰지 않는다', () => {
+    expect(PAYMENT_PROVIDER_DESCRIPTORS.BANK_TRANSFER.description).toBe('발급된 가상계좌로 입금');
+  });
+
+  // 간편결제 브랜드(카카오페이·네이버페이·토스페이)는 고객이 아는 결제수단이라 허용 대상이 아니다.
+  // 여기서 막는 건 고객이 알 필요 없는 PG사(결제대행사) 상호다.
+  const PG_BRAND_PATTERN = /토스페이먼츠|나이스페이|이니시스|KG모빌리언스|다날|효성|페이레터|헥토/;
+
+  it.each(DEFAULT_PAYMENT_PROVIDER_DESCRIPTORS.filter((d) => d.publicExposure === 'checkout').map((d) => [d.code, d]))(
+    '%s 의 고객 노출 문구에 PG사 상호가 없다',
+    (_code, descriptor) => {
+      const d = descriptor as (typeof DEFAULT_PAYMENT_PROVIDER_DESCRIPTORS)[number];
+      expect(d.displayName).not.toMatch(PG_BRAND_PATTERN);
+      expect(d.description ?? '').not.toMatch(PG_BRAND_PATTERN);
+    },
+  );
+});

--- a/apps/wallet/src/providers/provider-descriptors.ts
+++ b/apps/wallet/src/providers/provider-descriptors.ts
@@ -28,8 +28,8 @@ export const PAYMENT_PROVIDER_DESCRIPTORS = {
   },
   TOSS: {
     code: 'TOSS',
-    displayName: '토스페이먼츠',
-    description: '카드/간편결제 (토스페이먼츠)',
+    displayName: '카드 간편결제',
+    description: '카드, 카카오페이, 네이버페이, 토스페이 등',
     defaultEnabled: true,
     defaultSortOrder: 20,
     kind: 'gateway',
@@ -39,7 +39,7 @@ export const PAYMENT_PROVIDER_DESCRIPTORS = {
   BANK_TRANSFER: {
     code: 'BANK_TRANSFER',
     displayName: '무통장입금',
-    description: '토스 가상계좌',
+    description: '발급된 가상계좌로 입금',
     defaultEnabled: true,
     defaultSortOrder: 30,
     kind: 'gateway',


### PR DESCRIPTION
Closes #684

## 무엇을 바꿨나

결제창(`wallet-web`)이 고객에게 PG사 상호인 `토스페이먼츠` 를 그대로 보여주고 있었다. `카드 간편결제` 로 바꾼다.

| 위치 | before | after |
|---|---|---|
| TOSS `displayName` | `토스페이먼츠` | `카드 간편결제` |
| TOSS `description` | `카드/간편결제 (토스페이먼츠)` | `카드, 카카오페이, 네이버페이, 토스페이 등` |
| BANK_TRANSFER `description` | `토스 가상계좌` | `발급된 가상계좌로 입금` |
| pay-form 하위 방식 라벨 | `카드 / 간편결제` | `카드` |

## 왜 코드인가 (어드민에서 못 고친다)

라벨의 정본은 DB 가 아니라 `apps/wallet/src/providers/provider-descriptors.ts` 다.

- `payment-config.service.ts` 의 조회 경로(`toSupportedCatalogItem`, `getRegionMethods`, `getAvailablePaymentMethods`)가 **항상** `descriptor.displayName` 을 쓴다.
- DB `payment_method_catalog.display_name` 은 `putRegionMethods` 의 `onConflictDoUpdate` 가 descriptor 값으로 덮어쓴다.
- DB 행의 이름이 살아남는 건 registry 에서 사라진 retired provider 뿐(`toRetiredCatalogItem`).

## 이슈에 없던 것 두 가지

1. **설명줄도 고객에게 보인다.** `pay-form.tsx:667-671` 이 `description` 을 이름 아래에 렌더한다. TOSS 만 고쳐도 바로 아래 무통장입금이 `토스 가상계좌` 를 노출했다 → 같이 정리했다.
2. **어드민 결제설정 화면도 같은 descriptor 를 쓴다.** `payments/methods`(`catalog-template.tsx:80`)·`payments/regions`(`regions-template.tsx:244`) 의 표시명이 함께 바뀐다. 두 화면 모두 `TOSS` code 를 나란히 렌더하므로 운영자의 PG 식별은 유지된다고 보고 그대로 뒀다. 결제 상세의 유형 배지(`payment-method-type-cell.tsx`)와 인텐트 필터는 별도 하드코딩 맵이라 `토스페이먼츠` 그대로 — 이슈 범위대로 미변경.

## 회귀 방어선

`provider-descriptors.spec.ts` 신설. 확정 문안을 고정하고, `publicExposure === 'checkout'` 인 descriptor 의 `displayName`/`description` 에 PG사 상호가 다시 들어오면 실패한다. 간편결제 브랜드(카카오페이·네이버페이·토스페이)는 고객이 아는 결제수단이라 허용, 막는 건 결제대행사 상호다. `CMS_BATCH`(`효성 CMS 배치 출금`)는 `publicExposure: 'billing'` 이라 대상 밖.

## 검증

- `npm run type-check` — 에러 0
- `npx jest --maxWorkers=2` — 447 suite / 3819 test 전부 통과 (실패 0)
- `npx eslint <변경 파일>` — 이 PR 이 만든 위반 0 (pay-form 의 `no-misused-promises` 3건, service.spec 의 `no-unsafe-*` 6건은 develop 부터 있던 것)

## 배포

- **마이그레이션 0건.** seed 는 `ON CONFLICT DO NOTHING` 이라 라이브 DB 행의 옛 `display_name` 은 남지만, 그 값은 retired provider 에게만 읽히므로 손댈 필요 없다.
- 배포 순서 제약 없음. `wallet` 만 올라가도 결제창 라벨이 바뀐다 (wallet-web 은 API 응답을 그대로 그린다). `wallet-web` 변경은 현재 렌더되지 않는 하위 방식 UI(`TOSS_SUB_METHODS.length > 1` 가드) 의 문구 정리라 기능 영향 없음.

## 미확인

브라우저에서 실제 결제창을 띄워 보지는 않았다. 렌더 경로는 `pay-form.tsx:665` 한 줄이고 값이 API 패스스루라 위험은 낮지만, 배포 후 결제창 눈으로 한 번 확인 권장.

https://claude.ai/code/session_016LfAEYuJNwKnLMzTxDydQ2