### PR TITLE
fix(deps): package-lock 재동기화 — develop 의 npm ci 복구

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20982,6 +20982,30 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/itdoc/node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/itdoc/node_modules/yargs": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
@@ -21009,6 +21033,18 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/itdoc/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/iterare": {
@@ -26579,15 +26615,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
-    },
-    "node_modules/redoc-cli/node_modules/@types/mkdirp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
-      "integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
-      "extraneous": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/redoc-cli/node_modules/@types/node": {
       "version": "15.12.2",


### PR DESCRIPTION
## 지금 develop 이 빨갛다

`e03109cbb` (`feat(search): 자모 변환 기능 추가`) 가 `es-hangul` 을 `package.json` 에 추가하면서
`package-lock.json` 에서 `itdoc` 의 중첩 의존 `ws@8.21.3` 과 `zod@3.25.76` 항목을 **함께 지웠다.**
그 뒤로 CI 가 14초 만에 설치 단계에서 죽는다:

```
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json ... are in sync.
npm error Missing: ws@8.21.3 from lock file
npm error Missing: zod@3.25.76 from lock file
```

**develop 이 그 커밋 이후 4연속 실패**하고 있고, 마지막 초록은 `c084d5e1d` 다.

| 커밋 | gates |
|---|---|
| `cc96d9c53` feat(text): NFD 정규화… | ❌ |
| `81e7e4a34` test: toJamo 테스트 추가 | ❌ |
| `7ffcbcc43` feat(search): 검색 키워드 통계 (#730) | ❌ |
| `e03109cbb` feat(search): 자모 변환 ← **여기서 깨졌다** | ❌ |
| `c084d5e1d` feat(analytics): GA4 … | ✅ |

**설치 단계에서 죽으므로 `type-check` 도 `jest` 도 아예 돌지 않는다.** 열려 있는 모든 PR 이
merge ref 를 통해 같은 파손을 물려받는다 — 즉 지금 어떤 PR 의 초록/빨강도 의미가 없다.

## 이 PR

`npm install --package-lock-only` 로 락만 재생성했다. **`package.json` 은 손대지 않았다.**
변경은 셋뿐이다:

- `node_modules/itdoc/node_modules/ws` 복원 (dev · optional · peer)
- `node_modules/itdoc/node_modules/zod` 복원 (dev · optional · peer)
- `node_modules/redoc-cli/node_modules/@types/mkdirp` 의 `extraneous: true` 잔여 항목 제거

**실제 의존성 버전이 오르내린 것은 없다** — 위 셋 외에 `version` 이 바뀐 줄이 diff 에 없다
(`git diff package-lock.json | grep -E '^[+-]\s+"version"'` 이 3줄뿐이고 전부 위 항목들이다).

## 검증

- `npm ci --dry-run` 통과 (`added 109 packages`)
- 로컬 `npm run type-check` → 0
- 로컬 `npx jest --maxWorkers=2` → 473 suite 통과 / 실패 0

## 왜 별도 PR 인가

#732 (발주 당일취소·입고계획 락) 를 작업하다 CI 가 이 이유로 빨간 것을 발견했다. 의존성 변경을
버그 수정 PR 에 섞으면 리뷰어가 문맥을 잃고, 이 파손은 #732 보다 넓은 범위(모든 열린 PR)를
막고 있어서 따로 뗐다. **이게 먼저 머지돼야 #732 의 CI 결과가 의미를 갖는다.**

https://claude.ai/code/session_017u3vzwKZKxYUZbhnEmFcvf