### PR TITLE
fix(events): chainId 사슬을 소비·HTTP 양쪽에서 잇는다 (#612)

### DIFF
--- a/apps/analytics/src/main.ts
+++ b/apps/analytics/src/main.ts
@@ -5,7 +5,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import { GlobalExceptionFilter } from '@app/shared';
 import fastifyCookie from '@fastify/cookie';
-import { EventsModule, createKafkaConfigFromEnv } from '@app/events';
+import { mountEventChainContext, EventsModule, createKafkaConfigFromEnv } from '@app/events';
 import { Logger as PinoLogger } from 'nestjs-pino';
 import { AnalyticsModule } from './analytics.module';
 
@@ -14,6 +14,10 @@ async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(AnalyticsModule, new FastifyAdapter(), {
     bufferLogs: true,
   });
+
+  // HTTP 요청 하나 = 사슬 하나 (#612). CLS 컨텍스트가 없으면 한 요청 안의 두 발행이 서로
+  // 다른 chainId 를 받는다. 다른 미들웨어·전역 파이프보다 앞이어야 한다.
+  mountEventChainContext(app);
   app.useLogger(app.get(PinoLogger));
 
   await app.register(fastifyCookie);

--- a/apps/channel-adapter/src/main.ts
+++ b/apps/channel-adapter/src/main.ts
@@ -7,12 +7,16 @@ import { ValidationPipe } from '@nestjs/common';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import fastifyCookie from '@fastify/cookie';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
-import { EventsModule, createKafkaConfigFromEnv } from '@app/events';
+import { mountEventChainContext, EventsModule, createKafkaConfigFromEnv } from '@app/events';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(AdapterModule, new FastifyAdapter(), {
     bufferLogs: true,
   });
+
+  // HTTP 요청 하나 = 사슬 하나 (#612). CLS 컨텍스트가 없으면 한 요청 안의 두 발행이 서로
+  // 다른 chainId 를 받는다. 다른 미들웨어·전역 파이프보다 앞이어야 한다.
+  mountEventChainContext(app);
   app.useLogger(app.get(Logger));
 
   // admin-web 프록시(/api/proxy/channel/*)가 토큰을 accessToken 쿠키로 넘긴다.

--- a/apps/core/src/main.ts
+++ b/apps/core/src/main.ts
@@ -5,7 +5,7 @@ import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify
 import fastifyCookie from '@fastify/cookie';
 import fastifyMultipart from '@fastify/multipart';
 import { Logger } from 'nestjs-pino';
-import { EventsModule } from '@app/events';
+import { mountEventChainContext, EventsModule } from '@app/events';
 import { GlobalExceptionFilter } from '@app/shared';
 import { AppModule } from './app.module';
 import { createGlobalValidationPipe } from './platform/http/validation-pipe';
@@ -17,6 +17,10 @@ async function bootstrap() {
     // 부팅 로그를 버퍼링했다가 pino 로거가 준비되면 flush — 초기 로그도 JSON+trace_id 로.
     { bufferLogs: true },
   );
+
+  // HTTP 요청 하나 = 사슬 하나 (#612). CLS 컨텍스트가 없으면 한 요청 안의 두 발행이 서로
+  // 다른 chainId 를 받는다. 다른 미들웨어·전역 파이프보다 앞이어야 한다.
+  mountEventChainContext(app);
 
   // nestjs-pino 를 Nest 의 기본 로거로 사용. trace_id 주입은 instrumentation-pino 가 처리.
   app.useLogger(app.get(Logger));

--- a/apps/membership/src/main.ts
+++ b/apps/membership/src/main.ts
@@ -8,7 +8,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import fastifyCookie from '@fastify/cookie';
 import { ZodValidationPipe } from 'nestjs-zod';
 import { GlobalExceptionFilter } from '@app/shared/filters/http-exception.filter';
-import { EventsModule } from '@app/events';
+import { mountEventChainContext, EventsModule } from '@app/events';
 
 /**
  * 애플리케이션 부트스트랩 함수
@@ -26,6 +26,10 @@ async function bootstrap(): Promise<void> {
   const app = isDev
     ? await NestFactory.create<NestFastifyApplication>(AppModule, new FastifyAdapter(), { bufferLogs: true })
     : await NestFactory.create<NestFastifyApplication>(AppModule, new FastifyAdapter(), { bufferLogs: true });
+
+  // HTTP 요청 하나 = 사슬 하나 (#612). CLS 컨텍스트가 없으면 한 요청 안의 두 발행이 서로
+  // 다른 chainId 를 받는다. 다른 미들웨어·전역 파이프보다 앞이어야 한다.
+  mountEventChainContext(app);
   app.useLogger(app.get(Logger));
 
   // 쿠키 파서 등록 (Fastify)

--- a/apps/notification/src/main.ts
+++ b/apps/notification/src/main.ts
@@ -3,7 +3,7 @@ import './tracing';
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
-import { EventsModule, createKafkaConfigFromEnv } from '@app/events';
+import { mountEventChainContext, EventsModule, createKafkaConfigFromEnv } from '@app/events';
 import { Logger } from 'nestjs-pino';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import fastifyCookie from '@fastify/cookie';
@@ -16,6 +16,10 @@ async function bootstrap() {
     rawBody: true, // 웹훅 서명 검증용 raw body (req.rawBody: Buffer). 기존 body-parser verify 훅 대체.
     bufferLogs: true,
   });
+
+  // HTTP 요청 하나 = 사슬 하나 (#612). CLS 컨텍스트가 없으면 한 요청 안의 두 발행이 서로
+  // 다른 chainId 를 받는다. 다른 미들웨어·전역 파이프보다 앞이어야 한다.
+  mountEventChainContext(app);
   app.useLogger(app.get(Logger));
 
   // admin-web 은 이 서비스를 자기 프록시(/api/proxy/notification/*)로 부르면서 토큰을

--- a/apps/search/src/main.ts
+++ b/apps/search/src/main.ts
@@ -1,14 +1,20 @@
 import './tracing';
 import { Logger, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
-import { EventsModule, createKafkaConfigFromEnv } from '@app/events';
+import { mountEventChainContext, EventsModule, createKafkaConfigFromEnv } from '@app/events';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import { Logger as PinoLogger } from 'nestjs-pino';
 import { SearchModule } from './search.module';
 
 async function bootstrap() {
   const logger = new Logger('SearchBootstrap');
-  const app = await NestFactory.create<NestFastifyApplication>(SearchModule, new FastifyAdapter(), { bufferLogs: true });
+  const app = await NestFactory.create<NestFastifyApplication>(SearchModule, new FastifyAdapter(), {
+    bufferLogs: true,
+  });
+
+  // HTTP 요청 하나 = 사슬 하나 (#612). CLS 컨텍스트가 없으면 한 요청 안의 두 발행이 서로
+  // 다른 chainId 를 받는다. 다른 미들웨어·전역 파이프보다 앞이어야 한다.
+  mountEventChainContext(app);
   app.useLogger(app.get(PinoLogger));
   app.useGlobalPipes(
     new ValidationPipe({

--- a/apps/ugc-service/src/main.ts
+++ b/apps/ugc-service/src/main.ts
@@ -7,11 +7,16 @@ import { GlobalExceptionFilter } from '@app/shared';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import fastifyCookie from '@fastify/cookie';
+import { mountEventChainContext } from '@app/events';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(UgcServiceModule, new FastifyAdapter(), {
     bufferLogs: true,
   });
+
+  // HTTP 요청 하나 = 사슬 하나 (#612). CLS 컨텍스트가 없으면 한 요청 안의 두 발행이 서로
+  // 다른 chainId 를 받는다. 다른 미들웨어·전역 파이프보다 앞이어야 한다.
+  mountEventChainContext(app);
   app.useLogger(app.get(Logger));
 
   await app.register(fastifyCookie);

--- a/apps/user-service/src/main.ts
+++ b/apps/user-service/src/main.ts
@@ -12,6 +12,7 @@ import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify
 import { Logger as PinoLogger } from 'nestjs-pino';
 import { AppModule } from './app.module';
 import { FILE_SIZE_LIMIT } from './constants/file.constants';
+import { mountEventChainContext } from '@app/events';
 
 async function bootstrap() {
   const logger = new Logger('Bootstrap');
@@ -22,6 +23,10 @@ async function bootstrap() {
     }),
     { bufferLogs: true },
   );
+
+  // HTTP 요청 하나 = 사슬 하나 (#612). CLS 컨텍스트가 없으면 한 요청 안의 두 발행이 서로
+  // 다른 chainId 를 받는다. 다른 미들웨어·전역 파이프보다 앞이어야 한다.
+  mountEventChainContext(app);
   app.useLogger(app.get(PinoLogger));
 
   const configService = app.get(ConfigService);
@@ -30,7 +35,10 @@ async function bootstrap() {
   const configuredCorsOrigins = process.env.CORS_ORIGIN_DOMAINS ?? process.env.CORS_ORIGIN_DOMAIN;
   const corsOrigins =
     process.env.NODE_ENV === 'production'
-      ? (configuredCorsOrigins?.split(',').map((origin) => origin.trim()).filter(Boolean) ?? [])
+      ? (configuredCorsOrigins
+          ?.split(',')
+          .map((origin) => origin.trim())
+          .filter(Boolean) ?? [])
       : ['http://localhost:8000', 'http://localhost:8001', 'https://almondyoung-storefront.vercel.app'];
 
   logger.log('CORS:', corsOrigins);

--- a/apps/wallet/src/main.ts
+++ b/apps/wallet/src/main.ts
@@ -8,7 +8,7 @@ import fastifyCors from '@fastify/cors';
 import fastifyMultipart from '@fastify/multipart';
 import { Logger } from 'nestjs-pino';
 import { WalletModule } from './wallet.module';
-import { EventsModule } from '@app/events';
+import { mountEventChainContext, EventsModule } from '@app/events';
 
 function normalizeOrigin(value: string): string {
   return value.trim().replace(/\/+$/, '');
@@ -67,6 +67,10 @@ async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(WalletModule, new FastifyAdapter(), {
     bufferLogs: true,
   });
+
+  // HTTP 요청 하나 = 사슬 하나 (#612). CLS 컨텍스트가 없으면 한 요청 안의 두 발행이 서로
+  // 다른 chainId 를 받는다. 다른 미들웨어·전역 파이프보다 앞이어야 한다.
+  mountEventChainContext(app);
   app.useLogger(app.get(Logger));
 
   const isDev = process.env.NODE_ENV !== 'production';

--- a/libs/events/src/consumers/consumer-interceptors.ts
+++ b/libs/events/src/consumers/consumer-interceptors.ts
@@ -14,6 +14,7 @@
 
 import type { INestApplicationContext, NestInterceptor, Type } from '@nestjs/common';
 import { ModulesContainer, Reflector } from '@nestjs/core';
+import { ClsInterceptor } from 'nestjs-cls';
 import type { SchemaValidationOptions, StreamConfig } from '@packages/event-contracts/types';
 import { DLQHandler } from '../dlq/dlq-handler.service';
 import { ChainContextInterceptor } from '../interceptors/chain-context.interceptor';
@@ -89,6 +90,23 @@ export function buildConsumerInterceptors(app: INestApplicationContext, streams:
   const policy = optionalGet<EventsConsumerPolicy>(app, EVENTS_CONSUMER_POLICY);
 
   const interceptors: NestInterceptor[] = [
+    // **최외곽 — CLS 컨텍스트를 연다 (#612).** 소비 경로에는 ClsGuard/ClsInterceptor 가 없어
+    // CLS 가 아예 열리지 않았고, 그래서 `ChainContextInterceptor` 의 `setChainId` 가
+    // "No CLS context available" 로 던지며 그 안의 `catch` 에 삼켜졌다 — 완전 무증상이었다.
+    //
+    // 라이브러리 구현을 쓰는 이유: `cls.run(() => next.handle())` 은 **동작하지 않는다.**
+    // Observable 은 구독 시점에 실행되므로 핸들러가 도는 시점엔 `run` 콜백이 이미 반환된
+    // 뒤다. `ClsInterceptor` 는 `new Observable(sub => cls.runWith(store, () =>
+    // next.handle().subscribe(sub)))` 로 그 함정을 이미 풀어놨다.
+    //
+    // `ClsGuard` 는 대안이 아니다 — 그 구현은 `cls.enterWith()` 이고, 이는 컨텍스트를 현재
+    // async resource 의 남은 수명 전체에 눌러쓰므로 장수 컨슈머 루프에서 메시지 간 store 가
+    // 샐 수 있다.
+    //
+    // 최외곽인 이유: 재시도·DLQ·스키마 검증까지 전부 같은 사슬 컨텍스트 안에서 돌아야
+    // DLQ 로 나가는 메시지도 인바운드 사슬을 물고 나간다. 에러는 그대로 통과시키므로
+    // (`error: (err) => subscriber.error(err)`) 아래 재시도·분류망의 순서 의미는 그대로다.
+    new ClsInterceptor({ saveCtx: false, resolveProxyProviders: false }),
     new EventRetryInterceptor(reflector, optionalGet(app, DLQHandler)),
     new SchemaValidationInterceptor(reflector, streams, policy?.validation),
   ];

--- a/libs/events/src/http/mount-event-chain-context.spec.ts
+++ b/libs/events/src/http/mount-event-chain-context.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * HTTP 경로 사슬 (#612)
+ *
+ * 소비 경로만 고치면 사슬은 *이어지지만* 시작되지 않는다. HTTP 요청 하나가 이벤트를
+ * 둘 발행하면 서로 다른 `chainId` 를 받았다 — CLS 컨텍스트가 없어 발행부가 chainId 를
+ * 심을 곳이 없었기 때문이다.
+ *
+ * **운영과 같은 어댑터(Fastify)로 검증한다.** 이 저장소의 HTTP 앱 9개가 전부 Fastify 이고,
+ * `app.use` 미들웨어가 라우트 핸들러까지 async 컨텍스트를 전달하는지는 어댑터에 달린
+ * 문제라 Express 로 검증하면 아무것도 증명하지 못한다.
+ */
+
+import { Controller, Get } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { z } from 'zod';
+import { event, stream } from '@packages/event-contracts/types';
+import { EventsModule } from '../events.module';
+import { InjectPublisher } from '../publishers/inject-publisher';
+import { StreamPublisher } from '../publishers/stream-publisher.service';
+import { EVENT_TRANSPORT } from '../transport/transport.port';
+import { InMemoryBroker } from '../transport/in-memory.broker';
+import { InMemoryTransport } from '../transport/in-memory.transport';
+import { mountEventChainContext } from './mount-event-chain-context';
+
+const HTTP_STREAM = stream({
+  topic: 'harness.http.v1',
+  partitions: 1,
+  aggregateType: 'HttpHarness',
+  events: {
+    ThingHappened: event('ThingHappened', z.object({ thingId: z.string() })),
+  },
+});
+
+@Controller()
+class PublishTwiceController {
+  constructor(
+    @InjectPublisher(HTTP_STREAM)
+    private readonly publisher: StreamPublisher<typeof HTTP_STREAM.events>,
+  ) {}
+
+  /** 한 요청이 이벤트 둘을 내보내는 흔한 모양 */
+  @Get('/do-thing')
+  async doThing(): Promise<{ ok: true }> {
+    await this.publisher.publishEvent({
+      eventType: 'ThingHappened',
+      aggregateId: 'thing-1',
+      payload: { thingId: 'thing-1' },
+    });
+    await this.publisher.publishEvent({
+      eventType: 'ThingHappened',
+      aggregateId: 'thing-2',
+      payload: { thingId: 'thing-2' },
+    });
+    return { ok: true };
+  }
+}
+
+async function bootFastifyApp(broker: InMemoryBroker, mount: boolean): Promise<NestFastifyApplication> {
+  const moduleRef = await Test.createTestingModule({
+    imports: [
+      EventsModule.forApp({
+        publishes: [HTTP_STREAM],
+        serviceName: 'http-harness',
+        kafka: { clientId: 'http-harness', brokers: ['unused:9092'] },
+      }),
+    ],
+    controllers: [PublishTwiceController],
+  })
+    .overrideProvider(EVENT_TRANSPORT)
+    .useValue(new InMemoryTransport(broker))
+    .compile();
+
+  const app = moduleRef.createNestApplication<NestFastifyApplication>(new FastifyAdapter(), { logger: false });
+  if (mount) {
+    mountEventChainContext(app);
+  }
+  await app.init();
+  await app.getHttpAdapter().getInstance().ready();
+  return app;
+}
+
+describe('HTTP 요청 스코프 사슬 (mountEventChainContext)', () => {
+  let broker: InMemoryBroker;
+
+  beforeAll(() => {
+    // 토픽 부트스트랩은 Kafka admin 에 붙는다 — 하네스에서는 꺼야 한다
+    process.env.KAFKA_BOOTSTRAP_TOPICS = 'false';
+  });
+
+  beforeEach(() => {
+    broker = new InMemoryBroker();
+  });
+
+  it('마운트하면 한 요청의 두 발행이 같은 chainId 를 받는다', async () => {
+    const app = await bootFastifyApp(broker, true);
+    try {
+      const res = await app.inject({ method: 'GET', url: '/do-thing' });
+      expect(res.statusCode).toBe(200);
+
+      const published = broker.envelopesOn(HTTP_STREAM.topic.topic);
+      expect(published).toHaveLength(2);
+      expect(published[0].chainId).toBeDefined();
+      expect(published[1].chainId).toBe(published[0].chainId);
+    } finally {
+      await app.close();
+    }
+  });
+
+  /**
+   * 음성 대조군 — 이 스펙의 red 다.
+   *
+   * 마운트를 빼면 발행마다 새 사슬이 된다. 이것이 #612 이전의 라이브 동작이었고,
+   * 누군가 `main.ts` 의 호출을 지우면 위 테스트가 아니라 **이 테스트가** 무엇이 달라졌는지
+   * 말해준다.
+   */
+  it('마운트하지 않으면 발행마다 새 사슬이 된다 (수정 전 라이브 동작)', async () => {
+    const app = await bootFastifyApp(broker, false);
+    try {
+      const res = await app.inject({ method: 'GET', url: '/do-thing' });
+      expect(res.statusCode).toBe(200);
+
+      const published = broker.envelopesOn(HTTP_STREAM.topic.topic);
+      expect(published).toHaveLength(2);
+      expect(published[1].chainId).not.toBe(published[0].chainId);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/libs/events/src/http/mount-event-chain-context.ts
+++ b/libs/events/src/http/mount-event-chain-context.ts
@@ -1,0 +1,44 @@
+import type { INestApplication } from '@nestjs/common';
+import { ClsMiddleware } from 'nestjs-cls';
+
+/**
+ * HTTP 요청 하나 = 사슬 하나 (#612)
+ *
+ * 요청 스코프 CLS 컨텍스트를 연다. 이것이 없으면 `StreamPublisher` 가 `chainId` 를 심을
+ * 곳이 없어 **한 요청 안의 두 발행이 서로 다른 사슬을 받는다** — 사슬이 소비 경계에서만
+ * 끊긴 게 아니라 애초에 시작되지 않는다.
+ *
+ * ## 왜 `ClsModule.forRoot({ middleware: { mount: true } })` 가 아닌가
+ *
+ * `EventsModule.forApp` 은 **BC 별 다중 호출이 공식 패턴**이고(core 가 4번 부른다),
+ * Nest 11 은 동적 모듈을 참조로 dedupe 한다 — 구조 해시로 묶던 Nest 10 과 다르다.
+ * 그래서 `forApp` 안의 `ClsModule.forRoot` 는 앱마다 여러 벌이 되고, 거기에 mount 를
+ * 켜면 **미들웨어가 요청당 그 횟수만큼** 붙는다. 마운트는 앱당 한 번이어야 하므로
+ * 모듈 등록이 아니라 `main.ts` 의 명시 호출로 둔다.
+ *
+ * ## 왜 미들웨어인가
+ *
+ * `ClsMiddleware` 는 기본값(`useEnterWith: false`)에서 `cls.run(callback)` 으로 컨텍스트를
+ * 열고 그 안에서 `next()` 를 부른다 — 요청이 끝나면 컨텍스트도 끝난다. `ClsGuard` 는
+ * `cls.enterWith()` 라 컨텍스트가 현재 async resource 의 남은 수명에 눌러붙는다.
+ *
+ * 다른 미들웨어보다 **앞에서** 부를 것. 뒤에 두면 그 사이 미들웨어에서 일어난 발행이
+ * 컨텍스트 밖이 된다.
+ *
+ * @example
+ * const app = await NestFactory.create(AppModule);
+ * mountEventChainContext(app);
+ * await app.listen(port);
+ */
+export function mountEventChainContext(app: INestApplication): void {
+  app.use(
+    new ClsMiddleware({
+      // 요청/응답 객체는 담지 않는다 — 이 컨텍스트의 용도는 chainId·eventId 뿐이고,
+      // 담아두면 요청 수명 동안 참조가 남는다.
+      saveReq: false,
+      saveRes: false,
+      // proxy provider 를 쓰지 않으므로 요청마다 resolve 를 돌 이유가 없다.
+      resolveProxyProviders: false,
+    }).use,
+  );
+}

--- a/libs/events/src/index.ts
+++ b/libs/events/src/index.ts
@@ -68,6 +68,9 @@ export * from './outbox/outbox-dispatcher.service';
 // Utilities
 export * from './utils/message-id.util';
 
+// HTTP 요청 스코프 CLS 컨텍스트 마운트 (#612) — 앱 `main.ts` 에서 한 번 부른다
+export { mountEventChainContext } from './http/mount-event-chain-context';
+
 // Chain Tracking
 export { EventChainService } from './tracking/event-chain.service';
 export { EventTrackingService, EVENT_TRACKING_SERVICE_NAME } from './tracking/event-tracking.service';

--- a/libs/events/src/interceptors/chain-context.interceptor.ts
+++ b/libs/events/src/interceptors/chain-context.interceptor.ts
@@ -1,4 +1,4 @@
-import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler, Logger } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { KafkaContext } from '@nestjs/microservices';
 import { v7 } from 'uuid';
@@ -7,9 +7,16 @@ import { parseEnvelope } from '../utils/envelope.util';
 
 /**
  * Kafka 메시지 수신 시 envelope에서 chainId/eventId를 CLS에 설정하는 인터셉터
+ *
+ * **CLS 컨텍스트는 이 인터셉터가 열지 않는다.** `buildConsumerInterceptors` 가 최외곽에
+ * 얹는 `ClsInterceptor` 가 연다 (#612). 그 배선이 없던 동안 아래 `set` 이 매번
+ * "No CLS context available" 로 던졌고, 예외가 통째로 삼켜져 **완전 무증상**이었다 —
+ * 그래서 이 catch 는 이제 로그를 남긴다.
  */
 @Injectable()
 export class ChainContextInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(ChainContextInterceptor.name);
+
   constructor(private readonly eventChainService: EventChainService) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
@@ -31,8 +38,13 @@ export class ChainContextInterceptor implements NestInterceptor {
         this.eventChainService.setChainId(chainId);
         this.eventChainService.setEventId(eventId);
       }
-    } catch {
-      // 파싱 실패 시 무시 - 체인 추적은 베스트 에포트
+    } catch (error) {
+      // 체인 추적은 여전히 베스트 에포트다 — 메시지 처리를 막지 않는다. 다만 **조용히**
+      // 넘어가지는 않는다. 이 자리의 침묵이 #612 를 배포된 채로 오래 살려둔 원인이다.
+      this.logger.warn({
+        msg: '이벤트 체인 컨텍스트 설정 실패 — chainId 전파가 이 메시지에서 끊긴다',
+        reason: error instanceof Error ? error.message : String(error),
+      });
     }
 
     return next.handle();

--- a/libs/events/src/publishers/stream-publisher.service.ts
+++ b/libs/events/src/publishers/stream-publisher.service.ts
@@ -221,8 +221,11 @@ export class StreamPublisher<TEvents extends StreamEventTypes = StreamEventTypes
       validatedPayload = this.validatePayload(String(params.eventType), params.payload);
     }
 
-    // chainId: CLS에서 읽거나 새 UUID v7 생성
-    const chainId = this.eventChainService?.getChainId() ?? v7();
+    // chainId: CLS 에서 읽고, 없으면 만들어 **CLS 에 심는다** (#612).
+    // 옛 `getChainId() ?? v7()` 은 심지 않았기 때문에 같은 컨텍스트의 두 발행이 서로 다른
+    // 사슬을 받았다 — 사슬이 컨슈머 경계에서만 끊긴 게 아니라 애초에 시작되지 않았다.
+    // `EventChainService` 가 없는 앱(주입 optional)에서는 이 발행 한 건짜리 사슬이 맞다.
+    const chainId = this.eventChainService?.ensureChainId() ?? v7();
 
     return {
       messageId,

--- a/libs/events/src/tracking/event-chain.service.ts
+++ b/libs/events/src/tracking/event-chain.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ClsService } from 'nestjs-cls';
+import { v7 } from 'uuid';
 
 @Injectable()
 export class EventChainService {
@@ -19,6 +20,33 @@ export class EventChainService {
 
   setEventId(id: string): void {
     this.cls.set('eventId', id);
+  }
+
+  /**
+   * chainId 를 읽되, **없으면 만들어서 CLS 에 심는다.**
+   *
+   * 발행부의 옛 `getChainId() ?? v7()` 로는 사슬이 시작되지 않았다 — 심는 주체가 없어
+   * 같은 요청·같은 핸들러 안의 두 발행이 서로 다른 id 를 받았기 때문이다. 여기서 심어야
+   * "한 컨텍스트 = 한 사슬" 이 성립한다.
+   *
+   * CLS 컨텍스트 밖(크론·부트스트랩 스크립트)에서는 심을 곳이 없다. 그때는 생성만 해서
+   * 돌려주므로 **던지지 않고**, 발행마다 새 사슬이 된다는 점은 이 변경 전과 같다.
+   * `cls.set` 이 컨텍스트 없이 던지는 것이 #612 의 무증상 실패 경로였으므로, 이 가드가
+   * 그 실패를 되풀이하지 않는 유일한 이유다.
+   */
+  ensureChainId(): string {
+    if (!this.cls.isActive()) {
+      return v7();
+    }
+
+    const existing = this.getChainId();
+    if (existing) {
+      return existing;
+    }
+
+    const generated = v7();
+    this.cls.set('chainId', generated);
+    return generated;
   }
 
   /**

--- a/libs/events/src/transport/round-trip.spec.ts
+++ b/libs/events/src/transport/round-trip.spec.ts
@@ -10,8 +10,9 @@
  * 걸리지 않았고, 그래서 2026-08-08 아키텍처 리뷰가 오판했다.
  */
 
-import { Controller, INestMicroservice, UseInterceptors } from '@nestjs/common';
+import { Controller, INestMicroservice, Inject, UseInterceptors } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
+import { ClsService } from 'nestjs-cls';
 import { z } from 'zod';
 import { event, getDLQTopicName, stream } from '@packages/event-contracts/types';
 import type { DLQMessage } from '../dlq/dlq.types';
@@ -44,6 +45,9 @@ const HARNESS_STREAM = stream({
     OrderCreated: event('OrderCreated', OrderCreatedSchema),
     OrderCancelled: event<'OrderCancelled', { orderId: string }>('OrderCancelled'),
     OrderShipped: event<'OrderShipped', { orderId: string }>('OrderShipped'),
+    // 컨슈머가 **소비하면서 발행하는** 경로 전용 (#612). 다른 이벤트에 이 역할을 겸하게
+    // 하면 기존 스펙의 `calls` 기대값이 함께 흔들린다.
+    OrderRefunded: event<'OrderRefunded', { orderId: string }>('OrderRefunded'),
   },
 });
 
@@ -72,7 +76,11 @@ const calls: HandlerCall[] = [];
 @UseInterceptors(EventTypeGuard)
 class HarnessConsumer {
   // 생성자 주입이 하네스에서도 살아 있어야 한다 — 클로저 기반 핸들러였다면 잃었을 것
-  constructor(private readonly chain: EventChainService) {}
+  constructor(
+    private readonly chain: EventChainService,
+    @Inject(EventsModule.getPublisherToken(HARNESS_STREAM.topic.topic))
+    private readonly publisher: StreamPublisher<typeof HARNESS_STREAM.events>,
+  ) {}
 
   @On(HARNESS_STREAM, 'OrderCreated')
   onCreated(@EventPayload() payload: OrderCreatedPayload): void {
@@ -86,7 +94,21 @@ class HarnessConsumer {
 
   @On(HARNESS_STREAM, 'OrderShipped')
   onShipped(@EventPayload() payload: unknown): void {
-    calls.push({ handler: 'onShipped', payload });
+    calls.push({ handler: 'onShipped', payload, chainId: this.chain.getChainId() });
+  }
+
+  /**
+   * 소비하면서 발행하는 핸들러 — #612 가 끊었던 바로 그 자리다.
+   * 운영에서는 `apps/wallet/src/consumers/billing-charge.consumer.ts` 가 같은 모양이다.
+   */
+  @On(HARNESS_STREAM, 'OrderRefunded')
+  async onRefunded(@EventPayload() payload: { orderId: string }): Promise<void> {
+    calls.push({ handler: 'onRefunded', payload, chainId: this.chain.getChainId() });
+    await this.publisher.publishEvent({
+      eventType: 'OrderShipped',
+      aggregateId: payload.orderId,
+      payload: { orderId: payload.orderId },
+    });
   }
 }
 
@@ -171,19 +193,13 @@ describe('발행 → 소비 왕복 (인메모리 transport)', () => {
   });
 
   /**
-   * ⚠️ 알려진 실재 결함 — 이 태스크 범위 밖이라 고치지 않고 실행 가능한 형태로 박아둔다.
+   * #612 의 완료 판정. 오래 `it.failing` 으로 박혀 있던 자리다 — 소비 경로에 CLS 컨텍스트를
+   * 여는 주체가 없어 `setChainId` 가 "No CLS context available" 로 던졌고, 그 예외를
+   * `ChainContextInterceptor` 의 `catch` 가 삼켜 **완전 무증상**이었다.
    *
-   * 소비 경로에서 `chainId` 가 CLS 로 전파되지 않는다. 원인은 파싱이 아니라
-   * (그건 `parseEnvelope` 로 고쳤다) **CLS 컨텍스트가 아예 열리지 않는 것**이다:
-   * `ClsModule.forRoot({ middleware: { mount: false } })` 이고 RPC 경로에
-   * ClsGuard/ClsInterceptor 가 없어 `setChainId` 가
-   * "No CLS context available" 로 던지며, `ChainContextInterceptor` 의
-   * `catch {}` 가 그것을 삼킨다 (2026-08-09 실측).
-   *
-   * `it.failing` 이므로 **지금은 통과**하고, 누군가 CLS 배선을 고치면 이 테스트가
-   * 실패해 "이제 고쳐졌으니 일반 `it` 으로 바꿔라"고 알린다.
+   * 이제 `buildConsumerInterceptors` 의 최외곽 `ClsInterceptor` 가 컨텍스트를 연다.
    */
-  it.failing('ChainContextInterceptor 가 envelope 의 chainId 를 CLS 로 전파한다', async () => {
+  it('ChainContextInterceptor 가 envelope 의 chainId 를 CLS 로 전파한다', async () => {
     await publisher.publishEvent({
       eventType: 'OrderCreated',
       aggregateId: 'order-3',
@@ -193,6 +209,80 @@ describe('발행 → 소비 왕복 (인메모리 transport)', () => {
     const published = broker.envelopesOn(HARNESS_STREAM.topic.topic);
     expect(calls[0].chainId).toBeDefined();
     expect(calls[0].chainId).toBe(published[0].chainId);
+  });
+
+  /**
+   * 소비 경로가 사슬을 **이어서 내보내는지** — #612 의 본체다.
+   *
+   * 인바운드 `OrderRefunded` 를 받은 핸들러가 그 안에서 `OrderShipped` 를 발행한다.
+   * 고쳐지기 전에는 발행부가 CLS 를 못 읽어 후속 이벤트가 새 사슬을 팠다.
+   */
+  it('컨슈머 안에서 발행한 후속 이벤트가 인바운드 chainId 를 이어받는다', async () => {
+    await publisher.publishEvent({
+      eventType: 'OrderRefunded',
+      aggregateId: 'order-refund-1',
+      payload: { orderId: 'order-refund-1' },
+    });
+
+    const published = broker.envelopesOn(HARNESS_STREAM.topic.topic);
+    const inbound = published.find((e) => e.messageType === 'OrderRefunded');
+    const outbound = published.find((e) => e.messageType === 'OrderShipped');
+
+    expect(inbound?.chainId).toBeDefined();
+    expect(outbound?.chainId).toBe(inbound?.chainId);
+
+    // 사슬은 다음 홉의 핸들러까지 이어진다 — envelope 뿐 아니라 CLS 도 같은 값이어야 한다
+    expect(calls.map((call) => call.handler)).toEqual(['onRefunded', 'onShipped']);
+    expect(calls[1].chainId).toBe(inbound?.chainId);
+  });
+
+  /**
+   * 발행부의 시딩 (#612). `getChainId() ?? v7()` 은 **심지 않았기 때문에** 한 컨텍스트
+   * 안의 두 발행이 서로 다른 사슬을 받았다 — 소비 경계에서만 끊긴 게 아니라 애초에
+   * 사슬이 시작되지 않았다는 뜻이다. HTTP 요청 하나가 이벤트 둘을 내보내는 경우가 이 모양이다.
+   */
+  it('한 CLS 컨텍스트 안의 두 발행은 같은 chainId 를 받는다', async () => {
+    const cls = app.get(ClsService);
+
+    await cls.run(async () => {
+      await publisher.publishEvent({
+        eventType: 'OrderCreated',
+        aggregateId: 'order-seed-1',
+        payload: { orderId: 'order-seed-1', amount: 100 },
+      });
+      await publisher.publishEvent({
+        eventType: 'OrderCreated',
+        aggregateId: 'order-seed-2',
+        payload: { orderId: 'order-seed-2', amount: 200 },
+      });
+    });
+
+    const published = broker.envelopesOn(HARNESS_STREAM.topic.topic);
+    expect(published).toHaveLength(2);
+    expect(published[0].chainId).toBeDefined();
+    expect(published[1].chainId).toBe(published[0].chainId);
+  });
+
+  /**
+   * 시딩의 경계 — CLS 컨텍스트가 없으면 심을 곳이 없다. 크론·부트스트랩 스크립트가 이쪽이다.
+   * **던지지 않는 것**이 핵심이다. `cls.set` 이 컨텍스트 없이 던지는 것이 #612 의 무증상
+   * 실패 경로였으므로, 그 예외를 발행 경로로 옮겨 심지 않았음을 여기서 고정한다.
+   */
+  it('CLS 컨텍스트 밖 발행은 던지지 않고 발행마다 새 사슬이 된다', async () => {
+    await publisher.publishEvent({
+      eventType: 'OrderCreated',
+      aggregateId: 'order-nocls-1',
+      payload: { orderId: 'order-nocls-1', amount: 100 },
+    });
+    await publisher.publishEvent({
+      eventType: 'OrderCreated',
+      aggregateId: 'order-nocls-2',
+      payload: { orderId: 'order-nocls-2', amount: 200 },
+    });
+
+    const published = broker.envelopesOn(HARNESS_STREAM.topic.topic);
+    expect(published[0].chainId).toBeDefined();
+    expect(published[1].chainId).not.toBe(published[0].chainId);
   });
 
   it('EventTypeGuard 가 같은 토픽의 다중 핸들러 중 messageType 이 맞는 하나만 실행한다', async () => {


### PR DESCRIPTION
Closes #612

## 무엇이 문제였나

이벤트 인과 사슬(`chainId`)이 앱 경계를 넘어가지 못했다. 조사해 보니 **결함은 하나가 아니라 둘**이었다 — 사슬이 *이어지지* 않는 것과, 애초에 *시작되지* 않는 것.

### 1. 소비 경로 (이슈 본문)

RPC 경로에 CLS 컨텍스트를 여는 주체가 없었다. `ClsModule.forRoot({ middleware: { mount: false } })` 이고 `ClsGuard`/`ClsInterceptor` 등록이 없어 `setChainId` 가 `"No CLS context available"` 로 던졌고, `ChainContextInterceptor` 의 `catch {}` 가 그 예외를 삼켰다 → **완전 무증상**.

### 2. HTTP 경로 (이슈 본문 밖 — 같은 뿌리)

`ClsMiddleware`/`Guard`/`Interceptor` 등록이 **저장소 전체에 0건**이었다. 즉 요청 하나가 이벤트를 둘 발행하면 `chainId` 가 둘 생긴다. 사슬은 끊기기 전에 **시작부터 쪼개져 있었다.**

그리고 컨텍스트를 여는 것만으로는 부족하다 — 옛 `getChainId() ?? v7()` 은 **심지 않았기 때문에** 컨텍스트가 있어도 발행마다 새 id 를 뽑는다. 시딩이 한 세트로 붙어야 한다.

## 어떻게 고쳤나

| 파일 | 변경 |
|---|---|
| `consumers/consumer-interceptors.ts` | **최외곽**에 `ClsInterceptor` |
| `http/mount-event-chain-context.ts` (신규) | HTTP 요청 스코프 CLS 마운트 헬퍼 |
| `apps/*/src/main.ts` (9개) | `mountEventChainContext(app)` 한 줄씩 |
| `tracking/event-chain.service.ts` | `ensureChainId()` — 없으면 만들어 **CLS 에 심는다** |
| `publishers/stream-publisher.service.ts` | 시딩 사용 |
| `interceptors/chain-context.interceptor.ts` | `catch {}` → `logger.warn` |

### 되돌리면 안 되는 판단 3개

- 🔴 **`cls.run(() => next.handle())` 로 직접 짜면 안 된다.** Observable 은 구독 시점에 실행되므로 핸들러가 돌 때 `run` 콜백은 이미 반환된 뒤다. nestjs-cls 의 `ClsInterceptor` 가 `new Observable(sub => cls.runWith(store, () => next.handle().subscribe(sub)))` 로 이 함정을 이미 풀어놨다.
- 🔴 **`ClsGuard` 는 대안이 아니다.** 6.2.0 구현이 `cls.enterWith()` 이고, 이는 컨텍스트를 현재 async resource 의 남은 수명 전체에 눌러쓴다 → 장수 컨슈머 루프에서 메시지 간 store 누출 위험.
- 🔴 **HTTP 를 `ClsModule.forRoot({middleware:{mount:true}})` 로 켜면 안 된다.** `forApp` 은 BC 별 다중 호출이 **공식 패턴**이고(core 가 4번 부른다) Nest 11 은 동적 모듈을 **참조로 dedupe** 하므로, 거기서 mount 를 켜면 미들웨어가 요청당 그 횟수만큼 붙는다. 마운트는 앱당 한 번이어야 해서 `main.ts` 명시 호출로 뒀다.

### 조사 중 기각한 의심 (다시 파지 않도록)

- **중복 `ClsModule.forRoot`(events.module + adapter.module)는 원인이 아니다** — nestjs-cls 의 ALS 는 `cls-service.globals.js` 의 모듈 전역 싱글턴이라 store 는 하나다.
- **Fastify + `app.use` 는 깨지지 않는다** — 9개 앱 전부 Fastify 이고 `@fastify/middie` 가 직접 의존성에 없어 의심했으나, 실측 결과 미들웨어·인터셉터 **양쪽 다** 핸들러까지 컨텍스트를 전달했다. 미들웨어를 택한 건 가드·파이프까지 덮기 때문.
- **`trackEffect` 전멸은 사실이 아니다** — 호출자는 channel-adapter 2곳뿐이고 `inbox-worker` 경로는 `runWithChain` 이 있어 살아 있었다. 죽는 건 `membership-daily-sync` 크론 경로뿐.

## 테스트

`round-trip.spec.ts:186` 의 `it.failing` → 일반 `it` (**#612 의 완료 판정**), 그리고 신규 4건:

- 컨슈머 안에서 발행한 후속 이벤트가 인바운드 `chainId` 를 이어받는가 (운영에선 `apps/wallet/src/consumers/billing-charge.consumer.ts` 가 이 모양)
- 한 CLS 컨텍스트의 두 발행이 같은 `chainId` 를 받는가 (시딩)
- CLS 밖 발행은 던지지 않고 발행마다 새 사슬인가 (경계 — `cls.set` 이 던지는 것이 원래 결함의 무증상 경로였다)
- **HTTP 경로를 운영과 같은 Fastify 어댑터로** 검증 + **마운트 없는 음성 대조군**. 누군가 `main.ts` 호출을 지우면 그 테스트가 무엇이 달라졌는지 말해준다.

**red-green 은 스펙별로 개별 확인했다.** 초록만 보면 새 스펙이 공짜로 통과할 수 있어 수정을 하나씩 되돌려 봤다:

- 시딩만 되돌림 → 시딩 스펙 **1건만** 빨감
- `ClsInterceptor` 만 되돌림 → 전파·연쇄 스펙 **2건만** 빨감

## 검증 게이트

| 게이트 | 결과 |
|---|---|
| `npm run type-check` | **0** (tsbuildinfo 삭제 후 재실행, 종료코드 0) |
| `npx jest --maxWorkers=2` | **455 suite 통과 / 실패 0** (3902 tests) |
| `npm run audit:consume-validation -- --gate` | 위반 없음 |
| eslint (변경 파일) | 기준선 46 → **44**, 신규 파일 0건 |

## 범위 밖

- 크론 경로 CLS (`@UseCls` 필요) — `membership-daily-sync` 의 `trackEffect` 는 계속 skip 된다
- `causationId` 자동 채움 — admin 추적 그래프(`build-graph.ts`)가 간선을 **`chainId` 로만** 만들므로 불필요

## 배포

마이그레이션 **0** / 시크릿 **0** / env **0**.

`libs/events` 변경이므로 **9개 앱 전부 재배포** — core · user-service · notification · ugc-service · membership · wallet · analytics · channel-adapter · search. 앱 간 의존이 없어 **순서 무관**.

동작 변화(의도됨): 컨슈머발 이벤트가 인바운드 사슬을 물고, DLQ 메시지도 사슬을 상속한다. admin 이벤트 추적 그래프가 조각에서 하나로 합쳐진다.

https://claude.ai/code/session_01BhM1CHS5Dt9irDUxmtpBgG
