### PR TITLE
fix(inventory): 서울 당일 판정 이중 변환 + 입고계획 생성 락 (#724 항목 11·10-a)

### DIFF
--- a/apps/core/src/modules/inventory/inbound/services/inbound-plan-concurrent-create.integration.spec.ts
+++ b/apps/core/src/modules/inventory/inbound/services/inbound-plan-concurrent-create.integration.spec.ts
@@ -1,0 +1,125 @@
+import { randomUUID } from 'crypto';
+import { eq } from 'drizzle-orm';
+import * as postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { DbTx, wmsSchema, wmsTables } from '../../schema/inventory.schema';
+import { InboundService } from './inbound.service';
+import { Database, makeInboundService } from './__fixtures__/inbound-harness';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+
+/**
+ * 한 발주에 입고 계획은 하나뿐이다 — **동시 생성에서도** (#724 항목 10-a).
+ *
+ * 이 스펙이 존재하는 이유: `createInboundPlan` 이 발주 행을 잠그지 않고 "계획 있나?" 를
+ * 읽었다. 같은 PO 로 동시 `POST /inbound/plans` 2건이면 둘 다 "없음"을 보고 계획을 2행
+ * 만든다 → 그 PO 전 SKU 의 `inbound_pending` 이 2배가 된다. `ensurePlanForPurchaseOrder`
+ * 는 이미 `FOR UPDATE` 로 막고 있었지만 공개 API 는 그 경로를 안 거친다.
+ *
+ * ⚠️ **커밋형 스펙이다.** 다른 inbound 스펙들의 롤백 하네스로는 이 버그가 재현되지 않는다
+ * (동시 트랜잭션이 필요하다). 선례: stocktaking-scan-product-concurrency.integration.spec.ts.
+ * 그래서 시드 행을 직접 지운다.
+ *
+ * 실행: COMPOSE_PROJECT_NAME=almondyoung-server npm run test:core:integration:local -- inbound-plan-concurrent-create
+ */
+describeIfDb('createInboundPlan 동시 생성 (DB integration, commit-type)', () => {
+  jest.setTimeout(120_000);
+
+  let client: postgres.Sql;
+  let db: Database;
+  let svc: InboundService;
+
+  beforeAll(() => {
+    // 동시 트랜잭션을 재현해야 하므로 커넥션이 여러 개 필요하다.
+    client = postgres(DATABASE_URL as string, { max: 4 });
+    db = drizzle(client, { schema: wmsSchema });
+    svc = makeInboundService(db);
+  });
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  /** Promise.withResolvers 는 이 저장소의 lib 타깃(< es2024)에 없다. */
+  function deferred() {
+    let resolve: () => void = () => undefined;
+    const promise = new Promise<void>((r) => {
+      resolve = r;
+    });
+    return { promise, resolve };
+  }
+
+  async function seedPurchaseOrder() {
+    const suffix = randomUUID();
+    const [warehouse] = await db
+      .insert(wmsTables.warehouses)
+      .values({ name: `cc-wh-${suffix.slice(0, 8)}` })
+      .returning();
+    const [supplier] = await db
+      .insert(wmsTables.suppliers)
+      .values({ name: `cc-supplier-${suffix.slice(0, 8)}` })
+      .returning();
+    const [po] = await db
+      .insert(wmsTables.purchaseOrders)
+      .values({
+        supplierId: supplier.id,
+        type: 'domestic',
+        sourceWarehouseId: warehouse.id,
+        destinationWarehouseId: warehouse.id,
+      })
+      .returning();
+    return { warehouseId: warehouse.id, supplierId: supplier.id, poId: po.id };
+  }
+
+  async function cleanup(ids: { warehouseId: string; supplierId: string; poId: string }) {
+    await db.delete(wmsTables.inboundPlans).where(eq(wmsTables.inboundPlans.linkedPurchaseOrderId, ids.poId));
+    await db.delete(wmsTables.purchaseOrders).where(eq(wmsTables.purchaseOrders.id, ids.poId));
+    await db.delete(wmsTables.suppliers).where(eq(wmsTables.suppliers.id, ids.supplierId));
+    await db.delete(wmsTables.warehouses).where(eq(wmsTables.warehouses.id, ids.warehouseId));
+  }
+
+  it('같은 발주로 동시에 두 번 생성해도 계획은 한 행뿐이다', async () => {
+    const ids = await seedPurchaseOrder();
+    try {
+      const aHeld = deferred();
+      const aEntered = deferred();
+
+      // A: 계획을 만들고 커밋하지 않은 채 붙잡는다.
+      const a = db.transaction(async (txA) => {
+        await svc.createInboundPlan({ linkedPurchaseOrderId: ids.poId }, txA as unknown as DbTx);
+        aEntered.resolve();
+        await aHeld.promise;
+      });
+      await aEntered.promise;
+
+      // B: A 가 아직 커밋하지 않은 동안 같은 발주로 들어온다.
+      const b = db
+        .transaction(async (txB) => svc.createInboundPlan({ linkedPurchaseOrderId: ids.poId }, txB as unknown as DbTx))
+        .then(
+          () => 'created' as const,
+          (e: Error) => e,
+        );
+
+      // 잠금이 없으면 B 는 여기서 이미 끝나 있다(A 의 미커밋 행이 안 보이므로).
+      // 잠금이 있으면 B 는 발주 행에서 막혀 있다.
+      await sleep(300);
+      aHeld.resolve();
+      await a;
+
+      const outcome = await b;
+      expect(outcome).not.toBe('created');
+      expect((outcome as Error).message).toContain('already has an inbound plan');
+
+      const plans = await db
+        .select({ id: wmsTables.inboundPlans.id })
+        .from(wmsTables.inboundPlans)
+        .where(eq(wmsTables.inboundPlans.linkedPurchaseOrderId, ids.poId));
+      expect(plans).toHaveLength(1);
+    } finally {
+      await cleanup(ids);
+    }
+  });
+});

--- a/apps/core/src/modules/inventory/inbound/services/inbound.service.same-day-cancel.integration.spec.ts
+++ b/apps/core/src/modules/inventory/inbound/services/inbound.service.same-day-cancel.integration.spec.ts
@@ -1,0 +1,148 @@
+import { randomUUID } from 'crypto';
+import { eq } from 'drizzle-orm';
+import * as postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { DbTx, wmsSchema, wmsTables } from '../../schema/inventory.schema';
+import { InboundService } from './inbound.service';
+import { Database, inRollbackTx, makeInboundService } from './__fixtures__/inbound-harness';
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+
+/**
+ * 당일 취소 판정이 **서울 달력 날짜**를 보는지 고정한다 (#724 항목 11 / 발견 ⑪).
+ *
+ * 이 스펙이 존재하는 이유: 판정이 `isSameSeoulDay(nowSeoul(), occurredAt)` 이라 왼쪽에만
+ * 오프셋이 두 번 먹었다. 라이브(UTC 프로세스)에서 **KST 15:00~24:00 의 당일 취소가 전부 400** 이었다.
+ *
+ * ⚠️ **이 스펙은 서울 머신에서는 아무것도 증명하지 못한다.** `toZonedTime` 이 런타임 TZ 에
+ * 상대적이라 `Asia/Seoul` 에서는 이중 변환이 항등이 되고, 고치기 전 코드도 통과한다.
+ * jest 안에서 `process.env.TZ` 를 바꾸는 것도 무효다(실측 — 할당해도 오프셋이 안 바뀐다).
+ * **TZ 는 프로세스를 띄울 때 박아야 한다.** CI 러너와 라이브가 UTC 이므로 방어력은 CI 에서 나온다.
+ *
+ * 벽시계는 가짜 타이머로 못 박는다 — 판정이 `new Date()` 를 쓰므로 실행 시각이 새어 들어오면
+ * 스펙이 거짓말한다. 타이머 API 는 그대로 둔다(postgres.js 가 진짜 타이머를 쓴다).
+ *
+ * 로컬 실행(서울 머신에서 의미 있게 돌리려면 TZ 를 직접 박을 것):
+ *   TZ=UTC DATABASE_URL=postgresql://postgres:postgres@localhost:5432/core \
+ *     npx jest --testPathPattern=same-day-cancel.integration --runInBand
+ */
+describeIfDb('InboundService.cancelInbound 당일 판정 (PostgreSQL integration)', () => {
+  jest.setTimeout(120_000);
+
+  let client: postgres.Sql;
+  let db: Database;
+  let svc: InboundService;
+
+  /** KST 2026-08-25 23:00 — 이중 변환이면 KST 08-26 08:00 로 밀려 "어제"가 된다. */
+  const NOW = new Date('2026-08-25T14:00:00Z');
+
+  beforeAll(() => {
+    client = postgres(DATABASE_URL as string, { max: 1 });
+    db = drizzle(client, { schema: wmsSchema });
+    svc = makeInboundService(db);
+  });
+
+  afterAll(async () => {
+    await client.end();
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers({
+      doNotFake: [
+        'setTimeout',
+        'clearTimeout',
+        'setInterval',
+        'clearInterval',
+        'setImmediate',
+        'clearImmediate',
+        'nextTick',
+        'queueMicrotask',
+        'performance',
+        'hrtime',
+      ],
+    });
+    jest.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  async function seedReceivedLine(tx: DbTx, occurredAt: Date) {
+    const suffix = randomUUID();
+    const [warehouse] = await tx
+      .insert(wmsTables.warehouses)
+      .values({ name: `sdc-wh-${suffix.slice(0, 8)}` })
+      .returning();
+    const [holder] = await tx
+      .insert(wmsTables.holders)
+      .values({ name: `sdc-holder-${suffix.slice(0, 8)}` })
+      .returning();
+    const [sku] = await tx
+      .insert(wmsTables.skus)
+      .values({ name: 'sdc sku', code: `SDC-${suffix}`, holderId: holder.id })
+      .returning();
+    const [supplier] = await tx
+      .insert(wmsTables.suppliers)
+      .values({ name: `sdc-supplier-${suffix.slice(0, 8)}` })
+      .returning();
+    const [po] = await tx
+      .insert(wmsTables.purchaseOrders)
+      .values({
+        supplierId: supplier.id,
+        type: 'domestic',
+        sourceWarehouseId: warehouse.id,
+        destinationWarehouseId: warehouse.id,
+      })
+      .returning();
+    const [plan] = await tx
+      .insert(wmsTables.inboundPlans)
+      .values({
+        warehouseId: warehouse.id,
+        destinationWarehouseId: warehouse.id,
+        linkedPurchaseOrderId: po.id,
+        status: 'pending',
+      })
+      .returning();
+    const [item] = await tx
+      .insert(wmsTables.inboundPlanItems)
+      .values({ planId: plan.id, skuId: sku.id, expectedQty: 20, receivedQty: 0, status: 'pending' })
+      .returning();
+
+    const received = await svc.receiveFromPlan({ planItemId: item.id, quantity: 20, idempotencyKey: randomUUID() }, tx);
+
+    // 영수증 시각을 못 박는다 — 실행 시각이 판정에 새어 들어오면 스펙이 거짓말한다.
+    const line = await tx.query.inboundReceiptLines.findFirst({
+      where: eq(wmsTables.inboundReceiptLines.id, received.lineId),
+    });
+    await tx
+      .update(wmsTables.inboundReceipts)
+      .set({ occurredAt })
+      .where(eq(wmsTables.inboundReceipts.id, line!.receiptId));
+
+    return { lineId: received.lineId };
+  }
+
+  it('서울 기준 같은 날이면 KST 23:00 에도 취소된다', async () => {
+    await inRollbackTx(db, async (tx) => {
+      // KST 2026-08-25 00:30 — NOW 와 같은 서울 날짜다.
+      const { lineId } = await seedReceivedLine(tx, new Date('2026-08-24T15:30:00Z'));
+
+      await expect(
+        svc.cancelInbound({ lineId, quantity: 20, idempotencyKey: randomUUID() }, tx),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  it('서울 기준 전날이면 거부한다', async () => {
+    await inRollbackTx(db, async (tx) => {
+      // KST 2026-08-24 23:30 — NOW 의 전날이다.
+      const { lineId } = await seedReceivedLine(tx, new Date('2026-08-24T14:30:00Z'));
+
+      await expect(svc.cancelInbound({ lineId, quantity: 20, idempotencyKey: randomUUID() }, tx)).rejects.toThrow(
+        'cancel is allowed only on the same day (Asia/Seoul)',
+      );
+    });
+  });
+});

--- a/apps/core/src/modules/inventory/inbound/services/inbound.service.ts
+++ b/apps/core/src/modules/inventory/inbound/services/inbound.service.ts
@@ -21,7 +21,7 @@ import {
   ListPlanItemsQueryDto,
   InboundPendingListResponse,
 } from '../dto/simple-inbound.dto';
-import { isSameSeoulDay, nowSeoul } from '../../shared/services/time.util';
+import { isTodaySeoul } from '../../shared/services/time.util';
 import { SupplierResponseDto } from '../../suppliers/dto/supplier-response.dto';
 
 @Injectable()
@@ -647,6 +647,12 @@ export class InboundService {
     return this.dbService.run(async (trx) => {
       const { purchaseOrders } = wmsTables;
 
+      // 발주 행을 잠근 뒤에 계획 존재를 읽는다. 잠그지 않으면 같은 PO 로 동시에 들어온
+      // 두 요청이 둘 다 "계획 없음"을 보고 계획을 2행 만든다 → 그 PO 전 SKU 의
+      // inbound_pending 2배(#724 항목 10-a). 유니크 제약 대신 락인 이유는 아래 주석 참조.
+      // 잠금 불변식: **PO 행 → 라인 행** 순서. 여기는 PO 만 잠그므로 순서를 깨지 않는다.
+      // ensurePlanForPurchaseOrder 는 같은 트랜잭션에서 이미 이 행을 잠그고 들어오는데,
+      // 같은 행 재잠금은 no-op 이라 자기 데드락이 없다.
       const [po] = await trx
         .select({
           id: purchaseOrders.id,
@@ -655,7 +661,8 @@ export class InboundService {
         })
         .from(purchaseOrders)
         .where(eq(purchaseOrders.id, dto.linkedPurchaseOrderId))
-        .limit(1);
+        .limit(1)
+        .for('update');
 
       if (!po) {
         throw new NotFoundError(`Purchase order not found: ${dto.linkedPurchaseOrderId}`);
@@ -1071,7 +1078,7 @@ export class InboundService {
         where: eq(wmsTables.inboundReceipts.id, line.receiptId),
       });
       if (!receiptRow) throw new NotFoundException('inbound receipt not found');
-      if (!isSameSeoulDay(nowSeoul(), receiptRow.occurredAt)) {
+      if (!isTodaySeoul(receiptRow.occurredAt)) {
         throw new BadRequestException('cancel is allowed only on the same day (Asia/Seoul)');
       }
 

--- a/apps/core/src/modules/inventory/shared/services/time.util.spec.ts
+++ b/apps/core/src/modules/inventory/shared/services/time.util.spec.ts
@@ -1,0 +1,46 @@
+import { isTodaySeoul } from './time.util';
+
+/**
+ * `isTodaySeoul` — "이 순간이 서울 기준 오늘인가".
+ *
+ * 이 스펙이 존재하는 이유(#724 발견 ⑪): 호출부가 `isSameSeoulDay(nowSeoul(), occurredAt)` 로
+ * 쓰여 **왼쪽에만 서울 오프셋이 두 번** 먹었다. 기준 "오늘"이 9시간 앞서 KST 15:00~24:00 의
+ * 당일 입고 취소가 전부 400 이 됐다.
+ *
+ * ⚠️ **이 판정은 프로세스 TZ 에 민감하고, 그 민감함은 스펙 안에서 못 없앤다.**
+ * `toZonedTime` 은 런타임 TZ 에 상대적이라 개발 머신(Asia/Seoul)에서는 이중 변환이 항등이 돼
+ * 버그가 사라진다. 그리고 **jest 안에서 `process.env.TZ` 를 바꾸는 것은 무효다** — 실측했다
+ * (할당해도 `getTimezoneOffset()` 이 -540 그대로). TZ 는 프로세스를 띄울 때 박아야 한다.
+ * CI 러너와 라이브(ECS/Lambda)가 UTC 이므로 **이 스펙의 방어력은 CI 에서 나온다.**
+ * 서울 머신에서 로컬로 돌리면 통과하지만 아무것도 증명하지 못한다.
+ */
+describe('isTodaySeoul', () => {
+  // KST = UTC+9. 아래 주석의 KST 시각이 이 스펙이 말하려는 바다.
+  const NOW_KST_2300 = new Date('2026-08-25T14:00:00Z'); // KST 2026-08-25 23:00
+
+  it('같은 서울 날짜의 새벽 영수증을 밤 11시에도 오늘로 본다', () => {
+    const occurred = new Date('2026-08-24T15:30:00Z'); // KST 2026-08-25 00:30
+    expect(isTodaySeoul(occurred, NOW_KST_2300)).toBe(true);
+  });
+
+  it('서울 자정 정각은 그 날에 속한다', () => {
+    const occurred = new Date('2026-08-24T15:00:00Z'); // KST 2026-08-25 00:00:00
+    expect(isTodaySeoul(occurred, NOW_KST_2300)).toBe(true);
+  });
+
+  it('서울 기준 전날 밤 영수증은 오늘이 아니다', () => {
+    const occurred = new Date('2026-08-24T14:30:00Z'); // KST 2026-08-24 23:30
+    expect(isTodaySeoul(occurred, NOW_KST_2300)).toBe(false);
+  });
+
+  it('KST 15:00 이후에도 같은 날 영수증을 오늘로 본다 (이중 변환 회귀 고정)', () => {
+    // 이중 변환 시 now 가 KST 24:00 으로 밀려 다음 날이 되고, 이 판정이 false 로 뒤집힌다.
+    const now = new Date('2026-08-25T06:00:00Z'); // KST 15:00
+    const occurred = new Date('2026-08-25T05:00:00Z'); // KST 14:00
+    expect(isTodaySeoul(occurred, now)).toBe(true);
+  });
+
+  it('now 를 생략하면 실제 벽시계를 쓴다', () => {
+    expect(isTodaySeoul(new Date())).toBe(true);
+  });
+});

--- a/apps/core/src/modules/inventory/shared/services/time.util.ts
+++ b/apps/core/src/modules/inventory/shared/services/time.util.ts
@@ -17,3 +17,17 @@ export function isSameSeoulDay(a: Date | string | number, b: Date | string | num
 export function nowSeoul(): Date {
   return toSeoulTime(new Date());
 }
+
+/**
+ * 이 순간이 **서울 기준 오늘**인가.
+ *
+ * `isSameSeoulDay(nowSeoul(), x)` 로 쓰지 말 것 — `nowSeoul()` 은 이미 시프트된 Date 라
+ * 오프셋이 두 번 먹고 기준 "오늘"이 9시간 앞선다(#724 발견 ⑪: KST 15:00~24:00 의 당일
+ * 입고 취소가 전부 400 이었다). 그 오용이 불가능하도록 이 함수가 `now` 를 직접 만든다.
+ *
+ * @param instant 판정 대상 — **진짜 순간**(UTC 기준 Date). 시프트된 값을 넘기지 말 것.
+ * @param now 기준 시각. 스펙에서 벽시계를 고정할 때만 넘긴다.
+ */
+export function isTodaySeoul(instant: Date | string | number, now: Date = new Date()): boolean {
+  return isSameSeoulDay(instant, now);
+}

--- a/docs/superpowers/plans/2026-08-25-seoul-day-and-plan-lock.md
+++ b/docs/superpowers/plans/2026-08-25-seoul-day-and-plan-lock.md
@@ -1,0 +1,144 @@
+# 서울 당일 판정 이중 변환 + 입고계획 생성 락 (#724 항목 11 · 10-a)
+
+- 이슈: #724 항목 **11**(발견 ⑪) · 항목 **10-a**(파킹 1)
+- 근거 문서: `docs/inventory-procurement-audit-2026-08.md` §2 ⑪ / `2026-08-25-purchase-order-line-lifecycle.md` "남은 것"
+- 마이그레이션: **0건**
+- 범위: `apps/core` 백엔드만. admin-web 변경 없음.
+- 왜 둘을 같이: 서로 독립이고 둘 다 작다. 10-a 는 항목 12(admin-web 라인 실행 UI)의 **선행**이라
+  12 착수 전에 들어가 있어야 한다.
+
+## 항목 11 — `isSameSeoulDay(nowSeoul(), …)` 이중 변환
+
+### 증상
+
+`POST /inbound/receipts/:id/cancel` 계열의 당일 취소가 **KST 15:00~24:00 에 전부 400**
+(`cancel is allowed only on the same day (Asia/Seoul)`). 창고 저녁 근무 시간과 정확히 겹친다.
+
+### 기전
+
+`apps/core/src/modules/inventory/inbound/services/inbound.service.ts:1074`
+
+```ts
+if (!isSameSeoulDay(nowSeoul(), receiptRow.occurredAt)) { … }
+```
+
+- `nowSeoul()` = `toZonedTime(new Date(), 'Asia/Seoul')` — **이미 시프트된 Date** 를 돌려준다.
+- `isSameSeoulDay` 는 두 인자에 각각 `toSeoulTime` 을 **다시** 건다.
+- 그래서 왼쪽만 오프셋이 두 번 먹는다. 프로세스 TZ 가 UTC 면 `now + 18h` vs `occurredAt + 9h`
+  → **기준 "오늘"이 9시간 앞선다.** KST 15:00 부터 다음 날로 넘어가 당일 영수증이 어제가 된다.
+
+### ⚠️ 로컬에서는 재현되지 않는다
+
+`toZonedTime` 은 **런타임 TZ 에 상대적**이다. 개발 머신은 `Asia/Seoul` 이라 두 번 걸어도
+사실상 항등이고 버그가 사라진다. 라이브(ECS/Lambda)는 UTC 라 터진다.
+**따라서 스펙은 `TZ=UTC` 를 강제해야 하고, 그러지 않으면 RED 단계가 거짓 GREEN 이 된다.**
+
+### 고칠 방법
+
+호출부만 고치면(`isSameSeoulDay(new Date(), …)`) 같은 오용이 언제든 재발한다 — `nowSeoul()` 은
+export 돼 있고 이름이 "지금"이라 자연스럽게 손이 간다. 그래서 **오용이 불가능한 표면**을 만든다:
+
+```ts
+/** 인자는 '진짜 순간'(UTC 기준 Date)이어야 한다. nowSeoul() 을 넘기지 말 것 — 이중 변환된다. */
+export function isTodaySeoul(instant: Date | string | number, now: Date = new Date()): boolean
+```
+
+- 호출부는 `isTodaySeoul(receiptRow.occurredAt)` 하나로 줄어 `nowSeoul()` 을 아예 안 만진다.
+- `now` 를 주입 가능하게 둬 스펙이 벽시계를 고정할 수 있다.
+- `isSameSeoulDay` 자체는 **원시 순간 두 개에 대해서는 옳다** — 건드리지 않고 경고 주석만 단다.
+
+## 항목 10-a — `createInboundPlan` 에 `FOR UPDATE` 없음
+
+`inbound.service.ts:646` 의 `createInboundPlan` 은 PO 를 잠그지 않고 읽은 뒤
+`inbound_plans` 존재를 검사하고 insert 한다. 같은 PO 로 동시 `POST /inbound/plans` 2건이면
+둘 다 "계획 없음"을 보고 **계획 2행**을 만든다 → 그 PO 전 SKU 의 `inbound_pending` 2배.
+
+`ensurePlanForPurchaseOrder` (`:709`) 는 이미 PO 를 `.for('update')` 로 잠그고 같은 검사를
+하지만, 공개 `POST /inbound/plans` 는 그 경로를 안 거친다. 유니크 제약을 안 쓰는 이유는
+기존 주석이 소유한다(라이브에 PO 하나당 계획 둘인 행이 남아 있을 수 있어 마이그레이션이
+배포 중 실패할 위험).
+
+**고칠 방법**: PO select 에 `.for('update')` 추가 (1줄).
+
+### 잠금 불변식과의 정합
+
+계획서 "잠금 불변식": **PO 행 → 라인 행 순서로만 잠근다.** 이 편집은 PO 행만 추가로 잠그고
+라인은 안 잠그므로 순서를 깨지 않는다. `ensurePlanForPurchaseOrder` → `createInboundPlan(…, trx)`
+경로는 같은 트랜잭션에서 같은 행을 다시 잠그는 것이라 no-op 이다(자기 데드락 없음).
+
+## 테스트 (TDD — 실제로 일어난 일)
+
+| # | 스펙 | 종류 | RED 가 증명한 것 |
+|---|---|---|---|
+| 1 | `shared/services/time.util.spec.ts` | 유닛 | `isTodaySeoul` 부재(15/15 실패) |
+| 2 | `inbound.service.same-day-cancel.integration.spec.ts` | DB 통합 | **`TZ=UTC` 로 띄웠을 때만** 라이브 400 이 재현됐다 |
+| 3 | `inbound-plan-concurrent-create.integration.spec.ts` | DB 통합, 커밋형 | 두 번째 요청이 계획을 하나 더 만들었다(`created`) |
+
+### 🔴 첫 RED 가 거짓 GREEN 이었다 — 기록해 둔다
+
+2번 스펙을 처음 썼을 때 **수정 없이 통과했다.** 원인은 스펙 안의 TZ 고정이 무효였던 것:
+
+- **jest 안에서 `process.env.TZ` 를 바꿔도 먹지 않는다.** 실측했다 — 할당 전후로
+  `new Date().getTimezoneOffset()` 이 `-540` 그대로고 `Intl…resolvedOptions().timeZone` 도
+  `Asia/Seoul` 그대로다. (jest 밖 순수 node 에서는 런타임 할당이 먹는다 — 그래서 더 헷갈린다.)
+- 개발 머신이 `Asia/Seoul` 이라 `toZonedTime(x, 'Asia/Seoul')` 이 **항등**이 되고,
+  이중 변환과 정상 코드가 **문자 그대로 같은 함수**가 된다. 서울 머신에서는 이 버그를
+  어떤 테스트로도 관측할 수 없다.
+
+**따라서 TZ 는 프로세스를 띄울 때 박아야 한다:**
+
+```bash
+TZ=UTC DATABASE_URL=postgresql://postgres:postgres@localhost:5432/core \
+  npx jest --testPathPattern=same-day-cancel.integration --runInBand
+```
+
+이 스펙의 **방어력은 CI 에서 나온다**(러너가 UTC). 서울 머신 로컬 실행은 통과하지만
+아무것도 증명하지 않는다. 스펙 헤더에 이 사실을 적어 뒀다 — 무효한 TZ 조작 코드를
+남겨 두면 다음 사람이 "고정돼 있네"라고 오독한다.
+
+> 파생 질문(이 PR 범위 밖): **jest 를 UTC 로 띄우는 게 맞지 않나.** 라이브가 UTC 인데
+> 테스트가 KST 로 돌면 이 부류 전체가 로컬에서 안 보인다. `globalSetup` 으로 워커 포크
+> 전에 박으면 되지만, 다른 날짜 스펙들의 폭발 반경을 재야 해서 별도 항목이어야 한다.
+
+## 검증 게이트
+
+- `npm run type-check` → **0** ✅
+- `npx jest --maxWorkers=2` → **470 suite 통과 / 실패 0** (99 suite 는 DB 가드로 skip) ✅
+- DB 통합 스위트 → **내 변경이 만든 실패 0건** (아래 기준선 대조) ✅
+- 신규 2개 스펙을 `TZ=UTC` · `TZ=Asia/Seoul` · `TZ=America/New_York` 에서 각각 실행 → 전부 통과 ✅
+
+### 통합 스위트 기준선 대조 (숫자를 그냥 읽으면 오독한다)
+
+러너 패턴이 `integration` 이라 **다른 서비스 스펙까지 딸려 온다** — analytics·channel-adapter·
+membership 은 각자 DB 가 필요한데 `DATABASE_URL` 은 core 를 가리키므로 통째로 빨갛다.
+전체 19 suite 실패 중 core 는 8 suite 뿐이고, 그중 3개는 전용 scratch DB 를 요구하는
+환경 가드다(`variant_preview_scratch` 등).
+
+**그래서 숫자 대신 기준선과 대조했다** — `git stash -u` 로 변경을 걷어내고 같은 8 suite 를
+같은 DB 에 다시 돌렸다:
+
+| | Test Suites | Tests | 실패 항목명 |
+|---|---|---|---|
+| 기준선(develop) | 8 failed | 12 failed / 12 passed | 13건 |
+| 현재(이 변경 포함) | 8 failed | 12 failed / 12 passed | 13건 |
+
+실패 항목명 13건이 **문자열까지 동일**(diff 결과 없음). 이 변경이 만든 실패는 0건이다.
+
+발주·입고 계열은 전부 초록이다 — `purchase-order-single-plan` · `inbound-plan-port-invariant` ·
+`purchase-order-line-execution` · `cancel-plan-restore` · `plan-receive` + 신규 2개.
+
+## 배포
+
+마이그레이션 0건이므로 `deploy` 만. 순서 제약 없음. 계약 변경 없음(400 이 사라지는 방향이라
+admin-web 은 손댈 것이 없다).
+
+## 범위 밖 — 발견해서 남기는 것
+
+`nowSeoul()` 오용이 **한 군데 더 있다**: `inventory/shared/services/audit.service.ts:311` 이
+`audit_logs.timestamp` 에 `nowSeoul()` 을 그대로 insert 한다 → 라이브 감사 로그의 모든 행이
+**9시간 미래**로 저장되고, 같은 파일의 `fromDate`/`toDate` 필터(진짜 순간)와 어긋난다.
+
+여기서 같이 고치지 않는 이유: 고치는 순간 **옛 행(+9h)과 새 행(정상)이 섞여** 감사 로그 시간축이
+두 벌이 된다. 백필을 할지(어느 시점부터?) 말지가 사람의 결정이라 별도 항목이어야 한다.
+`fulfillment/services/policies.service.ts:27` · `sales-order/services/policies.service.ts:31` 의
+`nowSeoul()` 비교도 같은 부류이나 **세 갈래가 전부 `return policy` 라 죽은 비교**다(무해).


### PR DESCRIPTION
#724 의 **항목 11**(발견 ⑪)과 **항목 10-a**(파킹 1). 둘 다 작고 서로 독립이라 묶었다.
10-a 는 항목 12(admin-web 라인 실행 UI)의 선행이라 12 착수 전에 들어가 있어야 한다.

계획서: [`docs/superpowers/plans/2026-08-25-seoul-day-and-plan-lock.md`](../blob/fix/724-seoul-day-and-plan-lock/docs/superpowers/plans/2026-08-25-seoul-day-and-plan-lock.md)

**마이그레이션 0건 · 계약 변경 없음 · 배포 순서 제약 없음**

---

## 항목 11 — 당일 입고 취소가 저녁마다 400 (지금 라이브에서 사람이 겪는 버그)

`cancelInbound` 의 당일 제한이 `isSameSeoulDay(nowSeoul(), occurredAt)` 이었다.
`nowSeoul()` 은 **이미 시프트된 Date** 를 돌려주는데 `isSameSeoulDay` 가 두 인자에 각각
`toSeoulTime` 을 다시 걸어 **왼쪽만 오프셋이 두 번** 먹었다. 기준 "오늘"이 9시간 앞서
**KST 15:00~24:00 의 당일 취소가 전부 400** 이었다 — 창고 저녁 근무 시간대와 정확히 겹친다.

호출부만 고치면 재발한다(`nowSeoul()` 은 export 돼 있고 이름이 "지금"이라 자연스럽게 손이 간다).
그래서 **오용이 불가능한 표면**을 만들었다 — `isTodaySeoul(instant, now?)` 가 `now` 를 직접
만들고, 호출부는 `nowSeoul()` 을 아예 안 만진다.

## 항목 10-a — 같은 발주로 동시 요청 시 입고계획 2행

`createInboundPlan` 이 발주 행을 잠그지 않고 "계획 있나?" 를 읽어, 동시 요청 둘이 모두
"없음"을 보고 계획을 2행 만들 수 있었다 → 그 PO 전 SKU 의 `inbound_pending` 2배.
`.for('update')` 로 직렬화한다. 유니크 제약 대신 락인 이유는 기존 주석이 소유한다.

**잠금 불변식(PO 행 → 라인 행)은 유지된다** — 이 락은 언제나 트랜잭션의 첫 락이거나 이미
보유한 행의 재잠금(no-op)이라 ABBA 를 만들지 않는다. `lockPurchaseOrderForLineExecution` →
`ensurePlanForPurchaseOrder` → `createInboundPlan` 경로를 코드로 확인했다.

---

## 🔴 리뷰어가 알아야 할 것 — 이 스펙들의 방어력은 CI 에서만 나온다

`toZonedTime` 은 런타임 TZ 에 상대적이라 **개발 머신(Asia/Seoul)에서는 이중 변환이 항등**이
된다. 버그 코드와 정상 코드가 문자 그대로 같은 함수가 되어, 서울 머신에서는 이 버그를 어떤
테스트로도 관측할 수 없다. 게다가 **jest 안에서 `process.env.TZ` 를 바꾸는 것은 무효다**
(실측: 할당 전후로 `getTimezoneOffset()` 이 `-540` 그대로. jest 밖 순수 node 에서는 먹어서
더 헷갈린다).

그래서 **처음 쓴 통합 스펙이 수정 없이 통과했다 — 거짓 GREEN.** `TZ=UTC` 로 프로세스를 띄워서야
라이브 증상이 재현됐고 그게 진짜 RED 였다. 무효한 TZ 조작 코드는 스펙에서 걷어냈다(남기면
다음 사람이 "고정돼 있네"로 오독한다). CI 러너와 라이브가 UTC 라 방어는 CI 가 한다.

서울 머신에서 의미 있게 돌리려면:
```bash
TZ=UTC DATABASE_URL=postgresql://postgres:postgres@localhost:5432/core \
  npx jest --testPathPattern=same-day-cancel.integration --runInBand
```

> **후속 후보(이 PR 범위 밖)**: jest 를 `globalSetup` 으로 UTC 에 띄우면 이 부류 전체가
> 로컬에서도 보인다. 다른 날짜 스펙들의 폭발 반경을 재야 해서 분리했다.

## 🔴 범위 밖으로 남긴 발견 — `audit_logs.timestamp` 가 9시간 미래다

`inventory/shared/services/audit.service.ts:311` 이 `audit_logs.timestamp` 에 `nowSeoul()` 을
그대로 insert 한다 → **라이브 감사 로그 전 행이 +9h** 이고, 같은 파일의 `fromDate`/`toDate`
필터(진짜 순간)와 어긋난다. 같은 뿌리지만 여기서 안 고쳤다 — 고치는 순간 옛 행(+9h)과 새 행
(정상)이 섞여 시간축이 두 벌이 되고, 백필 여부·기준 시점이 사람 결정이라 별도 항목이어야 한다.

(`fulfillment`/`sales-order` 의 `policies.service.ts` 도 같은 부류이나 **세 갈래가 전부
`return policy` 라 죽은 비교**다 — 무해.)

---

## 검증

| 게이트 | 결과 |
|---|---|
| `npm run type-check` | **0** |
| `npx jest --maxWorkers=2` | **470 suite 통과 / 실패 0** |
| DB 통합 스위트 | **이 변경이 만든 실패 0건** (아래) |
| 신규 스펙 × TZ 3종(UTC·Seoul·NY) | 전부 통과 |
| eslint (신규 파일) | 0 |

### 통합 스위트는 숫자만 보면 오독한다

러너 패턴이 `integration` 이라 **타 서비스 스펙까지 딸려 온다** — analytics·channel-adapter·
membership 은 각자 DB 가 필요한데 `DATABASE_URL` 은 core 를 가리키므로 통째로 빨갛다. 전체
19 suite 실패 중 core 는 8 suite 뿐이고 그중 3개는 전용 scratch DB 를 요구하는 환경 가드다.

**그래서 숫자 대신 기준선을 직접 떴다** — `git stash -u` 로 변경을 걷어내고 같은 8 suite 를
같은 DB 에 다시 돌렸다:

| | Test Suites | Tests | 실패 항목명 |
|---|---|---|---|
| 기준선(develop) | 8 failed | 12 failed / 12 passed | 13건 |
| 이 PR | 8 failed | 12 failed / 12 passed | 13건 |

실패 항목명 13건이 **문자열까지 동일**(diff 결과 없음). 발주·입고 계열은 전부 초록이다 —
`purchase-order-single-plan` · `inbound-plan-port-invariant` · `purchase-order-line-execution` ·
`cancel-plan-restore` · `plan-receive` + 신규 2개.

https://claude.ai/code/session_017u3vzwKZKxYUZbhnEmFcvf