### PR TITLE
fix(analytics): 백필 tsx 부팅 오류 수정, 옵션 조합 variant 이름 시딩

### DIFF
--- a/libs/db/src/db.service.ts
+++ b/libs/db/src/db.service.ts
@@ -4,6 +4,13 @@ import { drizzle, PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as postgres from 'postgres';
 import { DrizzleSchema, TxFor } from './types';
 
+// nest build(CJS)에서는 네임스페이스가 곧 호출 가능한 함수지만, tsx 같은 ESM 로더는
+// ESM 빌드를 골라 함수가 default 아래에 온다. 어느 쪽이든 호출 가능한 쪽을 집는다.
+const postgresFn: typeof postgres =
+  typeof postgres === 'function'
+    ? postgres
+    : ((postgres as { default?: typeof postgres }).default as typeof postgres);
+
 export const DB_CONNECTION = 'DB_CONNECTION';
 export const DB_SCHEMA = 'DB_SCHEMA';
 
@@ -28,7 +35,7 @@ export class DbService<TSchema extends DrizzleSchema = Record<string, never>>
 
   private initializeConnection(): void {
     // postgres.js는 Connection String을 직접 받을 수 있습니다.
-    const client = postgres(this.config.connectionString);
+    const client = postgresFn(this.config.connectionString);
     this._client = client;
     this._db = drizzle(client, { schema: this.schema });
   }

--- a/scripts/ops/seed-analytics-product-dims.ts
+++ b/scripts/ops/seed-analytics-product-dims.ts
@@ -73,6 +73,11 @@ interface CategoryNameRow {
   name: string;
 }
 
+interface DerivedNameRow {
+  variant_id: string;
+  derived_name: string;
+}
+
 async function main() {
   if (!HAS_ENV_URLS) {
     await ensureInsideSstShell({ stage: args.stage, deployment: args.deployment });
@@ -103,6 +108,26 @@ async function main() {
           JOIN product_variants pv ON pv.id = mv.variant_id
           WHERE mv.version_id = ANY(${versionIds})`
       : [];
+
+    // 수동 이름이 없는 옵션 조합 variant 는 옵션값 표시명을 이어 붙여 이름을 만든다 (예: "1제 / 2제").
+    // 이 값은 core 에서도 화면 조립으로만 존재해 이벤트·수동이름 어느 쪽으로도 안 들어온다.
+    const derivedNames: DerivedNameRow[] = versionIds.length
+      ? await core<DerivedNameRow[]>`
+          SELECT mv.variant_id::text AS variant_id,
+                 string_agg(d.display_name, ' / ' ORDER BY d.sort_order, d.display_name) AS derived_name
+          FROM product_master_variants mv
+          JOIN variant_option_values vov ON vov.variant_id = mv.variant_id
+          JOIN product_option_value_displays d
+            ON d.option_value_id = vov.option_value_id
+           AND d.version_id = mv.version_id
+           AND d.master_id = mv.master_id
+           AND d.locale = 'ko-KR'
+          WHERE mv.version_id = ANY(${versionIds})
+          GROUP BY mv.variant_id`
+      : [];
+    const derivedNameByVariant = new Map(derivedNames.map((row) => [row.variant_id, row.derived_name]));
+    const effectiveVariantName = (v: VariantRow): string | null =>
+      v.variant_name ?? derivedNameByVariant.get(v.variant_id) ?? null;
 
     // 대표 버전의 카테고리 매핑 + 카테고리명
     const categoryLinks: CategoryLinkRow[] = versionIds.length
@@ -135,7 +160,7 @@ async function main() {
     const variantInserts = variants.filter((v) => !existingVariantMap.has(v.variant_id));
     const variantNameFills = variants.filter(
       (v) =>
-        v.variant_name != null &&
+        effectiveVariantName(v) != null &&
         existingVariantMap.has(v.variant_id) &&
         existingVariantMap.get(v.variant_id) == null,
     );
@@ -168,13 +193,13 @@ async function main() {
       const master = masterById.get(v.master_id as string);
       await analytics`
         INSERT INTO dim_product_variants (variant_id, master_id, version_id, variant_name, is_default, status)
-        VALUES (${v.variant_id}, ${v.master_id}, ${master?.version_id ?? v.version_id}, ${v.variant_name},
+        VALUES (${v.variant_id}, ${v.master_id}, ${master?.version_id ?? v.version_id}, ${effectiveVariantName(v)},
                 ${v.is_default}, ${v.status})
         ON CONFLICT (variant_id) DO NOTHING`;
     }
     for (const v of variantNameFills) {
       await analytics`
-        UPDATE dim_product_variants SET variant_name = ${v.variant_name}, updated_at = now()
+        UPDATE dim_product_variants SET variant_name = ${effectiveVariantName(v)}, updated_at = now()
         WHERE variant_id = ${v.variant_id} AND variant_name IS NULL`;
     }
 


### PR DESCRIPTION
## 백필 부팅 오류

`scripts/analytics-backfill`(Nest 컨텍스트를 tsx 로 띄우는 유일한 스크립트)가 `TypeError: postgres is not a function` 으로 죽는다. `libs/db` 의 `import * as postgres` 가 nest build(CJS)에서는 호출 가능한 함수지만, tsx 같은 ESM 로더는 postgres 의 ESM 빌드를 골라 함수가 `default` 아래로 온다. 호출 가능한 쪽을 골라 잡도록 수정 — CJS 경로 동작은 동일하다.

## 옵션 조합 variant 이름 시딩

1차 시딩 후에도 라이브에 이름 없는 비-기본 variant 가 1.8만 건 남았다. core 의 `variant_name` 은 수동 설정 이름이라 옵션 조합형 상품(예: 1제/2제)은 원래 비어 있고, 상품 이벤트에도 같은 값이 실려 어느 경로로도 안 채워진다. 시딩 스크립트가 옵션값 표시명(`product_option_value_displays`, ko-KR)을 sort_order 순으로 이어 붙여 이름을 만든다. 기존 규칙 유지 — dim 의 `variant_name` 이 NULL 인 행만 채우고 재실행 멱등.

## 검증

- 백필: 로컬 core·membership·analytics DB 로 dry-run 완주 (이전엔 부팅에서 죽음)
- 시딩: 로컬 core 에 수동 이름 없는 옵션 조합 variant 를 만들어 apply → dim 에 '옵션A / 옵션B' 채워짐, 재실행 시 변경 0
- type-check 0, 전체 jest 실패 0 (4081 통과)