### PR TITLE
fix(search): 쿠키로 오는 관리자 인증이 전부 401 나던 문제 수정

### DIFF
--- a/apps/search/src/main.ts
+++ b/apps/search/src/main.ts
@@ -3,6 +3,7 @@ import { Logger, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { mountEventChainContext, EventsModule, createKafkaConfigFromEnv } from '@app/events';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import fastifyCookie from '@fastify/cookie';
 import { Logger as PinoLogger } from 'nestjs-pino';
 import { SearchModule } from './search.module';
 
@@ -16,6 +17,12 @@ async function bootstrap() {
   // 다른 chainId 를 받는다. 다른 미들웨어·전역 파이프보다 앞이어야 한다.
   mountEventChainContext(app);
   app.useLogger(app.get(PinoLogger));
+
+  // admin-web 프록시는 인증을 Authorization 헤더가 아니라 accessToken 쿠키로 넘긴다.
+  // 이 등록이 없으면 req.cookies 가 undefined 라 JwtAccessStrategy 의 쿠키 추출이
+  // 조용히 실패해 관리자 라우트가 전부 401 이 된다 (analytics main.ts 와 같은 배선).
+  await app.register(fastifyCookie);
+
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,


### PR DESCRIPTION
라이브 통계 '검색 키워드' 탭이 "통계를 불러오지 못했습니다"로 뜨는 원인 수정.

- admin-web 프록시(forward.ts)는 인증을 Authorization 헤더가 아니라 accessToken 쿠키로 넘긴다
- search 앱은 Fastify 에 @fastify/cookie 를 등록하지 않아 req.cookies 가 undefined → JwtAccessStrategy 의 쿠키 추출이 조용히 실패 → 관리자 라우트 전부 401
- analytics(다른 탭들이 정상이던 이유)와 같은 배선으로 등록

로컬 실부팅 검증: 수정 전 쿠키 401 / Bearer 200 재현 → 수정 후 쿠키 admin 200 · 고객 토큰 403 · 무토큰 401 · 공개 검색/트렌딩/추천 무인증 200 불변.

배포는 ServicesBundleB 만 다시 나가면 된다.