### PR TITLE
fix(events): notification·wallet 소비 스키마 검증을 켠다 (#611)

### DIFF
--- a/.github/workflows/verification-gates.yml
+++ b/.github/workflows/verification-gates.yml
@@ -9,6 +9,11 @@ name: Verification gates
 # 즉 spec 의 타입을 지키는 건 type-check 뿐이다.
 #
 # 초록을 되찾은 뒤 다시 썩지 않게 하는 게 목적이므로 flagging 이 아니라 *차단*이다.
+#
+# 소비 스키마 검증 게이트도 여기 붙는다. 이건 타입도 테스트도 못 잡는 종류다 —
+# `validateOnConsume` 을 켠 앱들이 안전한 근거는 "발행이 전부 zod 파싱을 지난다"는
+# 정적 증명이고, 그 증명은 발행 경로가 지금 모양일 때만 성립한다. 새 `transport.send`
+# 호출이 하나 생기면 증명이 조용히 무너지므로 사람이 기억해서 돌리는 대신 여기서 센다 (#611).
 
 on:
   pull_request:
@@ -42,3 +47,9 @@ jobs:
       # DB 를 요구하는 통합 스펙은 describeIfDb / REQUIRE_*_DB 가드로 자동 skip 된다.
       - name: Unit tests
         run: npx jest --ci --silent
+
+      # 발행 경로가 소비 검증의 전제를 깨지 않는지 AST 로 센다. 둘 중 하나면 exit 1 —
+      # transport.send 호출 지점이 SEND_PATHS 와 어긋나거나, 검증을 켠 앱에
+      # 계약 미검증(UNVERIFIED) 이벤트가 생긴 경우. DB·네트워크·env 를 쓰지 않는다.
+      - name: Consume validation gate
+        run: npm run audit:consume-validation -- --gate

--- a/apps/notification/src/dispatcher/dispatcher.module.ts
+++ b/apps/notification/src/dispatcher/dispatcher.module.ts
@@ -27,7 +27,13 @@ import { MembershipEventConsumer } from './handlers/membership-event.consumer';
     // 여기서도 받았지만 어느 쪽도 쓰지 않았다 (ADR-0029 §1).
     EventsModule.forApp({
       policy: {
-        validateOnConsume: false, // HTTP 요청과 충돌 방지를 위해 비활성화
+        // HTTP 요청과 충돌하지 않는다. 이 앱은 하이브리드(Fastify + Kafka 소비자)라
+        // 2025-11 에 한 번 거기서 깨졌고(`e52e252ad8`) 그때 이 플래그를 꺼 둔 것인데,
+        // 그 고장은 이틀 뒤 `8bdfdb0686` 이 고쳤다. 지금 방어선은 두 겹이다 —
+        // `startConsumer` 가 인터셉터를 마이크로서비스 스코프로만 붙이고(ADR-0029 §8),
+        // 그 위에 `getType() === 'http'` 가드가 있다
+        // (`libs/events/src/interceptors/schema-validation.interceptor.spec.ts` 가 고정). #611
+        validateOnConsume: true,
       },
     }),
     // Redis가 있으면 NotificationProcessorModule import

--- a/apps/wallet/src/wallet.module.ts
+++ b/apps/wallet/src/wallet.module.ts
@@ -388,8 +388,7 @@ async function resolveCanActivate(result: boolean | Promise<boolean> | unknown):
       // 디스패처의 publisherMap 이 회수 대상 토픽을 처음부터 안다.
       enableOutbox: true,
       outbox: WALLET_OUTBOX_CONFIG,
-      // 이 `false` 는 이 워크스트림 이전부터의 상태다 — 5-C 대상이 아니었다.
-      policy: { validateOnConsume: false },
+      policy: { validateOnConsume: true },
     }),
     EventTraceApiModule,
   ],

--- a/libs/events/src/interceptors/schema-validation.interceptor.spec.ts
+++ b/libs/events/src/interceptors/schema-validation.interceptor.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * 소비 스키마 검증 인터셉터가 **HTTP 요청에는 손대지 않는다** (ADR-0029 §8, #611)
+ *
+ * ## 이 스펙이 잡는 고장
+ *
+ * `intercept()` 첫머리의 `context.getType() === 'http'` 조기 반환이 사라지거나, 이 인터셉터가
+ * 다시 전역(`APP_INTERCEPTOR`)으로 등록되면 — notification 처럼 HTTP 서버와 Kafka 소비자를
+ * 한 프로세스에 얹은 **하이브리드 앱의 모든 HTTP 엔드포인트가 500 으로 죽는다.**
+ *
+ * 조기 반환이 없으면 인터셉터는 HTTP 실행 컨텍스트를 `switchToRpc()` 로 읽는다. 그 자리에서
+ * 돌아오는 것은 `KafkaContext` 가 아니라 응답 객체(Fastify reply / Express res)이고, 거기엔
+ * `getTopic` 이 없다. 그 호출은 `try` 블록보다 **앞**에 있어 인터셉터가 스스로 삼키지도 못한다.
+ *
+ * ## 왜 실행으로 고정하는가
+ *
+ * 이건 가정이 아니라 실제로 났던 사고다. notification 은 2025-11-19 (`e52e252ad8`) 에 바로 이
+ * 고장 때문에 `validateOnConsume: false` 를 넣었고, 주석에 "HTTP 요청과 충돌 방지"라고 적었다.
+ * 가드는 이틀 뒤 (`8bdfdb0686`) 무관한 커밋에 묻어 들어왔지만 플래그는 9개월 동안 꺼진 채였다.
+ *
+ * 지금은 방어선이 두 겹이다 — `startConsumer` 가 마이크로서비스 스코프로만 붙이고(ADR-0029 §8),
+ * 그 위에 이 가드가 있다. 바깥 겹이 먼저 무너져도 안쪽이 버티는지를 여기서 고정한다. 가드가
+ * 지워져도 **지금 배선에서는 무증상**이라 — 소비 경로만 지나므로 — 리뷰로는 잡히지 않는다.
+ *
+ * 소비 검증 자체의 동작(통과·DLQ·재시도 안 함)은 `transport/consume-validation.spec.ts` 가 덮는다.
+ */
+import 'reflect-metadata';
+import { CallHandler } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ExecutionContextHost } from '@nestjs/core/helpers/execution-context-host';
+import { KafkaContext } from '@nestjs/microservices';
+import type { Consumer, KafkaMessage, Producer } from '@nestjs/microservices/external/kafka.interface';
+import { of } from 'rxjs';
+import { z } from 'zod';
+import { event, stream, SchemaValidationError } from '@packages/event-contracts/types';
+import { SchemaValidationInterceptor } from './schema-validation.interceptor';
+
+const HTTP_GUARD_STREAM = stream({
+  topic: 'http-guard.events.v1',
+  partitions: 1,
+  aggregateType: 'HttpGuard',
+  events: {
+    Placed: event('Placed', z.object({ orderId: z.string().min(1) })),
+  },
+});
+
+/** 계약이 `orderId: string` 을 요구하는데 숫자를 싣는다 — 검증이 켜져 있으면 반드시 걸린다. */
+const VIOLATING_ENVELOPE = {
+  messageType: 'Placed',
+  messageId: 'mid-1',
+  source: { aggregateId: 'agg-1' },
+  payload: { orderId: 12345 },
+};
+
+/** 검증을 켠 인터셉터 — notification·wallet 이 `validateOnConsume: true` 를 선언했을 때의 모양. */
+const interceptorWithValidationOn = () =>
+  new SchemaValidationInterceptor(new Reflector(), [HTTP_GUARD_STREAM], { validateOnConsume: true });
+
+/**
+ * Fastify HTTP 요청 컨텍스트. notification 은 `FastifyAdapter` 로 뜬다.
+ * Nest 의 HTTP 컨텍스트는 args = [request, reply] 이고, `switchToRpc().getContext()` 는 args[1] —
+ * 즉 `getTopic` 이 없는 reply 를 돌려준다. 그것이 위 헤더가 말한 고장의 실체다.
+ */
+function fastifyHttpContext(): ExecutionContextHost {
+  const request = { method: 'POST', url: '/notifications/send', body: { title: '주문이 접수되었습니다' } };
+  const reply = { send: jest.fn(), status: jest.fn() };
+
+  const host = new ExecutionContextHost([request, reply], class NotificationController {}, function send() {});
+  host.setType('http');
+  return host;
+}
+
+function kafkaContextWithViolatingMessage(): ExecutionContextHost {
+  const message = {
+    value: Buffer.from(JSON.stringify(VIOLATING_ENVELOPE)),
+    offset: '1',
+    headers: {},
+  } as unknown as KafkaMessage;
+
+  const kafkaCtx = new KafkaContext([
+    message,
+    0,
+    HTTP_GUARD_STREAM.topic.topic,
+    {} as unknown as Consumer,
+    jest.fn(),
+    {} as unknown as Producer,
+  ]);
+
+  // RpcContextCreator 가 만드는 형태 그대로: args = [data, context]
+  const host = new ExecutionContextHost([{}, kafkaCtx], class Consumer {}, function handle() {});
+  host.setType('rpc');
+  return host;
+}
+
+describe('SchemaValidationInterceptor — HTTP 요청은 통과시킨다', () => {
+  it('검증이 켜져 있어도 HTTP 요청은 핸들러에 그대로 도달한다', () => {
+    const handler = jest.fn(() => of('컨트롤러 응답'));
+    const next: CallHandler = { handle: handler };
+    let emitted: unknown;
+
+    interceptorWithValidationOn()
+      .intercept(fastifyHttpContext(), next)
+      .subscribe((value) => {
+        emitted = value;
+      });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(emitted).toBe('컨트롤러 응답');
+  });
+
+  it('대조군 — 같은 인터셉터가 Kafka 위반 메시지는 거부한다', () => {
+    // 이 케이스가 없으면 위 테스트는 "검증이 애초에 꺼져 있어서" 초록일 수도 있다.
+    // 그러면 HTTP 가드가 살아 있는지 아닌지를 아무것도 증명하지 못한다.
+    const handler = jest.fn(() => of('핸들러 실행됨'));
+    const next: CallHandler = { handle: handler };
+
+    expect(() => interceptorWithValidationOn().intercept(kafkaContextWithViolatingMessage(), next)).toThrow(
+      SchemaValidationError,
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #611

## 무엇을

`validateOnConsume` 이 꺼져 있던 마지막 두 앱을 켠다. 그동안 notification(핸들러 24개)·wallet(4개)은 인바운드 메시지를 계약(zod)과 대조하지 않고 곧장 핸들러에 넘겼다. 검증이 켜지면 계약 위반 메시지는 핸들러에 닿지 않고 DLQ 로 분류된다(`SchemaValidationError` 는 non-retryable 이라 재시도 폭풍 없이 즉시 DLQ·offset 전진).

## notification 의 `false` 는 왜 남아 있었나

주석이 `// HTTP 요청과 충돌 방지를 위해 비활성화` 였고, **그 고장은 실재했다.** 다만 이미 고쳐진 지 오래다.

| 시점 | 커밋 | 일 |
|---|---|---|
| 2025-11-19 | `e52e252ad8` | HTTP 라우트 리팩터 중 고장을 만나 플래그를 끄고 주석을 남김 |
| 2025-11-21 (**이틀 뒤**) | `8bdfdb0686` | `intercept()` 첫머리에 `getType() === 'http'` 가드 추가 — 무관한 커밋에 묻어 들어감 |
| 2026-08-10 | ADR-0029 Task 7 | 배선 변경. `APP_INTERCEPTOR` 는 `EventRetryInterceptor` 만 등록하고, `SchemaValidationInterceptor` 는 `startConsumer` 가 **마이크로서비스 스코프**로 붙임 |

당시 고장의 실체: 인터셉터가 전역이라 하이브리드 앱(Fastify HTTP + Kafka consumer)의 모든 HTTP 요청도 지났고, HTTP 컨텍스트에서 `switchToRpc().getContext()` 는 `getTopic` 이 없는 reply 객체를 준다. 그 호출이 `try` 블록 **밖**이라 `TypeError` 가 잡히지 않고 그대로 터졌다.

지금은 방어선이 두 겹이다 — 스코프 분리 + 가드. 플래그만 9개월 남아 있었다.

wallet 쪽 `false` 는 주석 내용이 "5-C 대상이 아니었다" 뿐으로, 기술적 근거가 없었다.

## 새 단위 테스트

`libs/events/src/interceptors/schema-validation.interceptor.spec.ts` 가 그 HTTP 가드를 고정한다. **가드가 지워져도 현재 배선에서는 무증상**이라(소비 경로만 지남) 리뷰로는 잡히지 않는 종류다.

config 를 grep 하는 테스트는 일부러 쓰지 않았다 — "모듈에 `true` 가 적혀 있다"는 change detector라 리팩터에만 터지고 진짜 고장엔 잠든다. 대신 인터셉터가 Fastify HTTP 컨텍스트를 받았을 때 핸들러가 실제로 호출되고 값이 흐르는지를 본다. 소비 검증 자체의 동작(통과·DLQ·재시도 안 함)은 `transport/consume-validation.spec.ts` 가 이미 덮고, 앱별 안전 판정은 그 스펙 헤더가 정한 대로 audit 게이트의 몫이다.

RED 는 실제로 확인했다 — 프로덕션 가드를 제거하니 `TypeError: kafkaContext.getTopic is not a function` 으로 실패하고(대조군은 초록 유지), 복원 후 2/2 통과.

## CI 게이트

`verification-gates.yml` 에 `audit:consume-validation -- --gate` 를 추가한다. 켜도 안전하다는 근거가 "발행이 전부 zod 파싱을 지난다"는 **정적 증명**이고, 그 증명은 발행 경로가 지금 모양일 때만 성립한다. 새 `transport.send` 호출이 하나 생기면 증명이 조용히 무너지는데, 지금까지 그걸 막는 건 사람이 기억해서 돌리는 것뿐이었다.

게이트가 실제로 exit 1 을 내는지 확인했다 — `SEND_PATHS` 항목 하나를 지우니 `🔴 transport.send 호출이 3곳인데 SEND_PATHS 는 2곳을 가정한다` 와 함께 exit 1, 복원 후 exit 0.

`tsx` 는 devDependency(=`npm ci` 가 설치)이고 스크립트는 env·DB·네트워크를 쓰지 않는 순수 AST 분석이다.

## 검증

| 항목 | 결과 |
|---|---|
| `audit:consume-validation` | **7개 앱 전부 ON**, UNVERIFIED 0 |
| `audit:consume-validation -- --gate` | exit 0 — 이제 notification·wallet 을 **포함해서** 검사(전엔 대상 밖) |
| `npm run type-check` | exit 0 |
| `npx jest --ci --silent` | **454 통과 / 0 실패**, 93 skipped(DB 가드) |
| eslint | 신규 0 (기존 4건은 `git show HEAD:… \| eslint --stdin` 으로 기준선 동일 확인) |

## 배포

마이그레이션 0 / 시크릿 0 / env 0 — 앱 재배포만 필요하다.

**앱 부팅은 안 해봤다.** `assertSinglePolicyDeclaration` 은 정책 선언이 2개 이상이면 부팅을 거부하는데, 확인한 건 정적 사실이다 — `EventsModule.forApp` 호출이 두 앱 각각 정확히 1곳이고 값만 뒤집었으므로 카운트가 변하지 않는다.

**알려진 한계(이슈 본문과 동일):** 토픽에 이미 쌓인 옛 메시지는 이 증명 밖이다. 평시엔 무해하지만 **컨슈머 오프셋을 되감으면** 그때 DLQ 가 생길 수 있다.

되돌리기는 해당 두 줄을 `false` 로 되돌리면 된다.

https://claude.ai/code/session_01BhM1CHS5Dt9irDUxmtpBgG
