### PR TITLE
fix(wallet): 토스 웹훅을 페이로드 대신 결제 재조회로 검증한다

### DIFF
--- a/apps/wallet/src/providers/toss/toss-api.client.ts
+++ b/apps/wallet/src/providers/toss/toss-api.client.ts
@@ -48,6 +48,17 @@ export interface TossVirtualAccountResponse {
   [key: string]: unknown;
 }
 
+export interface TossPaymentQueryResponse {
+  paymentKey: string;
+  orderId: string;
+  status: string; // WAITING_FOR_DEPOSIT | DONE | CANCELED | PARTIAL_CANCELED | ABORTED | EXPIRED ...
+  totalAmount: number;
+  // 발급 응답에만 값이 있고, 이후 조회에서는 보안상 null 로 돌아온다. 웹훅 secret 대조는
+  // 발급 시 charge 에 저장해 둔 값과 하며, 이 필드에 의존하지 않는다.
+  secret: string | null;
+  [key: string]: unknown;
+}
+
 export interface TossCashReceiptResponse {
   receiptKey: string;
   issueNumber: string;
@@ -165,6 +176,34 @@ export class TossApiClient {
     const body: Record<string, unknown> = {};
     if (amount !== undefined) body.amount = amount;
     return this.post<TossCashReceiptResponse>(`/cash-receipts/${receiptKey}/cancel`, body);
+  }
+
+  /**
+   * orderId(= 하이픈 뗀 chargeId)로 결제를 재조회한다. 웹훅 본문은 신뢰하지 않고 이 응답의
+   * status/totalAmount/paymentKey 를 authoritative 로 쓴다. paymentKey 가 아니라 orderId 로
+   * 조회하는 이유: 공격자가 본문 paymentKey 로 남의 결제를 우리 charge 에 갖다 붙이지 못하게 하기 위함.
+   */
+  async getPaymentByOrderId(orderId: string): Promise<TossApiResult<TossPaymentQueryResponse>> {
+    return this.get<TossPaymentQueryResponse>(`/payments/orders/${encodeURIComponent(orderId)}`);
+  }
+
+  private async get<T>(path: string): Promise<TossApiResult<T>> {
+    const url = `${this.baseUrl}${path}`;
+    this.logger.debug(`GET ${url}`);
+
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Basic ${this.auth}` },
+    });
+
+    if (res.ok) {
+      const data = (await res.json()) as T;
+      return { ok: true, data };
+    }
+
+    const error = await res.json().catch(() => ({ code: 'UNKNOWN', message: 'Unknown error' }));
+    this.logger.error(`Toss API error: ${res.status} ${this.stringifyError(error)}`);
+    return { ok: false, error: this.normalizeError(error), statusCode: res.status };
   }
 
   private async post<T>(

--- a/apps/wallet/src/webhooks/toss-webhook.service.spec.ts
+++ b/apps/wallet/src/webhooks/toss-webhook.service.spec.ts
@@ -4,42 +4,158 @@ import { TossWebhookBodyDto } from './dto';
 /** chargeId 하이픈 제거값이 토스 orderId — 웹훅은 이걸로 charge 를 복원한다. */
 const CHARGE_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 const ORDER_ID = 'aaaaaaaabbbbccccddddeeeeeeeeeeee';
+const CHARGE_AMOUNT = 12790;
 
 const depositWebhook = (): TossWebhookBodyDto => ({
   eventType: 'PAYMENT_STATUS_CHANGED',
   // 계약이 createdAt 을 요구한다. 이 스펙은 시각을 보지 않지만 캐스트로 덮으면
   // 다음 계약 변경도 못 잡으므로 채워 둔다.
   createdAt: '2026-08-13T00:00:00.000Z',
-  data: { orderId: ORDER_ID, status: 'DONE', paymentKey: 'pk_1', totalAmount: 12790 },
+  // 본문값은 공격자가 조작 가능한 값이다 — 방어 후에는 신뢰되지 않아야 한다.
+  data: { orderId: ORDER_ID, status: 'DONE', paymentKey: 'pk_body', totalAmount: CHARGE_AMOUNT },
 });
 
-function buildService(chargeStatus: string) {
+interface BuildOpts {
+  /** 토스 재조회가 돌려주는 authoritative status (기본 DONE). */
+  reQueryStatus?: string;
+  /** 토스 재조회가 돌려주는 authoritative 금액 (기본 charge 금액). */
+  reQueryAmount?: number;
+  /** 토스 재조회가 돌려주는 실제 paymentKey (기본 pk_toss). */
+  reQueryPaymentKey?: string;
+  /** 재조회 자체가 실패하는 경우 (일시적 5xx / 미존재 4xx). */
+  reQueryError?: { statusCode: number; code: string };
+  /** VA 발급 시 charge 에 저장돼 있던 secret (있으면 secret 대조 대상). */
+  storedSecret?: string;
+}
+
+function buildService(chargeStatus: string, opts: BuildOpts = {}) {
+  const {
+    reQueryStatus = 'DONE',
+    reQueryAmount = CHARGE_AMOUNT,
+    reQueryPaymentKey = 'pk_toss',
+    reQueryError,
+    storedSecret,
+  } = opts;
+
   const updateStatus = jest.fn().mockResolvedValue(undefined);
   const finalizeApproval = jest.fn().mockResolvedValue(undefined);
-  const repository = {
-    insertOrIgnore: jest.fn().mockResolvedValue({ inserted: true, id: 'receipt-1' }),
-    updateStatus,
-  };
+  const finalizeFailure = jest.fn().mockResolvedValue(undefined);
+  const insertOrIgnore = jest.fn().mockResolvedValue({ inserted: true, id: 'receipt-1' });
+  const repository = { insertOrIgnore, updateStatus };
   const chargesService = {
     findById: jest.fn().mockResolvedValue({
       id: CHARGE_ID,
       intentId: 'intent-1',
       operation: 'AUTHORIZE',
       status: chargeStatus,
-      amount: 12790,
+      amount: CHARGE_AMOUNT,
+      responsePayload: storedSecret ? { secret: storedSecret } : null,
     }),
   };
+  const getPaymentByOrderId = jest.fn().mockResolvedValue(
+    reQueryError
+      ? { ok: false, error: { code: reQueryError.code, message: 'x' }, statusCode: reQueryError.statusCode }
+      : {
+          ok: true,
+          data: { orderId: ORDER_ID, status: reQueryStatus, totalAmount: reQueryAmount, paymentKey: reQueryPaymentKey },
+        },
+  );
+  const tossApi = { getPaymentByOrderId };
+
   const service = new TossWebhookService(
     repository as never,
     chargesService as never,
-    { finalizeApproval } as never,
+    { finalizeApproval, finalizeFailure } as never,
     {} as never,
+    tossApi as never,
   );
-  return { service, updateStatus, finalizeApproval };
+  return { service, updateStatus, finalizeApproval, finalizeFailure, insertOrIgnore, getPaymentByOrderId };
 }
 
-describe('TossWebhookService — deposit on canceled charge', () => {
-  it('records a FAILED receipt instead of silently ignoring the deposit', async () => {
+describe('TossWebhookService — 위조 방어 (토스 재조회 + secret 대조)', () => {
+  it('본문 status 가 DONE 이어도 토스 재조회가 입금대기면 승인하지 않는다 (위조 DONE 차단)', async () => {
+    const { service, finalizeApproval } = buildService('REQUIRES_ACTION', {
+      reQueryStatus: 'WAITING_FOR_DEPOSIT',
+    });
+
+    await service.handle(depositWebhook());
+
+    expect(finalizeApproval).not.toHaveBeenCalled();
+  });
+
+  it('승인은 본문이 아니라 토스가 돌려준 실제 paymentKey 로 확정한다', async () => {
+    const { service, finalizeApproval } = buildService('REQUIRES_ACTION', {
+      reQueryStatus: 'DONE',
+      reQueryPaymentKey: 'pk_toss',
+    });
+
+    await service.handle(depositWebhook()); // 본문 paymentKey 는 pk_body
+
+    expect(finalizeApproval).toHaveBeenCalledWith(expect.anything(), 'pk_toss', expect.anything());
+  });
+
+  it('금액은 본문이 아니라 토스 재조회 금액으로 검증한다 (불일치면 FAILED)', async () => {
+    const { service, finalizeApproval, updateStatus } = buildService('REQUIRES_ACTION', {
+      reQueryStatus: 'DONE',
+      reQueryAmount: 9999, // charge.amount=12790 과 다름
+    });
+
+    await service.handle(depositWebhook()); // 본문 totalAmount 는 12790 로 위조
+
+    expect(finalizeApproval).not.toHaveBeenCalled();
+    expect(updateStatus).toHaveBeenCalledWith(
+      'receipt-1',
+      'FAILED',
+      expect.objectContaining({ errorCode: 'AMOUNT_MISMATCH' }),
+    );
+  });
+
+  it('VA 발급 시 저장된 secret 과 본문 secret 이 다르면 거부한다', async () => {
+    const { service, finalizeApproval, updateStatus } = buildService('REQUIRES_ACTION', {
+      reQueryStatus: 'DONE',
+      storedSecret: 'S_real',
+    });
+
+    const wh = depositWebhook();
+    wh.data.secret = 'S_forged';
+    await service.handle(wh);
+
+    expect(finalizeApproval).not.toHaveBeenCalled();
+    expect(updateStatus).toHaveBeenCalledWith(
+      'receipt-1',
+      'FAILED',
+      expect.objectContaining({ errorCode: 'SECRET_MISMATCH' }),
+    );
+  });
+
+  it('secret 불일치는 실제 status dedup 키를 소모하지 않는다 (뒤이어 오는 진짜 웹훅 보존)', async () => {
+    const { service, insertOrIgnore } = buildService('REQUIRES_ACTION', {
+      reQueryStatus: 'DONE',
+      storedSecret: 'S_real',
+    });
+
+    const wh = depositWebhook();
+    wh.data.secret = 'S_forged';
+    await service.handle(wh);
+
+    // 위조 웹훅은 전용 키로 기록되어야 하고, `orderId:DONE` 키를 절대 선점하면 안 된다.
+    const keys = insertOrIgnore.mock.calls.map((c) => c[0].providerEventId);
+    expect(keys).toContain(`${ORDER_ID}:SECRET_MISMATCH`);
+    expect(keys).not.toContain(`${ORDER_ID}:DONE`);
+  });
+
+  it('재조회가 일시적으로 실패하면 throw 하고 dedup 을 남기지 않는다 (웹훅 재시도 보존)', async () => {
+    const { service, insertOrIgnore } = buildService('REQUIRES_ACTION', {
+      reQueryError: { statusCode: 500, code: 'TOSS_5XX' },
+    });
+
+    await expect(service.handle(depositWebhook())).rejects.toThrow();
+    expect(insertOrIgnore).not.toHaveBeenCalled();
+  });
+});
+
+describe('TossWebhookService — 기존 동작 회귀', () => {
+  it('취소된 charge 에 실제 입금이 들어오면 FAILED 로 흔적을 남긴다', async () => {
     const { service, updateStatus, finalizeApproval } = buildService('CANCELED');
 
     await service.handle(depositWebhook());
@@ -53,7 +169,7 @@ describe('TossWebhookService — deposit on canceled charge', () => {
     );
   });
 
-  it('still approves a normal deposit on a REQUIRES_ACTION charge', async () => {
+  it('REQUIRES_ACTION charge 의 정상 입금은 승인한다', async () => {
     const { service, updateStatus, finalizeApproval } = buildService('REQUIRES_ACTION');
 
     await service.handle(depositWebhook());
@@ -62,7 +178,7 @@ describe('TossWebhookService — deposit on canceled charge', () => {
     expect(updateStatus).toHaveBeenCalledWith('receipt-1', 'PROCESSED', expect.anything());
   });
 
-  it('keeps ignoring an already-succeeded charge (duplicate webhook)', async () => {
+  it('이미 성공한 charge 는 계속 무시한다 (중복 웹훅)', async () => {
     const { service, updateStatus, finalizeApproval } = buildService('SUCCEEDED');
 
     await service.handle(depositWebhook());

--- a/apps/wallet/src/webhooks/toss-webhook.service.ts
+++ b/apps/wallet/src/webhooks/toss-webhook.service.ts
@@ -3,6 +3,7 @@ import { createHash } from 'crypto';
 import { ChargesService } from '../charges/charges.service';
 import { TossApproveService } from '../payment-intents/toss-approve.service';
 import { BillingMethodService } from '../billing/billing-method.service';
+import { TossApiClient } from '../providers/toss/toss-api.client';
 import { TossWebhookRepository } from './toss-webhook.repository';
 import { TossWebhookBodyDto } from './dto';
 
@@ -30,6 +31,7 @@ export class TossWebhookService {
     private readonly chargesService: ChargesService,
     private readonly tossApproveService: TossApproveService,
     private readonly billingMethodService: BillingMethodService,
+    private readonly tossApi: TossApiClient,
   ) {}
 
   async handle(dto: TossWebhookBodyDto): Promise<void> {
@@ -78,13 +80,84 @@ export class TossWebhookService {
   }
 
   private async handlePaymentStatusChanged(dto: TossWebhookBodyDto): Promise<void> {
+    // 웹훅 본문은 인증되지 않은 값이다(토스는 HMAC 서명을 제공하지 않는다). orderId 만 charge 를
+    // 찾는 데 쓰고, status/금액/paymentKey 는 토스에 재조회한 값(authoritative)으로 판단한다.
     const orderId = dto.data.orderId as string;
-    const tossStatus = dto.data.status as string;
-    const paymentKey = dto.data.paymentKey as string;
-    const totalAmount = dto.data.totalAmount as number;
 
-    // 1. 중복 제거
-    const providerEventId = `${orderId}:${tossStatus}`;
+    // 1. orderId → chargeId 복원 (형식 오류는 재시도 가치가 없음)
+    const chargeId = rehydrateUuid(orderId);
+    if (!chargeId) {
+      this.logger.warn(`Invalid orderId format: ${orderId}`);
+      const { id: receiptId } = await this.repository.insertOrIgnore({
+        providerType: 'TOSS',
+        providerEventId: `${orderId}:INVALID`,
+        payloadHash: sha256hex(JSON.stringify(dto)),
+        status: 'RECEIVED',
+        receivedAt: new Date(),
+      });
+      await this.repository.updateStatus(receiptId, 'FAILED', { errorCode: 'INVALID_ORDER_ID' });
+      return;
+    }
+
+    // 2. charge 조회 (외부 호출 전이라 여기서 걸러지면 재조회 비용도 안 든다)
+    const charge = await this.chargesService.findById(chargeId);
+    if (!charge || charge.operation !== 'AUTHORIZE') {
+      this.logger.log(`Charge not found or not AUTHORIZE: chargeId=${chargeId}`);
+      return;
+    }
+
+    // 3. 토스 재조회 — dedup 삽입 *앞*에서 한다. 일시적 실패(5xx)로 throw 해도 dedup 행이
+    //    남지 않아야 토스 재전송이 다시 처리될 수 있다(dedup 이 재시도를 영구 차단하는 사고 방지).
+    const query = await this.tossApi.getPaymentByOrderId(orderId);
+    if (!query.ok) {
+      // 5xx/429 는 일시적 → throw(500) → 토스 재전송. 4xx(미존재 등)는 재시도 무의미 → 기록만.
+      if (query.statusCode >= 500 || query.statusCode === 429) {
+        throw new Error(`Toss re-query failed transiently for orderId=${orderId}: ${query.error.code}`);
+      }
+      this.logger.error(`Toss re-query not found for orderId=${orderId}: ${query.error.code}`);
+      const { id: receiptId } = await this.repository.insertOrIgnore({
+        providerType: 'TOSS',
+        providerEventId: `${orderId}:NOT_FOUND`,
+        payloadHash: sha256hex(JSON.stringify(dto)),
+        status: 'RECEIVED',
+        receivedAt: new Date(),
+      });
+      await this.repository.updateStatus(receiptId, 'FAILED', {
+        errorCode: 'PAYMENT_NOT_FOUND',
+        errorMessage: `Toss re-query failed: ${query.error.code}`,
+      });
+      return;
+    }
+
+    const authStatus = query.data.status;
+    const authAmount = query.data.totalAmount;
+    const authPaymentKey = query.data.paymentKey;
+
+    // 4. VA secret 대조 — 토스가 문서화한 가상계좌 웹훅 인증. 발급 시 charge 에 저장해 둔 secret 과
+    //    본문 secret 이 *있는데* 다르면 위조로 보고 거부한다. 본문에 secret 이 없으면 재조회에
+    //    맡긴다(일부 이벤트에 secret 이 없을 수 있어, 정상 입금을 오차단하지 않기 위함).
+    //    dedup *앞*에서 한다 — 위조 웹훅이 `orderId:DONE` dedup 키를 소모해 뒤이어 오는 진짜
+    //    토스 웹훅을 중복으로 무시시키지 않도록, 전용 키로 기록한다.
+    const storedSecret = (charge.responsePayload as { secret?: string } | null)?.secret;
+    const bodySecret = typeof dto.data.secret === 'string' ? dto.data.secret : undefined;
+    if (storedSecret && bodySecret !== undefined && bodySecret !== storedSecret) {
+      this.logger.error(`Toss webhook secret mismatch: chargeId=${chargeId} orderId=${orderId}`);
+      const { id: mismatchReceiptId } = await this.repository.insertOrIgnore({
+        providerType: 'TOSS',
+        providerEventId: `${orderId}:SECRET_MISMATCH`,
+        payloadHash: sha256hex(JSON.stringify(dto)),
+        status: 'RECEIVED',
+        receivedAt: new Date(),
+      });
+      await this.repository.updateStatus(mismatchReceiptId, 'FAILED', {
+        errorCode: 'SECRET_MISMATCH',
+        errorMessage: 'Webhook secret does not match the one stored at virtual-account issuance',
+      });
+      return;
+    }
+
+    // 5. 중복 제거 (authoritative status 로 키를 만든다)
+    const providerEventId = `${orderId}:${authStatus}`;
     const { inserted, id: receiptId } = await this.repository.insertOrIgnore({
       providerType: 'TOSS',
       providerEventId,
@@ -92,41 +165,24 @@ export class TossWebhookService {
       status: 'RECEIVED',
       receivedAt: new Date(),
     });
-
     if (!inserted) {
       this.logger.log(`Duplicate webhook ignored: providerEventId=${providerEventId}`);
       return;
     }
 
-    // 2. orderId → chargeId 복원
-    const chargeId = rehydrateUuid(orderId);
-    if (!chargeId) {
-      this.logger.warn(`Invalid orderId format: ${orderId}`);
-      await this.repository.updateStatus(receiptId, 'FAILED', { errorCode: 'INVALID_ORDER_ID' });
-      return;
-    }
-
-    // 3. charge 조회
-    const charge = await this.chargesService.findById(chargeId);
-    if (!charge || charge.operation !== 'AUTHORIZE') {
-      this.logger.log(`Charge not found or not AUTHORIZE: chargeId=${chargeId}`);
-      await this.repository.updateStatus(receiptId, 'IGNORED_DUPLICATE');
-      return;
-    }
-
-    // 4. status별 처리 (인프라 에러는 throw → 500)
+    // 6. authoritative status 별 처리 (인프라 에러는 throw → 500)
     const correlationId = `webhook:toss:${charge.intentId}:${Date.now()}`;
 
-    if (tossStatus === 'DONE') {
+    if (authStatus === 'DONE') {
       if (charge.status === 'CANCELED') {
-        // 취소된 계좌에 입금이 들어왔다 = 돈은 받았는데 주문이 없는 상태. IGNORED_DUPLICATE 로
-        // 흘리면 아무도 모르게 묻히므로(실제 사고 발생) FAILED 로 남겨 추적 가능하게 한다.
+        // 취소된 계좌에 실제 입금이 들어왔다(재조회로 확인됨) = 돈은 받았는데 주문이 없는 상태.
+        // IGNORED_DUPLICATE 로 흘리면 아무도 모르게 묻히므로(실제 사고 발생) FAILED 로 남긴다.
         this.logger.error(
-          `Deposit on canceled charge: chargeId=${chargeId} intentId=${charge.intentId} paymentKey=${paymentKey} amount=${totalAmount}`,
+          `Deposit on canceled charge: chargeId=${chargeId} intentId=${charge.intentId} paymentKey=${authPaymentKey} amount=${authAmount}`,
         );
         await this.repository.updateStatus(receiptId, 'FAILED', {
           errorCode: 'DEPOSIT_ON_CANCELED_CHARGE',
-          errorMessage: `취소된 charge 에 입금 발생: paymentKey=${paymentKey} amount=${totalAmount}`,
+          errorMessage: `취소된 charge 에 입금 발생: paymentKey=${authPaymentKey} amount=${authAmount}`,
         });
         return;
       }
@@ -135,28 +191,31 @@ export class TossWebhookService {
         await this.repository.updateStatus(receiptId, 'IGNORED_DUPLICATE');
         return;
       }
-      if (charge.amount !== totalAmount) {
+      if (charge.amount !== authAmount) {
         this.logger.error(
-          `Amount mismatch: charge.amount=${charge.amount} toss.totalAmount=${totalAmount} chargeId=${chargeId}`,
+          `Amount mismatch: charge.amount=${charge.amount} toss.totalAmount=${authAmount} chargeId=${chargeId}`,
         );
         await this.repository.updateStatus(receiptId, 'FAILED', {
           errorCode: 'AMOUNT_MISMATCH',
-          errorMessage: `charge.amount=${charge.amount} toss.totalAmount=${totalAmount}`,
+          errorMessage: `charge.amount=${charge.amount} toss.totalAmount=${authAmount}`,
         });
         return;
       }
-      await this.tossApproveService.finalizeApproval(charge, paymentKey, correlationId);
+      // 본문이 아닌 토스가 돌려준 실제 paymentKey 로 확정한다(가짜 키가 charge 에 박혀
+      // 이후 취소/환불이 깨지는 것도 함께 방지).
+      await this.tossApproveService.finalizeApproval(charge, authPaymentKey, correlationId);
       await this.repository.updateStatus(receiptId, 'PROCESSED', { processedAt: new Date() });
-    } else if (['ABORTED', 'EXPIRED', 'CANCELED'].includes(tossStatus)) {
+    } else if (['ABORTED', 'EXPIRED', 'CANCELED'].includes(authStatus)) {
       if (charge.status !== 'REQUIRES_ACTION') {
         this.logger.log(`Charge already processed: chargeId=${chargeId} status=${charge.status}`);
         await this.repository.updateStatus(receiptId, 'IGNORED_DUPLICATE');
         return;
       }
-      await this.tossApproveService.finalizeFailure(charge, tossStatus, correlationId);
+      await this.tossApproveService.finalizeFailure(charge, authStatus, correlationId);
       await this.repository.updateStatus(receiptId, 'PROCESSED', { processedAt: new Date() });
     } else {
-      this.logger.log(`Unhandled toss status: ${tossStatus} for chargeId=${chargeId}`);
+      // WAITING_FOR_DEPOSIT 등 — 위조된 DONE 은 재조회에서 여기로 떨어져 승인되지 않는다.
+      this.logger.log(`Unhandled authoritative toss status: ${authStatus} for chargeId=${chargeId}`);
       await this.repository.updateStatus(receiptId, 'IGNORED_DUPLICATE');
     }
   }


### PR DESCRIPTION
## 배경

`POST /v1/webhooks/toss` 의 `PAYMENT_STATUS_CHANGED` 처리가 **웹훅 본문값(status·금액·paymentKey)을 그대로 신뢰**하고 승인·자동캡처까지 진행하고 있었다. 토스는 HMAC 웹훅 서명을 제공하지 않고, 가상계좌(VA) 발급 시 저장해 둔 `secret` 도 웹훅에서 대조하지 않았다. 결과적으로 orderId(= 하이픈 뗀 chargeId)와 금액만 아는 사람이 위조 웹훅으로 `REQUIRES_ACTION` charge 를 결제완료로 만들 수 있는 경로가 있었다. gateway provider 들의 `capture()` 가 no-op(토스 재호출 없이 `SUCCEEDED`)이라 무자금으로 주문이 완료되는 방향으로 증폭됐다.

(민감 사안이라 상세 재현은 여기 적지 않는다. 필요 시 오프라인 공유.)

## 변경

- **`toss-api.client`**: `getPaymentByOrderId` = `GET /v1/payments/orders/{orderId}` 추가. orderId 로 조회해 `status`·`totalAmount`·`paymentKey` 를 **authoritative** 로 삼는다(본문 paymentKey 로 타인 결제를 우리 charge 에 갖다 붙이는 것 방지).
- **`toss-webhook.service`**: 본문 대신 재조회 결과로 분기. 위조 `DONE` 은 재조회에서 `WAITING_FOR_DEPOSIT` 로 떨어져 승인되지 않는다. 승인은 토스가 돌려준 **실제 paymentKey** 로 확정 → 가짜 키가 charge 에 박혀 이후 취소/환불이 깨지던 부차 결함도 해소.
- **VA `secret` 대조**(토스 문서화 방식): 발급 시 저장한 secret 과 본문 secret 이 *있는데* 다르면 거부. 본문에 secret 이 없으면 재조회에 위임(정상 입금 오차단 방지).
- **순서 하드닝**: 재조회를 dedup 삽입 앞에 두어 일시적 5xx 는 `throw`(→ 토스 재전송)하되 dedup 이 재시도를 영구 차단하지 않게 함. secret 불일치도 전용 키로 기록해 위조가 진짜 웹훅의 `orderId:DONE` dedup 키를 선점하지 못하게 함.

웹훅은 `isPublic` 유지(토스는 JWT 를 붙일 수 없음) — 인증 레이어는 재조회 + secret 대조가 담당.

## 검증

- `npm run type-check` → 0
- `npx jest apps/wallet` → 38 suites / 230 tests green (위조 방어 6건 + 기존 회귀 3건, TDD RED→GREEN)
- `nest build wallet` → ok

## 배포

- **마이그레이션·시크릿·env 변경 없음.** `TOSS_SECRET_KEY` 재사용.
- 배포는 **wallet 서비스 단독**으로 충분.

https://claude.ai/code/session_01MAsa6inDdGiSxhcDVnwETu
