### PR TITLE
fix(admin-web): 프록시 forward 가 next/server 를 런타임에 요구하지 않게 한다

### DIFF
--- a/apps/admin-web/src/app/api/proxy/_lib/forward.ts
+++ b/apps/admin-web/src/app/api/proxy/_lib/forward.ts
@@ -1,4 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server';
+// `next/server` 는 **타입으로만** 가져온다. 값으로 가져오면 이 모듈이 런타임에 next 를
+// 요구하는데, CI 는 루트 `npm ci` 만 돌려 `apps/admin-web/node_modules` 를 깔지 않는다
+// → `forward.spec.ts` 가 `Cannot find module 'next/server'` 로 죽는다(로컬은 설치돼 있어 통과).
+// 반환은 웹 표준 `Response` 로 충분하다 — Next 의 응답 타입은 그 하위 타입이고 이 파일은
+// `Response` 에 없는 기능을 쓰지 않으며, App Router 라우트 핸들러는 `Response` 반환을 받는다.
+import type { NextRequest } from 'next/server';
 
 const FORWARDED_REQUEST_HEADERS = [
   'x-request-id',
@@ -29,7 +34,7 @@ export async function forwardRequest(
   targetBaseUrl: string,
   path: string[],
   options: ForwardOptions = {}
-): Promise<NextResponse> {
+): Promise<Response> {
   const {
     extraHeaders,
     timeoutMs = DEFAULT_TIMEOUT_MS,
@@ -89,9 +94,11 @@ export async function forwardRequest(
     });
   } catch (error) {
     if (controller.signal.aborted) {
-      return NextResponse.json(
-        { message: `Upstream request timed out after ${timeoutMs}ms` },
-        { status: 504 }
+      return new Response(
+        JSON.stringify({
+          message: `Upstream request timed out after ${timeoutMs}ms`,
+        }),
+        { status: 504, headers: { 'Content-Type': 'application/json' } }
       );
     }
     throw error;
@@ -101,12 +108,17 @@ export async function forwardRequest(
 
   // 204 No Content는 body가 없어야 함
   if (upstream.status === 204) {
-    return new NextResponse(null, { status: 204 });
+    return new Response(null, { status: 204 });
   }
 
   const location = upstream.headers.get('Location');
-  if (passThroughRedirects && upstream.status >= 300 && upstream.status < 400 && location) {
-    return new NextResponse(null, {
+  if (
+    passThroughRedirects &&
+    upstream.status >= 300 &&
+    upstream.status < 400 &&
+    location
+  ) {
+    return new Response(null, {
       status: upstream.status,
       headers: { Location: location },
     });
@@ -114,7 +126,7 @@ export async function forwardRequest(
 
   const data = await upstream.arrayBuffer();
 
-  return new NextResponse(data, {
+  return new Response(data, {
     status: upstream.status,
     headers: {
       'Content-Type':


### PR DESCRIPTION
develop 의 CI 를 초록으로 되돌린다.

## 증상

```
FAIL apps/admin-web/src/app/api/proxy/_lib/forward.spec.ts
  ● Test suite failed to run
    Cannot find module 'next/server' from 'apps/admin-web/src/app/api/proxy/_lib/forward.ts'
```

**develop 이 `1ded1543f`(2026-08-21) 이후 연속으로 빨갛다.** 마지막 초록은 `0eac399ca`. 그 커밋이 `_lib/forward.ts` 와 그 스펙을 새로 들여왔다.

## 원인 — 로컬과 CI 가 갈린다

`next` 는 `apps/admin-web/package.json` 에만 있고 `apps/admin-web/node_modules/` 에 별도로 설치된다(루트 호이스팅이 아니다). `verification-gates.yml` 의 Install 스텝은 **루트 `npm ci` 하나뿐**이라 그 의존성을 깔지 않는다.

그래서 `forward.ts` 의 `import { NextRequest, NextResponse } from 'next/server'` 가 CI 에서만 해석에 실패한다. 로컬에는 설치돼 있어 같은 스펙이 통과하므로, 커밋한 사람 화면에서는 초록이었다.

admin-web 에서 `next/server` 를 import 하는 파일은 20개지만 **스펙이 붙은 건 이 파일 하나뿐**이다(나머지는 route.ts·middleware.ts 라 jest 가 로드하지 않는다). 그래서 반경이 정확히 이 한 곳이다.

## 고침

런타임 의존을 없앤다.

- `import type { NextRequest }` — 타입으로만 쓰이므로 컴파일에서 지워진다
- 반환을 웹 표준 `Response` 로 내린다

Next 의 응답 타입은 `Response` 의 하위 타입이고 이 파일은 `Response` 에 없는 기능을 하나도 안 쓴다. 더 결정적으로 **Next 가 생성하는 라우트 계약 자체가 `Response` 로 적혀 있다**:

```ts
// .next/types/app/api/proxy/file/[...path]/route.ts
__return_type__: Response | void | never | Promise<Response | void | never>
```

admin-web 의 tsconfig 가 `.next/types/**/*.ts` 를 include 하므로 아래 tsc 실행이 이 계약까지 검사했다.

504 응답은 `NextResponse.json` 이 붙이던 `Content-Type: application/json` 을 명시적으로 보존했다.

**스펙은 손대지 않았다.** 원래부터 `NextRequest` 를 구조적으로 가짜로 만들고(`as unknown as NextRequest`) 단언도 `res.status` / `res.json()` / `res.headers.get()` 뿐이라, next 없이 돌 수 있는 스펙이었다.

## 검증

CI 조건을 로컬에서 재현했다 — `apps/admin-web/node_modules/next` 를 숨기고 돌렸다.

| | 결과 |
|---|---|
| 고치기 전 (next 숨김) | **RED** — `Cannot find module 'next/server'`, suite 자체가 실행 실패 |
| 고친 후 (next 숨김) | **3/3 GREEN** |
| `cd apps/admin-web && npx tsc --noEmit` | exit 0 — 생성 라우트 타입 포함, `forwardRequest` 를 쓰는 프록시 라우트 10곳 영향 없음 |
| 루트 `npm run type-check` | exit 0 |
| `npx jest --ci --silent` | 453 통과 / **0 실패** |
| eslint · prettier | clean |

## 곁가지 hunk 하나

같은 파일의 `passThroughRedirects` 조건줄이 HEAD 에서도 prettier 위반이었다(역시 `1ded1543f` 이 들여왔다). 파일을 이미 만지는 김에 같이 정리했다 — **그 hunk 는 포맷 전용이고 동작 변경이 없다.**

## 남는 이야기

이번 건의 구조적 원인은 `1ded1543f` 가 **PR 없이 develop 에 직접 푸시**된 것이다. `verification-gates.yml` 은 `push: branches: [develop]` 로도 돌지만 그건 들어간 뒤에 빨간불을 켤 뿐이라 막지 못한다. 별도로 논의할 만한 주제다.

관련: #690

https://claude.ai/code/session_01BhM1CHS5Dt9irDUxmtpBgG
