### PR TITLE
feat(analytics): 통계 화면의 상품·옵션·카테고리 ID 노출 해소

### DIFF
--- a/apps/admin-web/src/features/statistics/template/products.tsx
+++ b/apps/admin-web/src/features/statistics/template/products.tsx
@@ -108,7 +108,7 @@ export default function ProductStatisticsTemplate() {
               isEmpty={!data || data.categories.length === 0}
             >
               <HorizontalBarList
-                items={(data?.categories ?? []).map((row) => ({ label: row.categoryId, value: row.grossRevenue }))}
+                items={(data?.categories ?? []).map((row) => ({ label: row.categoryName ?? row.categoryId, value: row.grossRevenue }))}
                 formatValue={formatKrw}
               />
             </ChartCard>
@@ -132,7 +132,7 @@ export default function ProductStatisticsTemplate() {
                   <tbody>
                     {(data?.variants ?? []).map((row) => (
                       <tr key={row.variantId} className="border-b last:border-0">
-                        <td className="py-1.5">{row.variantName ?? row.variantId}</td>
+                        <td className="py-1.5">{row.variantName ?? (row.isDefault ? '기본 품목' : row.variantId)}</td>
                         <td className="py-1.5 text-gray-500">{row.masterName ?? row.masterId}</td>
                         <td className="py-1.5 text-right tabular-nums">{formatCount(row.quantitySold)}</td>
                         <td className="py-1.5 text-right tabular-nums">{formatKrw(row.grossRevenue)}</td>

--- a/apps/admin-web/src/lib/api/domains/analytics/index.ts
+++ b/apps/admin-web/src/lib/api/domains/analytics/index.ts
@@ -45,10 +45,11 @@ export interface ProductStatistics {
   range: { from: string; to: string };
   previousRange: { from: string; to: string };
   ranking: ProductRankingRow[];
-  categories: Array<{ categoryId: string; grossRevenue: number; quantitySold: number }>;
+  categories: Array<{ categoryId: string; categoryName: string | null; grossRevenue: number; quantitySold: number }>;
   variants: Array<{
     variantId: string;
     variantName: string | null;
+    isDefault: boolean;
     masterId: string;
     masterName: string | null;
     quantitySold: number;

--- a/apps/analytics/drizzle/20260825014344_add-dim-category-name.sql
+++ b/apps/analytics/drizzle/20260825014344_add-dim-category-name.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "dim_product_categories" ADD COLUMN "category_name" varchar(255);

--- a/apps/analytics/drizzle/meta/20260825014344_snapshot.json
+++ b/apps/analytics/drizzle/meta/20260825014344_snapshot.json
@@ -1,0 +1,2278 @@
+{
+  "id": "c52709f4-4d5c-4734-8a51-c4ed617a0d18",
+  "prevId": "f10dd4eb-339c-4d20-9f6a-2c7de4a28f8b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agg_channel_daily": {
+      "name": "agg_channel_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agg_date": {
+          "name": "agg_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_channel": {
+          "name": "sales_channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orders_count": {
+          "name": "orders_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "gross_revenue": {
+          "name": "gross_revenue",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cancelled_amount": {
+          "name": "cancelled_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "refunded_amount": {
+          "name": "refunded_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_agg_channel_daily": {
+          "name": "uq_agg_channel_daily",
+          "columns": [
+            {
+              "expression": "agg_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sales_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_channel_daily_date": {
+          "name": "idx_agg_channel_daily_date",
+          "columns": [
+            {
+              "expression": "agg_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agg_customer_lifetime": {
+      "name": "agg_customer_lifetime",
+      "schema": "",
+      "columns": {
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_order_at": {
+          "name": "first_order_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_order_at": {
+          "name": "last_order_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orders_count": {
+          "name": "orders_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_revenue": {
+          "name": "total_revenue",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agg_customer_lifetime_first_order": {
+          "name": "idx_agg_customer_lifetime_first_order",
+          "columns": [
+            {
+              "expression": "first_order_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agg_membership_daily": {
+      "name": "agg_membership_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agg_date": {
+          "name": "agg_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UNKNOWN'"
+        },
+        "members_count": {
+          "name": "members_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_agg_membership_daily": {
+          "name": "uq_agg_membership_daily",
+          "columns": [
+            {
+              "expression": "agg_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_membership_daily_date": {
+          "name": "idx_agg_membership_daily_date",
+          "columns": [
+            {
+              "expression": "agg_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agg_product_order_daily": {
+      "name": "agg_product_order_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agg_date": {
+          "name": "agg_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_channel": {
+          "name": "sales_channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orders_count": {
+          "name": "orders_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "quantity_sold": {
+          "name": "quantity_sold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "gross_revenue": {
+          "name": "gross_revenue",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cancelled_amount": {
+          "name": "cancelled_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "refunded_amount": {
+          "name": "refunded_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_agg_product_order_daily": {
+          "name": "uq_agg_product_order_daily",
+          "columns": [
+            {
+              "expression": "agg_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sales_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_product_order_daily_date": {
+          "name": "idx_agg_product_order_daily_date",
+          "columns": [
+            {
+              "expression": "agg_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_product_order_daily_master": {
+          "name": "idx_agg_product_order_daily_master",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_product_order_daily_channel": {
+          "name": "idx_agg_product_order_daily_channel",
+          "columns": [
+            {
+              "expression": "sales_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agg_user_product_purchase": {
+      "name": "agg_user_product_purchase",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_product_id": {
+          "name": "channel_product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_quantity": {
+          "name": "total_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_purchased_at": {
+          "name": "last_purchased_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_purchased_at": {
+          "name": "first_purchased_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_agg_user_product": {
+          "name": "uq_agg_user_product",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_user_product_customer": {
+          "name": "idx_agg_user_product_customer",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_user_product_master": {
+          "name": "idx_agg_user_product_master",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_user_product_count": {
+          "name": "idx_agg_user_product_count",
+          "columns": [
+            {
+              "expression": "purchase_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agg_variant_order_daily": {
+      "name": "agg_variant_order_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agg_date": {
+          "name": "agg_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_channel": {
+          "name": "sales_channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_sold": {
+          "name": "quantity_sold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "gross_revenue": {
+          "name": "gross_revenue",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_agg_variant_order_daily": {
+          "name": "uq_agg_variant_order_daily",
+          "columns": [
+            {
+              "expression": "agg_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sales_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_variant_order_daily_date": {
+          "name": "idx_agg_variant_order_daily_date",
+          "columns": [
+            {
+              "expression": "agg_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_variant_order_daily_master": {
+          "name": "idx_agg_variant_order_daily_master",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dim_customer_membership": {
+      "name": "dim_customer_membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UNKNOWN'"
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to": {
+          "name": "valid_to",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_dim_customer_membership": {
+          "name": "uq_dim_customer_membership",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_customer_membership_user": {
+          "name": "idx_dim_customer_membership_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_customer_membership_valid_to": {
+          "name": "idx_dim_customer_membership_valid_to",
+          "columns": [
+            {
+              "expression": "valid_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dim_product_categories": {
+      "name": "dim_product_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_name": {
+          "name": "category_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_dim_product_categories_master_category": {
+          "name": "uq_dim_product_categories_master_category",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_product_categories_master": {
+          "name": "idx_dim_product_categories_master",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_product_categories_category": {
+          "name": "idx_dim_product_categories_category",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_product_categories_primary": {
+          "name": "idx_dim_product_categories_primary",
+          "columns": [
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dim_product_masters": {
+      "name": "dim_product_masters",
+      "schema": "",
+      "columns": {
+        "master_id": {
+          "name": "master_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_change_reason": {
+          "name": "last_change_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_dim_product_masters_active": {
+          "name": "idx_dim_product_masters_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_product_masters_name": {
+          "name": "idx_dim_product_masters_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_product_masters_updated_at": {
+          "name": "idx_dim_product_masters_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dim_product_variants": {
+      "name": "dim_product_variants",
+      "schema": "",
+      "columns": {
+        "variant_id": {
+          "name": "variant_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_name": {
+          "name": "variant_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventory_management": {
+          "name": "inventory_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_stock_sellable": {
+          "name": "pre_stock_sellable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "always_sellable_zero_stock": {
+          "name": "always_sellable_zero_stock",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_dim_product_variants_master": {
+          "name": "idx_dim_product_variants_master",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_product_variants_status": {
+          "name": "idx_dim_product_variants_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_product_variants_updated_at": {
+          "name": "idx_dim_product_variants_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fact_membership_events": {
+      "name": "fact_membership_events",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(26)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_text": {
+          "name": "reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fact_membership_events_user": {
+          "name": "idx_fact_membership_events_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_membership_events_occurred_at": {
+          "name": "idx_fact_membership_events_occurred_at",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_membership_events_status": {
+          "name": "idx_fact_membership_events_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_membership_events_reason": {
+          "name": "idx_fact_membership_events_reason",
+          "columns": [
+            {
+              "expression": "reason_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fact_order_events": {
+      "name": "fact_order_events",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(26)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_version": {
+          "name": "message_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "message_kind": {
+          "name": "message_kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "varchar(26)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "causation_id": {
+          "name": "causation_id",
+          "type": "varchar(26)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregate_type": {
+          "name": "aggregate_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_service": {
+          "name": "source_service",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_channel": {
+          "name": "sales_channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fact_order_events_type": {
+          "name": "idx_fact_order_events_type",
+          "columns": [
+            {
+              "expression": "message_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_order_events_occurred_at": {
+          "name": "idx_fact_order_events_occurred_at",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_order_events_order": {
+          "name": "idx_fact_order_events_order",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_order_events_external_order": {
+          "name": "idx_fact_order_events_external_order",
+          "columns": [
+            {
+              "expression": "external_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fact_order_items": {
+      "name": "fact_order_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(26)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_channel": {
+          "name": "sales_channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_item_id": {
+          "name": "order_item_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_product_id": {
+          "name": "channel_product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_fact_order_items_order_item": {
+          "name": "uq_fact_order_items_order_item",
+          "columns": [
+            {
+              "expression": "order_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sales_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_order_items_master": {
+          "name": "idx_fact_order_items_master",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_order_items_occurred_at": {
+          "name": "idx_fact_order_items_occurred_at",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_order_items_order_key": {
+          "name": "idx_fact_order_items_order_key",
+          "columns": [
+            {
+              "expression": "order_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_order_items_customer": {
+          "name": "idx_fact_order_items_customer",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "event.outbox_events": {
+      "name": "outbox_events",
+      "schema": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_type": {
+          "name": "aggregate_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "partition_key": {
+          "name": "partition_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "outbox_status_idx": {
+          "name": "outbox_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_processing_started_idx": {
+          "name": "outbox_processing_started_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processing_started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_topic_idx": {
+          "name": "outbox_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_status_next_attempt_idx": {
+          "name": "outbox_status_next_attempt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_partition_created_idx": {
+          "name": "outbox_partition_created_idx",
+          "columns": [
+            {
+              "expression": "partition_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_event_outbox_topic_event_idempotency": {
+          "name": "uq_event_outbox_topic_event_idempotency",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "event.event_resource_links": {
+      "name": "event_resource_links",
+      "schema": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(26)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "erl_chain_idx": {
+          "name": "erl_chain_idx",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "erl_resource_idx": {
+          "name": "erl_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "erl_event_idx": {
+          "name": "erl_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.role_scope_mapping": {
+      "name": "role_scope_mapping",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_scope_unique_idx": {
+          "name": "role_scope_unique_idx",
+          "columns": [
+            {
+              "expression": "role_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_scope_mapping_scope_id_scopes_id_fk": {
+          "name": "role_scope_mapping_scope_id_scopes_id_fk",
+          "tableFrom": "role_scope_mapping",
+          "tableTo": "scopes",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.scopes": {
+      "name": "scopes",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microservice_name": {
+          "name": "microservice_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scopes_key_unique": {
+          "name": "scopes_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "event": "event",
+    "auth": "auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/analytics/drizzle/meta/_journal.json
+++ b/apps/analytics/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1786291953903,
       "tag": "20260809161233_outbox-partition-created-index",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1787622224208,
+      "tag": "20260825014344_add-dim-category-name",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/analytics/src/features/statistics/read-model/statistics.query.integration.spec.ts
+++ b/apps/analytics/src/features/statistics/read-model/statistics.query.integration.spec.ts
@@ -7,10 +7,13 @@ import {
   aggChannelDaily,
   aggMembershipDaily,
   aggProductOrderDaily,
+  aggVariantOrderDaily,
   analyticsSchema,
   dimCustomerMembership,
   dimProductCategories,
   dimProductMasters,
+  dimProductVariants,
+  factOrderItems,
 } from '../../../schema';
 import { MembershipDailySnapshotService } from '../../../datasets/memberships/aggregates/membership-daily-snapshot.service';
 import { toSeoulDateOnly } from '../../../shared/date.util';
@@ -36,6 +39,8 @@ describeIfDb('StatisticsQuery (실 Postgres)', () => {
   const channel = `itest-${randomUUID().slice(0, 8)}`;
   const masterA = `itest-master-${randomUUID().slice(0, 8)}`;
   const masterB = `itest-master-${randomUUID().slice(0, 8)}`;
+  const masterC = `itest-master-${randomUUID().slice(0, 8)}`; // dim 에 이름 없음 — fact 폴백 검증용
+  const variantC = `itest-variant-${randomUUID().slice(0, 8)}`;
   const categoryId = `itest-cat-${randomUUID().slice(0, 8)}`;
   const tierId = `itest-tier-${randomUUID().slice(0, 8)}`;
   const userPrefix = `itest-user-${randomUUID().slice(0, 8)}`;
@@ -68,7 +73,7 @@ describeIfDb('StatisticsQuery (실 Postgres)', () => {
       { masterId: masterB, name: '통합테스트 상품 B' },
     ]);
     await db.insert(dimProductCategories).values([
-      { masterId: masterA, categoryId, isPrimary: true },
+      { masterId: masterA, categoryId, categoryName: '통합테스트 카테고리', isPrimary: true },
       // primary 아님 — 카테고리 구성에 잡히면 중복 가산 버그다.
       { masterId: masterB, categoryId: `${categoryId}-secondary`, isPrimary: false },
     ]);
@@ -77,6 +82,22 @@ describeIfDb('StatisticsQuery (실 Postgres)', () => {
       { aggDate: '2026-08-02', masterId: masterB, salesChannel: channel, ordersCount: 1, quantitySold: 1, grossRevenue: 6000, cancelledAmount: 0, refundedAmount: 0 },
       // 직전 기간(7월) — previousNetRevenue 산출용
       { aggDate: '2026-07-02', masterId: masterA, salesChannel: channel, ordersCount: 1, quantitySold: 1, grossRevenue: 4000, cancelledAmount: 0, refundedAmount: 0 },
+      // dim 없는 상품 — 이름은 주문 라인 폴백으로 온다
+      { aggDate: '2026-08-03', masterId: masterC, salesChannel: channel, ordersCount: 1, quantitySold: 1, grossRevenue: 1000, cancelledAmount: 0, refundedAmount: 0 },
+    ]);
+
+    // 주문 라인 2건 — 폴백은 더 최근(occurredAt) 이름을 골라야 한다.
+    await db.insert(factOrderItems).values([
+      { messageId: `IT${randomUUID().replace(/-/g, '').slice(0, 24)}`, orderKey: `${masterC}-o1`, salesChannel: channel, masterId: masterC, productName: '옛 상품명', quantity: 1, occurredAt: new Date('2026-08-01T10:00:00+09:00') },
+      { messageId: `IT${randomUUID().replace(/-/g, '').slice(0, 24)}`, orderKey: `${masterC}-o2`, salesChannel: channel, masterId: masterC, productName: '폴백 상품명', quantity: 1, occurredAt: new Date('2026-08-03T10:00:00+09:00') },
+    ]);
+
+    // 옵션 집계: dim 은 이름 없는 기본 품목 — isDefault 가 내려가고 masterName 은 폴백돼야 한다.
+    await db.insert(dimProductVariants).values([
+      { variantId: variantC, masterId: masterC, versionId: `${masterC}-v1`, variantName: null, isDefault: true, status: 'ACTIVE' },
+    ]);
+    await db.insert(aggVariantOrderDaily).values([
+      { aggDate: '2026-08-03', variantId: variantC, masterId: masterC, salesChannel: channel, quantitySold: 1, grossRevenue: 1000 },
     ]);
 
     // 멤버십 dim: 열린 구간 2명 + 이미 닫힌 구간 1명 (스냅샷은 열린 구간만 세야 한다)
@@ -95,6 +116,9 @@ describeIfDb('StatisticsQuery (실 Postgres)', () => {
       await db.delete(dimProductMasters).where(eq(dimProductMasters.masterId, masterB));
       await db.delete(dimProductCategories).where(eq(dimProductCategories.masterId, masterA));
       await db.delete(dimProductCategories).where(eq(dimProductCategories.masterId, masterB));
+      await db.delete(factOrderItems).where(eq(factOrderItems.masterId, masterC));
+      await db.delete(dimProductVariants).where(eq(dimProductVariants.variantId, variantC));
+      await db.delete(aggVariantOrderDaily).where(eq(aggVariantOrderDaily.salesChannel, channel));
       await db.delete(dimCustomerMembership).where(eq(dimCustomerMembership.tierId, tierId));
       await db.delete(aggMembershipDaily).where(eq(aggMembershipDaily.tierId, tierId));
     }
@@ -132,13 +156,23 @@ describeIfDb('StatisticsQuery (실 Postgres)', () => {
   it('상품 랭킹에 이름·순매출·전기간 순매출이 붙는다', async () => {
     const result = await query.getProducts('2026-08-01', '2026-08-31', channel, 'revenue', 10);
 
-    expect(result.ranking).toHaveLength(2);
-    const [first, second] = result.ranking;
+    expect(result.ranking).toHaveLength(3);
+    const [first, second, third] = result.ranking;
     expect(first).toMatchObject({ masterId: masterA, name: '통합테스트 상품 A', netRevenue: 8000, previousNetRevenue: 4000 });
     expect(second).toMatchObject({ masterId: masterB, netRevenue: 6000, previousNetRevenue: 0 });
+    // dim 에 이름이 없으면 가장 최근 주문 라인의 상품명으로 폴백한다.
+    expect(third).toMatchObject({ masterId: masterC, name: '폴백 상품명', netRevenue: 1000 });
 
-    // primary 카테고리만 — masterB 의 비-primary 링크는 잡히면 안 된다.
-    expect(result.categories).toEqual([{ categoryId, grossRevenue: 9000, quantitySold: 3 }]);
+    // primary 카테고리만 — masterB 의 비-primary 링크는 잡히면 안 된다. 이름도 함께 내려간다.
+    expect(result.categories).toEqual([
+      { categoryId, categoryName: '통합테스트 카테고리', grossRevenue: 9000, quantitySold: 3 },
+    ]);
+  });
+
+  it('옵션별 판매는 기본 품목 여부와 폴백된 상품명을 함께 내린다', async () => {
+    const result = await query.getProducts('2026-08-01', '2026-08-31', channel, 'revenue', 10);
+    const row = result.variants.find((v) => v.variantId === variantC);
+    expect(row).toMatchObject({ variantName: null, isDefault: true, masterId: masterC, masterName: '폴백 상품명' });
   });
 
   it('스냅샷은 열린 구간만 세고, 재실행해도 값이 변하지 않는다', async () => {

--- a/apps/analytics/src/features/statistics/read-model/statistics.query.ts
+++ b/apps/analytics/src/features/statistics/read-model/statistics.query.ts
@@ -61,11 +61,13 @@ export interface ProductStatistics {
   previousRange: { from: string; to: string };
   ranking: ProductRankingRow[];
   /** primary 카테고리 기준 — 다중 카테고리 중복 가산을 피한다 */
-  categories: Array<{ categoryId: string; grossRevenue: number; quantitySold: number }>;
+  categories: Array<{ categoryId: string; categoryName: string | null; grossRevenue: number; quantitySold: number }>;
   /** 옵션별은 총매출만 존재한다 — 순매출로 라벨링하지 말 것 */
   variants: Array<{
     variantId: string;
     variantName: string | null;
+    /** 옵션 없는 상품의 기본 품목 — variantName 이 비어 있을 때 화면이 라벨을 대신 정한다 */
+    isDefault: boolean;
     masterId: string;
     masterName: string | null;
     quantitySold: number;
@@ -210,26 +212,10 @@ export class StatisticsQuery {
       }
     }
 
-    const ranking: ProductRankingRow[] = rankingRows.map((row) => {
-      const grossRevenue = Number(row.grossRevenue ?? 0);
-      const cancelledAmount = Number(row.cancelledAmount ?? 0);
-      const refundedAmount = Number(row.refundedAmount ?? 0);
-      return {
-        masterId: row.masterId,
-        name: row.name ?? null,
-        ordersCount: Number(row.ordersCount ?? 0),
-        quantitySold: Number(row.quantitySold ?? 0),
-        grossRevenue,
-        cancelledAmount,
-        refundedAmount,
-        netRevenue: grossRevenue - cancelledAmount - refundedAmount,
-        previousNetRevenue: previousByMaster.get(row.masterId) ?? 0,
-      };
-    });
-
-    const categoryRows = await this.db
+    const categoryRowsPromise = this.db
       .select({
         categoryId: dimProductCategories.categoryId,
+        categoryName: dimProductCategories.categoryName,
         grossRevenue: sql<string>`SUM(${aggProductOrderDaily.grossRevenue})`,
         quantitySold: sql<string>`SUM(${aggProductOrderDaily.quantitySold})`,
       })
@@ -242,7 +228,7 @@ export class StatisticsQuery {
         ),
       )
       .where(where)
-      .groupBy(dimProductCategories.categoryId)
+      .groupBy(dimProductCategories.categoryId, dimProductCategories.categoryName)
       .orderBy(sql`SUM(${aggProductOrderDaily.grossRevenue}) DESC`);
 
     const variantWhereParts: SQL[] = [
@@ -252,10 +238,11 @@ export class StatisticsQuery {
     if (channel) {
       variantWhereParts.push(eq(aggVariantOrderDaily.salesChannel, channel));
     }
-    const variantRows = await this.db
+    const variantRowsPromise = this.db
       .select({
         variantId: aggVariantOrderDaily.variantId,
         variantName: dimProductVariants.variantName,
+        isDefault: dimProductVariants.isDefault,
         masterId: aggVariantOrderDaily.masterId,
         masterName: dimProductMasters.name,
         quantitySold: sql<string>`SUM(${aggVariantOrderDaily.quantitySold})`,
@@ -268,11 +255,42 @@ export class StatisticsQuery {
       .groupBy(
         aggVariantOrderDaily.variantId,
         dimProductVariants.variantName,
+        dimProductVariants.isDefault,
         aggVariantOrderDaily.masterId,
         dimProductMasters.name,
       )
       .orderBy(sql`SUM(${aggVariantOrderDaily.grossRevenue}) DESC`)
       .limit(limit);
+
+    const [categoryRows, variantRows] = await Promise.all([categoryRowsPromise, variantRowsPromise]);
+
+    // dim 에 이름이 없는 상품(집계 가동 전 발행분)은 주문 라인이 실어온 최신 상품명으로 폴백한다.
+    const namelessMasterIds = [
+      ...new Set(
+        [
+          ...rankingRows.filter((row) => !row.name).map((row) => row.masterId),
+          ...variantRows.filter((row) => !row.masterName).map((row) => row.masterId),
+        ],
+      ),
+    ];
+    const fallbackNames = await this.latestOrderedProductNames(namelessMasterIds);
+
+    const ranking: ProductRankingRow[] = rankingRows.map((row) => {
+      const grossRevenue = Number(row.grossRevenue ?? 0);
+      const cancelledAmount = Number(row.cancelledAmount ?? 0);
+      const refundedAmount = Number(row.refundedAmount ?? 0);
+      return {
+        masterId: row.masterId,
+        name: row.name ?? fallbackNames.get(row.masterId) ?? null,
+        ordersCount: Number(row.ordersCount ?? 0),
+        quantitySold: Number(row.quantitySold ?? 0),
+        grossRevenue,
+        cancelledAmount,
+        refundedAmount,
+        netRevenue: grossRevenue - cancelledAmount - refundedAmount,
+        previousNetRevenue: previousByMaster.get(row.masterId) ?? 0,
+      };
+    });
 
     return {
       range: { from, to },
@@ -280,18 +298,38 @@ export class StatisticsQuery {
       ranking,
       categories: categoryRows.map((row) => ({
         categoryId: row.categoryId,
+        categoryName: row.categoryName ?? null,
         grossRevenue: Number(row.grossRevenue ?? 0),
         quantitySold: Number(row.quantitySold ?? 0),
       })),
       variants: variantRows.map((row) => ({
         variantId: row.variantId,
         variantName: row.variantName ?? null,
+        isDefault: row.isDefault ?? false,
         masterId: row.masterId,
-        masterName: row.masterName ?? null,
+        masterName: row.masterName ?? fallbackNames.get(row.masterId) ?? null,
         quantitySold: Number(row.quantitySold ?? 0),
         grossRevenue: Number(row.grossRevenue ?? 0),
       })),
     };
+  }
+
+  /** masterId 별로 가장 최근 주문 라인이 실어온 상품명. dim 에 이름이 없을 때만 쓰는 폴백. */
+  private async latestOrderedProductNames(masterIds: string[]): Promise<Map<string, string>> {
+    if (masterIds.length === 0) return new Map();
+    const rows = await this.db
+      .selectDistinctOn([factOrderItems.masterId], {
+        masterId: factOrderItems.masterId,
+        productName: factOrderItems.productName,
+      })
+      .from(factOrderItems)
+      .where(and(inArray(factOrderItems.masterId, masterIds), sql`${factOrderItems.productName} IS NOT NULL`))
+      .orderBy(factOrderItems.masterId, desc(factOrderItems.occurredAt));
+    const map = new Map<string, string>();
+    for (const row of rows) {
+      if (row.productName) map.set(row.masterId, row.productName);
+    }
+    return map;
   }
 
   async getCustomers(from: string, to: string, granularity: Granularity = 'day'): Promise<CustomerStatistics> {

--- a/apps/analytics/src/schema.ts
+++ b/apps/analytics/src/schema.ts
@@ -154,6 +154,8 @@ export const dimProductCategories = pgTable(
       .$defaultFn(() => uuidv7()),
     masterId: varchar('master_id', { length: 255 }).notNull(),
     categoryId: varchar('category_id', { length: 255 }).notNull(),
+    // 카테고리 표시명. 이벤트에는 없어 시딩 스크립트(scripts/ops/seed-analytics-product-dims.ts)가 채운다.
+    categoryName: varchar('category_name', { length: 255 }),
     isPrimary: boolean('is_primary').notNull().default(false),
     createdAt: timestamp('created_at').defaultNow(),
     updatedAt: timestamp('updated_at').defaultNow(),

--- a/scripts/ops/seed-analytics-product-dims.ts
+++ b/scripts/ops/seed-analytics-product-dims.ts
@@ -53,6 +53,26 @@ interface MasterRow {
   name: string;
 }
 
+interface VariantRow {
+  master_id: string;
+  version_id: string;
+  variant_id: string;
+  variant_name: string | null;
+  is_default: boolean;
+  status: string;
+}
+
+interface CategoryLinkRow {
+  master_id: string;
+  category_id: string;
+  is_primary: boolean;
+}
+
+interface CategoryNameRow {
+  category_id: string;
+  name: string;
+}
+
 async function main() {
   if (!HAS_ENV_URLS) {
     await ensureInsideSstShell({ stage: args.stage, deployment: args.deployment });
@@ -75,8 +95,8 @@ async function main() {
     const masterById = new Map(masters.map((m) => [m.master_id, m]));
 
     // 대표 버전에 매달린 variant 들 (이름·기본품목 여부·상태)
-    const variants = versionIds.length
-      ? await core`
+    const variants: VariantRow[] = versionIds.length
+      ? await core<VariantRow[]>`
           SELECT mv.master_id::text AS master_id, mv.version_id::text AS version_id,
                  pv.id::text AS variant_id, pv.variant_name, pv.is_default, pv.status
           FROM product_master_variants mv
@@ -85,13 +105,13 @@ async function main() {
       : [];
 
     // 대표 버전의 카테고리 매핑 + 카테고리명
-    const categoryLinks = versionIds.length
-      ? await core`
+    const categoryLinks: CategoryLinkRow[] = versionIds.length
+      ? await core<CategoryLinkRow[]>`
           SELECT mc.master_id::text AS master_id, mc.category_id::text AS category_id, mc.is_primary
           FROM product_master_categories mc
           WHERE mc.version_id = ANY(${versionIds})`
       : [];
-    const categoryNames = await core`SELECT id::text AS category_id, name FROM product_categories`;
+    const categoryNames = await core<CategoryNameRow[]>`SELECT id::text AS category_id, name FROM product_categories`;
 
     console.log(
       `원본: masters ${masters.length} / variants ${variants.length} / ` +

--- a/scripts/ops/seed-analytics-product-dims.ts
+++ b/scripts/ops/seed-analytics-product-dims.ts
@@ -1,0 +1,184 @@
+/**
+ * analytics 상품 dim 시딩 — core 카탈로그에서 이름을 읽어 dim 테이블을 채운다.
+ *
+ * dim_product_masters·dim_product_variants 는 상품 이벤트로 유지되는데, 집계 가동 이전에
+ * 발행된 상품은 이벤트를 받은 적이 없어 이름이 비어 있다(화면에 UUID 노출).
+ * dim_product_categories 의 category_name 은 이벤트에 아예 없어 이 스크립트가 유일한 공급원이다.
+ *
+ * 이벤트 소비와의 경합 규칙: **비어 있는 것만 채운다.**
+ *  - master/variant: 없는 행은 insert, 있는 행은 name 이 NULL 일 때만 update.
+ *    이벤트가 이미 쓴 최신 상태를 절대 덮어쓰지 않는다.
+ *  - category 매핑: 없는 (master, category) 행만 insert.
+ *  - category_name: core 가 유일한 canonical 원본이므로 항상 갱신한다.
+ *
+ * 실행 (dry-run 이 기본 — --apply 없이는 아무것도 쓰지 않는다):
+ *
+ *   npx tsx scripts/ops/seed-analytics-product-dims.ts --stage dev --deployment lcnine-services [--apply] [--allow-live]
+ *
+ * 로컬(도커) DB:
+ *
+ *   ANALYTICS_DATABASE_URL=... CORE_DATABASE_URL=... npx tsx scripts/ops/seed-analytics-product-dims.ts [--apply]
+ */
+import postgres, { Sql } from 'postgres';
+import { ensureInsideSstShell, parseCommonArgs } from '../seeding/lib/sst-shell-relaunch';
+
+const argvFlags = new Set(process.argv.slice(2).filter((a) => a.startsWith('--')));
+const args = parseCommonArgs(process.argv);
+const APPLY = argvFlags.has('--apply');
+const HAS_ENV_URLS = !!process.env.ANALYTICS_DATABASE_URL;
+
+if ((args.stage === 'live' || process.env.SST_STAGE === 'live') && !argvFlags.has('--allow-live')) {
+  console.error('live stage 는 --allow-live 없이 거부합니다. 실행은 운영자가 결정합니다.');
+  process.exit(1);
+}
+
+function sstCredentials() {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- sst shell 안에서만 로드
+  const { Resource } = require('sst') as { Resource: Record<string, any> };
+  const name = ['Db', 'IdpDb'].find((n) => process.env[`SST_RESOURCE_${n}`]);
+  if (!name) throw new Error('sst shell 밖입니다 — SST_RESOURCE_* 가 없습니다.');
+  const db = Resource[name];
+  return { host: db.host as string, port: db.port as number, user: db.username as string, password: db.password as string };
+}
+
+function connect(dbName: string, envUrl?: string): Sql {
+  if (envUrl) return postgres(envUrl, { max: 2 });
+  const creds = sstCredentials();
+  return postgres({ ...creds, database: dbName, ssl: 'require', max: 2 });
+}
+
+interface MasterRow {
+  master_id: string;
+  version_id: string;
+  name: string;
+}
+
+async function main() {
+  if (!HAS_ENV_URLS) {
+    await ensureInsideSstShell({ stage: args.stage, deployment: args.deployment });
+  }
+
+  const core = connect('core', process.env.CORE_DATABASE_URL);
+  const analytics = connect('analytics', process.env.ANALYTICS_DATABASE_URL);
+  const mode = APPLY ? 'APPLY' : 'DRY-RUN';
+  console.log(`[${mode}] core → analytics 상품 dim 시딩`);
+
+  try {
+    // 마스터별 대표 버전: active 우선, 없으면(미발행) 최신 버전. 삭제된 마스터는 제외.
+    const masters = await core<MasterRow[]>`
+      SELECT DISTINCT ON (v.master_id)
+             v.master_id::text AS master_id, v.id::text AS version_id, v.name
+      FROM product_master_versions v
+      JOIN product_masters m ON m.id = v.master_id AND m.deleted_at IS NULL
+      ORDER BY v.master_id, (v.status = 'active') DESC, v.version DESC`;
+    const versionIds = masters.map((m) => m.version_id);
+    const masterById = new Map(masters.map((m) => [m.master_id, m]));
+
+    // 대표 버전에 매달린 variant 들 (이름·기본품목 여부·상태)
+    const variants = versionIds.length
+      ? await core`
+          SELECT mv.master_id::text AS master_id, mv.version_id::text AS version_id,
+                 pv.id::text AS variant_id, pv.variant_name, pv.is_default, pv.status
+          FROM product_master_variants mv
+          JOIN product_variants pv ON pv.id = mv.variant_id
+          WHERE mv.version_id = ANY(${versionIds})`
+      : [];
+
+    // 대표 버전의 카테고리 매핑 + 카테고리명
+    const categoryLinks = versionIds.length
+      ? await core`
+          SELECT mc.master_id::text AS master_id, mc.category_id::text AS category_id, mc.is_primary
+          FROM product_master_categories mc
+          WHERE mc.version_id = ANY(${versionIds})`
+      : [];
+    const categoryNames = await core`SELECT id::text AS category_id, name FROM product_categories`;
+
+    console.log(
+      `원본: masters ${masters.length} / variants ${variants.length} / ` +
+        `category links ${categoryLinks.length} / categories ${categoryNames.length}`,
+    );
+
+    // ── dim_product_masters: 없는 행 insert, 있는 행은 name NULL 만 채움 ──
+    const existingMasters = await analytics`SELECT master_id, name FROM dim_product_masters`;
+    const existingMasterMap = new Map(existingMasters.map((r) => [r.master_id as string, r.name as string | null]));
+    const masterInserts = masters.filter((m) => !existingMasterMap.has(m.master_id));
+    const masterNameFills = masters.filter(
+      (m) => existingMasterMap.has(m.master_id) && existingMasterMap.get(m.master_id) == null,
+    );
+    console.log(`dim_product_masters: insert ${masterInserts.length}, name 채움 ${masterNameFills.length}`);
+
+    // ── dim_product_variants: 없는 행 insert, 있는 행은 variant_name NULL 만 채움 ──
+    const existingVariants = await analytics`SELECT variant_id, variant_name FROM dim_product_variants`;
+    const existingVariantMap = new Map(
+      existingVariants.map((r) => [r.variant_id as string, r.variant_name as string | null]),
+    );
+    const variantInserts = variants.filter((v) => !existingVariantMap.has(v.variant_id));
+    const variantNameFills = variants.filter(
+      (v) =>
+        v.variant_name != null &&
+        existingVariantMap.has(v.variant_id) &&
+        existingVariantMap.get(v.variant_id) == null,
+    );
+    console.log(`dim_product_variants: insert ${variantInserts.length}, name 채움 ${variantNameFills.length}`);
+
+    // ── dim_product_categories: 없는 (master, category) 매핑 insert + 이름 전체 갱신 ──
+    const existingLinks = await analytics`SELECT master_id, category_id FROM dim_product_categories`;
+    const existingLinkSet = new Set(existingLinks.map((r) => `${r.master_id}|${r.category_id}`));
+    const linkInserts = categoryLinks.filter((l) => !existingLinkSet.has(`${l.master_id}|${l.category_id}`));
+    console.log(`dim_product_categories: 매핑 insert ${linkInserts.length}, 이름 갱신 대상 ${categoryNames.length}종`);
+
+    if (!APPLY) {
+      console.log('dry-run 종료 — 반영하려면 --apply');
+      return;
+    }
+
+    for (const m of masterInserts) {
+      await analytics`
+        INSERT INTO dim_product_masters (master_id, name, active_version_id, is_active)
+        VALUES (${m.master_id}, ${m.name}, ${m.version_id}, true)
+        ON CONFLICT (master_id) DO NOTHING`;
+    }
+    for (const m of masterNameFills) {
+      await analytics`
+        UPDATE dim_product_masters SET name = ${m.name}, updated_at = now()
+        WHERE master_id = ${m.master_id} AND name IS NULL`;
+    }
+
+    for (const v of variantInserts) {
+      const master = masterById.get(v.master_id as string);
+      await analytics`
+        INSERT INTO dim_product_variants (variant_id, master_id, version_id, variant_name, is_default, status)
+        VALUES (${v.variant_id}, ${v.master_id}, ${master?.version_id ?? v.version_id}, ${v.variant_name},
+                ${v.is_default}, ${v.status})
+        ON CONFLICT (variant_id) DO NOTHING`;
+    }
+    for (const v of variantNameFills) {
+      await analytics`
+        UPDATE dim_product_variants SET variant_name = ${v.variant_name}, updated_at = now()
+        WHERE variant_id = ${v.variant_id} AND variant_name IS NULL`;
+    }
+
+    for (const l of linkInserts) {
+      await analytics`
+        INSERT INTO dim_product_categories (id, master_id, category_id, is_primary)
+        VALUES (gen_random_uuid(), ${l.master_id}, ${l.category_id}, ${l.is_primary})
+        ON CONFLICT (master_id, category_id) DO NOTHING`;
+    }
+    for (const c of categoryNames) {
+      await analytics`
+        UPDATE dim_product_categories SET category_name = ${c.name}, updated_at = now()
+        WHERE category_id = ${c.category_id}
+          AND (category_name IS DISTINCT FROM ${c.name})`;
+    }
+
+    console.log('반영 완료');
+  } finally {
+    await core.end();
+    await analytics.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## 문제

통계 화면(상품 랭킹·옵션별 판매·카테고리별 매출)에 상품/옵션/카테고리가 UUID 로 노출된다.

- 상품·옵션 dim 은 상품 이벤트로 유지되는데, 집계 가동 전에 발행된 상품은 이벤트를 받은 적이 없어 이름이 비어 있다.
- `dim_product_categories` 는 이름 컬럼 자체가 없어 지금 구조로는 항상 ID 만 나온다.

## 변경

- **쿼리 폴백**: 랭킹·옵션의 상품명이 dim 에 없으면 주문 라인이 실어온 최신 `fact_order_items.product_name` 으로 폴백. 옵션은 `is_default` 를 함께 내려 이름 없는 기본 품목을 화면이 '기본 품목' 으로 표시.
- **스키마**: `dim_product_categories.category_name` 추가 (additive — expand 순서: **migrate 먼저, deploy 나중**).
- **시딩 스크립트** `scripts/ops/seed-analytics-product-dims.ts`: core 카탈로그에서 상품명(active 버전 기준)·옵션명·카테고리 매핑/이름을 읽어 dim 3종을 채운다. dry-run 기본(`--apply` 필요), live 는 `--allow-live` 필요. **비어 있는 것만 채운다** — 없는 행 insert, 이름은 NULL 일 때만 update 라 이벤트가 쓴 최신 상태를 덮지 않는다(카테고리명만 core 가 canonical 이라 항상 갱신). 재실행 멱등.

## 검증

- 실 Postgres 통합 스펙 6건 통과 — 폴백(최신 주문 라인 이름 선택)·카테고리명·기본 품목 케이스 신규 추가
- 로컬 실측: dim 없는 상품이 랭킹에서 주문 라인 이름으로, 카테고리가 이름으로 응답되는 것 API 로 확인. 시딩 스크립트는 로컬 core→analytics 로 dry-run·apply·재실행(변경 0) 확인
- `type-check` 0, 전체 jest 실패 0, `test:admin-web` 581 통과, admin-web tsc 0

## 배포 순서

1. `db:migrate` (analytics — additive 1건)
2. `sst deploy --target ServicesBundleA --target AdminWeb`
3. 시딩 스크립트 실행 (운영자, dry-run 확인 후 `--apply`)