### PR TITLE
fix(admin): 통계 등급별 표·추이 차트의 tier UUID 를 등급 코드로 표시

### DIFF
--- a/apps/admin-web/src/features/statistics/template/customers.tsx
+++ b/apps/admin-web/src/features/statistics/template/customers.tsx
@@ -14,6 +14,7 @@ import {
   YAxis,
 } from 'recharts';
 import { useCustomerStatistics } from '@/lib/services/analytics';
+import { useTiersWithPlans } from '@/lib/services/membership';
 import { StatisticsShell } from '../components/shell';
 import { ChartCard, HorizontalBarList, KpiTile } from '../components/widgets';
 import { formatCount, formatKrw, formatPercent, SERIES_COLORS, useStatisticsRange } from '../shared';
@@ -21,6 +22,17 @@ import { formatCount, formatKrw, formatPercent, SERIES_COLORS, useStatisticsRang
 export default function CustomerStatisticsTemplate() {
   const range = useStatisticsRange();
   const { data, isLoading, isError } = useCustomerStatistics(range);
+  // analytics 는 tierId 만 안다 — 등급 이름은 membership 등급 목록으로 매핑하고, 실패하면 id 그대로 둔다.
+  const { data: tiersWithPlans } = useTiersWithPlans();
+  const tierLabel = useMemo(() => {
+    const byId = new Map((tiersWithPlans ?? []).map(({ tier }) => [tier.id, tier.code]));
+    return (tierId: string) => {
+      if (tierId === 'GUEST') return '비회원';
+      if (tierId === 'NON_MEMBER') return '일반 회원';
+      if (tierId === 'UNKNOWN') return '등급 미상';
+      return byId.get(tierId) ?? tierId;
+    };
+  }, [tiersWithPlans]);
 
   // 멤버십 추이는 (날짜, tier) 행으로 오므로 tier 를 시리즈 컬럼으로 피벗한다.
   const membershipSeries = useMemo(() => {
@@ -125,7 +137,7 @@ export default function CustomerStatisticsTemplate() {
                     key={tier}
                     type="monotone"
                     dataKey={tier}
-                    name={tier === 'UNKNOWN' ? '등급 미상' : tier}
+                    name={tierLabel(tier)}
                     stroke={SERIES_COLORS[index % SERIES_COLORS.length]}
                     strokeWidth={2}
                     dot={false}
@@ -157,7 +169,7 @@ export default function CustomerStatisticsTemplate() {
                     {(data?.tierRevenue ?? []).map((row) => (
                       <tr key={row.tierId} className="border-b last:border-0">
                         <td className="py-1.5 font-medium">
-                          {row.tierId === 'GUEST' ? '비회원' : row.tierId === 'NON_MEMBER' ? '일반 회원' : row.tierId}
+                          {tierLabel(row.tierId)}
                         </td>
                         <td className="py-1.5 text-right tabular-nums">{formatKrw(row.grossRevenue)}</td>
                         <td className="py-1.5 text-right tabular-nums">{formatCount(row.ordersCount)}</td>


### PR DESCRIPTION
"등급별 매출·객단가" 표와 "멤버십 회원 수 추이" 범례에 멤버십 등급이 UUID 로 노출된다. analytics 는 tierId 만 알고 등급 이름은 membership 에만 있어서다.

- 이미 쓰고 있는 `useTiersWithPlans`(GET /admin/tiers) 로 tierId → 등급 코드 매핑
- 등급 목록 조회 실패 시 id 그대로 표시 (통계 화면을 막지 않음)
- `UNKNOWN`(등급 미상 구간) 은 '등급 미상' 으로 표기

프론트만 변경 — 배포는 AdminWeb 만.

검증: admin-web tsc 0, test:admin-web 76 스위트 581 통과.