### PR TITLE
feat(statistics): 상품 랭킹 정렬 방향과 기간 내 무판매 상품 목록 추가

### DIFF
--- a/apps/admin-web/src/features/statistics/template/products.tsx
+++ b/apps/admin-web/src/features/statistics/template/products.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useSearchParams, usePathname, useRouter } from 'next/navigation';
-import { useProductStatistics } from '@/lib/services/analytics';
+import { useProductStatistics, useUnsoldProducts } from '@/lib/services/analytics';
 import { StatisticsShell } from '../components/shell';
 import { ChartCard, HorizontalBarList } from '../components/widgets';
 import { changeRate, formatCount, formatKrw, formatPercent, useStatisticsRange } from '../shared';
@@ -12,18 +12,25 @@ const SORT_OPTIONS = [
   { value: 'orders', label: '주문수순' },
 ] as const;
 
+const ORDER_OPTIONS = [
+  { value: 'desc', label: '상위' },
+  { value: 'asc', label: '하위' },
+] as const;
+
 export default function ProductStatisticsTemplate() {
   const range = useStatisticsRange();
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const sort = (searchParams.get('sort') as 'revenue' | 'quantity' | 'orders') ?? 'revenue';
+  const order = searchParams.get('order') === 'asc' ? 'asc' : 'desc';
 
-  const { data, isLoading, isError } = useProductStatistics({ ...range, sort, limit: 20 });
+  const { data, isLoading, isError } = useProductStatistics({ ...range, sort, limit: 20, order });
+  const unsold = useUnsoldProducts({ from: range.from, to: range.to, channel: range.channel, limit: 50 });
 
-  const setSort = (value: string) => {
+  const setParam = (key: string, value: string) => {
     const params = new URLSearchParams(searchParams.toString());
-    params.set('sort', value);
+    params.set(key, value);
     router.replace(`${pathname}?${params.toString()}`);
   };
 
@@ -36,20 +43,39 @@ export default function ProductStatisticsTemplate() {
       ) : (
         <div className="space-y-4">
           <ChartCard
-            title="상품 랭킹"
-            description="증감은 직전 동일 길이 기간의 순매출 대비입니다."
+            title={order === 'asc' ? '상품 랭킹 (하위)' : '상품 랭킹'}
+            description={
+              order === 'asc'
+                ? '판매 실적이 가장 낮은 상품부터 표시합니다. 기간 내 판매가 아예 없는 상품은 아래 무판매 상품 카드에서 확인하세요.'
+                : '증감은 직전 동일 길이 기간의 순매출 대비입니다.'
+            }
             isLoading={isLoading}
             isEmpty={!data || data.ranking.length === 0}
           >
-            <div className="mb-3 flex gap-1">
+            <div className="mb-3 flex flex-wrap items-center gap-1">
               {SORT_OPTIONS.map((option) => (
                 <button
                   key={option.value}
                   type="button"
-                  onClick={() => setSort(option.value)}
+                  onClick={() => setParam('sort', option.value)}
                   className={
                     sort === option.value
                       ? 'rounded-full bg-orange-500 px-3 py-1 text-xs font-medium text-white'
+                      : 'rounded-full border border-gray-200 px-3 py-1 text-xs text-gray-600 hover:bg-gray-50'
+                  }
+                >
+                  {option.label}
+                </button>
+              ))}
+              <span className="mx-1 h-4 w-px bg-gray-200" />
+              {ORDER_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setParam('order', option.value)}
+                  className={
+                    order === option.value
+                      ? 'rounded-full bg-gray-800 px-3 py-1 text-xs font-medium text-white'
                       : 'rounded-full border border-gray-200 px-3 py-1 text-xs text-gray-600 hover:bg-gray-50'
                   }
                 >
@@ -95,6 +121,40 @@ export default function ProductStatisticsTemplate() {
                       </tr>
                     );
                   })}
+                </tbody>
+              </table>
+            </div>
+          </ChartCard>
+
+          <ChartCard
+            title="기간 내 무판매 상품"
+            description={`판매중(활성) 상품 중 조회 기간에 판매가 0건인 상품입니다. 마지막 판매일이 오래된 순 · 최대 50개 표시${
+              unsold.data ? ` · 총 ${formatCount(unsold.data.total)}개` : ''
+            }`}
+            isLoading={unsold.isLoading}
+            isEmpty={!unsold.data || unsold.data.items.length === 0}
+          >
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b text-gray-500">
+                    <th className="py-1.5 text-left">#</th>
+                    <th className="py-1.5 text-left">상품</th>
+                    <th className="py-1.5 text-right">마지막 판매일</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(unsold.data?.items ?? []).map((row, index) => (
+                    <tr key={row.masterId} className="border-b last:border-0">
+                      <td className="py-1.5 text-gray-400">{index + 1}</td>
+                      <td className="py-1.5">
+                        <span className="font-medium text-gray-900">{row.name ?? row.masterId}</span>
+                      </td>
+                      <td className="py-1.5 text-right tabular-nums">
+                        {row.lastSoldDate ?? <span className="text-gray-400">판매 기록 없음</span>}
+                      </td>
+                    </tr>
+                  ))}
                 </tbody>
               </table>
             </div>

--- a/apps/admin-web/src/lib/api/domains/analytics/index.ts
+++ b/apps/admin-web/src/lib/api/domains/analytics/index.ts
@@ -57,6 +57,28 @@ export interface ProductStatistics {
   }>;
 }
 
+export type ProductSort = 'revenue' | 'quantity' | 'orders';
+export type ProductSortOrder = 'desc' | 'asc';
+
+export interface ProductStatisticsQuery extends StatisticsRangeQuery {
+  sort?: ProductSort;
+  limit?: number;
+  order?: ProductSortOrder;
+}
+
+export interface UnsoldProductRow {
+  masterId: string;
+  name: string | null;
+  /** 전 기간 통틀어 마지막 판매일. null 이면 집계 이래 판매 기록 없음 */
+  lastSoldDate: string | null;
+}
+
+export interface UnsoldProductsResult {
+  range: { from: string; to: string };
+  total: number;
+  items: UnsoldProductRow[];
+}
+
 export interface CustomerStatistics {
   range: { from: string; to: string };
   lifetime: {
@@ -110,13 +132,21 @@ export const analyticsApi = {
     return res.data;
   },
 
-  getProductStatistics: async (
-    query: StatisticsRangeQuery & { sort?: 'revenue' | 'quantity' | 'orders'; limit?: number }
-  ): Promise<ProductStatistics> => {
+  getProductStatistics: async (query: ProductStatisticsQuery): Promise<ProductStatistics> => {
     const params = new URLSearchParams(rangeQs(query));
     if (query.sort) params.set('sort', query.sort);
     if (query.limit) params.set('limit', String(query.limit));
+    if (query.order) params.set('order', query.order);
     const res = await client.get(`${ANALYTICS_SERVICE_BASE_URL}/statistics/products?${params.toString()}`);
+    return res.data;
+  },
+
+  getUnsoldProducts: async (
+    query: StatisticsRangeQuery & { limit?: number }
+  ): Promise<UnsoldProductsResult> => {
+    const params = new URLSearchParams(rangeQs(query));
+    if (query.limit) params.set('limit', String(query.limit));
+    const res = await client.get(`${ANALYTICS_SERVICE_BASE_URL}/statistics/products/unsold?${params.toString()}`);
     return res.data;
   },
 

--- a/apps/admin-web/src/lib/services/analytics/queries.ts
+++ b/apps/admin-web/src/lib/services/analytics/queries.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { analyticsApi, StatisticsRangeQuery } from '@/lib/api/domains/analytics';
+import { analyticsApi, ProductStatisticsQuery, StatisticsRangeQuery } from '@/lib/api/domains/analytics';
 import { analyticsQueryKeys } from './query-keys';
 
 export const useAnalyticsOverview = () => {
@@ -18,12 +18,17 @@ export const useSalesStatistics = (query: StatisticsRangeQuery) => {
   });
 };
 
-export const useProductStatistics = (
-  query: StatisticsRangeQuery & { sort?: 'revenue' | 'quantity' | 'orders'; limit?: number },
-) => {
+export const useProductStatistics = (query: ProductStatisticsQuery) => {
   return useQuery({
     queryKey: analyticsQueryKeys.products(query),
     queryFn: () => analyticsApi.getProductStatistics(query),
+  });
+};
+
+export const useUnsoldProducts = (query: StatisticsRangeQuery & { limit?: number }) => {
+  return useQuery({
+    queryKey: analyticsQueryKeys.unsoldProducts(query),
+    queryFn: () => analyticsApi.getUnsoldProducts(query),
   });
 };
 

--- a/apps/admin-web/src/lib/services/analytics/query-keys.ts
+++ b/apps/admin-web/src/lib/services/analytics/query-keys.ts
@@ -4,7 +4,9 @@ export const analyticsQueryKeys = {
   all: ['analytics'] as const,
   overview: () => [...analyticsQueryKeys.all, 'overview'] as const,
   sales: (query: StatisticsRangeQuery) => [...analyticsQueryKeys.all, 'sales', query] as const,
-  products: (query: StatisticsRangeQuery & { sort?: string; limit?: number }) =>
+  products: (query: StatisticsRangeQuery & { sort?: string; limit?: number; order?: string }) =>
     [...analyticsQueryKeys.all, 'products', query] as const,
+  unsoldProducts: (query: StatisticsRangeQuery & { limit?: number }) =>
+    [...analyticsQueryKeys.all, 'unsold-products', query] as const,
   customers: (query: StatisticsRangeQuery) => [...analyticsQueryKeys.all, 'customers', query] as const,
 };

--- a/apps/analytics/src/features/statistics/api/statistics-query.dto.ts
+++ b/apps/analytics/src/features/statistics/api/statistics-query.dto.ts
@@ -37,4 +37,19 @@ export class ProductStatisticsQueryDto extends StatisticsRangeQueryDto {
   @Min(1)
   @Max(100)
   limit?: number = 20;
+
+  @ApiPropertyOptional({ enum: ['desc', 'asc'], default: 'desc', description: '랭킹 정렬 방향 — asc 는 하위(bottom-N) 조회' })
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  order?: 'asc' | 'desc' = 'desc';
+}
+
+export class UnsoldProductsQueryDto extends StatisticsRangeQueryDto {
+  @ApiPropertyOptional({ example: 50, default: 50, description: '최대 행 수' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  limit?: number = 50;
 }

--- a/apps/analytics/src/features/statistics/api/statistics.controller.ts
+++ b/apps/analytics/src/features/statistics/api/statistics.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '@app/authorization';
 import { StatisticsQuery } from '../read-model/statistics.query';
-import { ProductStatisticsQueryDto, StatisticsRangeQueryDto } from './statistics-query.dto';
+import { ProductStatisticsQueryDto, StatisticsRangeQueryDto, UnsoldProductsQueryDto } from './statistics-query.dto';
 
 /**
  * 관리자 통계 조회 API. admin-web 프록시를 통해서만 호출된다.
@@ -33,7 +33,17 @@ export class StatisticsController {
     description: '상품 랭킹(순매출·직전 기간 대비), primary 카테고리 구성, 옵션별 판매(총매출만).',
   })
   getProducts(@Query() query: ProductStatisticsQueryDto) {
-    return this.statisticsQuery.getProducts(query.from, query.to, query.channel, query.sort, query.limit);
+    return this.statisticsQuery.getProducts(query.from, query.to, query.channel, query.sort, query.limit, query.order);
+  }
+
+  @Get('products/unsold')
+  @ApiOperation({
+    summary: '기간 내 무판매 활성 상품',
+    description:
+      '기간 내 판매가 0건이라 랭킹에 아예 나오지 않는 활성 상품 목록. 마지막 판매일이 오래된(없는) 순.',
+  })
+  getUnsoldProducts(@Query() query: UnsoldProductsQueryDto) {
+    return this.statisticsQuery.getUnsoldProducts(query.from, query.to, query.channel, query.limit);
   }
 
   @Get('customers')

--- a/apps/analytics/src/features/statistics/read-model/statistics.query.integration.spec.ts
+++ b/apps/analytics/src/features/statistics/read-model/statistics.query.integration.spec.ts
@@ -40,6 +40,8 @@ describeIfDb('StatisticsQuery (실 Postgres)', () => {
   const masterA = `itest-master-${randomUUID().slice(0, 8)}`;
   const masterB = `itest-master-${randomUUID().slice(0, 8)}`;
   const masterC = `itest-master-${randomUUID().slice(0, 8)}`; // dim 에 이름 없음 — fact 폴백 검증용
+  const masterD = `itest-master-${randomUUID().slice(0, 8)}`; // 활성인데 8월 판매 없음 — 무판매 목록 검증용
+  const masterE = `itest-master-${randomUUID().slice(0, 8)}`; // 비활성 — 무판매 목록에서 제외돼야 함
   const variantC = `itest-variant-${randomUUID().slice(0, 8)}`;
   const categoryId = `itest-cat-${randomUUID().slice(0, 8)}`;
   const tierId = `itest-tier-${randomUUID().slice(0, 8)}`;
@@ -69,8 +71,10 @@ describeIfDb('StatisticsQuery (실 Postgres)', () => {
     ]);
 
     await db.insert(dimProductMasters).values([
-      { masterId: masterA, name: '통합테스트 상품 A' },
+      { masterId: masterA, name: '통합테스트 상품 A', isActive: true },
       { masterId: masterB, name: '통합테스트 상품 B' },
+      { masterId: masterD, name: '통합테스트 상품 D', isActive: true },
+      { masterId: masterE, name: '통합테스트 상품 E', isActive: false },
     ]);
     await db.insert(dimProductCategories).values([
       { masterId: masterA, categoryId, categoryName: '통합테스트 카테고리', isPrimary: true },
@@ -84,6 +88,8 @@ describeIfDb('StatisticsQuery (실 Postgres)', () => {
       { aggDate: '2026-07-02', masterId: masterA, salesChannel: channel, ordersCount: 1, quantitySold: 1, grossRevenue: 4000, cancelledAmount: 0, refundedAmount: 0 },
       // dim 없는 상품 — 이름은 주문 라인 폴백으로 온다
       { aggDate: '2026-08-03', masterId: masterC, salesChannel: channel, ordersCount: 1, quantitySold: 1, grossRevenue: 1000, cancelledAmount: 0, refundedAmount: 0 },
+      // 활성 상품 D 는 7월에만 팔렸다 — 8월 조회에서 무판매 목록에 마지막 판매일과 함께 나와야 한다.
+      { aggDate: '2026-07-02', masterId: masterD, salesChannel: channel, ordersCount: 1, quantitySold: 1, grossRevenue: 2000, cancelledAmount: 0, refundedAmount: 0 },
     ]);
 
     // 주문 라인 2건 — 폴백은 더 최근(occurredAt) 이름을 골라야 한다.
@@ -114,6 +120,8 @@ describeIfDb('StatisticsQuery (실 Postgres)', () => {
       await db.delete(aggProductOrderDaily).where(eq(aggProductOrderDaily.salesChannel, channel));
       await db.delete(dimProductMasters).where(eq(dimProductMasters.masterId, masterA));
       await db.delete(dimProductMasters).where(eq(dimProductMasters.masterId, masterB));
+      await db.delete(dimProductMasters).where(eq(dimProductMasters.masterId, masterD));
+      await db.delete(dimProductMasters).where(eq(dimProductMasters.masterId, masterE));
       await db.delete(dimProductCategories).where(eq(dimProductCategories.masterId, masterA));
       await db.delete(dimProductCategories).where(eq(dimProductCategories.masterId, masterB));
       await db.delete(factOrderItems).where(eq(factOrderItems.masterId, masterC));
@@ -167,6 +175,36 @@ describeIfDb('StatisticsQuery (실 Postgres)', () => {
     expect(result.categories).toEqual([
       { categoryId, categoryName: '통합테스트 카테고리', grossRevenue: 9000, quantitySold: 3 },
     ]);
+  });
+
+  it('order=asc 는 같은 랭킹을 하위부터 내린다', async () => {
+    const result = await query.getProducts('2026-08-01', '2026-08-31', channel, 'revenue', 10, 'asc');
+    expect(result.ranking.map((row) => row.masterId)).toEqual([masterC, masterB, masterA]);
+    // 방향만 바뀌고 값 계산은 동일해야 한다.
+    expect(result.ranking[2]).toMatchObject({ masterId: masterA, netRevenue: 8000, previousNetRevenue: 4000 });
+  });
+
+  it('무판매 목록은 기간 내 판매 0건인 활성 상품만 마지막 판매일과 함께 내린다', async () => {
+    const result = await query.getUnsoldProducts('2026-08-01', '2026-08-31', channel, 200);
+
+    const rowD = result.items.find((row) => row.masterId === masterD);
+    expect(rowD).toMatchObject({ name: '통합테스트 상품 D', lastSoldDate: '2026-07-02' });
+    expect(result.total).toBeGreaterThanOrEqual(1);
+
+    const ids = result.items.map((row) => row.masterId);
+    expect(ids).not.toContain(masterA); // 기간 내 판매 있음
+    expect(ids).not.toContain(masterE); // 비활성
+    expect(ids).not.toContain(masterB); // isActive 미설정(null)
+
+    // 판매 기록 없는(null) 상품이 마지막 판매일 있는 상품보다 앞에 온다.
+    const firstDated = result.items.findIndex((row) => row.lastSoldDate !== null);
+    if (firstDated >= 0) {
+      expect(result.items.slice(firstDated).every((row) => row.lastSoldDate !== null)).toBe(true);
+    }
+
+    // 7월 조회에서는 D 가 팔렸으므로 빠져야 한다.
+    const july = await query.getUnsoldProducts('2026-07-01', '2026-07-31', channel, 200);
+    expect(july.items.map((row) => row.masterId)).not.toContain(masterD);
   });
 
   it('옵션별 판매는 기본 품목 여부와 폴백된 상품명을 함께 내린다', async () => {

--- a/apps/analytics/src/features/statistics/read-model/statistics.query.ts
+++ b/apps/analytics/src/features/statistics/read-model/statistics.query.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectTypedDb } from '@app/db/decorators';
 import { DbService } from '@app/db';
 import { BadRequestError } from '@app/shared';
-import { and, desc, eq, gt, gte, inArray, isNull, lt, lte, or, sql, SQL } from 'drizzle-orm';
+import { and, desc, eq, gt, gte, inArray, isNull, lt, lte, notExists, or, sql, SQL } from 'drizzle-orm';
 import {
   aggChannelDaily,
   aggCustomerLifetime,
@@ -73,6 +73,20 @@ export interface ProductStatistics {
     quantitySold: number;
     grossRevenue: number;
   }>;
+}
+
+export interface UnsoldProductRow {
+  masterId: string;
+  name: string | null;
+  /** 전 기간 통틀어 마지막 판매일 (agg 기준, 채널 필터 적용). null 이면 집계 이래 판매 기록 없음. */
+  lastSoldDate: string | null;
+}
+
+/** 기간 내 판매가 0건인 활성 상품 — agg 에 행이 없어 랭킹 asc 로도 보이지 않는 상품들. */
+export interface UnsoldProductsResult {
+  range: { from: string; to: string };
+  total: number;
+  items: UnsoldProductRow[];
 }
 
 export interface CustomerStatistics {
@@ -167,6 +181,7 @@ export class StatisticsQuery {
     channel?: string,
     sort: 'revenue' | 'quantity' | 'orders' = 'revenue',
     limit = 20,
+    order: 'asc' | 'desc' = 'desc',
   ): Promise<ProductStatistics> {
     this.assertRange(from, to);
     const prev = previousRange(from, to);
@@ -193,7 +208,7 @@ export class StatisticsQuery {
       .leftJoin(dimProductMasters, eq(dimProductMasters.masterId, aggProductOrderDaily.masterId))
       .where(where)
       .groupBy(aggProductOrderDaily.masterId, dimProductMasters.name)
-      .orderBy(sql`${sortExpr} DESC`)
+      .orderBy(order === 'asc' ? sql`${sortExpr} ASC` : sql`${sortExpr} DESC`)
       .limit(limit);
 
     const masterIds = rankingRows.map((row) => row.masterId);
@@ -310,6 +325,71 @@ export class StatisticsQuery {
         masterName: row.masterName ?? fallbackNames.get(row.masterId) ?? null,
         quantitySold: Number(row.quantitySold ?? 0),
         grossRevenue: Number(row.grossRevenue ?? 0),
+      })),
+    };
+  }
+
+  /**
+   * 기간 내 판매 0건인 활성 상품 — agg_product_order_daily 에 행이 없어 랭킹 정렬로는
+   * 나오지 않는 상품들. 마지막 판매일이 오래된(없는) 순으로 내려준다.
+   */
+  async getUnsoldProducts(
+    from: string,
+    to: string,
+    channel?: string,
+    limit = 50,
+  ): Promise<UnsoldProductsResult> {
+    this.assertRange(from, to);
+
+    const soldInRangeParts: SQL[] = [
+      eq(aggProductOrderDaily.masterId, dimProductMasters.masterId),
+      gte(aggProductOrderDaily.aggDate, from),
+      lte(aggProductOrderDaily.aggDate, to),
+    ];
+    if (channel) {
+      soldInRangeParts.push(eq(aggProductOrderDaily.salesChannel, channel));
+    }
+    const soldInRange = this.db
+      .select({ one: sql`1` })
+      .from(aggProductOrderDaily)
+      .where(and(...soldInRangeParts));
+
+    const unsoldWhere = and(
+      eq(dimProductMasters.isActive, true),
+      isNull(dimProductMasters.deletedAt),
+      notExists(soldInRange),
+    );
+
+    const lastSoldParts: SQL[] = [eq(aggProductOrderDaily.masterId, dimProductMasters.masterId)];
+    if (channel) {
+      lastSoldParts.push(eq(aggProductOrderDaily.salesChannel, channel));
+    }
+    const lastSoldExpr = sql<string | null>`(SELECT MAX(${aggProductOrderDaily.aggDate}) FROM ${aggProductOrderDaily} WHERE ${and(...lastSoldParts)})`;
+
+    const [totalRows, itemRows] = await Promise.all([
+      this.db.select({ total: sql<string>`COUNT(*)` }).from(dimProductMasters).where(unsoldWhere),
+      this.db
+        .select({
+          masterId: dimProductMasters.masterId,
+          name: dimProductMasters.name,
+          lastSoldDate: lastSoldExpr,
+        })
+        .from(dimProductMasters)
+        .where(unsoldWhere)
+        .orderBy(sql`3 ASC NULLS FIRST`, dimProductMasters.name)
+        .limit(limit),
+    ]);
+
+    const namelessMasterIds = itemRows.filter((row) => !row.name).map((row) => row.masterId);
+    const fallbackNames = await this.latestOrderedProductNames(namelessMasterIds);
+
+    return {
+      range: { from, to },
+      total: Number(totalRows[0]?.total ?? 0),
+      items: itemRows.map((row) => ({
+        masterId: row.masterId,
+        name: row.name ?? fallbackNames.get(row.masterId) ?? null,
+        lastSoldDate: row.lastSoldDate ? String(row.lastSoldDate) : null,
       })),
     };
   }

--- a/scripts/security/idor-reviewed.spec.ts
+++ b/scripts/security/idor-reviewed.spec.ts
@@ -61,6 +61,12 @@ const IDOR_REVIEWED: Record<string, { verdict: Verdict; evidence: string; predic
     predicate: '@UseGuards(JwtAuthGuard)',
     note: '상품별 전사 집계 — 사용자 소유 리소스 파라미터 없음. 컨트롤러 클래스에 JwtAuthGuard.',
   },
+  'analytics GET /statistics/products/unsold': {
+    verdict: 'N/A',
+    evidence: 'apps/analytics/src/features/statistics/api/statistics.controller.ts:15',
+    predicate: '@UseGuards(JwtAuthGuard)',
+    note: '기간 내 무판매 활성 상품 목록 — 쿼리 파라미터가 날짜/채널/limit 뿐이라 IDOR 대상 아님. 컨트롤러 클래스에 JwtAuthGuard.',
+  },
   'analytics GET /statistics/customers': {
     verdict: 'N/A',
     evidence: 'apps/analytics/src/features/statistics/api/statistics.controller.ts:15',
@@ -644,15 +650,15 @@ const keyOf = (r: AuditRow): string => `${r.app} ${r.verb} ${r.route}`;
 describe('IDOR 검사 대상 집합', () => {
   it('감사 스크립트가 idorTarget 을 내보낸다', () => {
     const targets = runAudit().filter((r) => r.idorTarget);
-    expect(targets).toHaveLength(100);
+    expect(targets).toHaveLength(101);
   });
 
   // search 와 analytics 가 둘 다 `GET /health` 다. `<VERB> <route>` 로 키를 만들면
   // 97건이 96개로 뭉개지고 스냅샷이 한 건을 조용히 잃는다.
   it('키에 app 이 들어가야 충돌하지 않는다', () => {
     const targets = runAudit().filter((r) => r.idorTarget);
-    expect(new Set(targets.map(keyOf)).size).toBe(100);
-    expect(new Set(targets.map((r) => `${r.verb} ${r.route}`)).size).toBe(99);
+    expect(new Set(targets.map(keyOf)).size).toBe(101);
+    expect(new Set(targets.map((r) => `${r.verb} ${r.route}`)).size).toBe(100);
   });
 
   it('감사 스크립트의 대상 집합과 명단이 정확히 일치한다', () => {


### PR DESCRIPTION
- 상품 랭킹에 order(asc|desc) 파라미터 — 하위(bottom-N) 조회 지원, 기본 desc 유지
- GET /statistics/products/unsold — 기간 내 판매 0건인 활성 상품을 마지막 판매일 오래된 순으로 제공
- products 탭에 상위/하위 토글과 무판매 상품 카드
- IDOR 검토 명단에 신규 라우트 추가