### PR TITLE
feat(statistics): 유입(GA4) 탭과 구매 기반 고객 분석 탭 추가

### DIFF
--- a/apps/admin-web/src/app/(admin)/statistics/insights/page.tsx
+++ b/apps/admin-web/src/app/(admin)/statistics/insights/page.tsx
@@ -1,0 +1,12 @@
+import RouteGuard from '@/components/layout/route-guard';
+import CustomerInsightsTemplate from '@/features/statistics/template/insights';
+
+export default function StatisticsInsightsPage() {
+  return (
+    <RouteGuard requireRole={['admin', 'master']}>
+      <div className="flex w-full max-w-[1600px] flex-col gap-y-2 p-3">
+        <CustomerInsightsTemplate />
+      </div>
+    </RouteGuard>
+  );
+}

--- a/apps/admin-web/src/app/(admin)/statistics/traffic/page.tsx
+++ b/apps/admin-web/src/app/(admin)/statistics/traffic/page.tsx
@@ -1,0 +1,12 @@
+import RouteGuard from '@/components/layout/route-guard';
+import TrafficStatisticsTemplate from '@/features/statistics/template/traffic';
+
+export default function StatisticsTrafficPage() {
+  return (
+    <RouteGuard requireRole={['admin', 'master']}>
+      <div className="flex w-full max-w-[1600px] flex-col gap-y-2 p-3">
+        <TrafficStatisticsTemplate />
+      </div>
+    </RouteGuard>
+  );
+}

--- a/apps/admin-web/src/features/statistics/components/shell.tsx
+++ b/apps/admin-web/src/features/statistics/components/shell.tsx
@@ -22,6 +22,7 @@ const TABS = [
   { href: '/statistics/products', label: '상품' },
   { href: '/statistics/customers', label: '고객·멤버십' },
   { href: '/statistics/keywords', label: '검색 키워드' },
+  { href: '/statistics/traffic', label: '유입' },
 ];
 
 /** 탭별로 의미 없는 필터를 숨긴다 — 검색 키워드 통계는 채널·집계 단위가 없다. */

--- a/apps/admin-web/src/features/statistics/components/shell.tsx
+++ b/apps/admin-web/src/features/statistics/components/shell.tsx
@@ -23,6 +23,7 @@ const TABS = [
   { href: '/statistics/customers', label: '고객·멤버십' },
   { href: '/statistics/keywords', label: '검색 키워드' },
   { href: '/statistics/traffic', label: '유입' },
+  { href: '/statistics/insights', label: '고객 분석' },
 ];
 
 /** 탭별로 의미 없는 필터를 숨긴다 — 검색 키워드 통계는 채널·집계 단위가 없다. */

--- a/apps/admin-web/src/features/statistics/template/insights.tsx
+++ b/apps/admin-web/src/features/statistics/template/insights.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import { useCustomerInsights } from '@/lib/services/analytics';
+import { StatisticsShell } from '../components/shell';
+import { ChartCard, HorizontalBarList, KpiTile } from '../components/widgets';
+import { formatCount, formatPercent, useStatisticsRange } from '../shared';
+
+/** 코호트 셀 배경 — 시리즈 1번 색(#2a78d6)의 투명도 스케일. 값 라벨을 늘 함께 찍는다. */
+function cohortCellBackground(rate: number): string {
+  const alpha = Math.min(rate, 1) * 0.45;
+  return `rgba(42, 120, 214, ${alpha.toFixed(3)})`;
+}
+
+const SEGMENT_HINTS: Record<string, string> = {
+  vip: '최근 90일 내 구매 · 4회 이상',
+  loyal: '최근 90일 내 구매 · 2~3회',
+  new: '30일 내 첫 구매',
+  'one-time': '1회 구매 후 재방문 없음',
+  'at-risk': '91~365일 무구매 · 재구매 이력 있음',
+  dormant: '1년 이상 무구매',
+};
+
+export default function CustomerInsightsTemplate() {
+  const range = useStatisticsRange();
+  const { data, isLoading, isError } = useCustomerInsights({ from: range.from, to: range.to });
+
+  return (
+    <StatisticsShell filterOptions={{ channel: false, granularity: false }}>
+      {isError ? (
+        <p className="py-10 text-center text-sm text-red-500">
+          통계를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          <ChartCard
+            title="RFM 고객 세그먼트"
+            description="전 고객 기준(기간 필터 무관) — 마지막 구매 경과(R)와 누적 구매 횟수(F)로 나눕니다."
+            isLoading={isLoading}
+            isEmpty={!data || data.rfm.totalCustomers === 0}
+          >
+            <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-6">
+              {(data?.rfm.segments ?? []).map((segment) => (
+                <KpiTile
+                  key={segment.key}
+                  label={segment.label}
+                  value={formatCount(segment.customers)}
+                  hint={SEGMENT_HINTS[segment.key]}
+                />
+              ))}
+            </div>
+            <div className="mt-4 overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b text-gray-500">
+                    <th className="py-1.5 text-left">마지막 구매 ＼ 구매 횟수</th>
+                    {(data?.rfm.frequencyBuckets ?? []).map((bucket) => (
+                      <th key={bucket} className="py-1.5 text-right">
+                        {bucket}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {(data?.rfm.recencyBuckets ?? []).map((recency) => (
+                    <tr key={recency} className="border-b last:border-0">
+                      <td className="py-1.5 text-gray-600">{recency}</td>
+                      {(data?.rfm.frequencyBuckets ?? []).map((frequency) => {
+                        const cell = data?.rfm.cells.find(
+                          (c) => c.recency === recency && c.frequency === frequency,
+                        );
+                        return (
+                          <td key={frequency} className="py-1.5 text-right tabular-nums">
+                            {cell ? formatCount(cell.customers) : <span className="text-gray-300">0</span>}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </ChartCard>
+
+          <ChartCard
+            title="코호트 리텐션"
+            description="종료일 기준 최근 12개월 — 각 달에 첫 구매한 고객이 이후 몇 달째에 다시 구매했는지의 비율입니다."
+            isLoading={isLoading}
+            isEmpty={!data || data.cohorts.rows.length === 0}
+          >
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b text-gray-500">
+                    <th className="py-1.5 text-left">첫 구매 월</th>
+                    <th className="py-1.5 text-right">고객 수</th>
+                    {Array.from({ length: (data?.cohorts.maxOffset ?? 0) + 1 }, (_, offset) => (
+                      <th key={offset} className="py-1.5 text-center">
+                        +{offset}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {(data?.cohorts.rows ?? []).map((row) => (
+                    <tr key={row.cohortMonth} className="border-b last:border-0">
+                      <td className="py-1.5 font-medium text-gray-900">{row.cohortMonth}</td>
+                      <td className="py-1.5 text-right tabular-nums">{formatCount(row.size)}</td>
+                      {row.retention.map((rate, offset) => (
+                        <td
+                          key={offset}
+                          className="py-1.5 text-center tabular-nums"
+                          style={rate != null ? { backgroundColor: cohortCellBackground(rate) } : undefined}
+                        >
+                          {rate == null ? (
+                            <span className="text-gray-300">–</span>
+                          ) : (
+                            <span className="text-gray-900">{Math.round(rate * 100)}%</span>
+                          )}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </ChartCard>
+
+          <ChartCard
+            title="재구매율 높은 상품"
+            description={`전 기간 누적 · 구매자 ${data?.repurchase.minBuyers ?? 5}명 이상인 상품만 — 정기 구매 전환·번들 기획 후보입니다.`}
+            isLoading={isLoading}
+            isEmpty={!data || data.repurchase.items.length === 0}
+          >
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b text-gray-500">
+                    <th className="py-1.5 text-left">#</th>
+                    <th className="py-1.5 text-left">상품</th>
+                    <th className="py-1.5 text-right">구매자</th>
+                    <th className="py-1.5 text-right">재구매자</th>
+                    <th className="py-1.5 text-right">재구매율</th>
+                    <th className="py-1.5 text-right">평균 재구매 주기</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(data?.repurchase.items ?? []).map((item, index) => (
+                    <tr key={item.masterId} className="border-b last:border-0">
+                      <td className="py-1.5 text-gray-400">{index + 1}</td>
+                      <td className="py-1.5">
+                        <span className="font-medium text-gray-900">{item.name ?? item.masterId}</span>
+                      </td>
+                      <td className="py-1.5 text-right tabular-nums">{formatCount(item.buyers)}</td>
+                      <td className="py-1.5 text-right tabular-nums">{formatCount(item.repeatBuyers)}</td>
+                      <td className="py-1.5 text-right tabular-nums">{formatPercent(item.repurchaseRate)}</td>
+                      <td className="py-1.5 text-right tabular-nums">
+                        {item.avgCycleDays == null ? '-' : `${Math.round(item.avgCycleDays)}일`}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </ChartCard>
+
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <ChartCard
+              title="기간 내 등급 전환"
+              description="실시간 수집 이전 이력은 없어 과거 구간은 실제보다 적게 잡힙니다."
+              isLoading={isLoading}
+              isEmpty={!data || data.tierFlow.transitions.length === 0}
+              emptyText="조회 기간에 등급 전환이 없습니다"
+            >
+              <div className="overflow-x-auto">
+                <table className="w-full text-xs">
+                  <thead>
+                    <tr className="border-b text-gray-500">
+                      <th className="py-1.5 text-left">이전 등급</th>
+                      <th className="py-1.5 text-left">새 등급</th>
+                      <th className="py-1.5 text-right">인원</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(data?.tierFlow.transitions ?? []).map((row) => (
+                      <tr key={`${row.fromTier}-${row.toTier}`} className="border-b last:border-0">
+                        <td className="py-1.5 text-gray-600">{row.fromTier}</td>
+                        <td className="py-1.5 font-medium text-gray-900">{row.toTier}</td>
+                        <td className="py-1.5 text-right tabular-nums">{formatCount(row.count)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </ChartCard>
+
+            <ChartCard
+              title="현재 등급 분포"
+              isLoading={isLoading}
+              isEmpty={!data || data.tierFlow.currentDistribution.length === 0}
+            >
+              <HorizontalBarList
+                items={(data?.tierFlow.currentDistribution ?? []).map((row) => ({
+                  label: row.tierId,
+                  value: row.count,
+                }))}
+                formatValue={formatCount}
+              />
+            </ChartCard>
+          </div>
+        </div>
+      )}
+    </StatisticsShell>
+  );
+}

--- a/apps/admin-web/src/features/statistics/template/traffic.tsx
+++ b/apps/admin-web/src/features/statistics/template/traffic.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { TrafficChannelGroup } from '@/lib/api/domains/analytics';
+import { useTrafficStatistics } from '@/lib/services/analytics';
+import { cn } from '@/lib/utils/ui';
+import { StatisticsShell } from '../components/shell';
+import { ChartCard, HorizontalBarList, KpiTile } from '../components/widgets';
+import { formatCount, formatPercent, SERIES_COLORS, useStatisticsRange } from '../shared';
+
+const CHANNEL_GROUP_OPTIONS: Array<{ value: TrafficChannelGroup; label: string }> = [
+  { value: 'organic', label: '자연검색' },
+  { value: 'all', label: '전체 유입' },
+];
+
+export default function TrafficStatisticsTemplate() {
+  const range = useStatisticsRange();
+  const [channelGroup, setChannelGroup] = useState<TrafficChannelGroup>('organic');
+  const { data, isLoading, isError } = useTrafficStatistics({
+    from: range.from,
+    to: range.to,
+    channelGroup,
+    limit: 10,
+  });
+
+  const totalSessions = data?.totals?.sessions ?? 0;
+
+  return (
+    <StatisticsShell filterOptions={{ channel: false, granularity: false }}>
+      <div className="mb-4 flex items-center gap-1">
+        {CHANNEL_GROUP_OPTIONS.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => setChannelGroup(option.value)}
+            className={cn(
+              'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+              channelGroup === option.value
+                ? 'border-orange-500 bg-orange-50 text-orange-600'
+                : 'border-gray-200 text-gray-500 hover:text-gray-800',
+            )}
+          >
+            {option.label}
+          </button>
+        ))}
+        <span className="ml-2 text-xs text-gray-400">GA4 기준 · 자연검색 = 검색엔진 무료 유입</span>
+      </div>
+
+      {isError ? (
+        <p className="py-10 text-center text-sm text-red-500">
+          GA4 조회에 실패했습니다. 잠시 후 다시 시도해주세요.
+        </p>
+      ) : data && !data.enabled ? (
+        <p className="py-10 text-center text-sm text-gray-400">
+          GA4 연동 대기 중입니다 — 서버에 GA4 설정이 배포되면 자동으로 표시됩니다.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+            <KpiTile label="세션" value={formatCount(data?.totals?.sessions)} isLoading={isLoading} />
+            <KpiTile label="방문자" value={formatCount(data?.totals?.totalUsers)} isLoading={isLoading} />
+            <KpiTile label="페이지뷰" value={formatCount(data?.totals?.pageViews)} isLoading={isLoading} />
+            <KpiTile
+              label="참여율"
+              value={formatPercent(data?.totals?.engagementRate)}
+              hint="참여 세션 ÷ 전체 세션"
+              isLoading={isLoading}
+            />
+          </div>
+
+          <ChartCard
+            title="일별 세션 추이"
+            description="GA4 속성 시간대 기준 · 세션이 없는 날은 0으로 표시됩니다."
+            isLoading={isLoading}
+            isEmpty={!data || data.series.length === 0}
+          >
+            <ResponsiveContainer width="100%" height={280}>
+              <LineChart data={data?.series ?? []} margin={{ top: 8, right: 16, bottom: 0, left: 8 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#eee" />
+                <XAxis dataKey="date" tick={{ fontSize: 11 }} stroke="#999" />
+                <YAxis tick={{ fontSize: 11 }} stroke="#999" allowDecimals={false} />
+                <Tooltip formatter={(value: number) => formatCount(value)} />
+                <Line
+                  type="monotone"
+                  dataKey="sessions"
+                  name="세션"
+                  stroke={SERIES_COLORS[0]}
+                  strokeWidth={2}
+                  dot={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </ChartCard>
+
+          <ChartCard
+            title="랜딩페이지별 세션"
+            description="유입이 처음 도착한 페이지 — 상품 페이지가 여기 없으면 검색 유입이 홈에만 몰려 있다는 뜻입니다."
+            isLoading={isLoading}
+            isEmpty={!data || data.landingPages.length === 0}
+          >
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b text-gray-500">
+                    <th className="py-1.5 text-left">#</th>
+                    <th className="py-1.5 text-left">랜딩페이지</th>
+                    <th className="py-1.5 text-right">세션</th>
+                    <th className="py-1.5 text-right">비중</th>
+                    <th className="py-1.5 text-right">참여율</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(data?.landingPages ?? []).map((rowItem, index) => (
+                    <tr key={rowItem.path} className="border-b last:border-0">
+                      <td className="py-1.5 text-gray-400">{index + 1}</td>
+                      <td className="py-1.5">
+                        <span className="font-medium text-gray-900 break-all">{rowItem.path}</span>
+                      </td>
+                      <td className="py-1.5 text-right tabular-nums">{formatCount(rowItem.sessions)}</td>
+                      <td className="py-1.5 text-right tabular-nums text-gray-500">
+                        {totalSessions > 0 ? formatPercent(rowItem.sessions / totalSessions) : '-'}
+                      </td>
+                      <td className="py-1.5 text-right tabular-nums">{formatPercent(rowItem.engagementRate)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </ChartCard>
+
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <ChartCard
+              title="기기별 세션"
+              isLoading={isLoading}
+              isEmpty={!data || data.devices.length === 0}
+            >
+              <HorizontalBarList
+                items={(data?.devices ?? []).map((rowItem) => ({ label: rowItem.label, value: rowItem.sessions }))}
+                formatValue={formatCount}
+              />
+            </ChartCard>
+
+            <ChartCard
+              title="국가별 세션"
+              isLoading={isLoading}
+              isEmpty={!data || data.countries.length === 0}
+            >
+              <HorizontalBarList
+                items={(data?.countries ?? []).map((rowItem) => ({ label: rowItem.label, value: rowItem.sessions }))}
+                formatValue={formatCount}
+              />
+            </ChartCard>
+          </div>
+        </div>
+      )}
+    </StatisticsShell>
+  );
+}

--- a/apps/admin-web/src/lib/api/domains/analytics/index.ts
+++ b/apps/admin-web/src/lib/api/domains/analytics/index.ts
@@ -102,6 +102,35 @@ export interface CustomerStatistics {
   }>;
 }
 
+export type TrafficChannelGroup = 'organic' | 'all';
+
+export interface TrafficStatisticsQuery {
+  from: string;
+  to: string;
+  channelGroup?: TrafficChannelGroup;
+  limit?: number;
+}
+
+export interface TrafficTotals {
+  sessions: number;
+  totalUsers: number;
+  pageViews: number;
+  /** 참여 세션 ÷ 전체 세션. GA4 bounceRate(UA 와 정의가 다름)의 역수 */
+  engagementRate: number | null;
+}
+
+export interface TrafficStatistics {
+  /** false 면 GA4 env 미배선 — 화면은 "연동 대기"를 보여준다 */
+  enabled: boolean;
+  range: { from: string; to: string };
+  channelGroup: TrafficChannelGroup;
+  totals: TrafficTotals | null;
+  series: Array<{ date: string; sessions: number; engagementRate: number | null }>;
+  landingPages: Array<{ path: string; sessions: number; engagementRate: number | null }>;
+  devices: Array<{ label: string; sessions: number }>;
+  countries: Array<{ label: string; sessions: number }>;
+}
+
 export interface DailyRevenueSummary extends RevenueTotals {
   date: string;
   avgOrderValue: number | null;
@@ -152,6 +181,14 @@ export const analyticsApi = {
 
   getCustomerStatistics: async (query: StatisticsRangeQuery): Promise<CustomerStatistics> => {
     const res = await client.get(`${ANALYTICS_SERVICE_BASE_URL}/statistics/customers?${rangeQs(query)}`);
+    return res.data;
+  },
+
+  getTrafficStatistics: async (query: TrafficStatisticsQuery): Promise<TrafficStatistics> => {
+    const params = new URLSearchParams({ from: query.from, to: query.to });
+    if (query.channelGroup) params.set('channelGroup', query.channelGroup);
+    if (query.limit) params.set('limit', String(query.limit));
+    const res = await client.get(`${ANALYTICS_SERVICE_BASE_URL}/statistics/traffic?${params.toString()}`);
     return res.data;
   },
 };

--- a/apps/admin-web/src/lib/api/domains/analytics/index.ts
+++ b/apps/admin-web/src/lib/api/domains/analytics/index.ts
@@ -102,6 +102,55 @@ export interface CustomerStatistics {
   }>;
 }
 
+export interface CustomerInsightsQuery {
+  from: string;
+  to: string;
+  limit?: number;
+  minBuyers?: number;
+}
+
+export interface CohortRow {
+  cohortMonth: string;
+  size: number;
+  /** 경과 개월별 재구매 고객 비율. 아직 오지 않은 달은 null */
+  retention: Array<number | null>;
+}
+
+export interface RfmCell {
+  recency: string;
+  frequency: string;
+  customers: number;
+  totalRevenue: number;
+}
+
+export interface CustomerInsights {
+  range: { from: string; to: string };
+  /** to 기준 최근 12개월 첫구매 코호트 — from 과 무관 */
+  cohorts: { rows: CohortRow[]; maxOffset: number };
+  rfm: {
+    recencyBuckets: string[];
+    frequencyBuckets: string[];
+    cells: RfmCell[];
+    segments: Array<{ key: string; label: string; customers: number }>;
+    totalCustomers: number;
+  };
+  repurchase: {
+    minBuyers: number;
+    items: Array<{
+      masterId: string;
+      name: string | null;
+      buyers: number;
+      repeatBuyers: number;
+      repurchaseRate: number;
+      avgCycleDays: number | null;
+    }>;
+  };
+  tierFlow: {
+    transitions: Array<{ fromTier: string; toTier: string; count: number }>;
+    currentDistribution: Array<{ tierId: string; count: number }>;
+  };
+}
+
 export type TrafficChannelGroup = 'organic' | 'all';
 
 export interface TrafficStatisticsQuery {
@@ -181,6 +230,14 @@ export const analyticsApi = {
 
   getCustomerStatistics: async (query: StatisticsRangeQuery): Promise<CustomerStatistics> => {
     const res = await client.get(`${ANALYTICS_SERVICE_BASE_URL}/statistics/customers?${rangeQs(query)}`);
+    return res.data;
+  },
+
+  getCustomerInsights: async (query: CustomerInsightsQuery): Promise<CustomerInsights> => {
+    const params = new URLSearchParams({ from: query.from, to: query.to });
+    if (query.limit) params.set('limit', String(query.limit));
+    if (query.minBuyers) params.set('minBuyers', String(query.minBuyers));
+    const res = await client.get(`${ANALYTICS_SERVICE_BASE_URL}/statistics/customers/insights?${params.toString()}`);
     return res.data;
   },
 

--- a/apps/admin-web/src/lib/services/analytics/queries.ts
+++ b/apps/admin-web/src/lib/services/analytics/queries.ts
@@ -3,6 +3,7 @@
 import { useQuery } from '@tanstack/react-query';
 import {
   analyticsApi,
+  CustomerInsightsQuery,
   ProductStatisticsQuery,
   StatisticsRangeQuery,
   TrafficStatisticsQuery,
@@ -41,6 +42,13 @@ export const useCustomerStatistics = (query: StatisticsRangeQuery) => {
   return useQuery({
     queryKey: analyticsQueryKeys.customers(query),
     queryFn: () => analyticsApi.getCustomerStatistics(query),
+  });
+};
+
+export const useCustomerInsights = (query: CustomerInsightsQuery) => {
+  return useQuery({
+    queryKey: analyticsQueryKeys.customerInsights(query),
+    queryFn: () => analyticsApi.getCustomerInsights(query),
   });
 };
 

--- a/apps/admin-web/src/lib/services/analytics/queries.ts
+++ b/apps/admin-web/src/lib/services/analytics/queries.ts
@@ -1,7 +1,12 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { analyticsApi, ProductStatisticsQuery, StatisticsRangeQuery } from '@/lib/api/domains/analytics';
+import {
+  analyticsApi,
+  ProductStatisticsQuery,
+  StatisticsRangeQuery,
+  TrafficStatisticsQuery,
+} from '@/lib/api/domains/analytics';
 import { analyticsQueryKeys } from './query-keys';
 
 export const useAnalyticsOverview = () => {
@@ -36,5 +41,14 @@ export const useCustomerStatistics = (query: StatisticsRangeQuery) => {
   return useQuery({
     queryKey: analyticsQueryKeys.customers(query),
     queryFn: () => analyticsApi.getCustomerStatistics(query),
+  });
+};
+
+export const useTrafficStatistics = (query: TrafficStatisticsQuery) => {
+  return useQuery({
+    queryKey: analyticsQueryKeys.traffic(query),
+    queryFn: () => analyticsApi.getTrafficStatistics(query),
+    // GA4 는 외부 API — 서버측 5분 캐시와 맞춰 탭 전환마다 재요청하지 않는다
+    staleTime: 5 * 60 * 1000,
   });
 };

--- a/apps/admin-web/src/lib/services/analytics/query-keys.ts
+++ b/apps/admin-web/src/lib/services/analytics/query-keys.ts
@@ -1,4 +1,4 @@
-import { StatisticsRangeQuery } from '@/lib/api/domains/analytics';
+import { StatisticsRangeQuery, TrafficStatisticsQuery } from '@/lib/api/domains/analytics';
 
 export const analyticsQueryKeys = {
   all: ['analytics'] as const,
@@ -9,4 +9,5 @@ export const analyticsQueryKeys = {
   unsoldProducts: (query: StatisticsRangeQuery & { limit?: number }) =>
     [...analyticsQueryKeys.all, 'unsold-products', query] as const,
   customers: (query: StatisticsRangeQuery) => [...analyticsQueryKeys.all, 'customers', query] as const,
+  traffic: (query: TrafficStatisticsQuery) => [...analyticsQueryKeys.all, 'traffic', query] as const,
 };

--- a/apps/admin-web/src/lib/services/analytics/query-keys.ts
+++ b/apps/admin-web/src/lib/services/analytics/query-keys.ts
@@ -1,4 +1,4 @@
-import { StatisticsRangeQuery, TrafficStatisticsQuery } from '@/lib/api/domains/analytics';
+import { CustomerInsightsQuery, StatisticsRangeQuery, TrafficStatisticsQuery } from '@/lib/api/domains/analytics';
 
 export const analyticsQueryKeys = {
   all: ['analytics'] as const,
@@ -10,4 +10,5 @@ export const analyticsQueryKeys = {
     [...analyticsQueryKeys.all, 'unsold-products', query] as const,
   customers: (query: StatisticsRangeQuery) => [...analyticsQueryKeys.all, 'customers', query] as const,
   traffic: (query: TrafficStatisticsQuery) => [...analyticsQueryKeys.all, 'traffic', query] as const,
+  customerInsights: (query: CustomerInsightsQuery) => [...analyticsQueryKeys.all, 'customer-insights', query] as const,
 };

--- a/apps/admin-web/src/lib/utils/menu.ts
+++ b/apps/admin-web/src/lib/utils/menu.ts
@@ -453,6 +453,7 @@ export const mainMenus: MainMenu[] = [
           { id: 'by-period', title: '기간별', path: '/statistics/sales' },
           { id: 'by-membership', title: '회원등급별', path: '/statistics/customers' },
           { id: 'by-keyword', title: '검색 키워드', path: '/statistics/keywords' },
+          { id: 'by-traffic', title: '유입', path: '/statistics/traffic' },
         ],
       },
       {

--- a/apps/admin-web/src/lib/utils/menu.ts
+++ b/apps/admin-web/src/lib/utils/menu.ts
@@ -454,6 +454,7 @@ export const mainMenus: MainMenu[] = [
           { id: 'by-membership', title: '회원등급별', path: '/statistics/customers' },
           { id: 'by-keyword', title: '검색 키워드', path: '/statistics/keywords' },
           { id: 'by-traffic', title: '유입', path: '/statistics/traffic' },
+          { id: 'customer-insights', title: '고객 분석', path: '/statistics/insights' },
         ],
       },
       {

--- a/apps/analytics/src/analytics.module.ts
+++ b/apps/analytics/src/analytics.module.ts
@@ -25,6 +25,9 @@ import { MembershipEventsConsumer } from './datasets/memberships/ingest/membersh
 import { MembershipDailySnapshotService } from './datasets/memberships/aggregates/membership-daily-snapshot.service';
 import { StatisticsController } from './features/statistics/api/statistics.controller';
 import { StatisticsQuery } from './features/statistics/read-model/statistics.query';
+import { TrafficController } from './features/traffic/api/traffic.controller';
+import { TrafficQuery } from './features/traffic/read-model/traffic.query';
+import { Ga4Client } from './features/traffic/ga4/ga4.client';
 import { SCHEDULE_ROOT } from '@app/shared/schedule/schedule-root';
 
 @Module({
@@ -65,7 +68,14 @@ import { SCHEDULE_ROOT } from '@app/shared/schedule/schedule-root';
       scopes: [],
     }),
   ],
-  controllers: [AnalyticsController, StatisticsController, OrderEventsConsumer, ProductEventsConsumer, MembershipEventsConsumer],
+  controllers: [
+    AnalyticsController,
+    StatisticsController,
+    TrafficController,
+    OrderEventsConsumer,
+    ProductEventsConsumer,
+    MembershipEventsConsumer,
+  ],
   providers: [
     AnalyticsService,
     OrderFactsService,
@@ -81,6 +91,8 @@ import { SCHEDULE_ROOT } from '@app/shared/schedule/schedule-root';
     MembershipDimensionsService,
     MembershipDailySnapshotService,
     StatisticsQuery,
+    Ga4Client,
+    TrafficQuery,
   ],
 })
 export class AnalyticsModule {}

--- a/apps/analytics/src/analytics.module.ts
+++ b/apps/analytics/src/analytics.module.ts
@@ -25,6 +25,8 @@ import { MembershipEventsConsumer } from './datasets/memberships/ingest/membersh
 import { MembershipDailySnapshotService } from './datasets/memberships/aggregates/membership-daily-snapshot.service';
 import { StatisticsController } from './features/statistics/api/statistics.controller';
 import { StatisticsQuery } from './features/statistics/read-model/statistics.query';
+import { CustomerInsightsController } from './features/statistics/api/customer-insights.controller';
+import { CustomerInsightsQuery } from './features/statistics/read-model/customer-insights.query';
 import { TrafficController } from './features/traffic/api/traffic.controller';
 import { TrafficQuery } from './features/traffic/read-model/traffic.query';
 import { Ga4Client } from './features/traffic/ga4/ga4.client';
@@ -71,6 +73,7 @@ import { SCHEDULE_ROOT } from '@app/shared/schedule/schedule-root';
   controllers: [
     AnalyticsController,
     StatisticsController,
+    CustomerInsightsController,
     TrafficController,
     OrderEventsConsumer,
     ProductEventsConsumer,
@@ -91,6 +94,7 @@ import { SCHEDULE_ROOT } from '@app/shared/schedule/schedule-root';
     MembershipDimensionsService,
     MembershipDailySnapshotService,
     StatisticsQuery,
+    CustomerInsightsQuery,
     Ga4Client,
     TrafficQuery,
   ],

--- a/apps/analytics/src/features/statistics/api/customer-insights.controller.ts
+++ b/apps/analytics/src/features/statistics/api/customer-insights.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { AdminRealmGuard, JwtAuthGuard } from '@app/authorization';
+import { CustomerInsights, CustomerInsightsQuery } from '../read-model/customer-insights.query';
+import { CustomerInsightsQueryDto } from './statistics-query.dto';
+
+/**
+ * 구매 기반 고객 분석. admin-web 프록시를 통해서만 호출된다.
+ *
+ * 기존 StatisticsController(JwtAuthGuard만)와 달리 AdminRealmGuard 를 함께 건다 —
+ * 신설 라우트부터 staff role 강제가 기본값이다. 기존 라우트 소급은 별도 작업.
+ */
+@ApiTags('Statistics')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, AdminRealmGuard)
+@Controller('statistics')
+export class CustomerInsightsController {
+  constructor(private readonly customerInsightsQuery: CustomerInsightsQuery) {}
+
+  @Get('customers/insights')
+  @ApiOperation({
+    summary: '구매 기반 고객 분석',
+    description:
+      '코호트 리텐션(to 기준 최근 12개월 첫구매), RFM 분포·세그먼트(전 고객), 상품별 재구매(전 기간 누적), 기간 내 멤버십 등급 전환.',
+  })
+  getInsights(@Query() query: CustomerInsightsQueryDto): Promise<CustomerInsights> {
+    return this.customerInsightsQuery.getInsights(query.from, query.to, query.limit, query.minBuyers);
+  }
+}

--- a/apps/analytics/src/features/statistics/api/statistics-query.dto.ts
+++ b/apps/analytics/src/features/statistics/api/statistics-query.dto.ts
@@ -1,17 +1,16 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsCalendarDateConstraint } from '@app/shared';
 import { Type } from 'class-transformer';
-import { IsIn, IsInt, IsOptional, Matches, Max, Min } from 'class-validator';
-
-const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+import { IsIn, IsInt, IsOptional, Max, Min, Validate } from 'class-validator';
 
 /** 기간 조회 공통 파라미터. 날짜는 KST 달력 날짜(YYYY-MM-DD), 양끝 포함. */
 export class StatisticsRangeQueryDto {
   @ApiProperty({ example: '2026-08-01', description: '조회 시작일 (KST, 포함)' })
-  @Matches(DATE_ONLY, { message: 'from 은 YYYY-MM-DD 형식이어야 합니다' })
+  @Validate(IsCalendarDateConstraint, { message: 'from 은 달력에 존재하는 YYYY-MM-DD 여야 합니다' })
   from: string;
 
   @ApiProperty({ example: '2026-08-24', description: '조회 종료일 (KST, 포함)' })
-  @Matches(DATE_ONLY, { message: 'to 는 YYYY-MM-DD 형식이어야 합니다' })
+  @Validate(IsCalendarDateConstraint, { message: 'to 는 달력에 존재하는 YYYY-MM-DD 여야 합니다' })
   to: string;
 
   @ApiPropertyOptional({ description: '판매 채널 필터 (생략 시 전체)' })

--- a/apps/analytics/src/features/statistics/api/statistics-query.dto.ts
+++ b/apps/analytics/src/features/statistics/api/statistics-query.dto.ts
@@ -43,6 +43,24 @@ export class ProductStatisticsQueryDto extends StatisticsRangeQueryDto {
   order?: 'asc' | 'desc' = 'desc';
 }
 
+export class CustomerInsightsQueryDto extends StatisticsRangeQueryDto {
+  @ApiPropertyOptional({ example: 20, default: 20, description: '재구매 상품 목록 최대 행 수' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({ example: 5, default: 5, description: '재구매 목록에 올릴 최소 구매자 수 (노이즈 컷)' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  minBuyers?: number = 5;
+}
+
 export class UnsoldProductsQueryDto extends StatisticsRangeQueryDto {
   @ApiPropertyOptional({ example: 50, default: 50, description: '최대 행 수' })
   @IsOptional()

--- a/apps/analytics/src/features/statistics/read-model/customer-insights.query.integration.spec.ts
+++ b/apps/analytics/src/features/statistics/read-model/customer-insights.query.integration.spec.ts
@@ -1,0 +1,172 @@
+import { randomUUID } from 'crypto';
+import * as postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { eq, inArray } from 'drizzle-orm';
+import type { DbService } from '@app/db';
+import {
+  aggCustomerLifetime,
+  aggUserProductPurchase,
+  analyticsSchema,
+  dimCustomerMembership,
+  dimProductMasters,
+  factOrderItems,
+} from '../../../schema';
+import { CustomerInsightsQuery } from './customer-insights.query';
+
+/**
+ * 고객 분석 read-model 을 실 Postgres 로 검증한다. 코호트·등급 전환은 2030년 날짜로
+ * 시드해 로컬 실데이터(2025~26)와 겹치지 않게 격리한다. RFM·재구매는 전 고객 스캔이라
+ * 완전 격리가 불가능하므로, 시드가 만든 행/셀의 존재만 단언한다.
+ *
+ * 실행: DATABASE_URL=postgresql://postgres:postgres@localhost:5432/analytics \
+ *   npx jest --testPathPattern="customer-insights.query.integration"
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+
+describeIfDb('CustomerInsightsQuery (실 Postgres)', () => {
+  jest.setTimeout(120_000);
+
+  const channel = `itest-${randomUUID().slice(0, 8)}`;
+  const masterR = `itest-master-${randomUUID().slice(0, 8)}`;
+  const tierA = `itest-tier-a-${randomUUID().slice(0, 8)}`;
+  const tierB = `itest-tier-b-${randomUUID().slice(0, 8)}`;
+  const u1 = `itest-user-${randomUUID().slice(0, 8)}`;
+  const u2 = `itest-user-${randomUUID().slice(0, 8)}`;
+  const u3 = `itest-user-${randomUUID().slice(0, 8)}`;
+  const u4 = `itest-user-${randomUUID().slice(0, 8)}`;
+  const uT = `itest-user-${randomUUID().slice(0, 8)}`;
+  const allUsers = [u1, u2, u3, u4, uT];
+
+  let sql: postgres.Sql;
+  let db: ReturnType<typeof drizzle<typeof analyticsSchema>>;
+  let query: CustomerInsightsQuery;
+
+  const messageId = () => `IT${randomUUID().replace(/-/g, '').slice(0, 24)}`;
+  const factRow = (customerId: string, occurredAt: string) => ({
+    messageId: messageId(),
+    orderKey: `${customerId}-${occurredAt}`,
+    salesChannel: channel,
+    customerId,
+    masterId: masterR,
+    quantity: 1,
+    occurredAt: new Date(`${occurredAt}T10:00:00+09:00`),
+  });
+
+  beforeAll(async () => {
+    sql = postgres(DATABASE_URL as string, { max: 1 });
+    db = drizzle(sql, { schema: analyticsSchema });
+    const dbService = {
+      db,
+      run: <T>(fn: (t: unknown) => Promise<T>, tx?: unknown): Promise<T> =>
+        tx ? fn(tx) : (db.transaction((t) => fn(t)) as Promise<T>),
+    } as unknown as DbService<typeof analyticsSchema>;
+    query = new CustomerInsightsQuery(dbService);
+
+    // 코호트: 2030-06 첫구매 2명(u1·u2), 2030-07 첫구매 1명(u3).
+    // u1 은 8월에 재구매, u2 는 무소식, u3 은 8월에 재구매.
+    await db.insert(aggCustomerLifetime).values([
+      { customerId: u1, firstOrderAt: new Date('2030-06-05T10:00:00+09:00'), lastOrderAt: new Date('2030-08-04T10:00:00+09:00'), ordersCount: 3, totalRevenue: 50000 },
+      { customerId: u2, firstOrderAt: new Date('2030-06-20T10:00:00+09:00'), lastOrderAt: new Date('2030-06-20T10:00:00+09:00'), ordersCount: 1, totalRevenue: 10000 },
+      { customerId: u3, firstOrderAt: new Date('2030-07-02T10:00:00+09:00'), lastOrderAt: new Date('2030-08-10T10:00:00+09:00'), ordersCount: 2, totalRevenue: 30000 },
+      // RFM 휴면 검증용 — 마지막 주문이 아주 오래됐고 주문수가 많다.
+      { customerId: u4, firstOrderAt: new Date('2019-01-05T10:00:00+09:00'), lastOrderAt: new Date('2019-06-05T10:00:00+09:00'), ordersCount: 12, totalRevenue: 990000 },
+    ]);
+    await db.insert(factOrderItems).values([
+      factRow(u1, '2030-06-05'),
+      factRow(u1, '2030-06-21'),
+      factRow(u1, '2030-08-04'),
+      factRow(u2, '2030-06-20'),
+      factRow(u3, '2030-07-02'),
+      factRow(u3, '2030-08-10'),
+    ]);
+
+    // 재구매: masterR 구매자 3명 중 2명이 재구매. 주기 평균 = (60/2 + 20/1) / 2 = 25일.
+    await db.insert(dimProductMasters).values([{ masterId: masterR, name: '통합테스트 재구매 상품', isActive: true }]);
+    await db.insert(aggUserProductPurchase).values([
+      { customerId: u1, masterId: masterR, purchaseCount: 3, totalQuantity: 3, firstPurchasedAt: new Date('2030-06-05T10:00:00+09:00'), lastPurchasedAt: new Date('2030-08-04T10:00:00+09:00') },
+      { customerId: u2, masterId: masterR, purchaseCount: 1, totalQuantity: 1, firstPurchasedAt: new Date('2030-06-20T10:00:00+09:00'), lastPurchasedAt: new Date('2030-06-20T10:00:00+09:00') },
+      { customerId: u3, masterId: masterR, purchaseCount: 2, totalQuantity: 2, firstPurchasedAt: new Date('2030-07-02T10:00:00+09:00'), lastPurchasedAt: new Date('2030-07-22T10:00:00+09:00') },
+    ]);
+
+    // 등급 전환: uT 가 8월 5일 tierA → tierB. tierB 구간은 열려 있다(현재 등급).
+    await db.insert(dimCustomerMembership).values([
+      { userId: uT, tierId: tierA, validFrom: new Date('2030-07-01T00:00:00+09:00'), validTo: new Date('2030-08-05T00:00:00+09:00') },
+      { userId: uT, tierId: tierB, validFrom: new Date('2030-08-05T00:00:00+09:00'), validTo: null },
+    ]);
+  });
+
+  afterAll(async () => {
+    await db.delete(factOrderItems).where(eq(factOrderItems.salesChannel, channel));
+    await db.delete(aggCustomerLifetime).where(inArray(aggCustomerLifetime.customerId, allUsers));
+    await db.delete(aggUserProductPurchase).where(eq(aggUserProductPurchase.masterId, masterR));
+    await db.delete(dimProductMasters).where(eq(dimProductMasters.masterId, masterR));
+    await db.delete(dimCustomerMembership).where(eq(dimCustomerMembership.userId, uT));
+    await sql.end();
+  });
+
+  it('코호트 매트릭스 — 크기·리텐션·미래 칸 null', async () => {
+    const result = await query.getInsights('2030-08-01', '2030-08-31');
+
+    const june = result.cohorts.rows.find((row) => row.cohortMonth === '2030-06');
+    expect(june).toBeDefined();
+    expect(june?.size).toBe(2);
+    // +0: 둘 다 6월에 주문 → 1. +1(7월): 아무도 없음 → 0. +2(8월): u1 만 → 0.5.
+    expect(june?.retention.slice(0, 3)).toEqual([1, 0, 0.5]);
+    // 2030-09 이후는 아직 오지 않았다.
+    expect(june?.retention[3]).toBeNull();
+
+    const july = result.cohorts.rows.find((row) => row.cohortMonth === '2030-07');
+    expect(july?.size).toBe(1);
+    expect(july?.retention.slice(0, 2)).toEqual([1, 1]);
+  });
+
+  it('RFM — 휴면 셀과 세그먼트에 시드 고객이 잡히고 셀 합 = 전체', async () => {
+    const result = await query.getInsights('2030-08-01', '2030-08-31');
+
+    const dormantCell = result.rfm.cells.find(
+      (cell) => cell.recency === '1년 이상' && cell.frequency === '10회 이상',
+    );
+    expect(dormantCell?.customers ?? 0).toBeGreaterThanOrEqual(1);
+
+    const dormantSegment = result.rfm.segments.find((segment) => segment.key === 'dormant');
+    expect(dormantSegment?.customers ?? 0).toBeGreaterThanOrEqual(1);
+
+    const cellSum = result.rfm.cells.reduce((sum, cell) => sum + cell.customers, 0);
+    const segmentSum = result.rfm.segments.reduce((sum, segment) => sum + segment.customers, 0);
+    expect(cellSum).toBe(result.rfm.totalCustomers);
+    expect(segmentSum).toBe(result.rfm.totalCustomers);
+  });
+
+  it('상품별 재구매 — 구매자·재구매율·평균 주기', async () => {
+    const result = await query.getInsights('2030-08-01', '2030-08-31', 200, 3);
+
+    const item = result.repurchase.items.find((row) => row.masterId === masterR);
+    expect(item).toBeDefined();
+    expect(item?.name).toBe('통합테스트 재구매 상품');
+    expect(item?.buyers).toBe(3);
+    expect(item?.repeatBuyers).toBe(2);
+    expect(item?.repurchaseRate).toBeCloseTo(2 / 3, 5);
+    expect(item?.avgCycleDays).toBeCloseTo(25, 1);
+  });
+
+  it('등급 전환 — 기간 내 전환 1건과 현재 분포', async () => {
+    const result = await query.getInsights('2030-08-01', '2030-08-31');
+
+    const transition = result.tierFlow.transitions.find(
+      (row) => row.fromTier === tierA && row.toTier === tierB,
+    );
+    expect(transition?.count).toBe(1);
+
+    const current = result.tierFlow.currentDistribution.find((row) => row.tierId === tierB);
+    expect(current?.count ?? 0).toBeGreaterThanOrEqual(1);
+  });
+
+  it('기간 밖에서는 등급 전환이 잡히지 않는다', async () => {
+    const result = await query.getInsights('2030-07-01', '2030-07-31');
+    const transition = result.tierFlow.transitions.find(
+      (row) => row.fromTier === tierA && row.toTier === tierB,
+    );
+    expect(transition).toBeUndefined();
+  });
+});

--- a/apps/analytics/src/features/statistics/read-model/customer-insights.query.spec.ts
+++ b/apps/analytics/src/features/statistics/read-model/customer-insights.query.spec.ts
@@ -1,0 +1,80 @@
+import {
+  COHORT_MONTHS,
+  FREQUENCY_BUCKETS,
+  RECENCY_BUCKETS,
+  addMonths,
+  buildCohortMatrix,
+  buildSegments,
+  monthDiff,
+  segmentOf,
+} from './customer-insights.query';
+
+describe('addMonths / monthDiff', () => {
+  it('연 경계를 넘는다', () => {
+    expect(addMonths('2026-11', 3)).toBe('2027-02');
+    expect(addMonths('2026-01', -2)).toBe('2025-11');
+    expect(monthDiff('2025-11', '2026-02')).toBe(3);
+  });
+});
+
+describe('buildCohortMatrix', () => {
+  it('활동 없는 칸은 0, 아직 오지 않은 달은 null 로 채운다', () => {
+    const rows = buildCohortMatrix(
+      [{ cohortMonth: '2026-06', size: 4 }],
+      [
+        { cohortMonth: '2026-06', activeMonth: '2026-06', customers: 4 },
+        { cohortMonth: '2026-06', activeMonth: '2026-08', customers: 1 },
+      ],
+      '2026-08',
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].retention.slice(0, 3)).toEqual([1, 0, 0.25]);
+    expect(rows[0].retention.slice(3)).toEqual(Array(COHORT_MONTHS - 3).fill(null));
+  });
+
+  it('코호트 월 오름차순으로 정렬한다', () => {
+    const rows = buildCohortMatrix(
+      [
+        { cohortMonth: '2026-08', size: 1 },
+        { cohortMonth: '2026-07', size: 2 },
+      ],
+      [],
+      '2026-08',
+    );
+    expect(rows.map((row) => row.cohortMonth)).toEqual(['2026-07', '2026-08']);
+  });
+});
+
+describe('segmentOf', () => {
+  it('모든 R×F 셀이 정확히 하나의 세그먼트에 속한다', () => {
+    const keys = new Set<string>();
+    for (let r = 0; r < RECENCY_BUCKETS.length; r += 1) {
+      for (let f = 0; f < FREQUENCY_BUCKETS.length; f += 1) {
+        keys.add(segmentOf(r, f));
+      }
+    }
+    expect([...keys].sort()).toEqual(['at-risk', 'dormant', 'loyal', 'new', 'one-time', 'vip']);
+  });
+
+  it('대표 케이스 — 최근·다구매는 VIP, 오래된 고객은 휴면', () => {
+    expect(segmentOf(0, 3)).toBe('vip');
+    expect(segmentOf(0, 0)).toBe('new');
+    expect(segmentOf(2, 2)).toBe('at-risk');
+    expect(segmentOf(4, 3)).toBe('dormant');
+  });
+});
+
+describe('buildSegments', () => {
+  it('셀 고객 수 합이 세그먼트 합과 같다 (누락·중복 없음)', () => {
+    const cells = [
+      { recency: '30일 이내', frequency: '10회 이상', customers: 3, totalRevenue: 0 },
+      { recency: '31~90일', frequency: '2~3회', customers: 5, totalRevenue: 0 },
+      { recency: '1년 이상', frequency: '1회', customers: 7, totalRevenue: 0 },
+    ];
+    const segments = buildSegments(cells);
+    expect(segments.reduce((sum, s) => sum + s.customers, 0)).toBe(15);
+    expect(segments.find((s) => s.key === 'vip')?.customers).toBe(3);
+    expect(segments.find((s) => s.key === 'loyal')?.customers).toBe(5);
+    expect(segments.find((s) => s.key === 'dormant')?.customers).toBe(7);
+  });
+});

--- a/apps/analytics/src/features/statistics/read-model/customer-insights.query.ts
+++ b/apps/analytics/src/features/statistics/read-model/customer-insights.query.ts
@@ -1,0 +1,401 @@
+import { Injectable } from '@nestjs/common';
+import { InjectTypedDb } from '@app/db/decorators';
+import { DbService } from '@app/db';
+import { BadRequestError } from '@app/shared';
+import { and, desc, eq, gte, inArray, isNull, lt, ne, sql, SQL } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
+import {
+  aggCustomerLifetime,
+  aggUserProductPurchase,
+  analyticsSchema,
+  dimCustomerMembership,
+  dimProductMasters,
+  factOrderItems,
+} from '../../../schema';
+import { SEOUL_TZ, seoulDayStart } from '../../../shared/date.util';
+
+/** 코호트 매트릭스가 다루는 개월 수 — 코호트 12개 × 경과 최대 +11개월. */
+export const COHORT_MONTHS = 12;
+
+export interface CohortRow {
+  /** 첫 주문 월 (KST, YYYY-MM) */
+  cohortMonth: string;
+  size: number;
+  /** 경과 개월별 재구매 고객 비율. 아직 오지 않은 달은 null. [0]은 정의상 1에 가깝다. */
+  retention: Array<number | null>;
+}
+
+export interface RfmCell {
+  recency: string;
+  frequency: string;
+  customers: number;
+  totalRevenue: number;
+}
+
+export interface RfmSegment {
+  key: string;
+  label: string;
+  customers: number;
+}
+
+export interface RepurchaseItem {
+  masterId: string;
+  name: string | null;
+  buyers: number;
+  repeatBuyers: number;
+  repurchaseRate: number;
+  /** 재구매 고객의 (마지막-첫 구매)/(구매횟수-1) 평균 일수. 재구매자가 없으면 null. */
+  avgCycleDays: number | null;
+}
+
+export interface CustomerInsights {
+  range: { from: string; to: string };
+  /** to 가 속한 달을 끝으로 하는 최근 12개월 첫구매 코호트 — from 과 무관하다. */
+  cohorts: { rows: CohortRow[]; maxOffset: number };
+  /** 전 고객 기준 (기간 필터 무관) — R=마지막 주문 경과, F=주문수, M=누적 총매출. */
+  rfm: {
+    recencyBuckets: string[];
+    frequencyBuckets: string[];
+    cells: RfmCell[];
+    segments: RfmSegment[];
+    totalCustomers: number;
+  };
+  /** 전 기간 누적 상품별 재구매 (agg_user_product_purchase) — 기간 필터 무관. */
+  repurchase: { minBuyers: number; items: RepurchaseItem[] };
+  /** 기간 내 등급 전환 + 현재 등급 분포. 실시간 수집 이전 이력은 없어 과거는 과소집계다. */
+  tierFlow: {
+    transitions: Array<{ fromTier: string; toTier: string; count: number }>;
+    currentDistribution: Array<{ tierId: string; count: number }>;
+  };
+}
+
+export const RECENCY_BUCKETS: Array<{ label: string; maxDays: number | null }> = [
+  { label: '30일 이내', maxDays: 30 },
+  { label: '31~90일', maxDays: 90 },
+  { label: '91~180일', maxDays: 180 },
+  { label: '181~365일', maxDays: 365 },
+  { label: '1년 이상', maxDays: null },
+];
+
+export const FREQUENCY_BUCKETS: Array<{ label: string; min: number; max: number | null }> = [
+  { label: '1회', min: 1, max: 1 },
+  { label: '2~3회', min: 2, max: 3 },
+  { label: '4~9회', min: 4, max: 9 },
+  { label: '10회 이상', min: 10, max: null },
+];
+
+const SEGMENT_LABELS: Record<string, string> = {
+  vip: 'VIP',
+  loyal: '단골',
+  new: '신규',
+  'one-time': '1회 구매 후 무소식',
+  'at-risk': '이탈 위험',
+  dormant: '휴면',
+};
+
+/**
+ * R×F 셀 → 세그먼트. 모든 셀이 정확히 하나의 세그먼트에 속한다 (합 = 전체 고객).
+ * M(금액)은 세그먼트 판정에 쓰지 않는다 — 축이 셋이면 표로 보여줄 수 없다.
+ */
+export function segmentOf(recencyIndex: number, frequencyIndex: number): string {
+  if (recencyIndex >= 4) return 'dormant';
+  if (recencyIndex <= 1) {
+    if (frequencyIndex >= 2) return 'vip';
+    if (frequencyIndex === 1) return 'loyal';
+    return recencyIndex === 0 ? 'new' : 'one-time';
+  }
+  return frequencyIndex === 0 ? 'one-time' : 'at-risk';
+}
+
+/** 'YYYY-MM' 두 달 사이의 개월 차. */
+export function monthDiff(fromMonth: string, toMonth: string): number {
+  const [fy, fm] = fromMonth.split('-').map(Number);
+  const [ty, tm] = toMonth.split('-').map(Number);
+  return (ty - fy) * 12 + (tm - fm);
+}
+
+/** 'YYYY-MM' 에 개월을 더한다. */
+export function addMonths(month: string, months: number): string {
+  const [year, monthNum] = month.split('-').map(Number);
+  const total = year * 12 + (monthNum - 1) + months;
+  const y = Math.floor(total / 12);
+  const m = (total % 12) + 1;
+  return `${y}-${String(m).padStart(2, '0')}`;
+}
+
+/**
+ * (코호트월, 활동월, 고객수) 행들을 코호트 매트릭스로 만든다.
+ * 활동이 없는 (코호트, 경과월) 칸은 0, endMonth 이후의 칸은 null.
+ */
+export function buildCohortMatrix(
+  sizes: Array<{ cohortMonth: string; size: number }>,
+  activity: Array<{ cohortMonth: string; activeMonth: string; customers: number }>,
+  endMonth: string,
+): CohortRow[] {
+  const activeByKey = new Map<string, number>();
+  for (const row of activity) {
+    activeByKey.set(`${row.cohortMonth}|${row.activeMonth}`, row.customers);
+  }
+  return sizes
+    .slice()
+    .sort((a, b) => a.cohortMonth.localeCompare(b.cohortMonth))
+    .map(({ cohortMonth, size }) => {
+      const retention: Array<number | null> = [];
+      for (let offset = 0; offset < COHORT_MONTHS; offset += 1) {
+        const activeMonth = addMonths(cohortMonth, offset);
+        if (activeMonth > endMonth) {
+          retention.push(null);
+          continue;
+        }
+        const active = activeByKey.get(`${cohortMonth}|${activeMonth}`) ?? 0;
+        retention.push(size > 0 ? active / size : null);
+      }
+      return { cohortMonth, size, retention };
+    });
+}
+
+export function buildSegments(cells: RfmCell[]): RfmSegment[] {
+  const byKey = new Map<string, number>();
+  for (const cell of cells) {
+    const recencyIndex = RECENCY_BUCKETS.findIndex((bucket) => bucket.label === cell.recency);
+    const frequencyIndex = FREQUENCY_BUCKETS.findIndex((bucket) => bucket.label === cell.frequency);
+    if (recencyIndex < 0 || frequencyIndex < 0) continue;
+    const key = segmentOf(recencyIndex, frequencyIndex);
+    byKey.set(key, (byKey.get(key) ?? 0) + cell.customers);
+  }
+  return Object.keys(SEGMENT_LABELS).map((key) => ({
+    key,
+    label: SEGMENT_LABELS[key],
+    customers: byKey.get(key) ?? 0,
+  }));
+}
+
+@Injectable()
+export class CustomerInsightsQuery {
+  constructor(
+    @InjectTypedDb<typeof analyticsSchema>()
+    private readonly dbService: DbService<typeof analyticsSchema>,
+  ) {}
+
+  private get db() {
+    return this.dbService.db;
+  }
+
+  async getInsights(from: string, to: string, limit = 20, minBuyers = 5): Promise<CustomerInsights> {
+    if (from > to) {
+      throw new BadRequestError(`조회 기간이 뒤집혔습니다: ${from} > ${to}`);
+    }
+
+    const [cohorts, rfm, repurchase, tierFlow] = await Promise.all([
+      this.cohortRetention(to),
+      this.rfmDistribution(),
+      this.productRepurchase(limit, minBuyers),
+      this.tierTransitions(from, to),
+    ]);
+
+    return { range: { from, to }, cohorts, rfm, repurchase, tierFlow };
+  }
+
+  /** to 가 속한 달을 마지막으로 하는 최근 12개월 코호트. */
+  private async cohortRetention(to: string): Promise<{ rows: CohortRow[]; maxOffset: number }> {
+    const endMonth = to.slice(0, 7);
+    const startMonth = addMonths(endMonth, -(COHORT_MONTHS - 1));
+    const windowStart = seoulDayStart(`${startMonth}-01`);
+    const windowEnd = seoulDayStart(`${addMonths(endMonth, 1)}-01`);
+
+    const cohortMonthExpr = sql<string>`to_char(${aggCustomerLifetime.firstOrderAt} AT TIME ZONE ${SEOUL_TZ}, 'YYYY-MM')`;
+    const cohortWhere = and(
+      gte(aggCustomerLifetime.firstOrderAt, windowStart),
+      lt(aggCustomerLifetime.firstOrderAt, windowEnd),
+    );
+
+    const [sizeRows, activityRows] = await Promise.all([
+      this.db
+        .select({ cohortMonth: cohortMonthExpr, size: sql<string>`COUNT(*)` })
+        .from(aggCustomerLifetime)
+        .where(cohortWhere)
+        .groupBy(sql`1`),
+      this.db
+        .select({
+          cohortMonth: cohortMonthExpr,
+          activeMonth: sql<string>`to_char(${factOrderItems.occurredAt} AT TIME ZONE ${SEOUL_TZ}, 'YYYY-MM')`,
+          customers: sql<string>`COUNT(DISTINCT ${factOrderItems.customerId})`,
+        })
+        .from(factOrderItems)
+        .innerJoin(aggCustomerLifetime, eq(aggCustomerLifetime.customerId, factOrderItems.customerId))
+        .where(and(cohortWhere, gte(factOrderItems.occurredAt, windowStart), lt(factOrderItems.occurredAt, windowEnd)))
+        .groupBy(sql`1`, sql`2`),
+    ]);
+
+    const rows = buildCohortMatrix(
+      sizeRows.map((row) => ({ cohortMonth: row.cohortMonth, size: Number(row.size ?? 0) })),
+      activityRows.map((row) => ({
+        cohortMonth: row.cohortMonth,
+        activeMonth: row.activeMonth,
+        customers: Number(row.customers ?? 0),
+      })),
+      endMonth,
+    );
+    return { rows, maxOffset: COHORT_MONTHS - 1 };
+  }
+
+  private async rfmDistribution(): Promise<CustomerInsights['rfm']> {
+    const rows = await this.db
+      .select({
+        recency: sql<string>`${recencyBucketCase()}`,
+        frequency: sql<string>`${frequencyBucketCase()}`,
+        customers: sql<string>`COUNT(*)`,
+        totalRevenue: sql<string>`COALESCE(SUM(${aggCustomerLifetime.totalRevenue}), 0)`,
+      })
+      .from(aggCustomerLifetime)
+      .where(sql`${aggCustomerLifetime.lastOrderAt} IS NOT NULL`)
+      .groupBy(sql`1`, sql`2`);
+
+    const cells: RfmCell[] = rows.map((row) => ({
+      recency: row.recency,
+      frequency: row.frequency,
+      customers: Number(row.customers ?? 0),
+      totalRevenue: Number(row.totalRevenue ?? 0),
+    }));
+
+    return {
+      recencyBuckets: RECENCY_BUCKETS.map((bucket) => bucket.label),
+      frequencyBuckets: FREQUENCY_BUCKETS.map((bucket) => bucket.label),
+      cells,
+      segments: buildSegments(cells),
+      totalCustomers: cells.reduce((sum, cell) => sum + cell.customers, 0),
+    };
+  }
+
+  private async productRepurchase(limit: number, minBuyers: number): Promise<CustomerInsights['repurchase']> {
+    const buyersExpr = sql`COUNT(*)`;
+    const repeatExpr = sql`COUNT(*) FILTER (WHERE ${aggUserProductPurchase.purchaseCount} >= 2)`;
+    const rows = await this.db
+      .select({
+        masterId: aggUserProductPurchase.masterId,
+        name: dimProductMasters.name,
+        buyers: sql<string>`${buyersExpr}`,
+        repeatBuyers: sql<string>`${repeatExpr}`,
+        avgCycleDays: sql<string | null>`AVG(
+          EXTRACT(EPOCH FROM (${aggUserProductPurchase.lastPurchasedAt} - ${aggUserProductPurchase.firstPurchasedAt}))
+            / 86400.0 / (${aggUserProductPurchase.purchaseCount} - 1)
+        ) FILTER (WHERE ${aggUserProductPurchase.purchaseCount} >= 2
+          AND ${aggUserProductPurchase.lastPurchasedAt} > ${aggUserProductPurchase.firstPurchasedAt})`,
+      })
+      .from(aggUserProductPurchase)
+      .leftJoin(dimProductMasters, eq(dimProductMasters.masterId, aggUserProductPurchase.masterId))
+      .groupBy(aggUserProductPurchase.masterId, dimProductMasters.name)
+      .having(sql`${buyersExpr} >= ${minBuyers}`)
+      .orderBy(sql`${repeatExpr}::float / ${buyersExpr} DESC`, sql`${buyersExpr} DESC`)
+      .limit(limit);
+
+    const namelessMasterIds = rows.filter((row) => !row.name).map((row) => row.masterId);
+    const fallbackNames = await this.latestOrderedProductNames(namelessMasterIds);
+
+    return {
+      minBuyers,
+      items: rows.map((row) => {
+        const buyers = Number(row.buyers ?? 0);
+        const repeatBuyers = Number(row.repeatBuyers ?? 0);
+        return {
+          masterId: row.masterId,
+          name: row.name ?? fallbackNames.get(row.masterId) ?? null,
+          buyers,
+          repeatBuyers,
+          repurchaseRate: buyers > 0 ? repeatBuyers / buyers : 0,
+          avgCycleDays: row.avgCycleDays == null ? null : Number(row.avgCycleDays),
+        };
+      }),
+    };
+  }
+
+  private async tierTransitions(from: string, to: string): Promise<CustomerInsights['tierFlow']> {
+    const fromInstant = seoulDayStart(from);
+    const toExclusive = seoulDayStart(nextDay(to));
+    const previousMembership = alias(dimCustomerMembership, 'previous_membership');
+
+    const [transitionRows, currentRows] = await Promise.all([
+      this.db
+        .select({
+          fromTier: previousMembership.tierId,
+          toTier: dimCustomerMembership.tierId,
+          count: sql<string>`COUNT(*)`,
+        })
+        .from(dimCustomerMembership)
+        .innerJoin(
+          previousMembership,
+          and(
+            eq(previousMembership.userId, dimCustomerMembership.userId),
+            eq(previousMembership.validTo, dimCustomerMembership.validFrom),
+          ),
+        )
+        .where(
+          and(
+            gte(dimCustomerMembership.validFrom, fromInstant),
+            lt(dimCustomerMembership.validFrom, toExclusive),
+            ne(previousMembership.tierId, dimCustomerMembership.tierId),
+          ),
+        )
+        .groupBy(previousMembership.tierId, dimCustomerMembership.tierId)
+        .orderBy(sql`COUNT(*) DESC`),
+      this.db
+        .select({ tierId: dimCustomerMembership.tierId, count: sql<string>`COUNT(*)` })
+        .from(dimCustomerMembership)
+        .where(isNull(dimCustomerMembership.validTo))
+        .groupBy(dimCustomerMembership.tierId)
+        .orderBy(sql`COUNT(*) DESC`),
+    ]);
+
+    return {
+      transitions: transitionRows.map((row) => ({
+        fromTier: row.fromTier,
+        toTier: row.toTier,
+        count: Number(row.count ?? 0),
+      })),
+      currentDistribution: currentRows.map((row) => ({ tierId: row.tierId, count: Number(row.count ?? 0) })),
+    };
+  }
+
+  /** masterId 별 최근 주문 라인의 상품명 — statistics.query 와 같은 폴백. */
+  private async latestOrderedProductNames(masterIds: string[]): Promise<Map<string, string>> {
+    if (masterIds.length === 0) return new Map();
+    const rows = await this.db
+      .selectDistinctOn([factOrderItems.masterId], {
+        masterId: factOrderItems.masterId,
+        productName: factOrderItems.productName,
+      })
+      .from(factOrderItems)
+      .where(and(inArray(factOrderItems.masterId, masterIds), sql`${factOrderItems.productName} IS NOT NULL`))
+      .orderBy(factOrderItems.masterId, desc(factOrderItems.occurredAt));
+    const map = new Map<string, string>();
+    for (const row of rows) {
+      if (row.productName) map.set(row.masterId, row.productName);
+    }
+    return map;
+  }
+}
+
+function recencyBucketCase(): SQL<string> {
+  const days = sql`EXTRACT(EPOCH FROM (now() - ${aggCustomerLifetime.lastOrderAt})) / 86400.0`;
+  const chunks = RECENCY_BUCKETS.map((bucket) =>
+    bucket.maxDays === null
+      ? sql`ELSE ${bucket.label}`
+      : sql`WHEN ${days} <= ${bucket.maxDays} THEN ${bucket.label}`,
+  );
+  return sql<string>`CASE ${sql.join(chunks, sql` `)} END`;
+}
+
+function frequencyBucketCase(): SQL<string> {
+  const chunks = FREQUENCY_BUCKETS.map((bucket) =>
+    bucket.max === null
+      ? sql`ELSE ${bucket.label}`
+      : sql`WHEN ${aggCustomerLifetime.ordersCount} <= ${bucket.max} THEN ${bucket.label}`,
+  );
+  return sql<string>`CASE ${sql.join(chunks, sql` `)} END`;
+}
+
+function nextDay(dateOnly: string): string {
+  const base = new Date(`${dateOnly}T00:00:00Z`);
+  base.setUTCDate(base.getUTCDate() + 1);
+  return base.toISOString().slice(0, 10);
+}

--- a/apps/analytics/src/features/traffic/api/traffic-query.dto.ts
+++ b/apps/analytics/src/features/traffic/api/traffic-query.dto.ts
@@ -1,0 +1,69 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsCalendarDateConstraint } from '@app/shared';
+import { Type } from 'class-transformer';
+import { IsIn, IsInt, IsOptional, Max, Min, Validate } from 'class-validator';
+
+export class TrafficStatisticsQueryDto {
+  @ApiProperty({ example: '2026-08-01', description: '조회 시작일 (GA4 속성 시간대 기준, 포함)' })
+  @Validate(IsCalendarDateConstraint, { message: 'from 은 달력에 존재하는 YYYY-MM-DD 여야 합니다' })
+  from: string;
+
+  @ApiProperty({ example: '2026-08-24', description: '조회 종료일 (GA4 속성 시간대 기준, 포함)' })
+  @Validate(IsCalendarDateConstraint, { message: 'to 는 달력에 존재하는 YYYY-MM-DD 여야 합니다' })
+  to: string;
+
+  @ApiPropertyOptional({
+    enum: ['organic', 'all'],
+    default: 'organic',
+    description: '채널 그룹 — organic 은 자연검색(Organic Search)만, all 은 전체 유입',
+  })
+  @IsOptional()
+  @IsIn(['organic', 'all'])
+  channelGroup?: 'organic' | 'all' = 'organic';
+
+  @ApiPropertyOptional({ example: 10, default: 10, description: '랜딩페이지·국가 목록 최대 행 수' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  limit?: number = 10;
+}
+
+export class TrafficTotalsDto {
+  sessions: number;
+  totalUsers: number;
+  pageViews: number;
+  /** 참여 세션(10초 이상 체류·전환·2페이지 이상) ÷ 전체 세션. GA4 bounceRate 의 역수 */
+  engagementRate: number | null;
+}
+
+export class TrafficDailyBucketDto {
+  /** GA4 속성 시간대의 달력 날짜 (YYYY-MM-DD) */
+  date: string;
+  sessions: number;
+  engagementRate: number | null;
+}
+
+export class LandingPageRowDto {
+  path: string;
+  sessions: number;
+  engagementRate: number | null;
+}
+
+export class SessionsByDimensionRowDto {
+  label: string;
+  sessions: number;
+}
+
+export class TrafficStatisticsResponseDto {
+  /** false 면 GA4 env 미배선 — 화면은 "연동 대기"를 보여준다 */
+  enabled: boolean;
+  range: { from: string; to: string };
+  channelGroup: 'organic' | 'all';
+  totals: TrafficTotalsDto | null;
+  series: TrafficDailyBucketDto[];
+  landingPages: LandingPageRowDto[];
+  devices: SessionsByDimensionRowDto[];
+  countries: SessionsByDimensionRowDto[];
+}

--- a/apps/analytics/src/features/traffic/api/traffic.controller.ts
+++ b/apps/analytics/src/features/traffic/api/traffic.controller.ts
@@ -1,0 +1,32 @@
+import { BadRequestException, Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { AdminRealmGuard, JwtAuthGuard } from '@app/authorization';
+import { TrafficQuery } from '../read-model/traffic.query';
+import { TrafficStatisticsQueryDto, TrafficStatisticsResponseDto } from './traffic-query.dto';
+
+/**
+ * 관리자 유입 통계 (GA4 Data API 조회 전용). admin-web 프록시를 통해서만 호출된다.
+ *
+ * JwtAuthGuard 뒤에 AdminRealmGuard — 모든 서비스가 AUTH_SECRET 을 공유하므로
+ * 인증만으로는 고객 토큰도 통과한다. staff role(admin/master)을 강제한다.
+ */
+@ApiTags('Statistics')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, AdminRealmGuard)
+@Controller('statistics')
+export class TrafficController {
+  constructor(private readonly trafficQuery: TrafficQuery) {}
+
+  @Get('traffic')
+  @ApiOperation({
+    summary: '유입 통계',
+    description:
+      'GA4 세션 지표 — 일별 추이, 랜딩페이지·기기·국가별. 기본은 자연검색(Organic Search)만. GA4 env 미배선이면 enabled=false 로 응답한다.',
+  })
+  getTraffic(@Query() query: TrafficStatisticsQueryDto): Promise<TrafficStatisticsResponseDto> {
+    if (query.from > query.to) {
+      throw new BadRequestException(`조회 기간이 뒤집혔습니다: ${query.from} > ${query.to}`);
+    }
+    return this.trafficQuery.getTraffic(query.from, query.to, query.channelGroup ?? 'organic', query.limit ?? 10);
+  }
+}

--- a/apps/analytics/src/features/traffic/ga4/ga4.client.ts
+++ b/apps/analytics/src/features/traffic/ga4/ga4.client.ts
@@ -1,0 +1,48 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { BetaAnalyticsDataClient, protos } from '@google-analytics/data';
+
+type RunReportRequest = protos.google.analytics.data.v1beta.IRunReportRequest;
+type RunReportResponse = protos.google.analytics.data.v1beta.IRunReportResponse;
+
+/**
+ * GA4 Data API 클라이언트 래퍼.
+ *
+ * env(GA4_SERVICE_ACCOUNT · GA4_PROPERTY_ID)가 없는 환경(로컬, env 배선 이전 배포)에서도
+ * analytics 가 부팅되어야 하므로 클라이언트를 부팅 시점이 아니라 **첫 조회 시점에** 만든다.
+ * env 부재는 에러가 아니라 `enabled=false` — 화면이 "연동 대기"를 보여줄 수 있게 한다.
+ */
+@Injectable()
+export class Ga4Client {
+  private readonly logger = new Logger(Ga4Client.name);
+  private client: BetaAnalyticsDataClient | null = null;
+
+  get enabled(): boolean {
+    return Boolean(process.env.GA4_SERVICE_ACCOUNT && process.env.GA4_PROPERTY_ID);
+  }
+
+  /** sst 배선은 'properties/…' 원문을 넣지만, 숫자만 온 경우도 흡수한다. */
+  get property(): string {
+    const raw = process.env.GA4_PROPERTY_ID ?? '';
+    return raw.startsWith('properties/') ? raw : `properties/${raw}`;
+  }
+
+  async runReport(request: Omit<RunReportRequest, 'property'>): Promise<RunReportResponse> {
+    const [response] = await this.getClient().runReport({ ...request, property: this.property });
+    return response;
+  }
+
+  private getClient(): BetaAnalyticsDataClient {
+    if (this.client) return this.client;
+    const raw = process.env.GA4_SERVICE_ACCOUNT ?? '';
+    let credentials: Record<string, unknown>;
+    try {
+      credentials = JSON.parse(raw);
+    } catch (error) {
+      // secret 이 잘려 들어오는 등 배선 사고 — 원문은 절대 로그에 남기지 않는다.
+      this.logger.error(`GA4_SERVICE_ACCOUNT 파싱 실패 (길이 ${raw.length})`);
+      throw error;
+    }
+    this.client = new BetaAnalyticsDataClient({ credentials });
+    return this.client;
+  }
+}

--- a/apps/analytics/src/features/traffic/read-model/traffic.query.spec.ts
+++ b/apps/analytics/src/features/traffic/read-model/traffic.query.spec.ts
@@ -1,0 +1,107 @@
+import { UpstreamUnavailableError } from '@app/shared';
+import { Ga4Client } from '../ga4/ga4.client';
+import { TrafficQuery, fromGa4Date, mapDailySeries } from './traffic.query';
+
+function row(dimension: string, metrics: number[]) {
+  return {
+    dimensionValues: [{ value: dimension }],
+    metricValues: metrics.map((value) => ({ value: String(value) })),
+  };
+}
+
+type ReportRequest = { dimensions?: Array<{ name: string }> };
+
+/** 요청의 차원 이름으로 어떤 리포트인지 판별해 응답을 돌려주는 가짜 GA4 */
+function fakeReports(request: ReportRequest) {
+  const dimension = request.dimensions?.[0]?.name;
+  if (!dimension) {
+    // totals: sessions, totalUsers, screenPageViews, engagedSessions
+    return { rows: [{ metricValues: [100, 80, 500, 60].map((v) => ({ value: String(v) })) }] };
+  }
+  if (dimension === 'date') {
+    return { rows: [row('20260801', [40, 30]), row('20260803', [60, 30])] };
+  }
+  if (dimension === 'landingPage') {
+    return { rows: [row('/kr', [50, 40]), row('/kr/search', [10, 2])] };
+  }
+  if (dimension === 'deviceCategory') {
+    return { rows: [row('mobile', [70]), row('desktop', [30])] };
+  }
+  return { rows: [row('South Korea', [90]), row('Japan', [10])] };
+}
+
+function buildQuery(overrides?: { enabled?: boolean; runReport?: jest.Mock }) {
+  const client = new Ga4Client();
+  jest.spyOn(client, 'enabled', 'get').mockReturnValue(overrides?.enabled ?? true);
+  const runReport = overrides?.runReport ?? jest.fn().mockImplementation(async (req) => fakeReports(req));
+  jest.spyOn(client, 'runReport').mockImplementation(runReport);
+  return { query: new TrafficQuery(client), runReport };
+}
+
+describe('fromGa4Date', () => {
+  it('YYYYMMDD 를 YYYY-MM-DD 로 바꾼다', () => {
+    expect(fromGa4Date('20260801')).toBe('2026-08-01');
+  });
+});
+
+describe('mapDailySeries', () => {
+  it('세션 없는 날짜를 0으로 채워 기간 전체를 돌려준다', () => {
+    const response = { rows: [row('20260801', [40, 30]), row('20260803', [60, 30])] };
+    const series = mapDailySeries(response, '2026-08-01', '2026-08-03');
+    expect(series).toEqual([
+      { date: '2026-08-01', sessions: 40, engagementRate: 0.75 },
+      { date: '2026-08-02', sessions: 0, engagementRate: null },
+      { date: '2026-08-03', sessions: 60, engagementRate: 0.5 },
+    ]);
+  });
+});
+
+describe('TrafficQuery.getTraffic', () => {
+  it('env 미배선이면 GA4 를 부르지 않고 enabled=false 를 돌려준다', async () => {
+    const { query, runReport } = buildQuery({ enabled: false });
+    const result = await query.getTraffic('2026-08-01', '2026-08-03', 'organic', 10);
+    expect(result.enabled).toBe(false);
+    expect(result.totals).toBeNull();
+    expect(result.series).toEqual([]);
+    expect(runReport).not.toHaveBeenCalled();
+  });
+
+  it('다섯 리포트를 응답 모양으로 변환한다', async () => {
+    const { query } = buildQuery();
+    const result = await query.getTraffic('2026-08-01', '2026-08-03', 'organic', 10);
+
+    expect(result.enabled).toBe(true);
+    expect(result.totals).toEqual({ sessions: 100, totalUsers: 80, pageViews: 500, engagementRate: 0.6 });
+    expect(result.series).toHaveLength(3);
+    expect(result.landingPages[0]).toEqual({ path: '/kr', sessions: 50, engagementRate: 0.8 });
+    expect(result.devices).toEqual([
+      { label: 'mobile', sessions: 70 },
+      { label: 'desktop', sessions: 30 },
+    ]);
+    expect(result.countries[0]).toEqual({ label: 'South Korea', sessions: 90 });
+  });
+
+  it('organic 은 자연검색 필터를 싣고, all 은 필터 없이 부른다', async () => {
+    const { query, runReport } = buildQuery();
+    await query.getTraffic('2026-08-01', '2026-08-03', 'organic', 10);
+    expect(runReport.mock.calls.every(([req]) => req.dimensionFilter !== undefined)).toBe(true);
+
+    await query.getTraffic('2026-08-01', '2026-08-03', 'all', 10);
+    const allCalls = runReport.mock.calls.slice(5);
+    expect(allCalls.every(([req]) => req.dimensionFilter === undefined)).toBe(true);
+  });
+
+  it('같은 조회는 캐시에서 돌려준다 (외부 API 쿼터 보호)', async () => {
+    const { query, runReport } = buildQuery();
+    await query.getTraffic('2026-08-01', '2026-08-03', 'organic', 10);
+    await query.getTraffic('2026-08-01', '2026-08-03', 'organic', 10);
+    expect(runReport).toHaveBeenCalledTimes(5);
+  });
+
+  it('GA4 호출 실패는 500 이 아니라 UpstreamUnavailableError(502)로 나간다', async () => {
+    const { query } = buildQuery({ runReport: jest.fn().mockRejectedValue(new Error('quota exceeded')) });
+    await expect(query.getTraffic('2026-08-01', '2026-08-03', 'organic', 10)).rejects.toBeInstanceOf(
+      UpstreamUnavailableError,
+    );
+  });
+});

--- a/apps/analytics/src/features/traffic/read-model/traffic.query.ts
+++ b/apps/analytics/src/features/traffic/read-model/traffic.query.ts
@@ -1,0 +1,192 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { UpstreamUnavailableError } from '@app/shared';
+import { protos } from '@google-analytics/data';
+import { Ga4Client } from '../ga4/ga4.client';
+import {
+  LandingPageRowDto,
+  SessionsByDimensionRowDto,
+  TrafficDailyBucketDto,
+  TrafficStatisticsResponseDto,
+  TrafficTotalsDto,
+} from '../api/traffic-query.dto';
+
+type RunReportResponse = protos.google.analytics.data.v1beta.IRunReportResponse;
+
+/** GA4 는 외부 API 라 지연·쿼터가 있다 — 같은 조회는 잠시 재사용한다. */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const CACHE_MAX_ENTRIES = 50;
+
+const ORGANIC_FILTER = {
+  filter: {
+    fieldName: 'sessionDefaultChannelGroup',
+    stringFilter: { matchType: 'EXACT' as const, value: 'Organic Search' },
+  },
+};
+
+function toNum(value: string | null | undefined): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function engagementRate(engaged: number, sessions: number): number | null {
+  return sessions > 0 ? engaged / sessions : null;
+}
+
+/** GA4 date 차원값(YYYYMMDD) → YYYY-MM-DD */
+export function fromGa4Date(value: string): string {
+  return `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
+}
+
+/** GA4 는 세션 0인 날짜를 행으로 주지 않는다 — 기간 전체를 0으로 채워 선이 끊기지 않게 한다. */
+export function mapDailySeries(response: RunReportResponse, from: string, to: string): TrafficDailyBucketDto[] {
+  const byDate = new Map<string, { sessions: number; engaged: number }>();
+  for (const row of response.rows ?? []) {
+    const date = fromGa4Date(row.dimensionValues?.[0]?.value ?? '');
+    byDate.set(date, {
+      sessions: toNum(row.metricValues?.[0]?.value),
+      engaged: toNum(row.metricValues?.[1]?.value),
+    });
+  }
+  const series: TrafficDailyBucketDto[] = [];
+  const cursor = new Date(`${from}T00:00:00.000Z`);
+  const end = new Date(`${to}T00:00:00.000Z`);
+  while (cursor.getTime() <= end.getTime()) {
+    const date = cursor.toISOString().slice(0, 10);
+    const found = byDate.get(date);
+    series.push({
+      date,
+      sessions: found?.sessions ?? 0,
+      engagementRate: found ? engagementRate(found.engaged, found.sessions) : null,
+    });
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  return series;
+}
+
+export function mapLandingPages(response: RunReportResponse): LandingPageRowDto[] {
+  return (response.rows ?? []).map((row) => {
+    const sessions = toNum(row.metricValues?.[0]?.value);
+    return {
+      path: row.dimensionValues?.[0]?.value ?? '(not set)',
+      sessions,
+      engagementRate: engagementRate(toNum(row.metricValues?.[1]?.value), sessions),
+    };
+  });
+}
+
+export function mapSessionsByDimension(response: RunReportResponse): SessionsByDimensionRowDto[] {
+  return (response.rows ?? []).map((row) => ({
+    label: row.dimensionValues?.[0]?.value ?? '(not set)',
+    sessions: toNum(row.metricValues?.[0]?.value),
+  }));
+}
+
+export function mapTotals(response: RunReportResponse): TrafficTotalsDto {
+  const row = response.rows?.[0];
+  const sessions = toNum(row?.metricValues?.[0]?.value);
+  return {
+    sessions,
+    totalUsers: toNum(row?.metricValues?.[1]?.value),
+    pageViews: toNum(row?.metricValues?.[2]?.value),
+    engagementRate: engagementRate(toNum(row?.metricValues?.[3]?.value), sessions),
+  };
+}
+
+@Injectable()
+export class TrafficQuery {
+  private readonly logger = new Logger(TrafficQuery.name);
+  private readonly cache = new Map<string, { at: number; value: TrafficStatisticsResponseDto }>();
+
+  constructor(private readonly ga4: Ga4Client) {}
+
+  async getTraffic(
+    from: string,
+    to: string,
+    channelGroup: 'organic' | 'all',
+    limit: number,
+  ): Promise<TrafficStatisticsResponseDto> {
+    const base = { range: { from, to }, channelGroup };
+    if (!this.ga4.enabled) {
+      return { ...base, enabled: false, totals: null, series: [], landingPages: [], devices: [], countries: [] };
+    }
+
+    const cacheKey = `${from}|${to}|${channelGroup}|${limit}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached && Date.now() - cached.at < CACHE_TTL_MS) return cached.value;
+
+    const dateRanges = [{ startDate: from, endDate: to }];
+    const dimensionFilter = channelGroup === 'organic' ? ORGANIC_FILTER : undefined;
+
+    let totals: RunReportResponse;
+    let daily: RunReportResponse;
+    let landing: RunReportResponse;
+    let devices: RunReportResponse;
+    let countries: RunReportResponse;
+    try {
+      [totals, daily, landing, devices, countries] = await Promise.all([
+        this.ga4.runReport({
+          dateRanges,
+          dimensionFilter,
+          metrics: [
+            { name: 'sessions' },
+            { name: 'totalUsers' },
+            { name: 'screenPageViews' },
+            { name: 'engagedSessions' },
+          ],
+        }),
+        this.ga4.runReport({
+          dateRanges,
+          dimensionFilter,
+          dimensions: [{ name: 'date' }],
+          metrics: [{ name: 'sessions' }, { name: 'engagedSessions' }],
+          orderBys: [{ dimension: { dimensionName: 'date' } }],
+          limit: 400,
+        }),
+        this.ga4.runReport({
+          dateRanges,
+          dimensionFilter,
+          dimensions: [{ name: 'landingPage' }],
+          metrics: [{ name: 'sessions' }, { name: 'engagedSessions' }],
+          orderBys: [{ metric: { metricName: 'sessions' }, desc: true }],
+          limit,
+        }),
+        this.ga4.runReport({
+          dateRanges,
+          dimensionFilter,
+          dimensions: [{ name: 'deviceCategory' }],
+          metrics: [{ name: 'sessions' }],
+          orderBys: [{ metric: { metricName: 'sessions' }, desc: true }],
+          limit: 10,
+        }),
+        this.ga4.runReport({
+          dateRanges,
+          dimensionFilter,
+          dimensions: [{ name: 'country' }],
+          metrics: [{ name: 'sessions' }],
+          orderBys: [{ metric: { metricName: 'sessions' }, desc: true }],
+          limit,
+        }),
+      ]);
+    } catch (error) {
+      this.logger.warn(`GA4 조회 실패: ${error instanceof Error ? error.message : String(error)}`);
+      throw new UpstreamUnavailableError('GA4 조회에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    }
+
+    const value: TrafficStatisticsResponseDto = {
+      ...base,
+      enabled: true,
+      totals: mapTotals(totals),
+      series: mapDailySeries(daily, from, to),
+      landingPages: mapLandingPages(landing),
+      devices: mapSessionsByDimension(devices),
+      countries: mapSessionsByDimension(countries),
+    };
+
+    if (this.cache.size >= CACHE_MAX_ENTRIES) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest !== undefined) this.cache.delete(oldest);
+    }
+    this.cache.set(cacheKey, { at: Date.now(), value });
+    return value;
+  }
+}

--- a/libs/shared/src/filters/domain-exceptions.ts
+++ b/libs/shared/src/filters/domain-exceptions.ts
@@ -43,6 +43,21 @@ export class ConflictError extends ApplicationException {
   }
 }
 
+/** 외부 시스템(GA4 등) 조회 실패 — 우리 잘못이 아니라 502 로 구분한다. */
+export class UpstreamUnavailableError extends ApplicationException {
+  constructor(message: string) {
+    super(message);
+  }
+
+  getErrorCode(): string {
+    return 'UPSTREAM_UNAVAILABLE';
+  }
+
+  getHttpStatus(): number {
+    return HttpStatus.BAD_GATEWAY;
+  }
+}
+
 export class UnauthorizedError extends ApplicationException {
   constructor(message: string) {
     super(message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@fastify/session": "^11.1.0",
         "@fastify/static": "^8.2.0",
         "@fastify/swagger-ui": "^5.2.3",
+        "@google-analytics/data": "^7.0.0",
         "@medusajs/js-sdk": "latest",
         "@medusajs/types": "latest",
         "@neondatabase/serverless": "^1.0.1",
@@ -4067,6 +4068,164 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@google-analytics/data": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@google-analytics/data/-/data-7.0.0.tgz",
+      "integrity": "sha512-pAucE4Ek6i6KDprqYXioAhKl2aiKUuM6i2IThOtZV/Andr95+XF3fBsUW67MgT1a+LcwJTCCJLhabzZWGDp9pA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-gax": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/gcp-metadata": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-9.0.3.tgz",
+      "integrity": "sha512-2YYnIlHaKBGT2IPg3G2M57hia9Galz15zsEOvw9T3oRf0lSn6KN6VcHQLqby7x8ksYKnjXvp3rp2KJyLCN6zfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.1.3",
+        "google-logging-utils": "^2.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/google-auth-library": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.2.tgz",
+      "integrity": "sha512-vzpgPutxrghPsnjrjpzLX2bdv8IOL719Rh0oEjGnQu8YCIbnbMuTTQ5zU9LcKvLdOPgCxBwppbvnhgW90Qna5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "^9.0.0",
+        "google-logging-utils": "^2.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/google-gax": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-6.0.3.tgz",
+      "integrity": "sha512-VD7ce93s2XJD/OmWOmCN+/abDmMv1AoQWLaagogLpVT5PF5YRpsTGsfaV/MHJlD60RIhuhKs/2FTkzNPN6UbPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "^11.0.0",
+        "google-logging-utils": "^2.0.0",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^4.0.0",
+        "protobufjs": "^7.5.4",
+        "retry-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/google-logging-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-2.0.1.tgz",
+      "integrity": "sha512-HMhaQghlOTvbcb3c4T5jmmOMtG3JUF1iOQMezaJXL86CDS+Tm2vHd0IeLFRAx3+ewd+bo9E1HFHoy17X5aJa9A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/proto3-json-serializer": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-4.0.2.tgz",
+      "integrity": "sha512-VUQlb/J2WjOG8BKhdLwJUz+MKxSMtBGYh+TaNmRtiYVhlIzXjzeAGIx7gtc3lXlA2iURzfF2+cXaQvC2ofwzpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/retry-request": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-9.0.1.tgz",
+      "integrity": "sha512-4kGHEBl0ME6gR+8QB1sPMyg58jUxLUcCZNeqLDrfqzk0eWQN8XJFmeu7fmZCjlZCRW0S2u64Ik1HkO/0sWgCYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@google-analytics/data/node_modules/teeny-request": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-11.0.1.tgz",
+      "integrity": "sha512-bNr5j2YjSdajgCVsp+8JVjRf1uHIbpNISLeKp/7V1NnVMX3Gh6H/kECNGlm2Q3I68ACODQ0iv6aZ3Rvm8WgLGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@google-cloud/firestore": {
@@ -15988,7 +16147,6 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
       "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
@@ -24162,7 +24320,6 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 6"
       }
@@ -31315,7 +31472,6 @@
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "stubs": "^3.0.0"
       }
@@ -31324,8 +31480,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -31604,8 +31759,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/styled-components": {
       "version": "6.3.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21140,6 +21140,30 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/itdoc/node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/itdoc/node_modules/yargs": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
@@ -21167,6 +21191,18 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/itdoc/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/iterare": {

--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
     "@fastify/session": "^11.1.0",
     "@fastify/static": "^8.2.0",
     "@fastify/swagger-ui": "^5.2.3",
+    "@google-analytics/data": "^7.0.0",
     "@medusajs/js-sdk": "latest",
     "@medusajs/types": "latest",
     "@neondatabase/serverless": "^1.0.1",

--- a/scripts/security/idor-reviewed.spec.ts
+++ b/scripts/security/idor-reviewed.spec.ts
@@ -73,6 +73,12 @@ const IDOR_REVIEWED: Record<string, { verdict: Verdict; evidence: string; predic
     predicate: '@UseGuards(JwtAuthGuard)',
     note: '고객·멤버십 전사 집계 — 개별 고객 식별자를 받지 않고 등급/버킷 단위로만 반환. 컨트롤러 클래스에 JwtAuthGuard.',
   },
+  'analytics GET /statistics/traffic': {
+    verdict: 'N/A',
+    evidence: 'apps/analytics/src/features/traffic/api/traffic.controller.ts:15',
+    predicate: '@UseGuards(JwtAuthGuard, AdminRealmGuard)',
+    note: 'GA4 유입 통계(세션·랜딩페이지·기기·국가) — 쿼리 파라미터가 날짜/채널그룹/limit 뿐이고 응답도 전사 집계라 IDOR 대상 아님. 컨트롤러 클래스에 JwtAuthGuard + AdminRealmGuard(staff role 강제).',
+  },
   'core GET /library/ownerships': {
     verdict: 'SAFE',
     evidence: 'apps/core/src/modules/library/services/ownership.service.ts:56',
@@ -656,15 +662,15 @@ const keyOf = (r: AuditRow): string => `${r.app} ${r.verb} ${r.route}`;
 describe('IDOR 검사 대상 집합', () => {
   it('감사 스크립트가 idorTarget 을 내보낸다', () => {
     const targets = runAudit().filter((r) => r.idorTarget);
-    expect(targets).toHaveLength(102);
+    expect(targets).toHaveLength(103);
   });
 
   // search 와 analytics 가 둘 다 `GET /health` 다. `<VERB> <route>` 로 키를 만들면
   // 97건이 96개로 뭉개지고 스냅샷이 한 건을 조용히 잃는다.
   it('키에 app 이 들어가야 충돌하지 않는다', () => {
     const targets = runAudit().filter((r) => r.idorTarget);
-    expect(new Set(targets.map(keyOf)).size).toBe(102);
-    expect(new Set(targets.map((r) => `${r.verb} ${r.route}`)).size).toBe(101);
+    expect(new Set(targets.map(keyOf)).size).toBe(103);
+    expect(new Set(targets.map((r) => `${r.verb} ${r.route}`)).size).toBe(102);
   });
 
   it('감사 스크립트의 대상 집합과 명단이 정확히 일치한다', () => {

--- a/scripts/security/idor-reviewed.spec.ts
+++ b/scripts/security/idor-reviewed.spec.ts
@@ -73,6 +73,12 @@ const IDOR_REVIEWED: Record<string, { verdict: Verdict; evidence: string; predic
     predicate: '@UseGuards(JwtAuthGuard)',
     note: '고객·멤버십 전사 집계 — 개별 고객 식별자를 받지 않고 등급/버킷 단위로만 반환. 컨트롤러 클래스에 JwtAuthGuard.',
   },
+  'analytics GET /statistics/customers/insights': {
+    verdict: 'N/A',
+    evidence: 'apps/analytics/src/features/statistics/api/customer-insights.controller.ts:15',
+    predicate: '@UseGuards(JwtAuthGuard, AdminRealmGuard)',
+    note: '구매 기반 고객 분석(코호트·RFM·재구매·등급전환) — 쿼리 파라미터가 날짜/limit/minBuyers 뿐이고 응답도 버킷·집계 단위(개별 고객 식별자 없음)라 IDOR 대상 아님. 컨트롤러 클래스에 JwtAuthGuard + AdminRealmGuard(staff role 강제).',
+  },
   'analytics GET /statistics/traffic': {
     verdict: 'N/A',
     evidence: 'apps/analytics/src/features/traffic/api/traffic.controller.ts:15',
@@ -662,15 +668,15 @@ const keyOf = (r: AuditRow): string => `${r.app} ${r.verb} ${r.route}`;
 describe('IDOR 검사 대상 집합', () => {
   it('감사 스크립트가 idorTarget 을 내보낸다', () => {
     const targets = runAudit().filter((r) => r.idorTarget);
-    expect(targets).toHaveLength(103);
+    expect(targets).toHaveLength(104);
   });
 
   // search 와 analytics 가 둘 다 `GET /health` 다. `<VERB> <route>` 로 키를 만들면
   // 97건이 96개로 뭉개지고 스냅샷이 한 건을 조용히 잃는다.
   it('키에 app 이 들어가야 충돌하지 않는다', () => {
     const targets = runAudit().filter((r) => r.idorTarget);
-    expect(new Set(targets.map(keyOf)).size).toBe(103);
-    expect(new Set(targets.map((r) => `${r.verb} ${r.route}`)).size).toBe(102);
+    expect(new Set(targets.map(keyOf)).size).toBe(104);
+    expect(new Set(targets.map((r) => `${r.verb} ${r.route}`)).size).toBe(103);
   });
 
   it('감사 스크립트의 대상 집합과 명단이 정확히 일치한다', () => {


### PR DESCRIPTION
통계 라운드 3 — 두 탭 신설.

## 유입 탭 (GA4 Data API)
- GET /statistics/traffic — 일별 세션 추이, 랜딩페이지별(세션·비중·참여율), 기기·국가별. 자연검색/전체 채널그룹 필터
- GA4 클라이언트는 첫 조회 때 지연 생성 — env 미배선 환경에서도 부팅되고 enabled=false 응답(화면은 "연동 대기")
- GA4 호출 실패는 502(UpstreamUnavailableError) 로 구분, 쿼터 보호용 서버 5분 캐시 + 프론트 staleTime 5분
- GA4 bounceRate 는 UA 와 정의가 달라 화면 라벨은 "참여율"(참여 세션 ÷ 전체 세션)로 표기
- env(GA4_SERVICE_ACCOUNT·GA4_PROPERTY_ID) 배선은 develop 에 이미 머지·배포된 것을 그대로 읽음 — 이 PR 에 인프라 변경 없음

## 고객 분석 탭
- GET /statistics/customers/insights — 코호트 리텐션(종료일 기준 최근 12개월 첫구매), RFM 분포·세그먼트(전 고객), 상품별 재구매율·평균 재구매 주기(전 기간 누적), 기간 내 멤버십 등급 전환(SCD-2 시점 조인)
- RFM 은 R×F 모든 셀이 정확히 하나의 세그먼트에 속해 세그먼트 합 = 전체 고객
- 등급 전환은 실시간 수집 이전 이력이 없어 과거 과소집계 — 화면에 명시

## 공통
- 신설 라우트는 JwtAuthGuard + AdminRealmGuard (staff role 강제) — 기존 통계 라우트는 변경 없음
- 통계 날짜 파라미터를 달력 실재 검증으로 통일 (2026-02-31 류가 500 대신 400)
- 검증: 유닛 13건 + 실 Postgres 통합 5건, 실부팅 HTTP(401/403/400/200·기존 라우트 회귀 없음), 기존 4탭 화면 불변