### PR TITLE
feat(admin): 관리자 통계 — 매출·상품·고객 3탭, 멤버십 회원수, 일별 스냅샷

### DIFF
--- a/apps/admin-web/src/app/(admin)/statistics/customers/page.tsx
+++ b/apps/admin-web/src/app/(admin)/statistics/customers/page.tsx
@@ -1,0 +1,12 @@
+import RouteGuard from '@/components/layout/route-guard';
+import CustomerStatisticsTemplate from '@/features/statistics/template/customers';
+
+export default function StatisticsCustomersPage() {
+  return (
+    <RouteGuard requireRole={['admin', 'master']}>
+      <div className="flex w-full max-w-[1600px] flex-col gap-y-2 p-3">
+        <CustomerStatisticsTemplate />
+      </div>
+    </RouteGuard>
+  );
+}

--- a/apps/admin-web/src/app/(admin)/statistics/page.tsx
+++ b/apps/admin-web/src/app/(admin)/statistics/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function StatisticsIndexPage() {
+  redirect('/statistics/sales');
+}

--- a/apps/admin-web/src/app/(admin)/statistics/products/page.tsx
+++ b/apps/admin-web/src/app/(admin)/statistics/products/page.tsx
@@ -1,0 +1,12 @@
+import RouteGuard from '@/components/layout/route-guard';
+import ProductStatisticsTemplate from '@/features/statistics/template/products';
+
+export default function StatisticsProductsPage() {
+  return (
+    <RouteGuard requireRole={['admin', 'master']}>
+      <div className="flex w-full max-w-[1600px] flex-col gap-y-2 p-3">
+        <ProductStatisticsTemplate />
+      </div>
+    </RouteGuard>
+  );
+}

--- a/apps/admin-web/src/app/(admin)/statistics/sales/page.tsx
+++ b/apps/admin-web/src/app/(admin)/statistics/sales/page.tsx
@@ -1,0 +1,12 @@
+import RouteGuard from '@/components/layout/route-guard';
+import SalesStatisticsTemplate from '@/features/statistics/template/sales';
+
+export default function StatisticsSalesPage() {
+  return (
+    <RouteGuard requireRole={['admin', 'master']}>
+      <div className="flex w-full max-w-[1600px] flex-col gap-y-2 p-3">
+        <SalesStatisticsTemplate />
+      </div>
+    </RouteGuard>
+  );
+}

--- a/apps/admin-web/src/app/api/proxy/analytics/[...path]/route.ts
+++ b/apps/admin-web/src/app/api/proxy/analytics/[...path]/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from 'next/server';
+import { forwardRequest } from '../../_lib/forward';
+
+const ANALYTICS_SERVICE_URL =
+  process.env.ANALYTICS_SERVICE_URL ?? 'http://localhost:3040';
+
+type Params = { params: Promise<{ path: string[] }> };
+
+export async function GET(request: NextRequest, { params }: Params) {
+  const { path } = await params;
+  return forwardRequest(request, ANALYTICS_SERVICE_URL, path);
+}
+
+export async function POST(request: NextRequest, { params }: Params) {
+  const { path } = await params;
+  return forwardRequest(request, ANALYTICS_SERVICE_URL, path);
+}

--- a/apps/admin-web/src/components/common/form/form-radio-group.tsx
+++ b/apps/admin-web/src/components/common/form/form-radio-group.tsx
@@ -38,6 +38,9 @@ export const FormRadioGroup = React.forwardRef<
     orientation = "horizontal",
     ...props
 }, ref) => {
+    // 한 화면에 값이 겹치는 라디오 그룹이 공존할 수 있어 (예: 기간 '당월'과 단위 '월별' 둘 다 'month')
+    // option.value 를 그대로 id 로 쓰면 라벨이 다른 그룹의 라디오에 연결된다.
+    const groupId = React.useId()
     return (
         <div className={cn("space-y-1", className)}>
             <RadioGroup
@@ -55,7 +58,7 @@ export const FormRadioGroup = React.forwardRef<
                     <div key={option.value} className="flex items-center gap-[6px]">
                         <RadioGroupItem
                             value={option.value}
-                            id={option.value}
+                            id={`${groupId}-${option.value}`}
                             disabled={option.disabled || disabled}
                             className={cn(
                                 "h-5 w-5 rounded-full border-0 text-white", // 기본 크기(20px), 기본 테두리 제거, 내부 점 흰색
@@ -74,7 +77,7 @@ export const FormRadioGroup = React.forwardRef<
                             )}
                         />
                         <Label
-                            htmlFor={option.value}
+                            htmlFor={`${groupId}-${option.value}`}
                             className={cn(
                                 "text-[15px] font-bold text-black cursor-pointer",
                                 (disabled || option.disabled) && "opacity-50 cursor-not-allowed"

--- a/apps/admin-web/src/const/api-const.ts
+++ b/apps/admin-web/src/const/api-const.ts
@@ -39,6 +39,12 @@ const MEDUSA_BASE_URL = isServer
   ? (process.env.MEDUSA_API_URL ?? 'http://localhost:9000')
   : '/proxy/medusa';
 
+// 로컬 기본 포트 3040 은 wallet 과 겹친다 (apps/analytics/src/main.ts 기본값).
+// 둘을 같이 띄우려면 한쪽의 PORT / *_SERVICE_URL 을 바꿔야 한다.
+const ANALYTICS_SERVICE_BASE_URL = isServer
+  ? (process.env.ANALYTICS_SERVICE_URL ?? 'http://localhost:3040')
+  : '/proxy/analytics';
+
 export {
   ALMONDYOUNG_API_BASE_URL,
   USER_SERVICE_BASE_URL,
@@ -49,4 +55,5 @@ export {
   UGC_SERVICE_BASE_URL,
   FILE_SERVICE_BASE_URL,
   MEDUSA_BASE_URL,
+  ANALYTICS_SERVICE_BASE_URL,
 };

--- a/apps/admin-web/src/features/main/template/MainTemplate.tsx
+++ b/apps/admin-web/src/features/main/template/MainTemplate.tsx
@@ -10,12 +10,14 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { QuickActionsCard } from '@/features/main/quick-actions/QuickActionsCard';
 import { useBusinessLicenses } from '@/lib/services/business-licenses';
+import { useMembershipMembersSummary } from '@/lib/services/membership';
 import { useOrderStats, useSalesOrders, usePendingMatchings } from '@/lib/services/orders';
 import { useQuestions } from '@/lib/services/qna';
 import { useAllUserCount } from '@/lib/services/users';
 import { usePendingBankTransfers, useRefundRequests } from '@/lib/services/wallet';
 import type { SalesOrderStatus } from '@/lib/types/dto/orders';
 import {
+  BadgeCheck,
   Banknote,
   Boxes,
   CheckCircle,
@@ -65,6 +67,7 @@ export default function MainTemplate() {
     status: 'under_review',
   });
   const { data: recentOrdersData, isLoading: isOrdersLoading } = useSalesOrders({ limit: 5 });
+  const { data: membersSummary, isLoading: isMembersSummaryLoading } = useMembershipMembersSummary();
 
   const stats = [
     {
@@ -94,6 +97,16 @@ export default function MainTemplate() {
       iconBg: 'bg-green-50',
       iconColor: 'text-green-600',
       path: '/account/customer',
+    },
+    {
+      // 활성 = 목록 ACTIVE 필터와 같은 기준 (해지 예약 포함, 일시정지 제외)
+      label: '멤버십 회원',
+      value: membersSummary?.active,
+      isLoading: isMembersSummaryLoading,
+      icon: BadgeCheck,
+      iconBg: 'bg-amber-50',
+      iconColor: 'text-amber-600',
+      path: '/membership/members?status=ACTIVE&page=1',
     },
     {
       label: '미답변 문의',

--- a/apps/admin-web/src/features/membership/members/components/summary-cards/index.tsx
+++ b/apps/admin-web/src/features/membership/members/components/summary-cards/index.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useRouter, usePathname } from 'next/navigation';
+import { useMembershipMembersSummary } from '@/lib/services/membership';
+
+type CardConfig = {
+  label: string;
+  count: number;
+  /** 클릭 시 이동할 목록 필터. 카드 숫자와 목록 total 은 서버에서 같은 쿼리로 계산된다. */
+  query: string;
+  hint?: string;
+};
+
+export function MembershipMembersSummaryCards() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { data: summary, isError } = useMembershipMembersSummary();
+
+  // 요약 실패가 목록 화면을 막으면 안 된다 — 카드만 조용히 숨긴다.
+  if (isError || !summary) return null;
+
+  const cards: CardConfig[] = [
+    { label: '전체 회원', count: summary.total, query: 'page=1', hint: '한 번이라도 구독했던 회원' },
+    { label: '활성', count: summary.active, query: 'status=ACTIVE&page=1', hint: '해지 예약 포함' },
+    { label: '해지 예약', count: summary.recurringCancelled, query: 'status=RECURRING_CANCELLED&page=1', hint: '잔여기간 이용 중' },
+    { label: '일시정지', count: summary.paused, query: 'status=PAUSED&page=1' },
+    { label: '만료', count: summary.expired, query: 'status=EXPIRED&page=1' },
+    { label: '해지', count: summary.cancelled, query: 'status=CANCELLED&page=1' },
+  ];
+
+  return (
+    <div className="mb-4 flex flex-wrap gap-3">
+      {cards.map((card) => (
+        <button
+          key={card.label}
+          type="button"
+          onClick={() => router.replace(`${pathname}?${card.query}`)}
+          className="flex min-w-[140px] flex-col gap-1 rounded-lg border border-border bg-card px-4 py-3 text-left transition-colors hover:bg-muted/60"
+        >
+          <span className="text-xs text-muted-foreground">{card.label}</span>
+          <span className="text-2xl font-bold text-foreground">{card.count.toLocaleString()}</span>
+          {card.hint && <span className="text-[11px] text-muted-foreground">{card.hint}</span>}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/admin-web/src/features/membership/members/template/index.tsx
+++ b/apps/admin-web/src/features/membership/members/template/index.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import { useQuery } from '@tanstack/react-query';
 import { MembershipMemberTable } from '../components/table';
 import { MembershipMemberFilterBox } from '../components/filter-box';
+import { MembershipMembersSummaryCards } from '../components/summary-cards';
 import { Container } from '@/components/admin-ui-experimental/common/container/container';
 import { Header } from '@/components/admin-ui-experimental/common/header/header';
 import { Button } from '@/components/ui/button';
@@ -211,6 +212,7 @@ export default function MembershipMemberListTemplate() {
           </Button>
         }
       />
+      <MembershipMembersSummaryCards />
       <MembershipMemberFilterBox />
       <MembershipMemberTable />
       <AdminGrantDialog

--- a/apps/admin-web/src/features/statistics/components/shell.tsx
+++ b/apps/admin-web/src/features/statistics/components/shell.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { ReactNode, useState } from 'react';
+import Link from 'next/link';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { Search } from 'lucide-react';
+import { Container } from '@/components/admin-ui-experimental/common/container/container';
+import { Header } from '@/components/admin-ui-experimental/common/header/header';
+import { Button } from '@/components/ui/button';
+import {
+  FormField,
+  FormInput,
+  FormRadioGroup,
+  FormDateRangePicker,
+} from '@/components/common/form';
+import { cn } from '@/lib/utils/ui';
+import { DatePreset, DATE_PRESET_OPTIONS, computeDateRange, toLocalDateString } from '@/lib/utils/date';
+import { defaultRange, useStatisticsRange } from '../shared';
+
+const TABS = [
+  { href: '/statistics/sales', label: '매출' },
+  { href: '/statistics/products', label: '상품' },
+  { href: '/statistics/customers', label: '고객·멤버십' },
+];
+
+const GRANULARITY_OPTIONS = [
+  { value: 'day', label: '일별' },
+  { value: 'month', label: '월별' },
+  { value: 'year', label: '연별' },
+];
+
+// '전체' 는 기간 필수인 통계에선 의미가 없어 뺀다.
+const PRESET_OPTIONS = DATE_PRESET_OPTIONS.filter((option) => option.value !== 'all');
+
+function StatisticsFilter() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const range = useStatisticsRange();
+
+  const [preset, setPreset] = useState<DatePreset>((searchParams.get('preset') as DatePreset) ?? 'custom');
+  const [from, setFrom] = useState(range.from);
+  const [to, setTo] = useState(range.to);
+  const [channel, setChannel] = useState(range.channel ?? '');
+  const [granularity, setGranularity] = useState(range.granularity ?? 'day');
+
+  const apply = () => {
+    let nextFrom = from;
+    let nextTo = to;
+    if (preset !== 'custom') {
+      const computed = computeDateRange(preset);
+      if (computed) {
+        nextFrom = computed.from;
+        nextTo = computed.to;
+        setFrom(computed.from);
+        setTo(computed.to);
+      }
+    }
+    const params = new URLSearchParams();
+    params.set('from', nextFrom);
+    params.set('to', nextTo);
+    params.set('granularity', granularity);
+    if (preset !== 'custom') params.set('preset', preset);
+    if (channel.trim()) params.set('channel', channel.trim());
+    router.replace(`${pathname}?${params.toString()}`);
+  };
+
+  const reset = () => {
+    const fallback = defaultRange();
+    setPreset('custom');
+    setFrom(fallback.from);
+    setTo(fallback.to);
+    setChannel('');
+    setGranularity('day');
+    router.replace(pathname);
+  };
+
+  return (
+    <div className="mb-4 space-y-3 rounded-[10px] border border-[#D9D9D9] bg-[#F5F5F5] p-4">
+      <div className="flex flex-wrap items-start gap-4">
+        <FormField label="기간" direction="horizontal">
+          <FormRadioGroup
+            value={preset}
+            onValueChange={(v) => setPreset(v as DatePreset)}
+            options={PRESET_OPTIONS}
+            orientation="horizontal"
+          />
+        </FormField>
+      </div>
+
+      {preset === 'custom' && (
+        <FormField label="조회 구간" direction="horizontal">
+          <FormDateRangePicker
+            value={from ? { from: new Date(from), to: to ? new Date(to) : undefined } : undefined}
+            onChange={(dateRange) => {
+              setFrom(dateRange?.from ? toLocalDateString(dateRange.from) : '');
+              setTo(dateRange?.to ? toLocalDateString(dateRange.to) : '');
+            }}
+          />
+        </FormField>
+      )}
+
+      <div className="flex flex-wrap items-end gap-4">
+        <FormField label="단위" direction="horizontal">
+          <FormRadioGroup
+            value={granularity}
+            onValueChange={(v) => setGranularity(v as typeof granularity)}
+            options={GRANULARITY_OPTIONS}
+            orientation="horizontal"
+          />
+        </FormField>
+        <FormField label="채널" direction="horizontal">
+          <div className="w-52">
+            <FormInput
+              placeholder="예: medusa (생략 시 전체)"
+              value={channel}
+              onChange={(e) => setChannel(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && apply()}
+            />
+          </div>
+        </FormField>
+      </div>
+
+      <div className="flex justify-center gap-2 pt-1">
+        <Button onClick={apply} className="h-9 w-28 bg-orange-500 text-white hover:bg-orange-600">
+          <Search className="mr-1.5 h-4 w-4" />
+          조회
+        </Button>
+        <Button variant="outline" onClick={reset} className="h-9 w-20">
+          초기화
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function StatisticsShell({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const qs = searchParams.toString();
+
+  return (
+    <Container>
+      <Header
+        title="판매 통계"
+        subtitle="매출·상품·고객 지표를 기간별로 조회합니다. 집계 가동 시점 이전(백필 전) 데이터는 표시되지 않습니다."
+      />
+      <div className="mb-4 flex gap-1 border-b border-gray-200">
+        {TABS.map((tab) => {
+          const active = pathname.startsWith(tab.href);
+          return (
+            <Link
+              key={tab.href}
+              href={qs ? `${tab.href}?${qs}` : tab.href}
+              className={cn(
+                'px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors',
+                active
+                  ? 'border-orange-500 text-orange-600'
+                  : 'border-transparent text-gray-500 hover:text-gray-800',
+              )}
+            >
+              {tab.label}
+            </Link>
+          );
+        })}
+      </div>
+      <StatisticsFilter />
+      {children}
+    </Container>
+  );
+}

--- a/apps/admin-web/src/features/statistics/components/widgets.tsx
+++ b/apps/admin-web/src/features/statistics/components/widgets.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils/ui';
+import { changeRate, formatPercent, SERIES_COLORS } from '../shared';
+
+export function KpiTile({
+  label,
+  value,
+  previous,
+  hint,
+  isLoading,
+}: {
+  label: string;
+  value: string;
+  /** 전기간 대비 증감 표기용 — {current, previous} 원값 */
+  previous?: { current: number; previous: number };
+  hint?: string;
+  isLoading?: boolean;
+}) {
+  const rate = previous ? changeRate(previous.current, previous.previous) : null;
+  return (
+    <Card className="bg-white border border-gray-200 shadow-sm">
+      <CardContent className="p-5">
+        <p className="text-xs font-medium text-gray-500">{label}</p>
+        {isLoading ? (
+          <Skeleton className="h-8 w-24 mt-1" />
+        ) : (
+          <p className="text-2xl font-bold mt-1 text-gray-900 tabular-nums">{value}</p>
+        )}
+        <div className="mt-1 flex items-center gap-2 text-xs">
+          {rate != null && (
+            <span className={cn('font-medium tabular-nums', rate >= 0 ? 'text-emerald-600' : 'text-red-600')}>
+              {rate >= 0 ? '▲' : '▼'} {formatPercent(Math.abs(rate))}
+            </span>
+          )}
+          {previous && rate != null && <span className="text-gray-400">전기간 대비</span>}
+          {hint && <span className="text-gray-400">{hint}</span>}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ChartCard({
+  title,
+  description,
+  children,
+  isLoading,
+  isEmpty,
+  emptyText = '조회 기간에 데이터가 없습니다',
+}: {
+  title: string;
+  description?: string;
+  children: ReactNode;
+  isLoading?: boolean;
+  isEmpty?: boolean;
+  emptyText?: string;
+}) {
+  return (
+    <Card className="bg-white border border-gray-200 shadow-sm">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-gray-900 text-base">{title}</CardTitle>
+        {description && <p className="text-xs text-gray-400">{description}</p>}
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-56 w-full" />
+        ) : isEmpty ? (
+          <p className="py-10 text-center text-sm text-gray-400">{emptyText}</p>
+        ) : (
+          children
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+/** 가로 막대 목록 — 값이 큰 순으로 정렬된 입력을 그대로 그린다. 직접 라벨 포함(대비 WARN 대응). */
+export function HorizontalBarList({
+  items,
+  formatValue,
+}: {
+  items: Array<{ label: string; value: number }>;
+  formatValue: (value: number) => string;
+}) {
+  const max = Math.max(...items.map((item) => item.value), 1);
+  return (
+    <div className="space-y-2">
+      {items.map((item) => (
+        <div key={item.label} className="flex items-center gap-2">
+          <span className="w-40 shrink-0 truncate text-xs text-gray-600" title={item.label}>
+            {item.label}
+          </span>
+          <div className="h-4 flex-1 rounded bg-gray-100">
+            <div
+              className="h-4 rounded"
+              style={{
+                width: `${Math.max((item.value / max) * 100, 0)}%`,
+                backgroundColor: SERIES_COLORS[0],
+              }}
+            />
+          </div>
+          <span className="w-28 shrink-0 text-right text-xs tabular-nums text-gray-900">
+            {formatValue(item.value)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/admin-web/src/features/statistics/shared.ts
+++ b/apps/admin-web/src/features/statistics/shared.ts
@@ -16,6 +16,14 @@ export function formatKrw(value: number | null | undefined): string {
   return `₩${Math.round(value).toLocaleString('ko-KR')}`;
 }
 
+/** 축 눈금용 축약 금액 — 전체 자릿수는 월별·연별 집계에서 축 폭을 넘어 잘린다. */
+export function formatKrwAxis(value: number): string {
+  const abs = Math.abs(value);
+  if (abs >= 1e8) return `${(value / 1e8).toLocaleString('ko-KR', { maximumFractionDigits: 1 })}억`;
+  if (abs >= 1e4) return `${Math.round(value / 1e4).toLocaleString('ko-KR')}만`;
+  return value.toLocaleString('ko-KR');
+}
+
 export function formatCount(value: number | null | undefined): string {
   if (value == null) return '-';
   return value.toLocaleString('ko-KR');

--- a/apps/admin-web/src/features/statistics/shared.ts
+++ b/apps/admin-web/src/features/statistics/shared.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Granularity, StatisticsRangeQuery } from '@/lib/api/domains/analytics';
+import { toLocalDateString } from '@/lib/utils/date';
+
+/**
+ * 시리즈 팔레트 — dataviz 검증 통과(light, 인접쌍 CVD ΔE≥8, 순서 고정).
+ * 3·4번 색은 밝은 배경 대비가 3:1 미만이라 반드시 직접 라벨/표와 함께 쓴다.
+ */
+export const SERIES_COLORS = ['#2a78d6', '#eb6834', '#1baf7a', '#eda100'] as const;
+
+export function formatKrw(value: number | null | undefined): string {
+  if (value == null) return '-';
+  return `₩${Math.round(value).toLocaleString('ko-KR')}`;
+}
+
+export function formatCount(value: number | null | undefined): string {
+  if (value == null) return '-';
+  return value.toLocaleString('ko-KR');
+}
+
+export function formatPercent(value: number | null | undefined): string {
+  if (value == null) return '-';
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+/** 전기간 대비 증감률. 기준이 0이면 비교 불가(null). */
+export function changeRate(current: number, previous: number): number | null {
+  if (previous === 0) return null;
+  return (current - previous) / previous;
+}
+
+export function defaultRange(): { from: string; to: string } {
+  const to = new Date();
+  const from = new Date();
+  from.setDate(from.getDate() - 29);
+  return { from: toLocalDateString(from), to: toLocalDateString(to) };
+}
+
+/** URL 쿼리에서 통계 조회 조건을 읽는다. 탭 전환 시 쿼리가 유지되어 조건이 따라간다. */
+export function useStatisticsRange(): StatisticsRangeQuery {
+  const searchParams = useSearchParams();
+  return useMemo(() => {
+    const fallback = defaultRange();
+    const from = searchParams.get('from') ?? fallback.from;
+    const to = searchParams.get('to') ?? fallback.to;
+    const channel = searchParams.get('channel') ?? undefined;
+    const granularity = (searchParams.get('granularity') as Granularity) ?? 'day';
+    return { from, to, channel, granularity };
+  }, [searchParams]);
+}

--- a/apps/admin-web/src/features/statistics/template/customers.tsx
+++ b/apps/admin-web/src/features/statistics/template/customers.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { useCustomerStatistics } from '@/lib/services/analytics';
+import { StatisticsShell } from '../components/shell';
+import { ChartCard, HorizontalBarList, KpiTile } from '../components/widgets';
+import { formatCount, formatKrw, formatPercent, SERIES_COLORS, useStatisticsRange } from '../shared';
+
+export default function CustomerStatisticsTemplate() {
+  const range = useStatisticsRange();
+  const { data, isLoading, isError } = useCustomerStatistics(range);
+
+  // 멤버십 추이는 (날짜, tier) 행으로 오므로 tier 를 시리즈 컬럼으로 피벗한다.
+  const membershipSeries = useMemo(() => {
+    const rows = data?.membershipTrend ?? [];
+    const tiers = [...new Set(rows.map((row) => row.tierId))];
+    const byDate = new Map<string, Record<string, number | string>>();
+    for (const row of rows) {
+      const entry = byDate.get(row.aggDate) ?? { aggDate: row.aggDate };
+      entry[row.tierId] = row.membersCount;
+      byDate.set(row.aggDate, entry);
+    }
+    return { tiers, rows: [...byDate.values()] };
+  }, [data?.membershipTrend]);
+
+  const lifetime = data?.lifetime;
+
+  return (
+    <StatisticsShell>
+      {isError ? (
+        <p className="py-10 text-center text-sm text-red-500">
+          통계를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <KpiTile
+              label="누적 구매 고객"
+              value={formatCount(lifetime?.customersTotal)}
+              hint="전 기간 누적 · 비회원 주문 제외"
+              isLoading={isLoading}
+            />
+            <KpiTile
+              label="재구매율"
+              value={formatPercent(lifetime?.repurchaseRate)}
+              hint="2회 이상 구매 고객 비율 (전 기간)"
+              isLoading={isLoading}
+            />
+            <KpiTile
+              label="고객당 누적 구매액"
+              value={formatKrw(lifetime?.avgRevenuePerCustomer)}
+              hint="총매출 기준"
+              isLoading={isLoading}
+            />
+            <KpiTile
+              label="누적 주문수"
+              value={formatCount(lifetime?.ordersTotal)}
+              hint="전 기간 누적"
+              isLoading={isLoading}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <ChartCard
+              title="신규 고객 추이"
+              description="조회 기간에 첫 주문이 발생한 고객 수"
+              isLoading={isLoading}
+              isEmpty={!data || data.newCustomers.length === 0}
+            >
+              <ResponsiveContainer width="100%" height={240}>
+                <BarChart data={data?.newCustomers ?? []} margin={{ top: 8, right: 16, bottom: 0, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#eee" />
+                  <XAxis dataKey="bucket" tick={{ fontSize: 11 }} stroke="#999" />
+                  <YAxis tick={{ fontSize: 11 }} stroke="#999" allowDecimals={false} />
+                  <Tooltip formatter={(value: number) => `${formatCount(value)}명`} />
+                  <Bar dataKey="count" name="신규 고객" fill={SERIES_COLORS[0]} radius={[4, 4, 0, 0]} maxBarSize={28} />
+                </BarChart>
+              </ResponsiveContainer>
+            </ChartCard>
+
+            <ChartCard
+              title="고객 생애 구매액 분포"
+              description="전 기간 누적 · 총매출 기준"
+              isLoading={isLoading}
+              isEmpty={!data || data.lifetimeDistribution.every((bucket) => bucket.count === 0)}
+            >
+              <HorizontalBarList
+                items={(data?.lifetimeDistribution ?? []).map((bucket) => ({
+                  label: bucket.bucket,
+                  value: bucket.count,
+                }))}
+                formatValue={(value) => `${formatCount(value)}명`}
+              />
+            </ChartCard>
+          </div>
+
+          <ChartCard
+            title="멤버십 회원 수 추이"
+            description="일별 스냅샷 (활성 기준). 스냅샷 크론 가동 이후 날짜만 존재합니다."
+            isLoading={isLoading}
+            isEmpty={!data || membershipSeries.rows.length === 0}
+            emptyText="아직 기록된 스냅샷이 없습니다"
+          >
+            <ResponsiveContainer width="100%" height={240}>
+              <LineChart data={membershipSeries.rows} margin={{ top: 8, right: 16, bottom: 0, left: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#eee" />
+                <XAxis dataKey="aggDate" tick={{ fontSize: 11 }} stroke="#999" />
+                <YAxis tick={{ fontSize: 11 }} stroke="#999" allowDecimals={false} />
+                <Tooltip formatter={(value: number) => `${formatCount(value)}명`} />
+                <Legend />
+                {membershipSeries.tiers.slice(0, 4).map((tier, index) => (
+                  <Line
+                    key={tier}
+                    type="monotone"
+                    dataKey={tier}
+                    name={tier === 'UNKNOWN' ? '등급 미상' : tier}
+                    stroke={SERIES_COLORS[index % SERIES_COLORS.length]}
+                    strokeWidth={2}
+                    dot={false}
+                  />
+                ))}
+              </LineChart>
+            </ResponsiveContainer>
+          </ChartCard>
+
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <ChartCard
+              title="등급별 매출·객단가"
+              description="주문 발생 시각의 멤버십 등급으로 귀속 (총매출 기준). GUEST=비회원, NON_MEMBER=멤버십 미가입 회원."
+              isLoading={isLoading}
+              isEmpty={!data || data.tierRevenue.length === 0}
+            >
+              <div className="overflow-x-auto">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b text-gray-500">
+                      <th className="py-1.5 text-left">등급</th>
+                      <th className="py-1.5 text-right">총매출</th>
+                      <th className="py-1.5 text-right">주문수</th>
+                      <th className="py-1.5 text-right">고객수</th>
+                      <th className="py-1.5 text-right">객단가</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(data?.tierRevenue ?? []).map((row) => (
+                      <tr key={row.tierId} className="border-b last:border-0">
+                        <td className="py-1.5 font-medium">
+                          {row.tierId === 'GUEST' ? '비회원' : row.tierId === 'NON_MEMBER' ? '일반 회원' : row.tierId}
+                        </td>
+                        <td className="py-1.5 text-right tabular-nums">{formatKrw(row.grossRevenue)}</td>
+                        <td className="py-1.5 text-right tabular-nums">{formatCount(row.ordersCount)}</td>
+                        <td className="py-1.5 text-right tabular-nums">{formatCount(row.customersCount)}</td>
+                        <td className="py-1.5 text-right tabular-nums">{formatKrw(row.avgOrderValue)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </ChartCard>
+
+            <ChartCard
+              title="멤버십 해지 사유"
+              description="조회 기간의 해지·해지예약 이벤트 기준 (건수)"
+              isLoading={isLoading}
+              isEmpty={!data || data.cancellationReasons.length === 0}
+              emptyText="조회 기간에 해지가 없습니다"
+            >
+              <HorizontalBarList
+                items={(data?.cancellationReasons ?? []).map((row) => ({
+                  label: row.reasonCode === 'UNKNOWN' ? '사유 미기재' : row.reasonCode,
+                  value: row.count,
+                }))}
+                formatValue={(value) => `${formatCount(value)}건`}
+              />
+            </ChartCard>
+          </div>
+        </div>
+      )}
+    </StatisticsShell>
+  );
+}

--- a/apps/admin-web/src/features/statistics/template/products.tsx
+++ b/apps/admin-web/src/features/statistics/template/products.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useSearchParams, usePathname, useRouter } from 'next/navigation';
+import { useProductStatistics } from '@/lib/services/analytics';
+import { StatisticsShell } from '../components/shell';
+import { ChartCard, HorizontalBarList } from '../components/widgets';
+import { changeRate, formatCount, formatKrw, formatPercent, useStatisticsRange } from '../shared';
+
+const SORT_OPTIONS = [
+  { value: 'revenue', label: '순매출순' },
+  { value: 'quantity', label: '판매량순' },
+  { value: 'orders', label: '주문수순' },
+] as const;
+
+export default function ProductStatisticsTemplate() {
+  const range = useStatisticsRange();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const sort = (searchParams.get('sort') as 'revenue' | 'quantity' | 'orders') ?? 'revenue';
+
+  const { data, isLoading, isError } = useProductStatistics({ ...range, sort, limit: 20 });
+
+  const setSort = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('sort', value);
+    router.replace(`${pathname}?${params.toString()}`);
+  };
+
+  return (
+    <StatisticsShell>
+      {isError ? (
+        <p className="py-10 text-center text-sm text-red-500">
+          통계를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          <ChartCard
+            title="상품 랭킹"
+            description="증감은 직전 동일 길이 기간의 순매출 대비입니다."
+            isLoading={isLoading}
+            isEmpty={!data || data.ranking.length === 0}
+          >
+            <div className="mb-3 flex gap-1">
+              {SORT_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setSort(option.value)}
+                  className={
+                    sort === option.value
+                      ? 'rounded-full bg-orange-500 px-3 py-1 text-xs font-medium text-white'
+                      : 'rounded-full border border-gray-200 px-3 py-1 text-xs text-gray-600 hover:bg-gray-50'
+                  }
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b text-gray-500">
+                    <th className="py-1.5 text-left">#</th>
+                    <th className="py-1.5 text-left">상품</th>
+                    <th className="py-1.5 text-right">판매량</th>
+                    <th className="py-1.5 text-right">주문수</th>
+                    <th className="py-1.5 text-right">총매출</th>
+                    <th className="py-1.5 text-right">순매출</th>
+                    <th className="py-1.5 text-right">전기간 대비</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(data?.ranking ?? []).map((row, index) => {
+                    const rate = changeRate(row.netRevenue, row.previousNetRevenue);
+                    return (
+                      <tr key={row.masterId} className="border-b last:border-0">
+                        <td className="py-1.5 text-gray-400">{index + 1}</td>
+                        <td className="py-1.5">
+                          <span className="font-medium text-gray-900">{row.name ?? row.masterId}</span>
+                        </td>
+                        <td className="py-1.5 text-right tabular-nums">{formatCount(row.quantitySold)}</td>
+                        <td className="py-1.5 text-right tabular-nums">{formatCount(row.ordersCount)}</td>
+                        <td className="py-1.5 text-right tabular-nums">{formatKrw(row.grossRevenue)}</td>
+                        <td className="py-1.5 text-right tabular-nums font-medium">{formatKrw(row.netRevenue)}</td>
+                        <td className="py-1.5 text-right tabular-nums">
+                          {rate == null ? (
+                            <span className="text-gray-400">신규</span>
+                          ) : (
+                            <span className={rate >= 0 ? 'text-emerald-600' : 'text-red-600'}>
+                              {rate >= 0 ? '▲' : '▼'} {formatPercent(Math.abs(rate))}
+                            </span>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </ChartCard>
+
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <ChartCard
+              title="카테고리별 매출 구성"
+              description="대표(primary) 카테고리 기준 · 총매출"
+              isLoading={isLoading}
+              isEmpty={!data || data.categories.length === 0}
+            >
+              <HorizontalBarList
+                items={(data?.categories ?? []).map((row) => ({ label: row.categoryId, value: row.grossRevenue }))}
+                formatValue={formatKrw}
+              />
+            </ChartCard>
+
+            <ChartCard
+              title="옵션별 판매"
+              description="옵션 단위는 취소·환불 귀속 정보가 없어 총매출만 제공됩니다 (순매출 아님)."
+              isLoading={isLoading}
+              isEmpty={!data || data.variants.length === 0}
+            >
+              <div className="overflow-x-auto">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b text-gray-500">
+                      <th className="py-1.5 text-left">옵션</th>
+                      <th className="py-1.5 text-left">상품</th>
+                      <th className="py-1.5 text-right">판매량</th>
+                      <th className="py-1.5 text-right">총매출</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(data?.variants ?? []).map((row) => (
+                      <tr key={row.variantId} className="border-b last:border-0">
+                        <td className="py-1.5">{row.variantName ?? row.variantId}</td>
+                        <td className="py-1.5 text-gray-500">{row.masterName ?? row.masterId}</td>
+                        <td className="py-1.5 text-right tabular-nums">{formatCount(row.quantitySold)}</td>
+                        <td className="py-1.5 text-right tabular-nums">{formatKrw(row.grossRevenue)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </ChartCard>
+          </div>
+        </div>
+      )}
+    </StatisticsShell>
+  );
+}

--- a/apps/admin-web/src/features/statistics/template/sales.tsx
+++ b/apps/admin-web/src/features/statistics/template/sales.tsx
@@ -13,7 +13,7 @@ import {
 import { useSalesStatistics } from '@/lib/services/analytics';
 import { StatisticsShell } from '../components/shell';
 import { ChartCard, HorizontalBarList, KpiTile } from '../components/widgets';
-import { formatCount, formatKrw, formatPercent, SERIES_COLORS, useStatisticsRange } from '../shared';
+import { formatCount, formatKrw, formatKrwAxis, formatPercent, SERIES_COLORS, useStatisticsRange } from '../shared';
 
 export default function SalesStatisticsTemplate() {
   const range = useStatisticsRange();
@@ -68,7 +68,7 @@ export default function SalesStatisticsTemplate() {
               <LineChart data={data?.series ?? []} margin={{ top: 8, right: 16, bottom: 0, left: 8 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="#eee" />
                 <XAxis dataKey="bucket" tick={{ fontSize: 11 }} stroke="#999" />
-                <YAxis tick={{ fontSize: 11 }} stroke="#999" tickFormatter={(v: number) => v.toLocaleString('ko-KR')} />
+                <YAxis tick={{ fontSize: 11 }} stroke="#999" tickFormatter={formatKrwAxis} />
                 <Tooltip formatter={(value: number) => formatKrw(value)} />
                 <Legend />
                 <Line

--- a/apps/admin-web/src/features/statistics/template/sales.tsx
+++ b/apps/admin-web/src/features/statistics/template/sales.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { useSalesStatistics } from '@/lib/services/analytics';
+import { StatisticsShell } from '../components/shell';
+import { ChartCard, HorizontalBarList, KpiTile } from '../components/widgets';
+import { formatCount, formatKrw, formatPercent, SERIES_COLORS, useStatisticsRange } from '../shared';
+
+export default function SalesStatisticsTemplate() {
+  const range = useStatisticsRange();
+  const { data, isLoading, isError } = useSalesStatistics(range);
+
+  const kpis = data?.kpis;
+  const prev = data?.previousKpis;
+
+  return (
+    <StatisticsShell>
+      {isError ? (
+        <p className="py-10 text-center text-sm text-red-500">
+          통계를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <KpiTile
+              label="순매출"
+              value={formatKrw(kpis?.netRevenue)}
+              previous={kpis && prev ? { current: kpis.netRevenue, previous: prev.netRevenue } : undefined}
+              hint="총매출 − 취소 − 환불"
+              isLoading={isLoading}
+            />
+            <KpiTile
+              label="주문수"
+              value={formatCount(kpis?.ordersCount)}
+              previous={kpis && prev ? { current: kpis.ordersCount, previous: prev.ordersCount } : undefined}
+              isLoading={isLoading}
+            />
+            <KpiTile
+              label="객단가"
+              value={formatKrw(kpis?.avgOrderValue)}
+              hint="순매출 ÷ 주문수"
+              isLoading={isLoading}
+            />
+            <KpiTile
+              label="취소·환불률"
+              value={formatPercent(kpis?.cancelRefundRate)}
+              hint="금액 기준 · 100% 초과 가능"
+              isLoading={isLoading}
+            />
+          </div>
+
+          <ChartCard
+            title="매출 추이"
+            description="취소·환불은 발생일에 귀속됩니다 — 과거 주문이 취소된 날은 순매출이 음수로 내려갈 수 있습니다."
+            isLoading={isLoading}
+            isEmpty={!data || data.series.length === 0}
+          >
+            <ResponsiveContainer width="100%" height={280}>
+              <LineChart data={data?.series ?? []} margin={{ top: 8, right: 16, bottom: 0, left: 8 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#eee" />
+                <XAxis dataKey="bucket" tick={{ fontSize: 11 }} stroke="#999" />
+                <YAxis tick={{ fontSize: 11 }} stroke="#999" tickFormatter={(v: number) => v.toLocaleString('ko-KR')} />
+                <Tooltip formatter={(value: number) => formatKrw(value)} />
+                <Legend />
+                <Line
+                  type="monotone"
+                  dataKey="grossRevenue"
+                  name="총매출"
+                  stroke={SERIES_COLORS[0]}
+                  strokeWidth={2}
+                  dot={false}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="netRevenue"
+                  name="순매출"
+                  stroke={SERIES_COLORS[1]}
+                  strokeWidth={2}
+                  dot={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </ChartCard>
+
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <ChartCard title="채널별 순매출" isLoading={isLoading} isEmpty={!data || data.channels.length === 0}>
+              <HorizontalBarList
+                items={(data?.channels ?? []).map((channel) => ({
+                  label: channel.salesChannel,
+                  value: channel.netRevenue,
+                }))}
+                formatValue={formatKrw}
+              />
+              <div className="mt-4 overflow-x-auto">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b text-gray-500">
+                      <th className="py-1.5 text-left">채널</th>
+                      <th className="py-1.5 text-right">총매출</th>
+                      <th className="py-1.5 text-right">취소</th>
+                      <th className="py-1.5 text-right">환불</th>
+                      <th className="py-1.5 text-right">순매출</th>
+                      <th className="py-1.5 text-right">주문수</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(data?.channels ?? []).map((channel) => (
+                      <tr key={channel.salesChannel} className="border-b last:border-0">
+                        <td className="py-1.5">{channel.salesChannel}</td>
+                        <td className="py-1.5 text-right tabular-nums">{formatKrw(channel.grossRevenue)}</td>
+                        <td className="py-1.5 text-right tabular-nums">{formatKrw(channel.cancelledAmount)}</td>
+                        <td className="py-1.5 text-right tabular-nums">{formatKrw(channel.refundedAmount)}</td>
+                        <td className="py-1.5 text-right tabular-nums font-medium">{formatKrw(channel.netRevenue)}</td>
+                        <td className="py-1.5 text-right tabular-nums">{formatCount(channel.ordersCount)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </ChartCard>
+
+            <ChartCard
+              title="취소 사유 분포"
+              description="조회 기간에 발생한 취소 이벤트 기준 (건수)"
+              isLoading={isLoading}
+              isEmpty={!data || data.cancelReasons.length === 0}
+              emptyText="조회 기간에 취소가 없습니다"
+            >
+              <HorizontalBarList
+                items={(data?.cancelReasons ?? []).map((row) => ({ label: row.reason, value: row.count }))}
+                formatValue={(value) => `${formatCount(value)}건`}
+              />
+            </ChartCard>
+          </div>
+        </div>
+      )}
+    </StatisticsShell>
+  );
+}

--- a/apps/admin-web/src/lib/api/domains/analytics/index.ts
+++ b/apps/admin-web/src/lib/api/domains/analytics/index.ts
@@ -1,0 +1,126 @@
+import { client } from '@/lib/api/client';
+import { ANALYTICS_SERVICE_BASE_URL } from '@/const/api-const';
+
+export type Granularity = 'day' | 'month' | 'year';
+
+export interface StatisticsRangeQuery {
+  from: string;
+  to: string;
+  channel?: string;
+  granularity?: Granularity;
+}
+
+export interface RevenueTotals {
+  grossRevenue: number;
+  cancelledAmount: number;
+  refundedAmount: number;
+  /** 취소가 취소일에 귀속되므로 음수가 될 수 있다 — 화면에서 숨기지 말고 표기한다 */
+  netRevenue: number;
+  ordersCount: number;
+}
+
+export interface SalesKpis extends RevenueTotals {
+  avgOrderValue: number | null;
+  cancelRefundRate: number | null;
+}
+
+export interface SalesStatistics {
+  range: { from: string; to: string };
+  previousRange: { from: string; to: string };
+  kpis: SalesKpis;
+  previousKpis: SalesKpis;
+  series: Array<{ bucket: string } & RevenueTotals>;
+  channels: Array<{ salesChannel: string } & RevenueTotals>;
+  cancelReasons: Array<{ reason: string; count: number }>;
+}
+
+export interface ProductRankingRow extends RevenueTotals {
+  masterId: string;
+  name: string | null;
+  quantitySold: number;
+  previousNetRevenue: number;
+}
+
+export interface ProductStatistics {
+  range: { from: string; to: string };
+  previousRange: { from: string; to: string };
+  ranking: ProductRankingRow[];
+  categories: Array<{ categoryId: string; grossRevenue: number; quantitySold: number }>;
+  variants: Array<{
+    variantId: string;
+    variantName: string | null;
+    masterId: string;
+    masterName: string | null;
+    quantitySold: number;
+    grossRevenue: number;
+  }>;
+}
+
+export interface CustomerStatistics {
+  range: { from: string; to: string };
+  lifetime: {
+    customersTotal: number;
+    repeatCustomers: number;
+    repurchaseRate: number | null;
+    ordersTotal: number;
+    totalRevenue: number;
+    avgRevenuePerCustomer: number | null;
+  };
+  newCustomers: Array<{ bucket: string; count: number }>;
+  lifetimeDistribution: Array<{ bucket: string; count: number }>;
+  membershipTrend: Array<{ aggDate: string; tierId: string; membersCount: number }>;
+  cancellationReasons: Array<{ reasonCode: string; count: number }>;
+  tierRevenue: Array<{
+    tierId: string;
+    grossRevenue: number;
+    ordersCount: number;
+    customersCount: number;
+    avgOrderValue: number | null;
+  }>;
+}
+
+export interface DailyRevenueSummary extends RevenueTotals {
+  date: string;
+  avgOrderValue: number | null;
+}
+
+export interface AnalyticsOverview {
+  today: DailyRevenueSummary;
+  yesterday: DailyRevenueSummary;
+  activeMembers: number | null;
+  activeMembersAsOf: string | null;
+}
+
+function rangeQs(query: StatisticsRangeQuery): string {
+  const params = new URLSearchParams({ from: query.from, to: query.to });
+  if (query.channel) params.set('channel', query.channel);
+  if (query.granularity) params.set('granularity', query.granularity);
+  return params.toString();
+}
+
+export const analyticsApi = {
+  getOverview: async (): Promise<AnalyticsOverview> => {
+    const res = await client.get(`${ANALYTICS_SERVICE_BASE_URL}/summary`);
+    return res.data;
+  },
+
+  getSalesStatistics: async (query: StatisticsRangeQuery): Promise<SalesStatistics> => {
+    const res = await client.get(`${ANALYTICS_SERVICE_BASE_URL}/statistics/sales?${rangeQs(query)}`);
+    return res.data;
+  },
+
+  getProductStatistics: async (
+    query: StatisticsRangeQuery & { sort?: 'revenue' | 'quantity' | 'orders'; limit?: number }
+  ): Promise<ProductStatistics> => {
+    const params = new URLSearchParams(rangeQs(query));
+    if (query.sort) params.set('sort', query.sort);
+    if (query.limit) params.set('limit', String(query.limit));
+    const res = await client.get(`${ANALYTICS_SERVICE_BASE_URL}/statistics/products?${params.toString()}`);
+    return res.data;
+  },
+
+  getCustomerStatistics: async (query: StatisticsRangeQuery): Promise<CustomerStatistics> => {
+    const res = await client.get(`${ANALYTICS_SERVICE_BASE_URL}/statistics/customers?${rangeQs(query)}`);
+    return res.data;
+  },
+};

--- a/apps/admin-web/src/lib/api/domains/membership/index.ts
+++ b/apps/admin-web/src/lib/api/domains/membership/index.ts
@@ -86,6 +86,20 @@ export interface AdminMembersResponse {
   limit: number;
 }
 
+/**
+ * 상태별 회원 수. 각 값은 같은 status 필터의 회원 목록 total 과 동일한 기준.
+ * active 는 해지 예약(recurringCancelled) 회원을 포함하고, recurringCancelled 는 그 부분집합이다 —
+ * 버킷을 더해 total 을 만들면 안 된다.
+ */
+export interface AdminMembersSummary {
+  total: number;
+  active: number;
+  paused: number;
+  recurringCancelled: number;
+  cancelled: number;
+  expired: number;
+}
+
 export interface AdminMemberDetail {
   contractId: string;
   userId: string;
@@ -315,6 +329,13 @@ export const membershipApi = {
     const qs = buildQueryString(query as Record<string, unknown>);
     const res = await client.get(
       `${MEMBERSHIP_SERVICE_BASE_URL}/admin/members${qs ? `?${qs}` : ''}`
+    );
+    return res.data;
+  },
+
+  getMembersSummary: async (): Promise<AdminMembersSummary> => {
+    const res = await client.get(
+      `${MEMBERSHIP_SERVICE_BASE_URL}/admin/members/summary`
     );
     return res.data;
   },

--- a/apps/admin-web/src/lib/services/analytics/index.ts
+++ b/apps/admin-web/src/lib/services/analytics/index.ts
@@ -1,0 +1,2 @@
+export * from './queries';
+export * from './query-keys';

--- a/apps/admin-web/src/lib/services/analytics/queries.ts
+++ b/apps/admin-web/src/lib/services/analytics/queries.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { analyticsApi, StatisticsRangeQuery } from '@/lib/api/domains/analytics';
+import { analyticsQueryKeys } from './query-keys';
+
+export const useAnalyticsOverview = () => {
+  return useQuery({
+    queryKey: analyticsQueryKeys.overview(),
+    queryFn: () => analyticsApi.getOverview(),
+  });
+};
+
+export const useSalesStatistics = (query: StatisticsRangeQuery) => {
+  return useQuery({
+    queryKey: analyticsQueryKeys.sales(query),
+    queryFn: () => analyticsApi.getSalesStatistics(query),
+  });
+};
+
+export const useProductStatistics = (
+  query: StatisticsRangeQuery & { sort?: 'revenue' | 'quantity' | 'orders'; limit?: number },
+) => {
+  return useQuery({
+    queryKey: analyticsQueryKeys.products(query),
+    queryFn: () => analyticsApi.getProductStatistics(query),
+  });
+};
+
+export const useCustomerStatistics = (query: StatisticsRangeQuery) => {
+  return useQuery({
+    queryKey: analyticsQueryKeys.customers(query),
+    queryFn: () => analyticsApi.getCustomerStatistics(query),
+  });
+};

--- a/apps/admin-web/src/lib/services/analytics/query-keys.ts
+++ b/apps/admin-web/src/lib/services/analytics/query-keys.ts
@@ -1,0 +1,10 @@
+import { StatisticsRangeQuery } from '@/lib/api/domains/analytics';
+
+export const analyticsQueryKeys = {
+  all: ['analytics'] as const,
+  overview: () => [...analyticsQueryKeys.all, 'overview'] as const,
+  sales: (query: StatisticsRangeQuery) => [...analyticsQueryKeys.all, 'sales', query] as const,
+  products: (query: StatisticsRangeQuery & { sort?: string; limit?: number }) =>
+    [...analyticsQueryKeys.all, 'products', query] as const,
+  customers: (query: StatisticsRangeQuery) => [...analyticsQueryKeys.all, 'customers', query] as const,
+};

--- a/apps/admin-web/src/lib/services/membership/queries.ts
+++ b/apps/admin-web/src/lib/services/membership/queries.ts
@@ -18,6 +18,13 @@ export const useMembershipMembers = (
   });
 };
 
+export const useMembershipMembersSummary = () => {
+  return useQuery({
+    queryKey: membershipQueryKeys.membersSummary(),
+    queryFn: () => membershipApi.getMembersSummary(),
+  });
+};
+
 export const useMemberDetail = (userId: string | null) => {
   return useQuery({
     queryKey: membershipQueryKeys.memberDetail(userId ?? ''),

--- a/apps/admin-web/src/lib/services/membership/query-keys.ts
+++ b/apps/admin-web/src/lib/services/membership/query-keys.ts
@@ -4,6 +4,7 @@ export const membershipQueryKeys = {
   all: ['membership'] as const,
   members: () => [...membershipQueryKeys.all, 'members'] as const,
   memberList: (query: AdminMembersQuery) => [...membershipQueryKeys.members(), query] as const,
+  membersSummary: () => [...membershipQueryKeys.members(), 'summary'] as const,
   memberDetail: (userId: string) => [...membershipQueryKeys.all, 'memberDetail', userId] as const,
   billingEvents: (userId: string) =>
     [...membershipQueryKeys.all, 'billingEvents', userId] as const,

--- a/apps/admin-web/src/lib/utils/menu.ts
+++ b/apps/admin-web/src/lib/utils/menu.ts
@@ -442,32 +442,35 @@ export const mainMenus: MainMenu[] = [
     id: 'sales-statistics',
     title: '판매/통계',
     icon: 'BarChart3',
+    defaultPath: '/statistics/sales',
     children: [
       {
         id: 'sales-status',
         title: '판매 현황',
         children: [
-          { id: 'by-product', title: '상품별' },
-          { id: 'by-option', title: '옵션별' },
-          { id: 'by-period', title: '기간별' },
-          { id: 'by-membership', title: '회원등급별' },
+          { id: 'by-product', title: '상품별', path: '/statistics/products' },
+          { id: 'by-option', title: '옵션별', path: '/statistics/products' },
+          { id: 'by-period', title: '기간별', path: '/statistics/sales' },
+          { id: 'by-membership', title: '회원등급별', path: '/statistics/customers' },
         ],
       },
       {
+        // 웹 행동 추적 데이터가 아직 없다 — 수집부터 시작하는 별도 프로젝트.
         id: 'analytics',
         title: '애널리틱스',
         children: [
-          { id: 'customer-behavior', title: '고객 행동' },
-          { id: 'conversion-rate', title: '전환율' },
+          { id: 'customer-behavior', title: '고객 행동', isComingSoon: true },
+          { id: 'conversion-rate', title: '전환율', isComingSoon: true },
         ],
       },
       {
+        // 물류 부문 — 원천 데이터 부재로 범위 밖.
         id: 'shipping-statistics',
         title: '배송 통계',
         children: [
-          { id: 'combined-shipping', title: '합배송' },
-          { id: 'wrong-shipping', title: '오배송' },
-          { id: 'package-size', title: '택배 사이즈' },
+          { id: 'combined-shipping', title: '합배송', isComingSoon: true },
+          { id: 'wrong-shipping', title: '오배송', isComingSoon: true },
+          { id: 'package-size', title: '택배 사이즈', isComingSoon: true },
         ],
       },
     ],

--- a/apps/analytics/src/analytics.module.ts
+++ b/apps/analytics/src/analytics.module.ts
@@ -22,9 +22,15 @@ import { UserPurchaseQuery } from './features/user-purchase/read-model/user-purc
 import { MembershipFactsService } from './datasets/memberships/facts/membership-facts.service';
 import { MembershipDimensionsService } from './datasets/memberships/dimensions/membership-dimensions.service';
 import { MembershipEventsConsumer } from './datasets/memberships/ingest/membership-events.consumer';
+import { MembershipDailySnapshotService } from './datasets/memberships/aggregates/membership-daily-snapshot.service';
+import { StatisticsController } from './features/statistics/api/statistics.controller';
+import { StatisticsQuery } from './features/statistics/read-model/statistics.query';
+import { SCHEDULE_ROOT } from '@app/shared/schedule/schedule-root';
 
 @Module({
   imports: [
+    // 단 하나의 forRoot 결과를 공유해야 한다 — 직접 부르면 @Cron 이 두 번 등록된다 (#599)
+    SCHEDULE_ROOT,
     LoggerModule.forRoot(loggerConfig),
     ConfigModule.forRoot({
       isGlobal: true,
@@ -59,7 +65,7 @@ import { MembershipEventsConsumer } from './datasets/memberships/ingest/membersh
       scopes: [],
     }),
   ],
-  controllers: [AnalyticsController, OrderEventsConsumer, ProductEventsConsumer, MembershipEventsConsumer],
+  controllers: [AnalyticsController, StatisticsController, OrderEventsConsumer, ProductEventsConsumer, MembershipEventsConsumer],
   providers: [
     AnalyticsService,
     OrderFactsService,
@@ -73,6 +79,8 @@ import { MembershipEventsConsumer } from './datasets/memberships/ingest/membersh
     UserPurchaseQuery,
     MembershipFactsService,
     MembershipDimensionsService,
+    MembershipDailySnapshotService,
+    StatisticsQuery,
   ],
 })
 export class AnalyticsModule {}

--- a/apps/analytics/src/datasets/memberships/aggregates/membership-daily-snapshot.service.spec.ts
+++ b/apps/analytics/src/datasets/memberships/aggregates/membership-daily-snapshot.service.spec.ts
@@ -1,0 +1,84 @@
+import { Logger } from '@nestjs/common';
+import { aggMembershipDaily } from '../../../schema';
+import { MembershipDailySnapshotService } from './membership-daily-snapshot.service';
+
+let logSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+});
+
+describe('MembershipDailySnapshotService', () => {
+  function makeService(openIntervalRows: Array<{ tierId: string; membersCount: number }>) {
+    const deleted: unknown[] = [];
+    const inserted: Array<Record<string, unknown>> = [];
+
+    const executor = {
+      select: jest.fn().mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            groupBy: jest.fn().mockResolvedValue(openIntervalRows),
+          }),
+        }),
+      }),
+      delete: jest.fn((table: unknown) => {
+        if (table !== aggMembershipDaily) {
+          throw new Error('Unexpected analytics table');
+        }
+        return {
+          where: jest.fn((condition: unknown) => {
+            deleted.push(condition);
+            return Promise.resolve(undefined);
+          }),
+        };
+      }),
+      insert: jest.fn((table: unknown) => {
+        if (table !== aggMembershipDaily) {
+          throw new Error('Unexpected analytics table');
+        }
+        return {
+          values: jest.fn((values: Array<Record<string, unknown>>) => {
+            inserted.push(...values);
+            return Promise.resolve(undefined);
+          }),
+        };
+      }),
+    };
+
+    const run = jest.fn((fn: (e: unknown) => unknown, tx?: unknown) => (tx ? fn(tx) : fn(executor)));
+    const dbService = { run };
+    return { service: new MembershipDailySnapshotService(dbService as never), executor, deleted, inserted };
+  }
+
+  it('열린 구간을 tier 별로 세어 그날 ACTIVE 행으로 대입한다 (지우고 다시 쓴다)', async () => {
+    const { service, deleted, inserted } = makeService([
+      { tierId: 'tier-1', membersCount: 3 },
+      { tierId: 'UNKNOWN', membersCount: 1 },
+    ]);
+
+    await service.snapshotFor('2026-08-24');
+
+    expect(deleted).toHaveLength(1);
+    expect(inserted).toHaveLength(2);
+    expect(inserted).toContainEqual(
+      expect.objectContaining({ aggDate: '2026-08-24', status: 'ACTIVE', tierId: 'tier-1', membersCount: 3 }),
+    );
+    expect(inserted).toContainEqual(
+      expect.objectContaining({ aggDate: '2026-08-24', status: 'ACTIVE', tierId: 'UNKNOWN', membersCount: 1 }),
+    );
+  });
+
+  it('열린 구간이 없으면 지우기만 하고 insert 하지 않는다', async () => {
+    const { service, executor, deleted, inserted } = makeService([]);
+
+    await service.snapshotFor('2026-08-24');
+
+    expect(deleted).toHaveLength(1);
+    expect(inserted).toHaveLength(0);
+    expect(executor.insert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/analytics/src/datasets/memberships/aggregates/membership-daily-snapshot.service.ts
+++ b/apps/analytics/src/datasets/memberships/aggregates/membership-daily-snapshot.service.ts
@@ -1,0 +1,91 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectTypedDb } from '@app/db/decorators';
+import { DbService } from '@app/db';
+import { and, countDistinct, eq, gt, isNull, lte, or } from 'drizzle-orm';
+import { analyticsSchema, aggMembershipDaily, dimCustomerMembership } from '../../../schema';
+import { DbTx } from '../../../db.types';
+import { SEOUL_TZ, seoulDayStart, toSeoulDateOnly } from '../../../shared/date.util';
+
+/**
+ * `agg_membership_daily` 일별 스냅샷 (periodic snapshot fact).
+ *
+ * 이벤트 증분으로는 만들 수 없다 — 아무 일도 없던 날에도 행이 필요하다. 대신
+ * `dim_customer_membership` 의 열린 구간을 그날 KST 00:00 기준으로 세어 기록한다.
+ * 구간이 SCD 이력이므로 **과거 어느 날짜든 같은 정의로 재계산**할 수 있고(백필·재실행에
+ * 자연 멱등), 이벤트 유실이 있어도 dim 이 복구되면 스냅샷도 따라온다.
+ *
+ * 지금 기록하는 status 는 `ACTIVE` 뿐이다 — dim 은 자격 보유 구간만 추적하고
+ * (PAUSED/CANCELLED/EXPIRED 는 구간을 닫는다), "회원 수 추이" 요구사항이 원하는 것도
+ * 자격 보유 회원 수다. 상태별 분포가 필요해지면 `fact_membership_events` 의 최신 상태
+ * 재생으로 확장한다.
+ */
+@Injectable()
+export class MembershipDailySnapshotService {
+  private readonly logger = new Logger(MembershipDailySnapshotService.name);
+
+  constructor(
+    @InjectTypedDb<typeof analyticsSchema>()
+    private readonly dbService: DbService<typeof analyticsSchema>,
+  ) {}
+
+  /**
+   * 매일 KST 00:05 — 오늘 날짜의 스냅샷을 기록한다.
+   * 00:00 정각을 피하는 것은 자정 경계에서 도착 중인 이벤트와의 경합을 줄이기 위해서다.
+   */
+  @Cron('5 0 * * *', { timeZone: SEOUL_TZ })
+  async snapshotToday(): Promise<void> {
+    const aggDate = toSeoulDateOnly(new Date());
+    try {
+      await this.snapshotFor(aggDate);
+    } catch (error) {
+      // 크론 경로 — throw 하면 조용히 죽는다. 다음 날 실행이 복구하지 못하는 건 그날 하루의
+      // 빈 행뿐이고, 그마저 snapshotFor(date) 수동 호출로 재계산 가능하다.
+      this.logger.error(`agg_membership_daily 스냅샷 실패: ${aggDate}`, error instanceof Error ? error.stack : String(error));
+    }
+  }
+
+  /**
+   * 주어진 KST 날짜의 스냅샷을 (재)기록한다. 같은 날짜에 다시 호출하면 지우고 다시 쓴다 —
+   * 부분 실패나 dim 소급 정정 후 재실행이 안전하다.
+   */
+  async snapshotFor(aggDate: string, tx?: DbTx): Promise<void> {
+    const asOf = seoulDayStart(aggDate);
+
+    await this.dbService.run(async (executor) => {
+      const rows = await executor
+        .select({
+          tierId: dimCustomerMembership.tierId,
+          membersCount: countDistinct(dimCustomerMembership.userId),
+        })
+        .from(dimCustomerMembership)
+        .where(
+          and(
+            lte(dimCustomerMembership.validFrom, asOf),
+            or(isNull(dimCustomerMembership.validTo), gt(dimCustomerMembership.validTo, asOf)),
+          ),
+        )
+        .groupBy(dimCustomerMembership.tierId);
+
+      // 스냅샷은 증분이 아니라 대입이다 — 지난 실행의 행을 남겨두면 사라진 tier 가 유령으로 남는다.
+      await executor
+        .delete(aggMembershipDaily)
+        .where(and(eq(aggMembershipDaily.aggDate, aggDate), eq(aggMembershipDaily.status, 'ACTIVE')));
+
+      if (rows.length > 0) {
+        const now = new Date();
+        await executor.insert(aggMembershipDaily).values(
+          rows.map((row) => ({
+            aggDate,
+            status: 'ACTIVE',
+            tierId: row.tierId,
+            membersCount: row.membersCount,
+            updatedAt: now,
+          })),
+        );
+      }
+
+      this.logger.log(`agg_membership_daily 스냅샷 기록: ${aggDate}, tier ${rows.length}종`);
+    }, tx);
+  }
+}

--- a/apps/analytics/src/features/analytics-api/analytics.controller.ts
+++ b/apps/analytics/src/features/analytics-api/analytics.controller.ts
@@ -32,16 +32,18 @@ export class AnalyticsController {
   }
 
   @Get('summary')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOperation({
-    summary: 'Summary metrics',
-    description: 'Returns a minimal analytics summary.',
+    summary: '대시보드 요약',
+    description: '오늘/어제(KST) 매출·주문·객단가와 최근 스냅샷 기준 활성 멤버십 회원 수.',
   })
   @ApiResponse({
     status: 200,
     description: 'Summary metrics response.',
     type: AnalyticsSummaryDto,
   })
-  getSummary(): AnalyticsSummaryDto {
+  getSummary(): Promise<AnalyticsSummaryDto> {
     return this.analyticsService.getSummary();
   }
 

--- a/apps/analytics/src/features/analytics-api/analytics.service.ts
+++ b/apps/analytics/src/features/analytics-api/analytics.service.ts
@@ -1,11 +1,15 @@
-import { Injectable, NotImplementedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { AnalyticsHealthDto, AnalyticsSummaryDto } from './dto';
 import { ProductOrderMetricDto } from '../product-ranking/api/dto';
 import { ProductRankingQuery } from '../product-ranking/read-model/product-ranking.query';
+import { StatisticsQuery } from '../statistics/read-model/statistics.query';
 
 @Injectable()
 export class AnalyticsService {
-  constructor(private readonly productRankingQuery: ProductRankingQuery) {}
+  constructor(
+    private readonly productRankingQuery: ProductRankingQuery,
+    private readonly statisticsQuery: StatisticsQuery,
+  ) {}
 
   getHealth(): AnalyticsHealthDto {
     return {
@@ -15,8 +19,8 @@ export class AnalyticsService {
     };
   }
 
-  getSummary(): AnalyticsSummaryDto {
-    throw new NotImplementedException('TODO: 뭘 리턴하게 할지 고민중');
+  getSummary(): Promise<AnalyticsSummaryDto> {
+    return this.statisticsQuery.getOverview();
   }
 
   async getProductOrderMetrics(categoryId?: string, limit: number = 10): Promise<ProductOrderMetricDto[]> {

--- a/apps/analytics/src/features/analytics-api/dto/analytics-summary.dto.ts
+++ b/apps/analytics/src/features/analytics-api/dto/analytics-summary.dto.ts
@@ -1,16 +1,38 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
+export class DailyRevenueSummaryDto {
+  @ApiProperty({ example: '2026-08-24', description: 'KST 달력 날짜' })
+  date: string;
+
+  @ApiProperty({ example: 0, description: '총매출 (취소·환불 미차감)' })
+  grossRevenue: number;
+
+  @ApiProperty({ example: 0, description: '그날 발생한 취소 금액 (취소일 귀속)' })
+  cancelledAmount: number;
+
+  @ApiProperty({ example: 0, description: '그날 발생한 환불 금액' })
+  refundedAmount: number;
+
+  @ApiProperty({ example: 0, description: '순매출 = 총매출 - 취소 - 환불. 음수 가능' })
+  netRevenue: number;
+
+  @ApiProperty({ example: 0 })
+  ordersCount: number;
+
+  @ApiPropertyOptional({ nullable: true, description: '객단가 = 순매출/주문수. 주문 0이면 null' })
+  avgOrderValue: number | null;
+}
+
 export class AnalyticsSummaryDto {
-  @ApiProperty({ example: 0, description: 'Total events processed.' })
-  totalEvents: number;
+  @ApiProperty({ type: DailyRevenueSummaryDto })
+  today: DailyRevenueSummaryDto;
 
-  @ApiProperty({ example: 0, description: 'Products tracked in aggregates.' })
-  productsTracked: number;
+  @ApiProperty({ type: DailyRevenueSummaryDto })
+  yesterday: DailyRevenueSummaryDto;
 
-  @ApiPropertyOptional({
-    example: '2025-01-01T00:00:00.000Z',
-    nullable: true,
-    description: 'Last aggregation timestamp.',
-  })
-  lastAggregatedAt?: string | null;
+  @ApiPropertyOptional({ nullable: true, description: '최근 스냅샷 기준 활성 멤버십 회원 수. 스냅샷이 없으면 null' })
+  activeMembers: number | null;
+
+  @ApiPropertyOptional({ nullable: true, description: '위 값의 스냅샷 날짜 (KST)' })
+  activeMembersAsOf: string | null;
 }

--- a/apps/analytics/src/features/statistics/api/statistics-query.dto.ts
+++ b/apps/analytics/src/features/statistics/api/statistics-query.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsIn, IsInt, IsOptional, Matches, Max, Min } from 'class-validator';
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+/** 기간 조회 공통 파라미터. 날짜는 KST 달력 날짜(YYYY-MM-DD), 양끝 포함. */
+export class StatisticsRangeQueryDto {
+  @ApiProperty({ example: '2026-08-01', description: '조회 시작일 (KST, 포함)' })
+  @Matches(DATE_ONLY, { message: 'from 은 YYYY-MM-DD 형식이어야 합니다' })
+  from: string;
+
+  @ApiProperty({ example: '2026-08-24', description: '조회 종료일 (KST, 포함)' })
+  @Matches(DATE_ONLY, { message: 'to 는 YYYY-MM-DD 형식이어야 합니다' })
+  to: string;
+
+  @ApiPropertyOptional({ description: '판매 채널 필터 (생략 시 전체)' })
+  @IsOptional()
+  channel?: string;
+
+  @ApiPropertyOptional({ enum: ['day', 'month', 'year'], default: 'day', description: '시계열 버킷 단위' })
+  @IsOptional()
+  @IsIn(['day', 'month', 'year'])
+  granularity?: 'day' | 'month' | 'year' = 'day';
+}
+
+export class ProductStatisticsQueryDto extends StatisticsRangeQueryDto {
+  @ApiPropertyOptional({ enum: ['revenue', 'quantity', 'orders'], default: 'revenue', description: '랭킹 정렬 기준' })
+  @IsOptional()
+  @IsIn(['revenue', 'quantity', 'orders'])
+  sort?: 'revenue' | 'quantity' | 'orders' = 'revenue';
+
+  @ApiPropertyOptional({ example: 20, default: 20, description: '랭킹 최대 행 수' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/apps/analytics/src/features/statistics/api/statistics.controller.ts
+++ b/apps/analytics/src/features/statistics/api/statistics.controller.ts
@@ -1,0 +1,48 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '@app/authorization';
+import { StatisticsQuery } from '../read-model/statistics.query';
+import { ProductStatisticsQueryDto, StatisticsRangeQueryDto } from './statistics-query.dto';
+
+/**
+ * 관리자 통계 조회 API. admin-web 프록시를 통해서만 호출된다.
+ *
+ * 가드는 JwtAuthGuard — membership 관리자 라우트와 같은 수준이다. 스코프 부여(#551 방식)는
+ * analytics 전반의 스코프 도입과 함께 별도로 다룬다.
+ */
+@ApiTags('Statistics')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('statistics')
+export class StatisticsController {
+  constructor(private readonly statisticsQuery: StatisticsQuery) {}
+
+  @Get('sales')
+  @ApiOperation({
+    summary: '매출 개요',
+    description:
+      'agg_channel_daily 기반 기간 KPI(순매출·주문수·객단가·취소환불률)와 시계열·채널 비중. 취소는 취소일에 귀속되므로 일별 순매출이 음수일 수 있다.',
+  })
+  getSales(@Query() query: StatisticsRangeQueryDto) {
+    return this.statisticsQuery.getSales(query.from, query.to, query.channel, query.granularity);
+  }
+
+  @Get('products')
+  @ApiOperation({
+    summary: '상품 통계',
+    description: '상품 랭킹(순매출·직전 기간 대비), primary 카테고리 구성, 옵션별 판매(총매출만).',
+  })
+  getProducts(@Query() query: ProductStatisticsQueryDto) {
+    return this.statisticsQuery.getProducts(query.from, query.to, query.channel, query.sort, query.limit);
+  }
+
+  @Get('customers')
+  @ApiOperation({
+    summary: '고객·멤버십 통계',
+    description:
+      '재구매율·생애 구매액(전 기간 누적), 기간 내 신규 고객 추이, 멤버십 회원 수 스냅샷, 해지 사유, 등급별 매출(시점 조인).',
+  })
+  getCustomers(@Query() query: StatisticsRangeQueryDto) {
+    return this.statisticsQuery.getCustomers(query.from, query.to, query.granularity);
+  }
+}

--- a/apps/analytics/src/features/statistics/read-model/statistics.query.integration.spec.ts
+++ b/apps/analytics/src/features/statistics/read-model/statistics.query.integration.spec.ts
@@ -1,0 +1,172 @@
+import { randomUUID } from 'crypto';
+import * as postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { and, eq } from 'drizzle-orm';
+import type { DbService } from '@app/db';
+import {
+  aggChannelDaily,
+  aggMembershipDaily,
+  aggProductOrderDaily,
+  analyticsSchema,
+  dimCustomerMembership,
+  dimProductCategories,
+  dimProductMasters,
+} from '../../../schema';
+import { MembershipDailySnapshotService } from '../../../datasets/memberships/aggregates/membership-daily-snapshot.service';
+import { toSeoulDateOnly } from '../../../shared/date.util';
+import { StatisticsQuery } from './statistics.query';
+
+/**
+ * 통계 read-model 을 실 Postgres 로 검증한다 — 검증 대상이 SQL(그룹핑·조인·집계) 자체라
+ * 목으로는 아무것도 확인하지 못한다. 시드는 고유 채널/tier 값으로 격리하고 끝나면 지운다.
+ *
+ * 실행: DATABASE_URL=postgresql://postgres:postgres@localhost:5432/analytics \
+ *   npx jest --testPathPattern="statistics.query.integration"
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+
+if (process.env.REQUIRE_ANALYTICS_DB === '1' && !DATABASE_URL) {
+  throw new Error('REQUIRE_ANALYTICS_DB=1 인데 DATABASE_URL 이 없습니다');
+}
+
+describeIfDb('StatisticsQuery (실 Postgres)', () => {
+  jest.setTimeout(120_000);
+
+  const channel = `itest-${randomUUID().slice(0, 8)}`;
+  const masterA = `itest-master-${randomUUID().slice(0, 8)}`;
+  const masterB = `itest-master-${randomUUID().slice(0, 8)}`;
+  const categoryId = `itest-cat-${randomUUID().slice(0, 8)}`;
+  const tierId = `itest-tier-${randomUUID().slice(0, 8)}`;
+  const userPrefix = `itest-user-${randomUUID().slice(0, 8)}`;
+
+  let sql: postgres.Sql;
+  let db: ReturnType<typeof drizzle<typeof analyticsSchema>>;
+  let query: StatisticsQuery;
+  let snapshot: MembershipDailySnapshotService;
+
+  beforeAll(async () => {
+    sql = postgres(DATABASE_URL as string, { max: 1 });
+    db = drizzle(sql, { schema: analyticsSchema });
+    const dbService = {
+      db,
+      run: <T>(fn: (t: unknown) => Promise<T>, tx?: unknown): Promise<T> =>
+        tx ? fn(tx) : (db.transaction((t) => fn(t)) as Promise<T>),
+    } as unknown as DbService<typeof analyticsSchema>;
+    query = new StatisticsQuery(dbService);
+    snapshot = new MembershipDailySnapshotService(dbService);
+
+    // 채널 일별: 7월 2일 + 8월 1·2일. 8월 2일에 취소가 얹힌다.
+    await db.insert(aggChannelDaily).values([
+      { aggDate: '2026-07-02', salesChannel: channel, ordersCount: 1, grossRevenue: 7000, cancelledAmount: 0, refundedAmount: 0 },
+      { aggDate: '2026-08-01', salesChannel: channel, ordersCount: 2, grossRevenue: 10000, cancelledAmount: 0, refundedAmount: 0 },
+      { aggDate: '2026-08-02', salesChannel: channel, ordersCount: 1, grossRevenue: 5000, cancelledAmount: 8000, refundedAmount: 1000 },
+    ]);
+
+    await db.insert(dimProductMasters).values([
+      { masterId: masterA, name: '통합테스트 상품 A' },
+      { masterId: masterB, name: '통합테스트 상품 B' },
+    ]);
+    await db.insert(dimProductCategories).values([
+      { masterId: masterA, categoryId, isPrimary: true },
+      // primary 아님 — 카테고리 구성에 잡히면 중복 가산 버그다.
+      { masterId: masterB, categoryId: `${categoryId}-secondary`, isPrimary: false },
+    ]);
+    await db.insert(aggProductOrderDaily).values([
+      { aggDate: '2026-08-01', masterId: masterA, salesChannel: channel, ordersCount: 2, quantitySold: 3, grossRevenue: 9000, cancelledAmount: 1000, refundedAmount: 0 },
+      { aggDate: '2026-08-02', masterId: masterB, salesChannel: channel, ordersCount: 1, quantitySold: 1, grossRevenue: 6000, cancelledAmount: 0, refundedAmount: 0 },
+      // 직전 기간(7월) — previousNetRevenue 산출용
+      { aggDate: '2026-07-02', masterId: masterA, salesChannel: channel, ordersCount: 1, quantitySold: 1, grossRevenue: 4000, cancelledAmount: 0, refundedAmount: 0 },
+    ]);
+
+    // 멤버십 dim: 열린 구간 2명 + 이미 닫힌 구간 1명 (스냅샷은 열린 구간만 세야 한다)
+    await db.insert(dimCustomerMembership).values([
+      { userId: `${userPrefix}-1`, tierId, validFrom: new Date('2026-08-01T00:00:00+09:00'), validTo: null },
+      { userId: `${userPrefix}-2`, tierId, validFrom: new Date('2026-08-10T00:00:00+09:00'), validTo: null },
+      { userId: `${userPrefix}-3`, tierId, validFrom: new Date('2026-07-01T00:00:00+09:00'), validTo: new Date('2026-08-01T00:00:00+09:00') },
+    ]);
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await db.delete(aggChannelDaily).where(eq(aggChannelDaily.salesChannel, channel));
+      await db.delete(aggProductOrderDaily).where(eq(aggProductOrderDaily.salesChannel, channel));
+      await db.delete(dimProductMasters).where(eq(dimProductMasters.masterId, masterA));
+      await db.delete(dimProductMasters).where(eq(dimProductMasters.masterId, masterB));
+      await db.delete(dimProductCategories).where(eq(dimProductCategories.masterId, masterA));
+      await db.delete(dimProductCategories).where(eq(dimProductCategories.masterId, masterB));
+      await db.delete(dimCustomerMembership).where(eq(dimCustomerMembership.tierId, tierId));
+      await db.delete(aggMembershipDaily).where(eq(aggMembershipDaily.tierId, tierId));
+    }
+    await sql?.end();
+  });
+
+  it('매출 KPI·시계열·전기간 비교가 컬럼 합과 일치한다', async () => {
+    const result = await query.getSales('2026-08-01', '2026-08-31', channel, 'day');
+
+    expect(result.kpis).toMatchObject({
+      grossRevenue: 15000,
+      cancelledAmount: 8000,
+      refundedAmount: 1000,
+      netRevenue: 6000,
+      ordersCount: 3,
+      avgOrderValue: 2000,
+      cancelRefundRate: 9000 / 15000,
+    });
+    // 직전 동일 길이 기간(7월) 에는 7월 2일 한 건만 있다.
+    expect(result.previousRange).toEqual({ from: '2026-07-01', to: '2026-07-31' });
+    expect(result.previousKpis).toMatchObject({ grossRevenue: 7000, netRevenue: 7000, ordersCount: 1 });
+
+    expect(result.series.map((row) => row.bucket)).toEqual(['2026-08-01', '2026-08-02']);
+    expect(result.series[1]).toMatchObject({ grossRevenue: 5000, netRevenue: -4000 }); // 음수 순매출 보존
+    expect(result.channels).toHaveLength(1);
+    expect(result.channels[0]).toMatchObject({ salesChannel: channel, netRevenue: 6000 });
+  });
+
+  it('월별 버킷이 to_char 그룹핑으로 합쳐진다', async () => {
+    const result = await query.getSales('2026-07-01', '2026-08-31', channel, 'month');
+    expect(result.series.map((row) => row.bucket)).toEqual(['2026-07', '2026-08']);
+    expect(result.series[1]).toMatchObject({ grossRevenue: 15000, ordersCount: 3 });
+  });
+
+  it('상품 랭킹에 이름·순매출·전기간 순매출이 붙는다', async () => {
+    const result = await query.getProducts('2026-08-01', '2026-08-31', channel, 'revenue', 10);
+
+    expect(result.ranking).toHaveLength(2);
+    const [first, second] = result.ranking;
+    expect(first).toMatchObject({ masterId: masterA, name: '통합테스트 상품 A', netRevenue: 8000, previousNetRevenue: 4000 });
+    expect(second).toMatchObject({ masterId: masterB, netRevenue: 6000, previousNetRevenue: 0 });
+
+    // primary 카테고리만 — masterB 의 비-primary 링크는 잡히면 안 된다.
+    expect(result.categories).toEqual([{ categoryId, grossRevenue: 9000, quantitySold: 3 }]);
+  });
+
+  it('스냅샷은 열린 구간만 세고, 재실행해도 값이 변하지 않는다', async () => {
+    const today = toSeoulDateOnly(new Date());
+    await snapshot.snapshotFor(today);
+    await snapshot.snapshotFor(today); // 멱등 확인
+
+    const rows = await db
+      .select()
+      .from(aggMembershipDaily)
+      .where(and(eq(aggMembershipDaily.aggDate, today), eq(aggMembershipDaily.tierId, tierId)));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ status: 'ACTIVE', membersCount: 2 });
+
+    // getCustomers 의 membershipTrend 로도 같은 값이 나온다.
+    const customers = await query.getCustomers(today, today);
+    const trendRow = customers.membershipTrend.find((row) => row.tierId === tierId);
+    expect(trendRow).toMatchObject({ aggDate: today, membersCount: 2 });
+  });
+
+  it('과거 날짜 스냅샷은 그 시점에 열려 있던 구간으로 재계산된다', async () => {
+    await snapshot.snapshotFor('2026-08-05');
+    const rows = await db
+      .select()
+      .from(aggMembershipDaily)
+      .where(and(eq(aggMembershipDaily.aggDate, '2026-08-05'), eq(aggMembershipDaily.tierId, tierId)));
+    // 8월 5일 00:00 KST 기준: user-1 만 열려 있다 (user-2 는 8/10 시작, user-3 은 8/1 종료).
+    expect(rows).toHaveLength(1);
+    expect(rows[0].membersCount).toBe(1);
+  });
+});

--- a/apps/analytics/src/features/statistics/read-model/statistics.query.spec.ts
+++ b/apps/analytics/src/features/statistics/read-model/statistics.query.spec.ts
@@ -1,0 +1,31 @@
+import { BadRequestError } from '@app/shared';
+import { previousRange, StatisticsQuery } from './statistics.query';
+
+describe('previousRange', () => {
+  it('직전 동일 길이 기간을 만든다 (하루짜리)', () => {
+    expect(previousRange('2026-08-24', '2026-08-24')).toEqual({ from: '2026-08-23', to: '2026-08-23' });
+  });
+
+  it('직전 동일 길이 기간을 만든다 (여러 날, 월 경계)', () => {
+    expect(previousRange('2026-08-01', '2026-08-07')).toEqual({ from: '2026-07-25', to: '2026-07-31' });
+  });
+
+  it('연 경계를 넘는다', () => {
+    expect(previousRange('2026-01-01', '2026-01-31')).toEqual({ from: '2025-12-01', to: '2025-12-31' });
+  });
+});
+
+describe('StatisticsQuery 기간 검증', () => {
+  it('뒤집힌 기간은 DB 를 건드리기 전에 거부한다', async () => {
+    const dbService = {
+      get db() {
+        throw new Error('DB 에 닿으면 안 된다');
+      },
+    };
+    const query = new StatisticsQuery(dbService as never);
+
+    await expect(query.getSales('2026-08-24', '2026-08-01')).rejects.toBeInstanceOf(BadRequestError);
+    await expect(query.getProducts('2026-08-24', '2026-08-01')).rejects.toBeInstanceOf(BadRequestError);
+    await expect(query.getCustomers('2026-08-24', '2026-08-01')).rejects.toBeInstanceOf(BadRequestError);
+  });
+});

--- a/apps/analytics/src/features/statistics/read-model/statistics.query.ts
+++ b/apps/analytics/src/features/statistics/read-model/statistics.query.ts
@@ -1,0 +1,623 @@
+import { Injectable } from '@nestjs/common';
+import { InjectTypedDb } from '@app/db/decorators';
+import { DbService } from '@app/db';
+import { BadRequestError } from '@app/shared';
+import { and, desc, eq, gt, gte, inArray, isNull, lt, lte, or, sql, SQL } from 'drizzle-orm';
+import {
+  aggChannelDaily,
+  aggCustomerLifetime,
+  aggMembershipDaily,
+  aggProductOrderDaily,
+  aggVariantOrderDaily,
+  analyticsSchema,
+  dimCustomerMembership,
+  dimProductCategories,
+  dimProductMasters,
+  dimProductVariants,
+  factMembershipEvents,
+  factOrderItems,
+} from '../../../schema';
+import { SEOUL_TZ, seoulDayStart, toSeoulDateOnly } from '../../../shared/date.util';
+
+export type Granularity = 'day' | 'month' | 'year';
+
+/** 순매출을 낼 수 있는 표(agg_channel_daily·agg_product_order_daily)의 공통 금액 묶음. */
+export interface RevenueTotals {
+  grossRevenue: number;
+  cancelledAmount: number;
+  refundedAmount: number;
+  /** grossRevenue - cancelledAmount - refundedAmount. 취소가 취소일에 귀속되므로 음수가 될 수 있다. */
+  netRevenue: number;
+  ordersCount: number;
+}
+
+export interface SalesKpis extends RevenueTotals {
+  /** 순매출 / 주문수. 주문이 없으면 null. */
+  avgOrderValue: number | null;
+  /** (취소+환불) / 총매출 — 금액 기준. 코호트 교차 비율이라 1을 넘을 수 있다. 총매출 0이면 null. */
+  cancelRefundRate: number | null;
+}
+
+export interface SalesStatistics {
+  range: { from: string; to: string };
+  previousRange: { from: string; to: string };
+  kpis: SalesKpis;
+  previousKpis: SalesKpis;
+  series: Array<{ bucket: string } & RevenueTotals>;
+  channels: Array<{ salesChannel: string } & RevenueTotals>;
+  cancelReasons: Array<{ reason: string; count: number }>;
+}
+
+export interface ProductRankingRow extends RevenueTotals {
+  masterId: string;
+  name: string | null;
+  quantitySold: number;
+  /** 직전 동일 길이 기간의 순매출 — 급상승/급하락 판정용 */
+  previousNetRevenue: number;
+}
+
+export interface ProductStatistics {
+  range: { from: string; to: string };
+  previousRange: { from: string; to: string };
+  ranking: ProductRankingRow[];
+  /** primary 카테고리 기준 — 다중 카테고리 중복 가산을 피한다 */
+  categories: Array<{ categoryId: string; grossRevenue: number; quantitySold: number }>;
+  /** 옵션별은 총매출만 존재한다 — 순매출로 라벨링하지 말 것 */
+  variants: Array<{
+    variantId: string;
+    variantName: string | null;
+    masterId: string;
+    masterName: string | null;
+    quantitySold: number;
+    grossRevenue: number;
+  }>;
+}
+
+export interface CustomerStatistics {
+  range: { from: string; to: string };
+  /** 전 기간 누적 지표 — 기간 필터와 무관하다 (agg_customer_lifetime 이 전 기간 원장). */
+  lifetime: {
+    customersTotal: number;
+    repeatCustomers: number;
+    /** ordersCount>=2 고객 비율. 고객이 없으면 null. 비회원 주문은 분모에 없다. */
+    repurchaseRate: number | null;
+    ordersTotal: number;
+    totalRevenue: number;
+    avgRevenuePerCustomer: number | null;
+  };
+  /** 기간 내 첫 주문 고객 수 추이 (신규 고객) */
+  newCustomers: Array<{ bucket: string; count: number }>;
+  /** 총매출 기준 — 취소·환불 미차감 */
+  lifetimeDistribution: Array<{ bucket: string; count: number }>;
+  /** agg_membership_daily 스냅샷 (status=ACTIVE). 스냅샷 크론 가동 이후 날짜만 존재한다. */
+  membershipTrend: Array<{ aggDate: string; tierId: string; membersCount: number }>;
+  cancellationReasons: Array<{ reasonCode: string; count: number }>;
+  /** 시점 조인(fact ⋈ dim SCD2) — 주문 발생 시각의 등급으로 귀속. 총매출 기준. */
+  tierRevenue: Array<{
+    tierId: string;
+    grossRevenue: number;
+    ordersCount: number;
+    customersCount: number;
+    avgOrderValue: number | null;
+  }>;
+}
+
+export interface StatisticsOverview {
+  today: { date: string } & RevenueTotals & { avgOrderValue: number | null };
+  yesterday: { date: string } & RevenueTotals & { avgOrderValue: number | null };
+  /** 최근 스냅샷 기준 활성 멤버십 회원 수. 스냅샷이 아직 없으면 null. */
+  activeMembers: number | null;
+  activeMembersAsOf: string | null;
+}
+
+const LIFETIME_BUCKETS: Array<{ label: string; min: number; max: number | null }> = [
+  { label: '1만원 미만', min: 0, max: 10_000 },
+  { label: '1~5만원', min: 10_000, max: 50_000 },
+  { label: '5~10만원', min: 50_000, max: 100_000 },
+  { label: '10~30만원', min: 100_000, max: 300_000 },
+  { label: '30~50만원', min: 300_000, max: 500_000 },
+  { label: '50~100만원', min: 500_000, max: 1_000_000 },
+  { label: '100만원 이상', min: 1_000_000, max: null },
+];
+
+@Injectable()
+export class StatisticsQuery {
+  constructor(
+    @InjectTypedDb<typeof analyticsSchema>()
+    private readonly dbService: DbService<typeof analyticsSchema>,
+  ) {}
+
+  private get db() {
+    return this.dbService.db;
+  }
+
+  async getSales(
+    from: string,
+    to: string,
+    channel?: string,
+    granularity: Granularity = 'day',
+  ): Promise<SalesStatistics> {
+    this.assertRange(from, to);
+    const prev = previousRange(from, to);
+
+    const [kpis, previousKpis, series, channels, cancelReasons] = await Promise.all([
+      this.channelTotals(from, to, channel),
+      this.channelTotals(prev.from, prev.to, channel),
+      this.channelSeries(from, to, channel, granularity),
+      this.channelBreakdown(from, to, channel),
+      this.cancelReasonDistribution(from, to),
+    ]);
+
+    return {
+      range: { from, to },
+      previousRange: prev,
+      kpis: withDerivedKpis(kpis),
+      previousKpis: withDerivedKpis(previousKpis),
+      series,
+      channels,
+      cancelReasons,
+    };
+  }
+
+  async getProducts(
+    from: string,
+    to: string,
+    channel?: string,
+    sort: 'revenue' | 'quantity' | 'orders' = 'revenue',
+    limit = 20,
+  ): Promise<ProductStatistics> {
+    this.assertRange(from, to);
+    const prev = previousRange(from, to);
+    const where = this.productRangeWhere(from, to, channel);
+
+    const sortExpr =
+      sort === 'quantity'
+        ? sql`SUM(${aggProductOrderDaily.quantitySold})`
+        : sort === 'orders'
+          ? sql`SUM(${aggProductOrderDaily.ordersCount})`
+          : sql`SUM(${aggProductOrderDaily.grossRevenue} - ${aggProductOrderDaily.cancelledAmount} - ${aggProductOrderDaily.refundedAmount})`;
+
+    const rankingRows = await this.db
+      .select({
+        masterId: aggProductOrderDaily.masterId,
+        name: dimProductMasters.name,
+        ordersCount: sql<string>`SUM(${aggProductOrderDaily.ordersCount})`,
+        quantitySold: sql<string>`SUM(${aggProductOrderDaily.quantitySold})`,
+        grossRevenue: sql<string>`SUM(${aggProductOrderDaily.grossRevenue})`,
+        cancelledAmount: sql<string>`SUM(${aggProductOrderDaily.cancelledAmount})`,
+        refundedAmount: sql<string>`SUM(${aggProductOrderDaily.refundedAmount})`,
+      })
+      .from(aggProductOrderDaily)
+      .leftJoin(dimProductMasters, eq(dimProductMasters.masterId, aggProductOrderDaily.masterId))
+      .where(where)
+      .groupBy(aggProductOrderDaily.masterId, dimProductMasters.name)
+      .orderBy(sql`${sortExpr} DESC`)
+      .limit(limit);
+
+    const masterIds = rankingRows.map((row) => row.masterId);
+    const previousByMaster = new Map<string, number>();
+    if (masterIds.length > 0) {
+      const prevRows = await this.db
+        .select({
+          masterId: aggProductOrderDaily.masterId,
+          netRevenue: sql<string>`SUM(${aggProductOrderDaily.grossRevenue} - ${aggProductOrderDaily.cancelledAmount} - ${aggProductOrderDaily.refundedAmount})`,
+        })
+        .from(aggProductOrderDaily)
+        .where(and(this.productRangeWhere(prev.from, prev.to, channel), inArray(aggProductOrderDaily.masterId, masterIds)))
+        .groupBy(aggProductOrderDaily.masterId);
+      for (const row of prevRows) {
+        previousByMaster.set(row.masterId, Number(row.netRevenue ?? 0));
+      }
+    }
+
+    const ranking: ProductRankingRow[] = rankingRows.map((row) => {
+      const grossRevenue = Number(row.grossRevenue ?? 0);
+      const cancelledAmount = Number(row.cancelledAmount ?? 0);
+      const refundedAmount = Number(row.refundedAmount ?? 0);
+      return {
+        masterId: row.masterId,
+        name: row.name ?? null,
+        ordersCount: Number(row.ordersCount ?? 0),
+        quantitySold: Number(row.quantitySold ?? 0),
+        grossRevenue,
+        cancelledAmount,
+        refundedAmount,
+        netRevenue: grossRevenue - cancelledAmount - refundedAmount,
+        previousNetRevenue: previousByMaster.get(row.masterId) ?? 0,
+      };
+    });
+
+    const categoryRows = await this.db
+      .select({
+        categoryId: dimProductCategories.categoryId,
+        grossRevenue: sql<string>`SUM(${aggProductOrderDaily.grossRevenue})`,
+        quantitySold: sql<string>`SUM(${aggProductOrderDaily.quantitySold})`,
+      })
+      .from(aggProductOrderDaily)
+      .innerJoin(
+        dimProductCategories,
+        and(
+          eq(dimProductCategories.masterId, aggProductOrderDaily.masterId),
+          eq(dimProductCategories.isPrimary, true),
+        ),
+      )
+      .where(where)
+      .groupBy(dimProductCategories.categoryId)
+      .orderBy(sql`SUM(${aggProductOrderDaily.grossRevenue}) DESC`);
+
+    const variantWhereParts: SQL[] = [
+      gte(aggVariantOrderDaily.aggDate, from),
+      lte(aggVariantOrderDaily.aggDate, to),
+    ];
+    if (channel) {
+      variantWhereParts.push(eq(aggVariantOrderDaily.salesChannel, channel));
+    }
+    const variantRows = await this.db
+      .select({
+        variantId: aggVariantOrderDaily.variantId,
+        variantName: dimProductVariants.variantName,
+        masterId: aggVariantOrderDaily.masterId,
+        masterName: dimProductMasters.name,
+        quantitySold: sql<string>`SUM(${aggVariantOrderDaily.quantitySold})`,
+        grossRevenue: sql<string>`SUM(${aggVariantOrderDaily.grossRevenue})`,
+      })
+      .from(aggVariantOrderDaily)
+      .leftJoin(dimProductVariants, eq(dimProductVariants.variantId, aggVariantOrderDaily.variantId))
+      .leftJoin(dimProductMasters, eq(dimProductMasters.masterId, aggVariantOrderDaily.masterId))
+      .where(and(...variantWhereParts))
+      .groupBy(
+        aggVariantOrderDaily.variantId,
+        dimProductVariants.variantName,
+        aggVariantOrderDaily.masterId,
+        dimProductMasters.name,
+      )
+      .orderBy(sql`SUM(${aggVariantOrderDaily.grossRevenue}) DESC`)
+      .limit(limit);
+
+    return {
+      range: { from, to },
+      previousRange: prev,
+      ranking,
+      categories: categoryRows.map((row) => ({
+        categoryId: row.categoryId,
+        grossRevenue: Number(row.grossRevenue ?? 0),
+        quantitySold: Number(row.quantitySold ?? 0),
+      })),
+      variants: variantRows.map((row) => ({
+        variantId: row.variantId,
+        variantName: row.variantName ?? null,
+        masterId: row.masterId,
+        masterName: row.masterName ?? null,
+        quantitySold: Number(row.quantitySold ?? 0),
+        grossRevenue: Number(row.grossRevenue ?? 0),
+      })),
+    };
+  }
+
+  async getCustomers(from: string, to: string, granularity: Granularity = 'day'): Promise<CustomerStatistics> {
+    this.assertRange(from, to);
+    const fromInstant = seoulDayStart(from);
+    const toExclusive = seoulDayStart(nextDay(to));
+
+    const [lifetimeRows, newCustomerRows, distributionRows, trendRows, reasonRows, tierRows] = await Promise.all([
+      this.db
+        .select({
+          customersTotal: sql<string>`COUNT(*)`,
+          repeatCustomers: sql<string>`COUNT(*) FILTER (WHERE ${aggCustomerLifetime.ordersCount} >= 2)`,
+          ordersTotal: sql<string>`COALESCE(SUM(${aggCustomerLifetime.ordersCount}), 0)`,
+          totalRevenue: sql<string>`COALESCE(SUM(${aggCustomerLifetime.totalRevenue}), 0)`,
+        })
+        .from(aggCustomerLifetime),
+      this.db
+        .select({
+          bucket: sql<string>`to_char(${aggCustomerLifetime.firstOrderAt} AT TIME ZONE ${SEOUL_TZ}, ${bucketFormat(granularity)})`,
+          count: sql<string>`COUNT(*)`,
+        })
+        .from(aggCustomerLifetime)
+        .where(and(gte(aggCustomerLifetime.firstOrderAt, fromInstant), lt(aggCustomerLifetime.firstOrderAt, toExclusive)))
+        .groupBy(sql`1`)
+        .orderBy(sql`1`),
+      this.db
+        .select({
+          bucket: sql<string>`${lifetimeBucketCase()}`,
+          count: sql<string>`COUNT(*)`,
+        })
+        .from(aggCustomerLifetime)
+        .groupBy(sql`1`),
+      this.db
+        .select({
+          aggDate: aggMembershipDaily.aggDate,
+          tierId: aggMembershipDaily.tierId,
+          membersCount: aggMembershipDaily.membersCount,
+        })
+        .from(aggMembershipDaily)
+        .where(
+          and(
+            gte(aggMembershipDaily.aggDate, from),
+            lte(aggMembershipDaily.aggDate, to),
+            eq(aggMembershipDaily.status, 'ACTIVE'),
+          ),
+        )
+        .orderBy(aggMembershipDaily.aggDate),
+      this.db
+        .select({
+          reasonCode: sql<string>`COALESCE(${factMembershipEvents.reasonCode}, 'UNKNOWN')`,
+          count: sql<string>`COUNT(*)`,
+        })
+        .from(factMembershipEvents)
+        .where(
+          and(
+            gte(factMembershipEvents.occurredAt, fromInstant),
+            lt(factMembershipEvents.occurredAt, toExclusive),
+            inArray(factMembershipEvents.status, ['CANCELLED', 'RECURRING_CANCELLED']),
+          ),
+        )
+        .groupBy(sql`1`)
+        .orderBy(sql`COUNT(*) DESC`),
+      this.db
+        .select({
+          tierId: sql<string>`CASE WHEN ${factOrderItems.customerId} IS NULL THEN 'GUEST' ELSE COALESCE(${dimCustomerMembership.tierId}, 'NON_MEMBER') END`,
+          grossRevenue: sql<string>`COALESCE(SUM(${factOrderItems.totalPrice}), 0)`,
+          ordersCount: sql<string>`COUNT(DISTINCT ${factOrderItems.orderKey})`,
+          customersCount: sql<string>`COUNT(DISTINCT ${factOrderItems.customerId})`,
+        })
+        .from(factOrderItems)
+        .leftJoin(
+          dimCustomerMembership,
+          and(
+            eq(dimCustomerMembership.userId, factOrderItems.customerId),
+            lte(dimCustomerMembership.validFrom, factOrderItems.occurredAt),
+            or(isNull(dimCustomerMembership.validTo), gt(dimCustomerMembership.validTo, factOrderItems.occurredAt)),
+          ),
+        )
+        .where(and(gte(factOrderItems.occurredAt, fromInstant), lt(factOrderItems.occurredAt, toExclusive)))
+        .groupBy(sql`1`)
+        .orderBy(sql`COALESCE(SUM(${factOrderItems.totalPrice}), 0) DESC`),
+    ]);
+
+    const lifetime = lifetimeRows[0];
+    const customersTotal = Number(lifetime?.customersTotal ?? 0);
+    const repeatCustomers = Number(lifetime?.repeatCustomers ?? 0);
+    const totalRevenue = Number(lifetime?.totalRevenue ?? 0);
+
+    // 히스토그램은 버킷 정의 순서로 정렬해 내려준다 — 문자열 정렬로는 금액 순서가 나오지 않는다.
+    const distributionByLabel = new Map(distributionRows.map((row) => [row.bucket, Number(row.count ?? 0)]));
+
+    return {
+      range: { from, to },
+      lifetime: {
+        customersTotal,
+        repeatCustomers,
+        repurchaseRate: customersTotal > 0 ? repeatCustomers / customersTotal : null,
+        ordersTotal: Number(lifetime?.ordersTotal ?? 0),
+        totalRevenue,
+        avgRevenuePerCustomer: customersTotal > 0 ? totalRevenue / customersTotal : null,
+      },
+      newCustomers: newCustomerRows.map((row) => ({ bucket: row.bucket, count: Number(row.count ?? 0) })),
+      lifetimeDistribution: LIFETIME_BUCKETS.map((bucket) => ({
+        bucket: bucket.label,
+        count: distributionByLabel.get(bucket.label) ?? 0,
+      })),
+      membershipTrend: trendRows.map((row) => ({
+        aggDate: String(row.aggDate),
+        tierId: row.tierId,
+        membersCount: row.membersCount,
+      })),
+      cancellationReasons: reasonRows.map((row) => ({ reasonCode: row.reasonCode, count: Number(row.count ?? 0) })),
+      tierRevenue: tierRows.map((row) => {
+        const grossRevenue = Number(row.grossRevenue ?? 0);
+        const ordersCount = Number(row.ordersCount ?? 0);
+        return {
+          tierId: row.tierId,
+          grossRevenue,
+          ordersCount,
+          customersCount: Number(row.customersCount ?? 0),
+          avgOrderValue: ordersCount > 0 ? grossRevenue / ordersCount : null,
+        };
+      }),
+    };
+  }
+
+  /** 대시보드 홈 요약 — 오늘/어제(KST) 매출과 최근 스냅샷의 활성 멤버십 수. */
+  async getOverview(): Promise<StatisticsOverview> {
+    const today = toSeoulDateOnly(new Date());
+    const yesterday = previousRange(today, today).from;
+
+    const [todayTotals, yesterdayTotals, latestSnapshotRows] = await Promise.all([
+      this.channelTotals(today, today),
+      this.channelTotals(yesterday, yesterday),
+      this.db
+        .select({
+          aggDate: aggMembershipDaily.aggDate,
+          membersCount: sql<string>`SUM(${aggMembershipDaily.membersCount})`,
+        })
+        .from(aggMembershipDaily)
+        .where(eq(aggMembershipDaily.status, 'ACTIVE'))
+        .groupBy(aggMembershipDaily.aggDate)
+        .orderBy(desc(aggMembershipDaily.aggDate))
+        .limit(1),
+    ]);
+
+    const snapshot = latestSnapshotRows[0];
+    return {
+      today: { date: today, ...todayTotals, avgOrderValue: avgOrderValue(todayTotals) },
+      yesterday: { date: yesterday, ...yesterdayTotals, avgOrderValue: avgOrderValue(yesterdayTotals) },
+      activeMembers: snapshot ? Number(snapshot.membersCount ?? 0) : null,
+      activeMembersAsOf: snapshot ? String(snapshot.aggDate) : null,
+    };
+  }
+
+  private assertRange(from: string, to: string): void {
+    if (from > to) {
+      throw new BadRequestError(`조회 기간이 뒤집혔습니다: ${from} > ${to}`);
+    }
+  }
+
+  private channelRangeWhere(from: string, to: string, channel?: string): SQL | undefined {
+    const parts: SQL[] = [gte(aggChannelDaily.aggDate, from), lte(aggChannelDaily.aggDate, to)];
+    if (channel) {
+      parts.push(eq(aggChannelDaily.salesChannel, channel));
+    }
+    return and(...parts);
+  }
+
+  private productRangeWhere(from: string, to: string, channel?: string): SQL | undefined {
+    const parts: SQL[] = [gte(aggProductOrderDaily.aggDate, from), lte(aggProductOrderDaily.aggDate, to)];
+    if (channel) {
+      parts.push(eq(aggProductOrderDaily.salesChannel, channel));
+    }
+    return and(...parts);
+  }
+
+  private async channelTotals(from: string, to: string, channel?: string): Promise<RevenueTotals> {
+    const rows = await this.db
+      .select({
+        grossRevenue: sql<string>`COALESCE(SUM(${aggChannelDaily.grossRevenue}), 0)`,
+        cancelledAmount: sql<string>`COALESCE(SUM(${aggChannelDaily.cancelledAmount}), 0)`,
+        refundedAmount: sql<string>`COALESCE(SUM(${aggChannelDaily.refundedAmount}), 0)`,
+        ordersCount: sql<string>`COALESCE(SUM(${aggChannelDaily.ordersCount}), 0)`,
+      })
+      .from(aggChannelDaily)
+      .where(this.channelRangeWhere(from, to, channel));
+    return toRevenueTotals(rows[0]);
+  }
+
+  private async channelSeries(
+    from: string,
+    to: string,
+    channel: string | undefined,
+    granularity: Granularity,
+  ): Promise<Array<{ bucket: string } & RevenueTotals>> {
+    const bucketExpr =
+      granularity === 'day'
+        ? sql<string>`${aggChannelDaily.aggDate}::text`
+        : sql<string>`to_char(${aggChannelDaily.aggDate}, ${bucketFormat(granularity)})`;
+
+    const rows = await this.db
+      .select({
+        bucket: bucketExpr,
+        grossRevenue: sql<string>`SUM(${aggChannelDaily.grossRevenue})`,
+        cancelledAmount: sql<string>`SUM(${aggChannelDaily.cancelledAmount})`,
+        refundedAmount: sql<string>`SUM(${aggChannelDaily.refundedAmount})`,
+        ordersCount: sql<string>`SUM(${aggChannelDaily.ordersCount})`,
+      })
+      .from(aggChannelDaily)
+      .where(this.channelRangeWhere(from, to, channel))
+      .groupBy(sql`1`)
+      .orderBy(sql`1`);
+
+    return rows.map((row) => ({ bucket: row.bucket, ...toRevenueTotals(row) }));
+  }
+
+  private async channelBreakdown(
+    from: string,
+    to: string,
+    channel?: string,
+  ): Promise<Array<{ salesChannel: string } & RevenueTotals>> {
+    const rows = await this.db
+      .select({
+        salesChannel: aggChannelDaily.salesChannel,
+        grossRevenue: sql<string>`SUM(${aggChannelDaily.grossRevenue})`,
+        cancelledAmount: sql<string>`SUM(${aggChannelDaily.cancelledAmount})`,
+        refundedAmount: sql<string>`SUM(${aggChannelDaily.refundedAmount})`,
+        ordersCount: sql<string>`SUM(${aggChannelDaily.ordersCount})`,
+      })
+      .from(aggChannelDaily)
+      .where(this.channelRangeWhere(from, to, channel))
+      .groupBy(aggChannelDaily.salesChannel)
+      .orderBy(sql`SUM(${aggChannelDaily.grossRevenue}) DESC`);
+
+    return rows.map((row) => ({ salesChannel: row.salesChannel, ...toRevenueTotals(row) }));
+  }
+
+  /**
+   * 취소 사유 분포 — fact 스캔. 취소 봉투에는 salesChannel 이 실리지 않아 채널 필터가 없다.
+   * OrderCancelled payload 의 `reason` 을 그대로 센다 (없으면 UNKNOWN).
+   */
+  private async cancelReasonDistribution(from: string, to: string): Promise<Array<{ reason: string; count: number }>> {
+    const fromInstant = seoulDayStart(from);
+    const toExclusive = seoulDayStart(nextDay(to));
+    const { factOrderEvents } = analyticsSchema;
+
+    const rows = await this.db
+      .select({
+        reason: sql<string>`COALESCE(${factOrderEvents.payload} ->> 'reason', 'UNKNOWN')`,
+        count: sql<string>`COUNT(*)`,
+      })
+      .from(factOrderEvents)
+      .where(
+        and(
+          eq(factOrderEvents.messageType, 'OrderCancelled'),
+          gte(factOrderEvents.occurredAt, fromInstant),
+          lt(factOrderEvents.occurredAt, toExclusive),
+        ),
+      )
+      .groupBy(sql`1`)
+      .orderBy(sql`COUNT(*) DESC`);
+
+    return rows.map((row) => ({ reason: row.reason, count: Number(row.count ?? 0) }));
+  }
+}
+
+function toRevenueTotals(row?: {
+  grossRevenue: string | number | null;
+  cancelledAmount: string | number | null;
+  refundedAmount: string | number | null;
+  ordersCount: string | number | null;
+}): RevenueTotals {
+  const grossRevenue = Number(row?.grossRevenue ?? 0);
+  const cancelledAmount = Number(row?.cancelledAmount ?? 0);
+  const refundedAmount = Number(row?.refundedAmount ?? 0);
+  return {
+    grossRevenue,
+    cancelledAmount,
+    refundedAmount,
+    netRevenue: grossRevenue - cancelledAmount - refundedAmount,
+    ordersCount: Number(row?.ordersCount ?? 0),
+  };
+}
+
+function avgOrderValue(totals: RevenueTotals): number | null {
+  return totals.ordersCount > 0 ? totals.netRevenue / totals.ordersCount : null;
+}
+
+function withDerivedKpis(totals: RevenueTotals): SalesKpis {
+  return {
+    ...totals,
+    avgOrderValue: avgOrderValue(totals),
+    cancelRefundRate:
+      totals.grossRevenue > 0 ? (totals.cancelledAmount + totals.refundedAmount) / totals.grossRevenue : null,
+  };
+}
+
+/** 누적 구매액 히스토그램 버킷 CASE — LIFETIME_BUCKETS 정의와 1:1 이어야 한다. */
+function lifetimeBucketCase(): SQL<string> {
+  const chunks = LIFETIME_BUCKETS.map((bucket) =>
+    bucket.max === null
+      ? sql`WHEN ${aggCustomerLifetime.totalRevenue} >= ${bucket.min} THEN ${bucket.label}`
+      : sql`WHEN ${aggCustomerLifetime.totalRevenue} >= ${bucket.min} AND ${aggCustomerLifetime.totalRevenue} < ${bucket.max} THEN ${bucket.label}`,
+  );
+  return sql<string>`CASE ${sql.join(chunks, sql` `)} ELSE 'UNKNOWN' END`;
+}
+
+function bucketFormat(granularity: Granularity): string {
+  return granularity === 'year' ? 'YYYY' : granularity === 'month' ? 'YYYY-MM' : 'YYYY-MM-DD';
+}
+
+/** 날짜 문자열 산술은 KST 오프셋과 무관하다 — 달력 날짜끼리의 덧뺄셈은 UTC 기준으로 해도 같다. */
+function addDays(dateOnly: string, days: number): string {
+  const base = new Date(`${dateOnly}T00:00:00Z`);
+  base.setUTCDate(base.getUTCDate() + days);
+  return base.toISOString().slice(0, 10);
+}
+
+function nextDay(dateOnly: string): string {
+  return addDays(dateOnly, 1);
+}
+
+/** 직전 동일 길이 기간 — [from-len, from-1] */
+export function previousRange(from: string, to: string): { from: string; to: string } {
+  const lengthDays =
+    Math.round((Date.parse(`${to}T00:00:00Z`) - Date.parse(`${from}T00:00:00Z`)) / 86_400_000) + 1;
+  return { from: addDays(from, -lengthDays), to: addDays(from, -1) };
+}

--- a/apps/analytics/src/shared/date.util.ts
+++ b/apps/analytics/src/shared/date.util.ts
@@ -30,3 +30,14 @@ export const SEOUL_TZ = 'Asia/Seoul';
 export function toSeoulDateOnly(value: Date): string {
   return formatInTimeZone(value, SEOUL_TZ, 'yyyy-MM-dd');
 }
+
+/**
+ * KST 달력 날짜(`YYYY-MM-DD`)의 자정 시각(instant).
+ *
+ * 일별 스냅샷의 기준 시점이다 — "그날 몇 명이었나"는 그날 KST 00:00 에 열려 있던 구간의
+ * 수로 정의한다. 한국은 현재 DST 가 없어 고정 오프셋 표기(+09:00)로 충분하며, IANA 역사
+ * 오프셋이 필요한 방향(과거 timestamp → 날짜 키)은 `toSeoulDateOnly` 가 담당한다.
+ */
+export function seoulDayStart(dateOnly: string): Date {
+  return new Date(`${dateOnly}T00:00:00+09:00`);
+}

--- a/apps/membership/src/controllers/admin-operations.controller.ts
+++ b/apps/membership/src/controllers/admin-operations.controller.ts
@@ -888,6 +888,27 @@ export class AdminOperationsController {
   }
 
   /**
+   * 멤버십 회원 수 요약 (상태별)
+   *
+   * GET /admin/members/summary
+   * `members/:userId` 보다 먼저 선언해야 "summary" 가 userId 로 잡히지 않는다.
+   */
+  @Get('members/summary')
+  @ApiOperation({
+    summary: '멤버십 회원 수 요약',
+    description: '상태별 회원 수. 각 값은 같은 status 필터의 회원 목록 total 과 동일한 기준으로 계산됩니다.',
+  })
+  @UseGuards(JwtAuthGuard)
+  async getMembersSummary() {
+    try {
+      const result = await this.adminOperationsService.getMembersSummary();
+      return { success: true, data: result };
+    } catch (error) {
+      this.handleError(error, '멤버십 회원 수 요약');
+    }
+  }
+
+  /**
    * 멤버십 회원 상세 조회
    *
    * GET /admin/members/:userId

--- a/apps/membership/src/services/admin-operations.service.ts
+++ b/apps/membership/src/services/admin-operations.service.ts
@@ -146,6 +146,10 @@ export class AdminOperationsService {
     return this.adminMembersReader.findAllWithDetails(query);
   }
 
+  async getMembersSummary() {
+    return this.adminMembersReader.countMembersByStatus();
+  }
+
   async getMemberDetail(userId: string) {
     return this.adminMembersReader.findDetailByUserId(userId);
   }

--- a/apps/membership/src/services/admin/admin-members.reader.count.integration.spec.ts
+++ b/apps/membership/src/services/admin/admin-members.reader.count.integration.spec.ts
@@ -1,0 +1,148 @@
+import { randomUUID } from 'crypto';
+import * as postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { inArray, eq } from 'drizzle-orm';
+import type { DbService } from '@app/db';
+import { membershipSchema } from '../../shared/schemas/entities/schema';
+import * as schema from '../../shared/schemas/entities/schema';
+import { AdminMembersReader, ADMIN_MEMBER_STATUS_FILTERS, AdminMemberStatusFilter } from './admin-members.reader';
+
+/**
+ * 요약 카운트 = 같은 status 필터의 목록 total 인지 실 Postgres 로 대조한다.
+ *
+ * 검증 대상이 distinct-on subquery 의 재사용 자체라 DB 를 목으로 두면 아무것도 확인하지
+ * 못한다. 두 값 모두 전역 카운트이므로 DB 에 다른 데이터가 있어도 등식은 성립해야 한다 —
+ * 시드는 각 상태 버킷이 0 이 아니게 만들기 위해서만 필요하다.
+ *
+ * 실행: DATABASE_URL=postgresql://postgres:postgres@localhost:5432/membership \
+ *   npx jest --testPathPattern="admin-members.reader.count.integration"
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+
+// CI 등 DB 가 반드시 있어야 하는 경로에서는 REQUIRE_MEMBERSHIP_DB=1 로 누락을 실패시킨다.
+if (process.env.REQUIRE_MEMBERSHIP_DB === '1' && !DATABASE_URL) {
+  throw new Error('REQUIRE_MEMBERSHIP_DB=1 인데 DATABASE_URL 이 없습니다');
+}
+
+describeIfDb('멤버십 상태별 카운트는 목록 total 과 같은 정의를 쓴다 (실 Postgres)', () => {
+  jest.setTimeout(120_000);
+
+  const marker = `itest-${randomUUID().slice(0, 8)}`;
+  let sql: postgres.Sql;
+  let reader: AdminMembersReader;
+  let db: ReturnType<typeof drizzle<typeof membershipSchema>>;
+  let tierId: string;
+  let planId: string;
+  const seededUserIds: string[] = [];
+
+  beforeAll(async () => {
+    sql = postgres(DATABASE_URL as string, { max: 1 });
+    db = drizzle(sql, { schema: membershipSchema });
+
+    const dbService = { db } as unknown as DbService<typeof membershipSchema>;
+    // countMembersByStatus / findAllWithDetails 는 협력자를 쓰지 않는다.
+    reader = new AdminMembersReader(dbService, {} as never, {} as never, {} as never);
+
+    const [tier] = await db
+      .insert(schema.tiers)
+      .values({ code: marker, priorityLevel: 100000 + Math.floor(Math.random() * 800000) })
+      .returning({ id: schema.tiers.id });
+    tierId = tier.id;
+    const [planRow] = await db
+      .insert(schema.plan)
+      .values({ tierId, price: 10000, durationDays: 30 })
+      .returning({ id: schema.plan.id });
+    planId = planRow.id;
+
+    const today = new Date().toISOString().slice(0, 10);
+    const seedContract = async (opts: {
+      status: string;
+      pausedAt?: Date;
+      recurringCancelledAt?: Date;
+      cancelledAt?: Date;
+    }) => {
+      const userId = `${marker}-${randomUUID().slice(0, 8)}`;
+      seededUserIds.push(userId);
+      await db.insert(schema.subscriptionContracts).values({
+        userId,
+        planId,
+        billingDate: today,
+        status: opts.status,
+        cancelledAt: opts.cancelledAt ?? null,
+        recurringCancelledAt: opts.recurringCancelledAt ?? null,
+      });
+      await db.insert(schema.subscriptionEntitlement).values({
+        userId,
+        tierId,
+        startsAt: today,
+        endsAt: today,
+        isCurrent: true,
+        pausedAt: opts.pausedAt ?? null,
+      });
+      return userId;
+    };
+
+    await seedContract({ status: 'ACTIVE' });
+    await seedContract({ status: 'ACTIVE', pausedAt: new Date() });
+    await seedContract({ status: 'ACTIVE', recurringCancelledAt: new Date() }); // 해지 예약
+    await seedContract({ status: 'CANCELLED', cancelledAt: new Date() });
+    await seedContract({ status: 'EXPIRED' });
+    await seedContract({ status: 'EXPIRED', recurringCancelledAt: new Date() }); // 해지 예약 후 종료
+  });
+
+  afterAll(async () => {
+    if (db && seededUserIds.length > 0) {
+      await db
+        .delete(schema.subscriptionEntitlement)
+        .where(inArray(schema.subscriptionEntitlement.userId, seededUserIds));
+      await db
+        .delete(schema.subscriptionContracts)
+        .where(inArray(schema.subscriptionContracts.userId, seededUserIds));
+      await db.delete(schema.plan).where(eq(schema.plan.id, planId));
+      await db.delete(schema.tiers).where(eq(schema.tiers.id, tierId));
+    }
+    await sql?.end();
+  });
+
+  it('버킷별 카운트가 같은 필터의 목록 total 과 일치한다', async () => {
+    const summary = await reader.countMembersByStatus();
+
+    const totalFor = async (status?: AdminMemberStatusFilter) => {
+      const { total } = await reader.findAllWithDetails({ page: 1, limit: 1, status });
+      return total;
+    };
+
+    expect(summary.total).toBe(await totalFor(undefined));
+    expect(summary.active).toBe(await totalFor('ACTIVE'));
+    expect(summary.paused).toBe(await totalFor('PAUSED'));
+    expect(summary.recurringCancelled).toBe(await totalFor('RECURRING_CANCELLED'));
+    expect(summary.cancelled).toBe(await totalFor('CANCELLED'));
+    expect(summary.expired).toBe(await totalFor('EXPIRED'));
+
+    // 시드가 실제로 각 버킷에 최소 1건씩 반영됐는지 — 0=0 등식으로 통과하는 빈 검증 방지.
+    expect(summary.active).toBeGreaterThanOrEqual(2); // ACTIVE + 해지예약(ACTIVE 유지)
+    expect(summary.paused).toBeGreaterThanOrEqual(1);
+    expect(summary.recurringCancelled).toBeGreaterThanOrEqual(1);
+    expect(summary.cancelled).toBeGreaterThanOrEqual(1);
+    expect(summary.expired).toBeGreaterThanOrEqual(2);
+  });
+
+  it('해지 예약(잔여기간 이용 중) 회원은 active 에 포함되고 recurringCancelled 에도 집계된다', async () => {
+    const summary = await reader.countMembersByStatus();
+    const recurring = await reader.findAllWithDetails({ page: 1, limit: 50, status: 'RECURRING_CANCELLED' });
+
+    const seededRecurring = recurring.data.filter((row) => row.userId.startsWith(marker));
+    expect(seededRecurring).toHaveLength(1);
+    // 같은 회원이 ACTIVE 필터에서도 나온다 — 서버 status 는 ACTIVE.
+    const active = await reader.findAllWithDetails({ page: 1, limit: 50, status: 'ACTIVE', q: seededRecurring[0].userId });
+    expect(active.total).toBe(1);
+    expect(summary.recurringCancelled).toBeLessThanOrEqual(summary.active);
+  });
+
+  it('알 수 없는 상태 필터는 명시적으로 거부된다', async () => {
+    await expect(
+      reader.findAllWithDetails({ page: 1, limit: 1, status: 'BOGUS' as (typeof ADMIN_MEMBER_STATUS_FILTERS)[number] }),
+    ).rejects.toThrow('알 수 없는 상태 필터');
+  });
+});

--- a/apps/membership/src/services/admin/admin-members.reader.ts
+++ b/apps/membership/src/services/admin/admin-members.reader.ts
@@ -96,6 +96,21 @@ export interface AdminMembersResponse {
   limit: number;
 }
 
+/**
+ * 상태별 회원 수. 각 값은 같은 status 필터의 목록 API total 과 같은 쿼리로 센다.
+ *  - active 는 해지 예약(recurringCancelled) 회원을 포함한다 — 잔여기간 이용 중이라 목록의 ACTIVE 필터와 동일.
+ *  - recurringCancelled 는 active 의 부분집합이므로 버킷을 더해 total 을 만들면 안 된다.
+ */
+export interface AdminMembersSummary {
+  /** 멤버십을 한 번이라도 구독했던 회원 수 (필터 없음) */
+  total: number;
+  active: number;
+  paused: number;
+  recurringCancelled: number;
+  cancelled: number;
+  expired: number;
+}
+
 export interface AdminMemberDetail {
   contractId: string;
   userId: string;
@@ -332,9 +347,13 @@ export class AdminMembersReader {
     private readonly contractReader: SubscriptionContractReader,
   ) {}
 
-  async findAllWithDetails(query: AdminMembersQuery): Promise<AdminMembersResponse> {
-    const { page = 1, limit = 20, status, q, userIds, dateFrom, dateTo, dateCriteria = 'createdAt', refundPending } = query;
-    const offset = (page - 1) * limit;
+  /**
+   * 목록과 카운트가 공유하는 원천 subquery — user 별 최신 계약 1행.
+   * 필터 조건을 여기(subquery WHERE)에 넣은 뒤 distinct-on 하므로, 목록 total 과 요약 카운트가
+   * 같은 정의를 갖는다. 카운트를 따로 정의하면 화면의 카드 숫자와 목록 total 이 어긋난다.
+   */
+  private buildLatestPerUserSubquery(query: Omit<AdminMembersQuery, 'page' | 'limit'>) {
+    const { status, q, userIds, dateFrom, dateTo, dateCriteria = 'createdAt', refundPending } = query;
 
     // 모르는 상태값을 조용히 무시하면 조건이 통째로 빠져 '해지 내역' 화면에 전체 회원이 나온다.
     // 배포 과도기(옛 서버 + 새 화면)에 그렇게 되면 CS 가 목록을 믿을 수 없다 — 명시적으로 거부한다.
@@ -421,7 +440,7 @@ export class AdminMembersReader {
       eq(schema.subscriptionEntitlement.isCurrent, true),
     );
 
-    const latestPerUser = this.dbService.db
+    return this.dbService.db
       .selectDistinctOn([schema.subscriptionContracts.userId], {
         contractId: schema.subscriptionContracts.id,
         userId: schema.subscriptionContracts.userId,
@@ -456,6 +475,33 @@ export class AdminMembersReader {
       .where(whereClause)
       .orderBy(schema.subscriptionContracts.userId, desc(schema.subscriptionContracts.createdAt))
       .as('lc');
+  }
+
+  /** 상태별 회원 수. 각 버킷은 같은 status 필터의 목록 total 과 같은 쿼리로 계산된다. */
+  async countMembersByStatus(): Promise<AdminMembersSummary> {
+    const countFor = async (status?: AdminMemberStatusFilter) => {
+      const sub = this.buildLatestPerUserSubquery({ status });
+      const [{ total }] = await this.dbService.db.select({ total: count() }).from(sub);
+      return total;
+    };
+
+    const [total, active, paused, recurringCancelled, cancelled, expired] = await Promise.all([
+      countFor(undefined),
+      countFor('ACTIVE'),
+      countFor('PAUSED'),
+      countFor('RECURRING_CANCELLED'),
+      countFor('CANCELLED'),
+      countFor('EXPIRED'),
+    ]);
+
+    return { total, active, paused, recurringCancelled, cancelled, expired };
+  }
+
+  async findAllWithDetails(query: AdminMembersQuery): Promise<AdminMembersResponse> {
+    const { page = 1, limit = 20 } = query;
+    const offset = (page - 1) * limit;
+
+    const latestPerUser = this.buildLatestPerUserSubquery(query);
 
     const [[{ total }], rows] = await Promise.all([
       this.dbService.db.select({ total: count() }).from(latestPerUser),

--- a/deployments/lcnine/services/infra/services.ts
+++ b/deployments/lcnine/services/infra/services.ts
@@ -608,6 +608,7 @@ export function setup(infra: SharedInfra) {
       CHANNEL_ADAPTER_SERVICE_URL: url('channel-adapter'),
       FILE_SERVICE_URL: url('file'),
       UGC_SERVICE_URL: url('ugc'),
+      ANALYTICS_SERVICE_URL: url('analytics'),
       ADMIN_DOMAIN: domain('admin'),
       OIDC_ISSUER_URL: idpUserServiceUrl,
       OAUTH_ISSUER_URL: idpUserServiceUrl,

--- a/scripts/analytics-backfill/index.ts
+++ b/scripts/analytics-backfill/index.ts
@@ -1,0 +1,559 @@
+/**
+ * analytics 백필 — 원본 DB(core·membership)를 읽어 합성 이벤트를 만들고,
+ * 실시간 컨슈머가 부르는 **같은 서비스 메서드**에 먹인다. 집계 로직이 한 벌만 존재하므로
+ * 백필 결과와 실시간 결과가 어긋날 수 없다 (설계: docs/superpowers/specs/2026-07-31-admin-statistics-design.md).
+ *
+ * 실행 (dry-run 이 기본 — `--apply` 없이는 아무것도 쓰지 않는다):
+ *
+ *   npx tsx scripts/analytics-backfill/index.ts --stage dev --deployment lcnine-services \
+ *     [--orders] [--memberships] [--from YYYY-MM-DD] [--apply] [--allow-live]
+ *
+ * 로컬(도커) DB 로 시험하려면 sst shell 없이 env 로 연결을 준다:
+ *
+ *   ANALYTICS_DATABASE_URL=... CORE_DATABASE_URL=... MEMBERSHIP_DATABASE_URL=... \
+ *     npx tsx scripts/analytics-backfill/index.ts --orders --memberships [--apply]
+ *
+ * 멱등성:
+ *  - 합성 messageId 는 원본 키에서 결정론적으로 생성된다 → 백필 재실행은 claimed 게이트에 걸린다.
+ *  - OrderCreated 는 fact_order_items 의 (orderKey, salesChannel, orderItemId) 유니크가
+ *    실시간 이벤트와의 겹침도 막는다 (두 번째 게이트).
+ *  - OrderCancelled 는 두 번째 게이트가 없다 — 먹이기 전에 그 주문의 취소 봉투가
+ *    fact_order_events 에 이미 있는지 확인하고, 있으면 건너뛴다 (설계 문서 요건 1).
+ *
+ * 알려진 근사치 (dry-run 로그에도 남긴다):
+ *  - 원본 line 에 skuId 가 없어 variantId 를 skuId 로 쓴다 (analytics 는 skuId 를 집계에 안 쓴다).
+ *  - 멤버십은 subscription_entitlement 구간에서 ACTIVE/EXPIRED 만 복원한다 — 일시정지 이력은
+ *    복원하지 않는다 (pause_events 재생은 범위 밖).
+ *  - 취소 사유 원본이 없어 reason=ADMIN_CANCEL + reasonDetail 로 표시한다.
+ */
+import { createHash } from 'crypto';
+import { Module } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import postgres, { Sql } from 'postgres';
+import { DbModule, DbService } from '@app/db';
+import { and, eq, inArray } from 'drizzle-orm';
+import { DomainEvent } from '@packages/event-contracts/types';
+import {
+  ORDER_STREAM,
+  OrderCancelledPayload,
+  OrderCreatedPayload,
+  OrderItem,
+  SALES_CHANNELS,
+  SalesChannel,
+} from '@packages/event-contracts/streams/orders.stream';
+import {
+  MEMBERSHIP_STREAM,
+  MembershipStatusChangedPayload,
+} from '@packages/event-contracts/streams/membership.stream';
+import { analyticsSchema, factOrderEvents } from '../../apps/analytics/src/schema';
+import { OrderFactsService } from '../../apps/analytics/src/datasets/orders/facts/order-facts.service';
+import { OrderAggregatesService } from '../../apps/analytics/src/datasets/orders/aggregates/order-aggregates.service';
+import { UserPurchaseAggregatesService } from '../../apps/analytics/src/datasets/orders/aggregates/user-purchase-aggregates.service';
+import { ChannelAggregatesService } from '../../apps/analytics/src/datasets/orders/aggregates/channel-aggregates.service';
+import { VariantAggregatesService } from '../../apps/analytics/src/datasets/orders/aggregates/variant-aggregates.service';
+import { CustomerLifetimeService } from '../../apps/analytics/src/datasets/orders/aggregates/customer-lifetime.service';
+import { MembershipFactsService } from '../../apps/analytics/src/datasets/memberships/facts/membership-facts.service';
+import { MembershipDimensionsService } from '../../apps/analytics/src/datasets/memberships/dimensions/membership-dimensions.service';
+import { MembershipDailySnapshotService } from '../../apps/analytics/src/datasets/memberships/aggregates/membership-daily-snapshot.service';
+import { toSeoulDateOnly } from '../../apps/analytics/src/shared/date.util';
+import {
+  ensureInsideSstShell,
+  parseCommonArgs,
+} from '../seeding/lib/sst-shell-relaunch';
+
+const BATCH_SIZE = 200;
+
+// ───────────────────────── CLI ─────────────────────────
+
+const argvFlags = new Set(process.argv.slice(2).filter((a) => a.startsWith('--')));
+const args = parseCommonArgs(process.argv);
+const APPLY = argvFlags.has('--apply');
+const DO_ORDERS = argvFlags.has('--orders');
+const DO_MEMBERSHIPS = argvFlags.has('--memberships');
+const FROM = (() => {
+  const idx = process.argv.indexOf('--from');
+  return idx >= 0 ? process.argv[idx + 1] : undefined;
+})();
+
+const HAS_ENV_URLS = !!process.env.ANALYTICS_DATABASE_URL;
+
+if ((args.stage === 'live' || process.env.SST_STAGE === 'live') && !argvFlags.has('--allow-live')) {
+  console.error('live stage 는 --allow-live 없이 거부합니다. 실행은 운영자가 결정합니다.');
+  process.exit(1);
+}
+
+if (!DO_ORDERS && !DO_MEMBERSHIPS) {
+  console.error('대상을 지정하세요: --orders 그리고/또는 --memberships');
+  process.exit(1);
+}
+
+// ───────────────────────── 연결 ─────────────────────────
+
+function sstCredentials() {
+  // scripts/seeding/lib/db-connection.ts 와 같은 방식 — sst shell 이 주입한 Resource 사용.
+  // 이 파일에서 직접 읽는 이유: 그 모듈은 import 시점에 'sst' 를 로드해 env-URL 모드에서도
+  // sst 밖 실행이 막힌다.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- sst shell 안에서만 로드
+  const { Resource } = require('sst') as { Resource: Record<string, any> };
+  const name = ['Db', 'IdpDb'].find((n) => process.env[`SST_RESOURCE_${n}`]);
+  if (!name) throw new Error('sst shell 밖입니다 — SST_RESOURCE_* 가 없습니다.');
+  const db = Resource[name];
+  return { host: db.host as string, port: db.port as number, user: db.username as string, password: db.password as string };
+}
+
+function sourceConnection(dbName: string, envUrl?: string): Sql {
+  if (envUrl) return postgres(envUrl, { max: 4 });
+  const creds = sstCredentials();
+  return postgres({ ...creds, database: dbName, ssl: 'require', max: 4 });
+}
+
+function analyticsConnectionString(): string {
+  if (process.env.ANALYTICS_DATABASE_URL) return process.env.ANALYTICS_DATABASE_URL;
+  const { user, password, host, port } = sstCredentials();
+  return `postgresql://${user}:${password}@${host}:${port}/analytics?sslmode=require`;
+}
+
+// ───────────────────────── 합성 봉투 ─────────────────────────
+
+/** 원본 키에서 결정론적 26자 messageId. 'BF' 접두로 합성분을 육안 식별할 수 있다. */
+function syntheticMessageId(kind: string, key: string): string {
+  return `BF${createHash('sha256').update(`${kind}|${key}`).digest('hex').slice(0, 24).toUpperCase()}`;
+}
+
+function envelope<T>(
+  messageType: string,
+  aggregateType: string,
+  aggregateId: string,
+  messageId: string,
+  occurredAtIso: string,
+  payload: T,
+): DomainEvent<T> {
+  return {
+    messageId,
+    messageType,
+    messageVersion: 1,
+    messageKind: 'event',
+    correlationId: messageId,
+    timestamp: occurredAtIso,
+    source: { service: 'analytics-backfill', aggregateType, aggregateId },
+    payload,
+  } as DomainEvent<T>;
+}
+
+// ───────────────────────── Nest 컨텍스트 (Kafka 없음) ─────────────────────────
+
+function buildBackfillModule(connectionString: string) {
+  // AnalyticsModule 을 그대로 부팅하면 EventsModule/Logger/Schedule 이 딸려온다.
+  // 필요한 것은 DbService 와 집계 서비스뿐이다 — 컨슈머는 등록하지 않는다.
+  @Module({
+    imports: [
+      DbModule.forRoot({
+        config: { connectionString },
+        schema: analyticsSchema,
+      }),
+    ],
+    providers: [
+      OrderFactsService,
+      OrderAggregatesService,
+      UserPurchaseAggregatesService,
+      ChannelAggregatesService,
+      VariantAggregatesService,
+      CustomerLifetimeService,
+      MembershipFactsService,
+      MembershipDimensionsService,
+      MembershipDailySnapshotService,
+    ],
+  })
+  class BackfillModule {}
+  return BackfillModule;
+}
+
+// ───────────────────────── 주문 백필 ─────────────────────────
+
+interface CoreOrderRow {
+  id: string;
+  channel_order_id: string;
+  sales_channel: string;
+  status: string;
+  customer_id: string | null;
+  customer_name: string | null;
+  shipping_address: Record<string, unknown> | null;
+  total_amount: number | null;
+  shipping_fee: number;
+  order_date: Date;
+  updated_at: Date;
+  cancelled_at: Date | null;
+}
+
+interface CoreLineRow {
+  id: string;
+  sales_order_id: string;
+  variant_id: string;
+  product_name: string;
+  quantity: number;
+  unit_price: number | null;
+  total_price: number | null;
+  master_id: string | null;
+  version_id: string | null;
+}
+
+function toOrderItem(line: CoreLineRow): OrderItem | null {
+  if (!line.master_id || !line.version_id) return null; // 매핑 없는 라인은 상품 귀속 불가 — 건너뛴다
+  return {
+    orderItemId: line.id,
+    skuId: line.variant_id, // 원본 line 에 skuId 없음 — variantId 로 대체 (집계 미사용 필드)
+    masterId: line.master_id,
+    versionId: line.version_id,
+    variantId: line.variant_id,
+    productName: line.product_name || '-',
+    quantity: line.quantity,
+    unitPrice: line.unit_price ?? 0,
+    totalPrice: line.total_price ?? 0,
+  };
+}
+
+function toShippingAddress(raw: Record<string, unknown> | null, fallbackName: string | null) {
+  const value = (key: string) => {
+    const v = raw?.[key];
+    return typeof v === 'string' && v.length > 0 ? v : undefined;
+  };
+  return {
+    recipientName: value('recipientName') ?? value('recipient_name') ?? fallbackName ?? '-',
+    phone: value('phone') ?? '-',
+    postalCode: value('postalCode') ?? value('postal_code') ?? '-',
+    roadAddress: value('roadAddress') ?? value('road_address') ?? value('address1') ?? '-',
+    detailAddress: value('detailAddress') ?? value('detail_address') ?? value('address2') ?? '-',
+  };
+}
+
+async function backfillOrders(core: Sql, dbService: DbService<typeof analyticsSchema>, services: {
+  facts: OrderFactsService;
+  orderAgg: OrderAggregatesService;
+  userPurchase: UserPurchaseAggregatesService;
+  channelAgg: ChannelAggregatesService;
+  variantAgg: VariantAggregatesService;
+  lifetime: CustomerLifetimeService;
+}) {
+  const orderCreatedSchema = ORDER_STREAM.events.OrderCreated.schema;
+  const orderCancelledSchema = ORDER_STREAM.events.OrderCancelled.schema;
+
+  const counters = {
+    read: 0,
+    createdApplied: 0,
+    createdDuplicate: 0,
+    cancelApplied: 0,
+    cancelSkippedExisting: 0,
+    cancelOrphan: 0,
+    linesDroppedNoMapping: 0,
+    invalidPayload: 0,
+    unknownChannel: 0,
+  };
+
+  let offset = 0;
+  for (;;) {
+    const orders = await core<CoreOrderRow[]>`
+      SELECT o.id, o.channel_order_id, o.sales_channel::text AS sales_channel, o.status::text AS status,
+             o.customer_id, o.customer_name, o.shipping_address, o.total_amount, o.shipping_fee,
+             o.order_date, o.updated_at,
+             (SELECT MIN(e.created_at) FROM order_events e
+               WHERE e.order_id = o.id AND e.event_type = 'ORDER_CANCELLED') AS cancelled_at
+      FROM sales_orders o
+      ${FROM ? core`WHERE o.order_date >= ${FROM}::date` : core``}
+      ORDER BY o.order_date ASC, o.id ASC
+      LIMIT ${BATCH_SIZE} OFFSET ${offset}
+    `;
+    if (orders.length === 0) break;
+    offset += orders.length;
+    counters.read += orders.length;
+
+    const orderIds = orders.map((o) => o.id);
+    const lines = await core<CoreLineRow[]>`
+      SELECT l.id, l.sales_order_id, l.variant_id, l.product_name, l.quantity, l.unit_price, l.total_price,
+             pmv.master_id, pmv.version_id
+      FROM sales_order_lines l
+      LEFT JOIN LATERAL (
+        SELECT master_id, version_id FROM product_master_variants
+        WHERE variant_id = l.variant_id
+        ORDER BY created_at DESC LIMIT 1
+      ) pmv ON true
+      WHERE l.sales_order_id IN ${core(orderIds)}
+    `;
+    const linesByOrder = new Map<string, CoreLineRow[]>();
+    for (const line of lines) {
+      const list = linesByOrder.get(line.sales_order_id) ?? [];
+      list.push(line);
+      linesByOrder.set(line.sales_order_id, list);
+    }
+
+    // 취소 겹침 방지: 이 배치의 주문에 대한 취소 봉투가 이미 있는지 한 번에 조회.
+    const cancelKeys = orders
+      .filter((o) => o.status === 'cancelled')
+      .flatMap((o) => [o.id, o.channel_order_id]);
+    const existingCancelOrderIds = new Set<string>();
+    if (cancelKeys.length > 0) {
+      const rows = await dbService.db
+        .select({ orderId: factOrderEvents.orderId })
+        .from(factOrderEvents)
+        .where(and(eq(factOrderEvents.messageType, 'OrderCancelled'), inArray(factOrderEvents.orderId, cancelKeys)));
+      for (const row of rows) {
+        if (row.orderId) existingCancelOrderIds.add(row.orderId);
+      }
+    }
+
+    for (const order of orders) {
+      if (!(SALES_CHANNELS as readonly string[]).includes(order.sales_channel)) {
+        counters.unknownChannel += 1;
+        continue;
+      }
+      const rawLines = linesByOrder.get(order.id) ?? [];
+      const items = rawLines.map(toOrderItem).filter((item): item is OrderItem => item !== null);
+      counters.linesDroppedNoMapping += rawLines.length - items.length;
+      if (items.length === 0) continue;
+
+      const createdAtIso = order.order_date.toISOString();
+      const subtotal = items.reduce((sum, item) => sum + item.totalPrice, 0);
+      const payload: OrderCreatedPayload = {
+        orderId: order.id,
+        externalOrderId: order.channel_order_id,
+        salesChannel: order.sales_channel as SalesChannel,
+        customerId: order.customer_id,
+        items,
+        totalAmount: order.total_amount ?? subtotal + order.shipping_fee,
+        subtotalAmount: subtotal,
+        shippingAmount: order.shipping_fee,
+        discountAmount: 0,
+        currency: 'KRW',
+        shippingAddress: toShippingAddress(order.shipping_address, order.customer_name),
+        status: order.status as OrderCreatedPayload['status'],
+        createdAt: createdAtIso,
+      };
+
+      const parsed = orderCreatedSchema?.safeParse(payload);
+      if (parsed && !parsed.success) {
+        counters.invalidPayload += 1;
+        console.warn(`  잘못된 합성 OrderCreated — 건너뜀: ${order.channel_order_id} (${parsed.error.issues[0]?.message})`);
+        continue;
+      }
+
+      const orderKey = payload.externalOrderId ?? payload.orderId;
+      const messageId = syntheticMessageId('OrderCreated', `${orderKey}|${payload.salesChannel}`);
+
+      if (APPLY) {
+        await dbService.run(async (tx) => {
+          const result = await services.facts.recordOrderCreated(
+            envelope('OrderCreated', 'Order', payload.orderId, messageId, createdAtIso, payload),
+            payload,
+            tx,
+          );
+          if (!result.claimed) {
+            counters.createdDuplicate += 1;
+            return;
+          }
+          counters.createdApplied += 1;
+          await services.orderAgg.applyOrderCreated(result.seeds, tx);
+          await services.userPurchase.applyOrderCreated(payload.customerId, payload.items, new Date(payload.createdAt), tx);
+          await services.variantAgg.applyOrderCreated(result.variantSeeds, tx);
+          if (result.channelSeed) await services.channelAgg.applyOrderCreated(result.channelSeed, tx);
+          if (result.customerSeed) await services.lifetime.applyOrderCreated(result.customerSeed, tx);
+        });
+      } else {
+        counters.createdApplied += 1; // dry-run: 적용 예정 건수
+      }
+
+      if (order.status === 'cancelled') {
+        if (existingCancelOrderIds.has(order.id) || existingCancelOrderIds.has(order.channel_order_id)) {
+          counters.cancelSkippedExisting += 1;
+          continue;
+        }
+        const cancelledAtIso = (order.cancelled_at ?? order.updated_at).toISOString();
+        const cancelPayload: OrderCancelledPayload = {
+          // recordOrderCancelled 는 orderKey/orderId 양쪽으로 원본을 찾는다 — 합성 생성분의
+          // orderKey(=channelOrderId)와 맞추기 위해 channelOrderId 를 쓴다.
+          orderId: order.channel_order_id,
+          salesChannel: order.sales_channel as SalesChannel,
+          externalOrderId: order.channel_order_id,
+          reason: 'ADMIN_CANCEL',
+          reasonDetail: 'backfill: 원본 취소 사유 미보존',
+          cancelledBy: 'analytics-backfill',
+          cancelledAt: cancelledAtIso,
+          refundRequired: false,
+        };
+        const cancelParsed = orderCancelledSchema?.safeParse(cancelPayload);
+        if (cancelParsed && !cancelParsed.success) {
+          counters.invalidPayload += 1;
+          continue;
+        }
+        const cancelMessageId = syntheticMessageId('OrderCancelled', `${orderKey}|${payload.salesChannel}`);
+
+        if (APPLY) {
+          await dbService.run(async (tx) => {
+            const result = await services.facts.recordOrderCancelled(
+              envelope('OrderCancelled', 'Order', cancelPayload.orderId, cancelMessageId, cancelledAtIso, cancelPayload),
+              cancelPayload,
+              tx,
+            );
+            if (!result.claimed) return;
+            if (result.orphan || !result.salesChannel) {
+              counters.cancelOrphan += 1;
+              return;
+            }
+            counters.cancelApplied += 1;
+            await services.orderAgg.applyCancellation(result.occurredDate, result.salesChannel, result.masterAmounts, tx);
+            await services.channelAgg.applyCancellation(result.occurredDate, result.salesChannel, result.totalAmount, tx);
+          });
+        } else {
+          counters.cancelApplied += 1;
+        }
+      }
+    }
+    console.log(`  주문 진행: ${counters.read}건 읽음`);
+  }
+
+  return counters;
+}
+
+// ───────────────────────── 멤버십 백필 ─────────────────────────
+
+interface EntitlementRow {
+  user_id: string;
+  tier_id: string;
+  starts_at: string; // date
+  ends_at: string; // date
+  closed_at: Date | null;
+}
+
+async function backfillMemberships(
+  membership: Sql,
+  dbService: DbService<typeof analyticsSchema>,
+  services: { facts: MembershipFactsService; dims: MembershipDimensionsService },
+) {
+  const schema = MEMBERSHIP_STREAM.events.MembershipStatusChanged.schema;
+  const counters = { entitlements: 0, opened: 0, closed: 0, duplicate: 0, invalidPayload: 0 };
+  const now = new Date();
+
+  const rows = await membership<EntitlementRow[]>`
+    SELECT e.user_id, e.tier_id, e.starts_at::text AS starts_at, e.ends_at::text AS ends_at, e.closed_at
+    FROM subscription_entitlement e
+    ${FROM ? membership`WHERE e.starts_at >= ${FROM}::date` : membership``}
+    ORDER BY e.user_id ASC, e.starts_at ASC
+  `;
+  counters.entitlements = rows.length;
+
+  const feed = async (payload: MembershipStatusChangedPayload, key: string) => {
+    const parsed = schema?.safeParse(payload);
+    if (parsed && !parsed.success) {
+      counters.invalidPayload += 1;
+      return;
+    }
+    if (!APPLY) return;
+    const messageId = syntheticMessageId('MembershipStatusChanged', key);
+    await dbService.run(async (tx) => {
+      const result = await services.facts.recordStatusChanged(
+        envelope('MembershipStatusChanged', 'Membership', payload.userId, messageId, payload.occurredAt, payload),
+        payload,
+        tx,
+      );
+      if (!result.claimed) {
+        counters.duplicate += 1;
+        return;
+      }
+      await services.dims.applyStatusChanged(result, tx);
+    });
+  };
+
+  for (const row of rows) {
+    // 자격 시작 = KST 그 날짜 00:00. dim 구간과 스냅샷 정의가 모두 KST 자정 기준이다.
+    const startInstant = new Date(`${row.starts_at}T00:00:00+09:00`);
+    await feed(
+      {
+        userId: row.user_id,
+        status: 'ACTIVE',
+        occurredAt: startInstant.toISOString(),
+        tierId: row.tier_id,
+      },
+      `${row.user_id}|${row.starts_at}|open`,
+    );
+    counters.opened += 1;
+
+    // 종료 시점: 조기 종료(closed_at)가 있으면 그 시각, 아니면 ends_at 다음날 KST 자정.
+    const endInstant = row.closed_at ?? new Date(`${row.ends_at}T00:00:00+09:00`);
+    if (!row.closed_at) endInstant.setUTCDate(endInstant.getUTCDate() + 1);
+    if (endInstant <= now) {
+      await feed(
+        {
+          userId: row.user_id,
+          status: 'EXPIRED',
+          occurredAt: endInstant.toISOString(),
+          tierId: row.tier_id,
+        },
+        `${row.user_id}|${row.starts_at}|close`,
+      );
+      counters.closed += 1;
+    }
+  }
+
+  return counters;
+}
+
+// ───────────────────────── main ─────────────────────────
+
+async function main() {
+  if (!HAS_ENV_URLS) {
+    await ensureInsideSstShell({ stage: args.stage, deployment: args.deployment });
+  }
+
+  console.log(`analytics 백필 — ${APPLY ? 'APPLY' : 'DRY-RUN (쓰지 않음)'}${FROM ? `, from=${FROM}` : ''}`);
+
+  const app = await NestFactory.createApplicationContext(buildBackfillModule(analyticsConnectionString()), {
+    logger: ['warn', 'error'],
+  });
+
+  try {
+    const dbService = app.get(DbService) as DbService<typeof analyticsSchema>;
+
+    if (DO_ORDERS) {
+      const core = sourceConnection('core', process.env.CORE_DATABASE_URL);
+      try {
+        const counters = await backfillOrders(core, dbService, {
+          facts: app.get(OrderFactsService),
+          orderAgg: app.get(OrderAggregatesService),
+          userPurchase: app.get(UserPurchaseAggregatesService),
+          channelAgg: app.get(ChannelAggregatesService),
+          variantAgg: app.get(VariantAggregatesService),
+          lifetime: app.get(CustomerLifetimeService),
+        });
+        console.log('주문 백필 결과:', JSON.stringify(counters));
+      } finally {
+        await core.end();
+      }
+    }
+
+    if (DO_MEMBERSHIPS) {
+      const membership = sourceConnection('membership', process.env.MEMBERSHIP_DATABASE_URL);
+      try {
+        const counters = await backfillMemberships(membership, dbService, {
+          facts: app.get(MembershipFactsService),
+          dims: app.get(MembershipDimensionsService),
+        });
+        console.log('멤버십 백필 결과:', JSON.stringify(counters));
+
+        // dim 이 채워졌으니 오늘자 스냅샷을 다시 굽는다 (과거 날짜는 필요 시
+        // snapshotFor(date) 를 날짜별로 호출해 재계산할 수 있다).
+        if (APPLY) {
+          const snapshot = app.get(MembershipDailySnapshotService);
+          await snapshot.snapshotFor(toSeoulDateOnly(new Date()));
+          console.log('오늘자 agg_membership_daily 스냅샷 재기록 완료');
+        }
+      } finally {
+        await membership.end();
+      }
+    }
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/security/idor-reviewed.spec.ts
+++ b/scripts/security/idor-reviewed.spec.ts
@@ -45,9 +45,27 @@ const IDOR_REVIEWED: Record<string, { verdict: Verdict; evidence: string; predic
   },
   'analytics GET /summary': {
     verdict: 'N/A',
-    evidence: 'apps/analytics/src/features/analytics-api/analytics.service.ts:19',
-    predicate: "throw new NotImplementedException('TODO: 뭘 리턴하게 할지 고민중');",
-    note: '무인증(컨트롤러에 @UseGuards 없음, analytics.controller.ts:34,44) 이지만 AnalyticsService.getSummary() 가 현재 NotImplementedException 만 던지는 미구현 스텁 — 실제로는 항상 501 이 나가고 매출/구매 데이터는 반환되지 않는다. 구현이 채워지면(특히 집계에 사용자별 필드가 들어가면) 인증/스코프 재검토 필요.',
+    evidence: 'apps/analytics/src/features/analytics-api/analytics.controller.ts:35',
+    predicate: '@UseGuards(JwtAuthGuard)',
+    note: '대시보드 요약(오늘/어제 전사 매출 + 활성 멤버십 수) — 사용자 소유 리소스 파라미터가 없어 IDOR 대상 아님. JwtAuthGuard 로 인증 요구. 응답이 전사 매출 수치라 관리자 스코프 제한은 analytics 전반 스코프 도입과 함께 별도 검토.',
+  },
+  'analytics GET /statistics/sales': {
+    verdict: 'N/A',
+    evidence: 'apps/analytics/src/features/statistics/api/statistics.controller.ts:15',
+    predicate: '@UseGuards(JwtAuthGuard)',
+    note: '기간별 전사 매출 집계 — 쿼리 파라미터가 날짜/채널뿐이라 IDOR 대상 아님. 컨트롤러 클래스에 JwtAuthGuard. 관리자 스코프는 위 /summary 와 같은 별도 검토 항목.',
+  },
+  'analytics GET /statistics/products': {
+    verdict: 'N/A',
+    evidence: 'apps/analytics/src/features/statistics/api/statistics.controller.ts:15',
+    predicate: '@UseGuards(JwtAuthGuard)',
+    note: '상품별 전사 집계 — 사용자 소유 리소스 파라미터 없음. 컨트롤러 클래스에 JwtAuthGuard.',
+  },
+  'analytics GET /statistics/customers': {
+    verdict: 'N/A',
+    evidence: 'apps/analytics/src/features/statistics/api/statistics.controller.ts:15',
+    predicate: '@UseGuards(JwtAuthGuard)',
+    note: '고객·멤버십 전사 집계 — 개별 고객 식별자를 받지 않고 등급/버킷 단위로만 반환. 컨트롤러 클래스에 JwtAuthGuard.',
   },
   'core GET /library/ownerships': {
     verdict: 'SAFE',
@@ -626,15 +644,15 @@ const keyOf = (r: AuditRow): string => `${r.app} ${r.verb} ${r.route}`;
 describe('IDOR 검사 대상 집합', () => {
   it('감사 스크립트가 idorTarget 을 내보낸다', () => {
     const targets = runAudit().filter((r) => r.idorTarget);
-    expect(targets).toHaveLength(97);
+    expect(targets).toHaveLength(100);
   });
 
   // search 와 analytics 가 둘 다 `GET /health` 다. `<VERB> <route>` 로 키를 만들면
   // 97건이 96개로 뭉개지고 스냅샷이 한 건을 조용히 잃는다.
   it('키에 app 이 들어가야 충돌하지 않는다', () => {
     const targets = runAudit().filter((r) => r.idorTarget);
-    expect(new Set(targets.map(keyOf)).size).toBe(97);
-    expect(new Set(targets.map((r) => `${r.verb} ${r.route}`)).size).toBe(96);
+    expect(new Set(targets.map(keyOf)).size).toBe(100);
+    expect(new Set(targets.map((r) => `${r.verb} ${r.route}`)).size).toBe(99);
   });
 
   it('감사 스크립트의 대상 집합과 명단이 정확히 일치한다', () => {


### PR DESCRIPTION
## 요약

설계 문서 `docs/superpowers/specs/2026-07-31-admin-statistics-design.md` 의 나머지 단계 구현.

- **멤버십 회원수**: membership `GET /admin/members/summary` + 관리자 회원 페이지 상태별 카드 6종 + 대시보드 홈 카드. 카드 숫자는 목록 API 와 같은 subquery(`buildLatestPerUserSubquery`)를 재사용해 **같은 필터의 목록 total 과 쿼리 정의상 동일**하다. active 는 해지 예약 포함, recurringCancelled 는 active 의 부분집합이라 버킷 합산으로 total 을 만들지 않는다.
- **`agg_membership_daily` 일별 스냅샷**: 매일 KST 00:05 크론. 이벤트 증분이 아니라 `dim_customer_membership` 열린 구간을 그날 기준으로 재계산(delete+insert)한다 — 멤버십 이벤트 유실 이력이 있어 유실에 강한 쪽을 택했다. `snapshotFor(date)` 로 과거 날짜 재계산 가능, 재실행 멱등.
- **조회 API**: analytics `GET /statistics/{sales,products,customers}`. 기간(from/to, KST 포함)·단위(day/month/year)·채널 필터, 직전 동일 길이 기간 자동 비교. 객단가 = 순매출÷주문수, 취소·환불률은 금액 기준. 취소는 취소일에 귀속되므로 일별 순매출이 음수로 내려갈 수 있다(의도).
- **화면**: 판매/통계 메뉴 3탭(매출·상품·고객멤버십), 필터 조건 URL 쿼리 유지(탭 전환 시 따라감), recharts.
- **백필 스크립트**: `scripts/analytics-backfill/` — dry-run 기본, `--apply`/`--allow-live` 가드. 원본을 실시간 컨슈머와 같은 서비스 메서드에 같은 순서로 먹인다. 아직 실행 전 — 배포 후 dry-run 부터 진행 예정.

## 결정 근거

- 통계 API 가드는 membership 관리자 라우트와 같은 `JwtAuthGuard` 수준으로 맞췄다. 스코프 부여는 analytics 전반 도입과 함께 별도로 다룬다.
- 기존 `/best-product` 는 스토어프론트 소비 가능성이 있어 건드리지 않았다(무가드 상태는 별도 이슈로).