### PR TITLE
chore(observability): MetricsService 죽은 API 제거 + Alloy 이미지 버전 핀 (#706, #708)

### DIFF
--- a/apps/core/src/modules/inventory/shared/services/ledger-drift-metric.spec.ts
+++ b/apps/core/src/modules/inventory/shared/services/ledger-drift-metric.spec.ts
@@ -12,14 +12,14 @@ describe('MetricsService.setLedgerDrift', () => {
 
   it('두 severity 라벨을 모두 게이지에 기록한다', async () => {
     metrics.setLedgerDrift({ mismatch: 2, critical: 1 });
-    const out = await metrics.getMetrics();
+    const out = await register.metrics();
     expect(out).toContain('wms_ledger_drift_grains{severity="MISMATCH"} 2');
     expect(out).toContain('wms_ledger_drift_grains{severity="CRITICAL"} 1');
   });
 
   it('정상(0 drift) 실행도 0 을 명시적으로 기록한다', async () => {
     metrics.setLedgerDrift({ mismatch: 0, critical: 0 });
-    const out = await metrics.getMetrics();
+    const out = await register.metrics();
     expect(out).toContain('wms_ledger_drift_grains{severity="MISMATCH"} 0');
     expect(out).toContain('wms_ledger_drift_grains{severity="CRITICAL"} 0');
   });

--- a/apps/core/src/modules/inventory/shared/services/metrics.service.ts
+++ b/apps/core/src/modules/inventory/shared/services/metrics.service.ts
@@ -43,13 +43,6 @@ export class MetricsService implements OnModuleInit {
     registers: [register],
   });
 
-  private readonly availableStock = new Gauge({
-    name: 'wms_available_stock',
-    help: 'Available stock quantity by SKU and warehouse',
-    labelNames: ['sku_id', 'warehouse_id'],
-    registers: [register],
-  });
-
   // 시스템 메트릭
   private readonly errorCounter = new Counter({
     name: 'wms_errors_total',
@@ -189,13 +182,6 @@ export class MetricsService implements OnModuleInit {
   }
 
   /**
-   * 가용 재고 수량 업데이트
-   */
-  setAvailableStock(skuId: string, warehouseId: string, quantity: number) {
-    this.availableStock.set({ sku_id: skuId, warehouse_id: warehouseId }, quantity);
-  }
-
-  /**
    * 에러 메트릭 증가
    */
   incrementErrorCounter(module: string, errorType: string, severity: 'low' | 'medium' | 'high' | 'critical') {
@@ -224,33 +210,11 @@ export class MetricsService implements OnModuleInit {
   }
 
   /**
-   * 모든 메트릭 조회 (Prometheus 엔드포인트용)
-   */
-  async getMetrics(): Promise<string> {
-    return await register.metrics();
-  }
-
-  /**
    * 특정 메트릭 초기화 (테스트용)
    */
   reset() {
     register.resetMetrics();
     this.logger.warn('Metrics have been reset');
-  }
-
-  /**
-   * 비즈니스 메트릭 업데이트 (배치 작업용)
-   */
-  updateBusinessMetrics() {
-    try {
-      // 이 메소드는 주기적으로 호출되어 비즈니스 메트릭을 업데이트할 수 있습니다.
-      // 예: 총 주문 수, 평균 재고 회전율 등
-
-      this.logger.debug('Business metrics updated');
-    } catch (error) {
-      this.logger.error('Failed to update business metrics:', error);
-      this.incrementErrorCounter('metrics', 'business_update_failed', 'medium');
-    }
   }
 
   /**
@@ -288,36 +252,5 @@ export class MetricsService implements OnModuleInit {
     for (const [kind, count] of Object.entries(counts)) {
       this.fulfillmentInvariantViolationsGauge.set({ kind }, count);
     }
-  }
-
-  /**
-   * 커스텀 메트릭 생성
-   */
-  createCustomCounter(name: string, help: string, labelNames?: string[]) {
-    return new Counter({
-      name: `wms_${name}`,
-      help,
-      labelNames: labelNames || [],
-      registers: [register],
-    });
-  }
-
-  createCustomHistogram(name: string, help: string, labelNames?: string[], buckets?: number[]) {
-    return new Histogram({
-      name: `wms_${name}`,
-      help,
-      labelNames: labelNames || [],
-      buckets: buckets || [0.1, 0.5, 1, 2, 5, 10],
-      registers: [register],
-    });
-  }
-
-  createCustomGauge(name: string, help: string, labelNames?: string[]) {
-    return new Gauge({
-      name: `wms_${name}`,
-      help,
-      labelNames: labelNames || [],
-      registers: [register],
-    });
   }
 }

--- a/deployments/lcnine/services/observability/alloy/Dockerfile
+++ b/deployments/lcnine/services/observability/alloy/Dockerfile
@@ -1,4 +1,15 @@
-FROM grafana/alloy:latest
+# 버전 핀 — `:latest` 는 배포할 때마다 업스트림 최신을 끌어와, 우리 변경이 없는데도
+# 관측이 깨질 수 있다. #703 이 `discovery.dns` 와 `prometheus.relabel` 을 새로 쓰기
+# 시작하면서 그 표면이 넓어졌다.
+#
+# v1.18.1 은 2026-08-23 기준 `:latest` 와 동일한 다이제스트
+# (sha256:0f4434c92b3e6cdac38bb129b344e1790c246f7b6e2eaffcc16a5fa363240e33) 다.
+# 즉 #703 이 실제로 검증한 그 이미지를 이름으로 고정한 것이고, 이 핀 자체는 배포 동작을
+# 바꾸지 않는다.
+#
+# 올릴 때: 태그를 바꾸는 것이 곧 의도적인 업그레이드다. config.alloy 를 로드시켜 부팅 로그에
+# 오류가 없는지 확인하고, 배포 후 9개 job 의 `up` 시리즈가 그대로인지 본다.
+FROM grafana/alloy:v1.18.1
 
 COPY deployments/lcnine/services/observability/alloy/config.alloy /etc/alloy/config.alloy
 


### PR DESCRIPTION
#703 검수 중 범위 밖으로 뺐던 정리 항목 둘. 마이그레이션 0건, 시크릿 0건, env 0건, 이벤트 계약 변화 0건이라 배포 순서 제약이 없다.

## #706 — `MetricsService` 의 죽은 public API 제거

`apps/core/src/modules/inventory/shared/services/metrics.service.ts` 에서 호출처가 0곳인 멤버를 지운다.

그중 `setAvailableStock` 은 단순한 죽은 코드가 아니다 — `wms_available_stock` 의 라벨이 `sku_id` × `warehouse_id` 라, 누가 부르기 시작하는 순간 시리즈가 SKU 수 × 창고 수로 폭발한다. **지금 라이브 샘플이 0건이라 무해했을 뿐이다.** 게이지 등록도 함께 지운다.

| 제거 | 사유 |
|---|---|
| `setAvailableStock` + `wms_available_stock` Gauge 등록 | 호출처 0곳 + 카디널리티 폭탄 |
| `createCustomCounter` / `createCustomHistogram` / `createCustomGauge` | 호출처 0곳 |
| `getMetrics()` | #703 이 `MetricsController` 를 제거하면서 프로덕션 호출처 0곳 |
| `updateBusinessMetrics()` | 본문이 `logger.debug` 한 줄뿐인 실질 no-op |

`getMetrics()` 의 유일한 호출자였던 `ledger-drift-metric.spec.ts` 는 `register.metrics()` 를 직접 부르게 바꿨다. 원래 `getMetrics()` 본문이 `register.metrics()` 한 줄이었고 spec 이 이미 같은 전역 레지스트리를 `beforeEach` 에서 비우고 있어서, 검증 대상은 그대로다.

**남긴 것**: `MetricsService` 본체(5곳이 주입받아 쓴다)와 `onModuleInit()` 의 `collectDefaultMetrics()`(#703 이후에도 Core 만 켠 상태).

**손대지 않은 것**: `reset()` 도 호출처가 0곳이다. "테스트용" 주석이 붙어 있는데 정작 spec 들은 `register.clear()` 를 직접 쓴다. 이슈 표에 없어서 이번 범위에서 뺐다.

## #708 — Alloy 이미지 버전 핀 (1번만)

`FROM grafana/alloy:latest` → `v1.18.1`. 저장소에서 `:latest` 를 쓰던 Dockerfile 은 이것 하나뿐이었다.

태그 선정은 추측이 아니라 실측이다 — `v1.18.1` 과 `latest` 의 매니페스트 다이제스트가 `sha256:0f4434c92b3e6cdac38bb129b344e1790c246f7b6e2eaffcc16a5fa363240e33` 로 **동일**하다. 즉 지금 라이브에 떠 있는 바로 그 이미지를 이름으로 고정한 것이고, **이 핀은 배포 동작을 바꾸지 않는다.**

**이슈의 2번(스크레이프 대상 침묵 감시 알림)은 이 PR 범위 밖이다.** 저장소에 Grafana 알림 IaC 가 없어 코드로 표현할 대상이 아니다. 그래서 `Closes` 가 아니라 `Refs` 로 건다 — #708 은 알림까지 끝나야 닫힌다.

참고로 이슈 본문의 완료 판정 쿼리는 그대로 쓰면 안 된다:

```promql
count(up) by (job) < 9   # ❌ job 마다 target 수(=1)를 9와 비교 → 항상 발동
```

의도한 "job 개수"를 세려면 집계를 한 겹 더 씌워야 하고, 9개가 전부 사라지면 결과가 빈 벡터라 `Firing` 이 아니라 `No Data` 가 된다는 함정도 있다(규칙에 **No data → Alerting** 필요). 알림을 실제로 걸 때 이슈에서 다시 다룬다.

## 부팅 검증 중 나온 것 (이 PR 에서 조치 안 함)

핀한 이미지로 `config.alloy` 를 로드시키면 경고가 2건 난다:

```
msg="one or more paths were modified to include their context prefix, please rewrite them accordingly"
```

`redact` 프로세서의 OTTL 구문이다 — `attributes` → `span.attributes`, `body` → `log.body` 로 **지금은 Alloy 가 자동 변환해 준다.** 업스트림이 이 자동 변환을 걷어내면 크레덴셜 마스킹 규칙이 조용히 죽는다. NestJS 서비스들에겐 이게 유일한 방어선이라 실제 위험이고, 공교롭게도 #708 1번이 막으려던 바로 그 종류의 사고다. 현재 동작에는 문제가 없어 별도 항목으로 남긴다.

## 검증

| 게이트 | 결과 |
|---|---|
| `npm run type-check` | exit 0 (캐시 없음 — `tsbuildinfo` 부재 확인) |
| `npx jest --maxWorkers=2` | 458 suite 통과 / **실패 0**, 3929 테스트 |
| `npx eslint` (변경 2파일) | exit 0 |
| Alloy 컨테이너 실부팅 | 그래프 평가 완료, `level=error` **0건**, 컴포넌트 빌드 실패 **0건**, `prometheus.scrape.*` 노드 **9개 전부** 확인 |

#706 완료 판정 grep — **0건**:

```
grep -rn 'setAvailableStock\|createCustomCounter\|createCustomHistogram\|createCustomGauge' apps/ libs/
```

배포 후 라이브 `/metrics` 응답에서 `wms_available_stock` HELP 줄이 사라지는지가 남은 확인이다.

Closes #706
Refs #708

https://claude.ai/code/session_01Xh97pRcQdSePstJ5cQTbUf