### PR TITLE
fix(categories): 카테고리 이름만 고쳐도 스토어프론트 순서가 밀리던 문제 수정

### DIFF
--- a/apps/channel-adapter/src/adapters/medusa/medusa.client.spec.ts
+++ b/apps/channel-adapter/src/adapters/medusa/medusa.client.spec.ts
@@ -1011,8 +1011,7 @@ describe('MedusaClient.refreshCustomerCartPrices', () => {
 });
 
 describe('MedusaClient.ensureCategoryFromSnapshot 부모 갱신', () => {
-  // currentParent = Medusa 에 저장돼 있는 현재 부모. 부모 갱신은 이 값과 다를 때만
-  // payload 에 실린다 (같은 값을 다시 보내면 Medusa 가 형제 맨 뒤로 재배치한다).
+  // currentParent = Medusa 에 저장된 현재 부모. 이 값과 다를 때만 payload 에 실린다.
   function makeCategoryClient(parentLookup: { id: string } | null, currentParent: string | null = 'pcat_old_parent') {
     const update = jest.fn().mockResolvedValue({ product_category: { id: 'pcat_child' } });
     const client = Object.create(MedusaClient.prototype) as MedusaClient;
@@ -1222,10 +1221,7 @@ describe('MedusaClient.ensureCategoryFromSnapshot 상품 경로는 필드를 건
   });
 })
 
-/**
- * rank·parent 는 형제 순서를 흔든다. 단건 갱신은 둘 다 건드리지 않아야 한다 —
- * 이름만 고쳐도 순서가 무너지던 사고의 재발 방지.
- */
+/** rank·parent 는 형제 순서를 흔든다. 단건 갱신은 둘 다 건드리지 않아야 한다. */
 describe('MedusaClient 카테고리 순서', () => {
   function makeClient() {
     const update = jest.fn().mockResolvedValue({ product_category: { id: 'pcat_x' } });
@@ -1234,7 +1230,9 @@ describe('MedusaClient 카테고리 순서', () => {
       sdk: { value: { admin: { productCategory: { update } } } },
       logger: { value: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
       cacheOnlyMode: { value: false, writable: true },
+      categoryCache: { value: new Map(), writable: true },
     });
+    (client as any).primeCategoryCache = jest.fn().mockResolvedValue(0);
     const existing = { id: 'pcat_x', handle: 'cafe24-cat-499', metadata: {} };
     (client as any).findCategoryByPimRef = jest.fn().mockResolvedValue(null);
     (client as any).findCategoryByCandidateHandles = jest.fn().mockResolvedValue(existing);
@@ -1320,7 +1318,36 @@ describe('MedusaClient 카테고리 순서', () => {
     ]);
   });
 
-  // 구멍을 남기면 그 자리를 남의 카테고리가 차지한다.
+  it('형제 목록은 한 번만 훑는다 (형제마다 LIST 스캔 금지)', async () => {
+    const { client } = makeClient();
+    (client as any).findCategoryByPimRef = jest.fn(async (pimId: string) => ({ id: `medusa-${pimId}` }));
+
+    await client.syncSiblingRanks(['pim-a', 'pim-b', 'pim-c']);
+
+    expect((client as any).primeCategoryCache).toHaveBeenCalledTimes(1);
+    for (const call of (client as any).findCategoryByPimRef.mock.calls) {
+      expect(call[1]).toEqual({ cacheOnly: true });
+    }
+  });
+
+  // 슬롯을 비우면 그 자리를 남의 카테고리가 차지한다.
+  it('update 가 실패한 형제는 rank 슬롯을 소비하지 않는다', async () => {
+    const { client, update } = makeClient();
+    (client as any).findCategoryByPimRef = jest.fn(async (pimId: string) => ({ id: `medusa-${pimId}` }));
+    update.mockImplementation(async (id: string) => {
+      if (id === 'medusa-pim-b') throw new Error('boom');
+      return { product_category: { id } };
+    });
+
+    await client.syncSiblingRanks(['pim-a', 'pim-b', 'pim-c']);
+
+    expect(update.mock.calls).toEqual([
+      ['medusa-pim-a', { rank: 0 }],
+      ['medusa-pim-b', { rank: 1 }],
+      ['medusa-pim-c', { rank: 1 }],
+    ]);
+  });
+
   it('Medusa 에 아직 없는 형제 자리는 비우지 않고 뒤를 당긴다', async () => {
     const { client, update } = makeClient();
     (client as any).findCategoryByPimRef = jest.fn(async (pimId: string) =>

--- a/apps/channel-adapter/src/adapters/medusa/medusa.client.spec.ts
+++ b/apps/channel-adapter/src/adapters/medusa/medusa.client.spec.ts
@@ -1011,7 +1011,9 @@ describe('MedusaClient.refreshCustomerCartPrices', () => {
 });
 
 describe('MedusaClient.ensureCategoryFromSnapshot 부모 갱신', () => {
-  function makeCategoryClient(parentLookup: { id: string } | null) {
+  // currentParent = Medusa 에 저장돼 있는 현재 부모. 부모 갱신은 이 값과 다를 때만
+  // payload 에 실린다 (같은 값을 다시 보내면 Medusa 가 형제 맨 뒤로 재배치한다).
+  function makeCategoryClient(parentLookup: { id: string } | null, currentParent: string | null = 'pcat_old_parent') {
     const update = jest.fn().mockResolvedValue({ product_category: { id: 'pcat_child' } });
     const client = Object.create(MedusaClient.prototype) as MedusaClient;
     Object.defineProperties(client, {
@@ -1022,7 +1024,12 @@ describe('MedusaClient.ensureCategoryFromSnapshot 부모 갱신', () => {
     });
 
     // ensureCategoryFromSnapshot 이 쓰는 조회/캐시 헬퍼만 대체한다.
-    const existing = { id: 'pcat_child', handle: 'cafe24-cat-531', metadata: {} };
+    const existing = {
+      id: 'pcat_child',
+      handle: 'cafe24-cat-531',
+      metadata: {},
+      parent_category_id: currentParent,
+    };
     (client as any).findCategoryByPimRef = jest.fn().mockResolvedValue(parentLookup);
     (client as any).findCategoryByCandidateHandles = jest.fn().mockResolvedValue(existing);
     (client as any).findCategoryByPimId = jest.fn().mockResolvedValue(existing);
@@ -1214,3 +1221,117 @@ describe('MedusaClient.ensureCategoryFromSnapshot 상품 경로는 필드를 건
     expect(update.mock.calls[0][1].metadata.isVisibleToMembersOnly).toBe(true);
   });
 })
+
+/**
+ * rank·parent 는 형제 순서를 흔든다. 단건 갱신은 둘 다 건드리지 않아야 한다 —
+ * 이름만 고쳐도 순서가 무너지던 사고의 재발 방지.
+ */
+describe('MedusaClient 카테고리 순서', () => {
+  function makeClient() {
+    const update = jest.fn().mockResolvedValue({ product_category: { id: 'pcat_x' } });
+    const client = Object.create(MedusaClient.prototype) as MedusaClient;
+    Object.defineProperties(client, {
+      sdk: { value: { admin: { productCategory: { update } } } },
+      logger: { value: { log: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } },
+      cacheOnlyMode: { value: false, writable: true },
+    });
+    const existing = { id: 'pcat_x', handle: 'cafe24-cat-499', metadata: {} };
+    (client as any).findCategoryByPimRef = jest.fn().mockResolvedValue(null);
+    (client as any).findCategoryByCandidateHandles = jest.fn().mockResolvedValue(existing);
+    (client as any).findCategoryByPimId = jest.fn().mockResolvedValue(existing);
+    (client as any).getCategoryById = jest.fn().mockResolvedValue(existing);
+    (client as any).setCategoryCache = jest.fn();
+    return { client, update };
+  }
+
+  it('단건 갱신은 sortOrder 를 받아도 rank 를 보내지 않는다', async () => {
+    const { client, update } = makeClient();
+
+    await client.ensureCategoryFromSnapshot(
+      {
+        id: 'pim-499',
+        name: '전체상품 보기',
+        slug: 'cafe24-cat-499',
+        path: '499',
+        parentId: null,
+        isActive: true,
+        visibility: true,
+        showOnMainCategory: false,
+        sortOrder: 0,
+      },
+      { refreshFields: true },
+    );
+
+    expect(update).toHaveBeenCalled();
+    expect(update.mock.calls[0][1]).not.toHaveProperty('rank');
+  });
+
+  it('부모가 그대로면 parent_category_id 를 보내지 않는다', async () => {
+    const { client, update } = makeClient();
+
+    await client.ensureCategoryFromSnapshot(
+      {
+        id: 'pim-499',
+        name: '전체상품 보기',
+        slug: 'cafe24-cat-499',
+        path: '499',
+        parentId: null,
+        isActive: true,
+        visibility: true,
+        showOnMainCategory: false,
+      },
+      { refreshFields: true },
+    );
+
+    expect(update.mock.calls[0][1]).not.toHaveProperty('parent_category_id');
+  });
+
+  it('부모가 실제로 바뀌면 parent_category_id 를 보낸다', async () => {
+    const { client, update } = makeClient();
+    (client as any).findCategoryByPimRef = jest.fn().mockResolvedValue({ id: 'medusa-parent' });
+
+    await client.ensureCategoryFromSnapshot(
+      {
+        id: 'pim-499',
+        name: '전체상품 보기',
+        slug: 'cafe24-cat-499',
+        path: '499',
+        parentId: 'pim-parent',
+        isActive: true,
+        visibility: true,
+        showOnMainCategory: false,
+      },
+      { refreshFields: true },
+    );
+
+    expect(update.mock.calls[0][1].parent_category_id).toBe('medusa-parent');
+  });
+
+  it('syncSiblingRanks 는 배열 순서대로 rank 0..n-1 을 순차로 민다', async () => {
+    const { client, update } = makeClient();
+    (client as any).findCategoryByPimRef = jest.fn(async (pimId: string) => ({ id: `medusa-${pimId}` }));
+
+    await client.syncSiblingRanks(['pim-a', 'pim-b', 'pim-c']);
+
+    expect(update.mock.calls).toEqual([
+      ['medusa-pim-a', { rank: 0 }],
+      ['medusa-pim-b', { rank: 1 }],
+      ['medusa-pim-c', { rank: 2 }],
+    ]);
+  });
+
+  // 구멍을 남기면 그 자리를 남의 카테고리가 차지한다.
+  it('Medusa 에 아직 없는 형제 자리는 비우지 않고 뒤를 당긴다', async () => {
+    const { client, update } = makeClient();
+    (client as any).findCategoryByPimRef = jest.fn(async (pimId: string) =>
+      pimId === 'pim-b' ? null : { id: `medusa-${pimId}` },
+    );
+
+    await client.syncSiblingRanks(['pim-a', 'pim-b', 'pim-c']);
+
+    expect(update.mock.calls).toEqual([
+      ['medusa-pim-a', { rank: 0 }],
+      ['medusa-pim-c', { rank: 1 }],
+    ]);
+  });
+});

--- a/apps/channel-adapter/src/adapters/medusa/medusa.client.ts
+++ b/apps/channel-adapter/src/adapters/medusa/medusa.client.ts
@@ -721,13 +721,22 @@ export class MedusaClient {
         return existing.id;
       }
 
+      // 부모가 실제로 바뀔 때만 보낸다. 같은 값이어도 키가 있으면 Medusa 는 부모 이동으로
+      // 보고 카테고리를 형제 맨 뒤로 재배치한다 (루트에 null 재전송 → 형제 21건 동반 이동).
+      const currentParentId = verified.parent_category_id ?? null;
+      const desiredParentId = 'parent_category_id' in parentUpdate ? parentUpdate.parent_category_id ?? null : undefined;
+      const parentPatch =
+        desiredParentId !== undefined && desiredParentId !== currentParentId
+          ? { parent_category_id: desiredParentId }
+          : {};
+
       const updatePayload = {
         name: categorySnapshot.name,
         handle: preferredHandle,
         is_internal: false,
         is_active: isActive,
-        ...parentUpdate,
-        ...(categorySnapshot.sortOrder != null && { rank: categorySnapshot.sortOrder }),
+        ...parentPatch,
+        // rank 는 보내지 않는다 — 순서는 syncSiblingRanks 만 만진다.
         ...(categorySnapshot.description !== undefined && {
           description: categorySnapshot.description ?? '',
         }),
@@ -756,7 +765,8 @@ export class MedusaClient {
       is_internal: false,
       is_active: isActive,
       parent_category_id: parentMedusaId,
-      ...(categorySnapshot.sortOrder != null && { rank: categorySnapshot.sortOrder }),
+      // 신규도 rank 를 지정하지 않는다. Medusa 가 맨 뒤에 붙이고, 순서에 뜻이 있으면
+      // 뒤따르는 syncSiblingRanks 가 제자리로 옮긴다.
       ...(categorySnapshot.description !== undefined && {
         description: categorySnapshot.description ?? '',
       }),
@@ -770,6 +780,36 @@ export class MedusaClient {
     this.setCategoryCache(categorySnapshot.id, created.id);
     this.logger.log(`Created Medusa category ${created.id} from snapshot for PIM category ${categorySnapshot.id}`);
     return created.id;
+  }
+
+  /**
+   * 형제 전체의 rank 를 PIM 순서대로 0..n-1 로 다시 매긴다.
+   *
+   * Medusa 는 rank 를 받을 때마다 형제를 시프트하므로 앞에서부터 순차로 밀어야 한다.
+   * 병렬로 보내면 시프트가 서로를 덮어써 순서가 어긋난다.
+   *
+   * rank 는 배열 index 가 아니라 실제로 적용한 횟수로 센다. Medusa 에 아직 없는
+   * 카테고리 자리에 구멍을 남기면 그 자리를 남의 카테고리가 차지한다.
+   * PIM 배열에 없는 형제(비활성 legacy 등)는 자연히 뒤로 밀린다.
+   */
+  async syncSiblingRanks(orderedPimCategoryIds: string[]): Promise<void> {
+    let rank = 0;
+
+    for (const pimCategoryId of orderedPimCategoryIds) {
+      const found = await this.findCategoryByPimRef(pimCategoryId);
+      if (!found?.id) {
+        this.logger.warn(`Category ${pimCategoryId} not in Medusa — 순서 적용 건너뜀`);
+        continue;
+      }
+
+      try {
+        await this.sdk.admin.productCategory.update(found.id, { rank });
+        rank++;
+      } catch (err) {
+        const fetchError = err as FetchError;
+        this.logger.warn(`Failed to set rank ${rank} on Medusa category ${found.id}: ${fetchError.message}`);
+      }
+    }
   }
 
   // 상품을 지정된 카테고리에 강제 매핑 (Medusa v2: 제품 업데이트로 categories 설정)

--- a/apps/channel-adapter/src/adapters/medusa/medusa.client.ts
+++ b/apps/channel-adapter/src/adapters/medusa/medusa.client.ts
@@ -721,8 +721,7 @@ export class MedusaClient {
         return existing.id;
       }
 
-      // 부모가 실제로 바뀔 때만 보낸다. 같은 값이어도 키가 있으면 Medusa 는 부모 이동으로
-      // 보고 카테고리를 형제 맨 뒤로 재배치한다 (루트에 null 재전송 → 형제 21건 동반 이동).
+      // 같은 값이어도 키가 실려 있으면 Medusa 가 부모 이동으로 보고 형제 맨 뒤로 보낸다.
       const currentParentId = verified.parent_category_id ?? null;
       const desiredParentId = 'parent_category_id' in parentUpdate ? parentUpdate.parent_category_id ?? null : undefined;
       const parentPatch =
@@ -765,8 +764,7 @@ export class MedusaClient {
       is_internal: false,
       is_active: isActive,
       parent_category_id: parentMedusaId,
-      // 신규도 rank 를 지정하지 않는다. Medusa 가 맨 뒤에 붙이고, 순서에 뜻이 있으면
-      // 뒤따르는 syncSiblingRanks 가 제자리로 옮긴다.
+      // rank 미지정 = 맨 뒤. 순서에 뜻이 있으면 syncSiblingRanks 가 옮긴다.
       ...(categorySnapshot.description !== undefined && {
         description: categorySnapshot.description ?? '',
       }),
@@ -783,20 +781,22 @@ export class MedusaClient {
   }
 
   /**
-   * 형제 전체의 rank 를 PIM 순서대로 0..n-1 로 다시 매긴다.
+   * 형제 전체를 PIM 순서대로 rank 0..n-1 로 다시 세운다.
    *
-   * Medusa 는 rank 를 받을 때마다 형제를 시프트하므로 앞에서부터 순차로 밀어야 한다.
-   * 병렬로 보내면 시프트가 서로를 덮어써 순서가 어긋난다.
-   *
-   * rank 는 배열 index 가 아니라 실제로 적용한 횟수로 센다. Medusa 에 아직 없는
-   * 카테고리 자리에 구멍을 남기면 그 자리를 남의 카테고리가 차지한다.
-   * PIM 배열에 없는 형제(비활성 legacy 등)는 자연히 뒤로 밀린다.
+   * rank 는 자리 번호가 아니라 삽입 위치다. 앞에서부터 순차로 밀어야 하고
+   * (병렬이면 시프트가 서로를 덮는다), 못 옮긴 형제의 번호는 비우지 않고 당겨 쓴다
+   * — 비우면 그 자리를 남의 카테고리가 차지한다.
    */
   async syncSiblingRanks(orderedPimCategoryIds: string[]): Promise<void> {
+    // 캐시 미스마다 목록을 통째로 훑으므로(형제 수 × 페이지 수) 한 번만 채우고 cacheOnly 로 본다.
+    if (orderedPimCategoryIds.some((pimCategoryId) => !this.categoryCache.has(pimCategoryId))) {
+      await this.primeCategoryCache();
+    }
+
     let rank = 0;
 
     for (const pimCategoryId of orderedPimCategoryIds) {
-      const found = await this.findCategoryByPimRef(pimCategoryId);
+      const found = await this.findCategoryByPimRef(pimCategoryId, { cacheOnly: true });
       if (!found?.id) {
         this.logger.warn(`Category ${pimCategoryId} not in Medusa — 순서 적용 건너뜀`);
         continue;

--- a/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts
+++ b/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts
@@ -683,7 +683,7 @@ export class PimMedusaSyncService {
    * Handle CategoryChanged event from PIM
    */
   async handleCategoryChanged(event: CategoryChangedPayload): Promise<SyncResult> {
-    const { categoryId, changeType, category, ancestors } = event;
+    const { categoryId, changeType, category, ancestors, siblingOrder } = event;
 
     this.logger.log(`Processing CategoryChanged: ${categoryId} (${changeType})`);
 
@@ -751,6 +751,12 @@ export class PimMedusaSyncService {
       );
 
       this.logger.log(`Category synced to Medusa: PIM=${categoryId} → Medusa=${medusaCategoryId}`);
+
+      // 순서가 실제로 바뀐 변경에만 실린다. 카테고리 자체를 보장한 뒤에 밀어야
+      // 방금 만든 카테고리도 제자리를 잡는다.
+      if (siblingOrder?.length) {
+        await this.medusaClient.syncSiblingRanks(siblingOrder);
+      }
 
       await this.storefrontRevalidate.revalidateCategory(medusaCategoryId);
 

--- a/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts
+++ b/apps/channel-adapter/src/adapters/medusa/pim-medusa-sync.service.ts
@@ -752,8 +752,7 @@ export class PimMedusaSyncService {
 
       this.logger.log(`Category synced to Medusa: PIM=${categoryId} → Medusa=${medusaCategoryId}`);
 
-      // 순서가 실제로 바뀐 변경에만 실린다. 카테고리 자체를 보장한 뒤에 밀어야
-      // 방금 만든 카테고리도 제자리를 잡는다.
+      // 카테고리를 보장한 뒤에 밀어야 방금 만든 것도 제자리를 잡는다.
       if (siblingOrder?.length) {
         await this.medusaClient.syncSiblingRanks(siblingOrder);
       }

--- a/apps/core/src/modules/catalog/core/categories/categories.service.spec.ts
+++ b/apps/core/src/modules/catalog/core/categories/categories.service.spec.ts
@@ -554,28 +554,28 @@ describe('ProductCategoriesService CategoryChanged 계약 적합성', () => {
   });
 });
 
-/**
- * 순서는 형제 전체를 아는 쪽만 정할 수 있다. 소비자(Medusa)의 rank 는 형제 목록 안의
- * 삽입 위치라, 한 건씩 보내면 그 건이 남의 자리를 뺏고 뒷사람을 민다. 그래서 PIM 이
- * 형제 순서를 배열째 넘기되, **순서가 실제로 바뀐 저장에만** 싣는다 — 어드민 폼은
- * 정렬값을 건드리지 않아도 현재 값을 그대로 실어 보내기 때문이다.
- */
+/** 형제 순서는 배열째 넘기되, 순서가 실제로 바뀐 저장에만 싣는다. */
 describe('ProductCategoriesService siblingOrder', () => {
+  // 계약이 uuid 로 못박고 있어 테스트 데이터도 UUID.
+  const CAT_1 = '11111111-1111-4111-8111-111111111111';
+  const CAT_2 = '22222222-2222-4222-8222-222222222222';
+  const CAT_3 = '33333333-3333-4333-8333-333333333333';
+
   function makeService(currentSortOrder = 0) {
-    const siblingRows = [{ id: 'cat-1' }, { id: 'cat-2' }, { id: 'cat-3' }];
+    const siblingRows = [{ id: CAT_1 }, { id: CAT_2 }, { id: CAT_3 }];
     const tx = {
       update: jest.fn(() => ({
         set: () => ({
           where: () => ({
             returning: () => [
               {
-                id: 'cat-1',
+                id: CAT_1,
                 name: 'Lip',
                 slug: 'lip',
                 description: null,
                 parentId: null,
                 level: 0,
-                path: 'cat-1',
+                path: CAT_1,
                 sortOrder: 5,
                 isActive: true,
                 visibility: true,
@@ -619,15 +619,22 @@ describe('ProductCategoriesService siblingOrder', () => {
   it('정렬값이 실제로 바뀐 저장에만 형제 순서를 싣는다', async () => {
     const { service, productPublisher } = makeService(0);
 
-    await service.updateCategory('cat-1', { sortOrder: 5 } as any);
+    await service.updateCategory(CAT_1, { sortOrder: 5 } as any);
 
-    expect(categoryPayloads(productPublisher as any)[0].siblingOrder).toEqual(['cat-1', 'cat-2', 'cat-3']);
+    const payload = categoryPayloads(productPublisher as any)[0];
+    expect(payload.siblingOrder).toEqual([CAT_1, CAT_2, CAT_3]);
+    // 적재 시점 zod 가 미선언 키를 조용히 떼어내므로, 계약을 여기서 태워 둔다.
+    expect(PRODUCT_STREAM.events.CategoryChanged.schema!.parse(payload).siblingOrder).toEqual([
+      CAT_1,
+      CAT_2,
+      CAT_3,
+    ]);
   });
 
   it('정렬값을 같은 값으로 다시 보내면 형제 순서를 싣지 않는다', async () => {
     const { service, productPublisher } = makeService(5);
 
-    await service.updateCategory('cat-1', { sortOrder: 5 } as any);
+    await service.updateCategory(CAT_1, { sortOrder: 5 } as any);
 
     expect(categoryPayloads(productPublisher as any)[0].siblingOrder).toBeUndefined();
   });
@@ -635,7 +642,7 @@ describe('ProductCategoriesService siblingOrder', () => {
   it('이름만 고치면 형제 순서를 싣지 않는다', async () => {
     const { service, productPublisher } = makeService(0);
 
-    await service.updateCategory('cat-1', { name: 'Updated Lip' } as any);
+    await service.updateCategory(CAT_1, { name: 'Updated Lip' } as any);
 
     expect(categoryPayloads(productPublisher as any)[0].siblingOrder).toBeUndefined();
   });

--- a/apps/core/src/modules/catalog/core/categories/categories.service.spec.ts
+++ b/apps/core/src/modules/catalog/core/categories/categories.service.spec.ts
@@ -553,3 +553,90 @@ describe('ProductCategoriesService CategoryChanged 계약 적합성', () => {
     expect(parsed).toEqual(payload);
   });
 });
+
+/**
+ * 순서는 형제 전체를 아는 쪽만 정할 수 있다. 소비자(Medusa)의 rank 는 형제 목록 안의
+ * 삽입 위치라, 한 건씩 보내면 그 건이 남의 자리를 뺏고 뒷사람을 민다. 그래서 PIM 이
+ * 형제 순서를 배열째 넘기되, **순서가 실제로 바뀐 저장에만** 싣는다 — 어드민 폼은
+ * 정렬값을 건드리지 않아도 현재 값을 그대로 실어 보내기 때문이다.
+ */
+describe('ProductCategoriesService siblingOrder', () => {
+  function makeService(currentSortOrder = 0) {
+    const siblingRows = [{ id: 'cat-1' }, { id: 'cat-2' }, { id: 'cat-3' }];
+    const tx = {
+      update: jest.fn(() => ({
+        set: () => ({
+          where: () => ({
+            returning: () => [
+              {
+                id: 'cat-1',
+                name: 'Lip',
+                slug: 'lip',
+                description: null,
+                parentId: null,
+                level: 0,
+                path: 'cat-1',
+                sortOrder: 5,
+                isActive: true,
+                visibility: true,
+                imageUrl: null,
+                displaySettings: null,
+                seoConfig: null,
+                templateConfig: null,
+                createdAt: new Date('2026-06-07T00:00:00.000Z'),
+                updatedAt: new Date('2026-06-07T00:00:00.000Z'),
+              },
+            ],
+          }),
+        }),
+      })),
+      // 이전 sortOrder 조회는 where() 에서 끝나고, 형제 순서 조회는 orderBy() 까지 간다.
+      select: jest.fn(() => ({
+        from: () => ({
+          where: () => Object.assign([{ sortOrder: currentSortOrder }], { orderBy: () => siblingRows }),
+        }),
+      })),
+    };
+    const db = {
+      run: jest.fn(async (callback: (trx: typeof tx) => Promise<unknown>, t?: typeof tx) => callback(t ?? tx)),
+    };
+    const productPublisher = { enqueue: jest.fn().mockResolvedValue(undefined) };
+    const service = new (ProductCategoriesService as any)(
+      db,
+      { assembleActiveVersionSnapshot: jest.fn() },
+      productPublisher,
+    ) as ProductCategoriesService;
+
+    return { service, productPublisher };
+  }
+
+  function categoryPayloads(productPublisher: { enqueue: jest.Mock }) {
+    return productPublisher.enqueue.mock.calls
+      .filter(([params]: [{ eventType: string }]) => params.eventType === 'CategoryChanged')
+      .map(([params]: [{ payload: { siblingOrder?: string[] } }]) => params.payload);
+  }
+
+  it('정렬값이 실제로 바뀐 저장에만 형제 순서를 싣는다', async () => {
+    const { service, productPublisher } = makeService(0);
+
+    await service.updateCategory('cat-1', { sortOrder: 5 } as any);
+
+    expect(categoryPayloads(productPublisher as any)[0].siblingOrder).toEqual(['cat-1', 'cat-2', 'cat-3']);
+  });
+
+  it('정렬값을 같은 값으로 다시 보내면 형제 순서를 싣지 않는다', async () => {
+    const { service, productPublisher } = makeService(5);
+
+    await service.updateCategory('cat-1', { sortOrder: 5 } as any);
+
+    expect(categoryPayloads(productPublisher as any)[0].siblingOrder).toBeUndefined();
+  });
+
+  it('이름만 고치면 형제 순서를 싣지 않는다', async () => {
+    const { service, productPublisher } = makeService(0);
+
+    await service.updateCategory('cat-1', { name: 'Updated Lip' } as any);
+
+    expect(categoryPayloads(productPublisher as any)[0].siblingOrder).toBeUndefined();
+  });
+});

--- a/apps/core/src/modules/catalog/core/categories/categories.service.ts
+++ b/apps/core/src/modules/catalog/core/categories/categories.service.ts
@@ -113,9 +113,18 @@ export class ProductCategoriesService {
           await this._linkTagGroups(newCategory.id, tagGroupLinks, client);
         }
 
-        // Enqueue CategoryChanged event
+        // sortOrder 를 명시한 경우에만 형제 순서를 함께 보낸다.
+        // 생략했다면 위치에 뜻이 없으므로 소비자 기본값(맨 뒤)에 맡긴다.
         const snapshot = this.buildCategorySnapshot(newCategory);
-        await this.publishCategoryEvent(newCategory.id, 'created', snapshot, client);
+        await this.publishCategoryEvent(
+          newCategory.id,
+          'created',
+          snapshot,
+          client,
+          categoryData.sortOrder !== undefined
+            ? await this.loadSiblingOrder(newCategory.parentId ?? null, client)
+            : undefined,
+        );
 
         const responseDto: CategoryResponseDto = CategoryMapper.toDto(newCategory);
         return responseDto;
@@ -148,6 +157,21 @@ export class ProductCategoriesService {
       // 현재 값을 payload 에 실어 보내는데, undefined 만 보고 판단하면 저장 한 번에
       // 자손 전체(수십~수백 건)가 큐로 쏟아진다.
       let membersOnlyChanged = false;
+      // 어드민 폼은 정렬값을 건드리지 않아도 현재 값을 그대로 실어 보낸다.
+      // undefined 만 보고 판단하면 이름 한 글자 수정에도 형제 전체가 재정렬된다.
+      let sortOrderChanged = false;
+      if (categoryData.sortOrder !== undefined) {
+        const [current] = await client
+          .select({ sortOrder: pimSchema.productCategories.sortOrder })
+          .from(pimSchema.productCategories)
+          .where(eq(pimSchema.productCategories.id, categoryId));
+
+        if (!current) {
+          throw new NotFoundError(`Category not found: ${categoryId}`);
+        }
+        sortOrderChanged = current.sortOrder !== categoryData.sortOrder;
+      }
+
       if (isVisibleToMembersOnly !== undefined || isBrand !== undefined) {
         const [current] = await client
           .select({ displaySettings: pimSchema.productCategories.displaySettings })
@@ -190,7 +214,13 @@ export class ProductCategoriesService {
 
       // Enqueue CategoryChanged event
       const snapshot = this.buildCategorySnapshot(updatedCategory);
-      await this.publishCategoryEvent(categoryId, 'updated', snapshot, client);
+      await this.publishCategoryEvent(
+        categoryId,
+        'updated',
+        snapshot,
+        client,
+        sortOrderChanged ? await this.loadSiblingOrder(updatedCategory.parentId ?? null, client) : undefined,
+      );
 
       if (membersOnlyChanged) {
         await this.publishDescendantsChanged(categoryId, client);
@@ -770,10 +800,18 @@ export class ProductCategoriesService {
         }
       }
 
-      // 4. 각 카테고리에 대해 CategoryChanged 이벤트 enqueue
-      for (const category of updatedCategories) {
+      // 4. 각 카테고리에 대해 CategoryChanged 이벤트 enqueue.
+      //    형제 순서는 첫 이벤트에만 싣는다 (배열 하나로 형제 전체가 정렬되므로).
+      const siblingOrder = await this.loadSiblingOrder(parentId || null, txn);
+      for (const [index, category] of updatedCategories.entries()) {
         const snapshot = this.buildCategorySnapshot(category);
-        await this.publishCategoryEvent(category.id, 'updated', snapshot, txn);
+        await this.publishCategoryEvent(
+          category.id,
+          'updated',
+          snapshot,
+          txn,
+          index === 0 ? siblingOrder : undefined,
+        );
       }
     };
 
@@ -895,6 +933,24 @@ export class ProductCategoriesService {
   }
 
   /**
+   * 형제 전체의 최종 순서를 PIM 카테고리 ID 배열로 만든다.
+   * sortOrder 는 중복될 수 있어 name 으로 갈라 결정적인 순서를 만든다.
+   */
+  private async loadSiblingOrder(parentId: string | null, tx: DbTransaction): Promise<string[]> {
+    const siblings = await tx
+      .select({ id: pimSchema.productCategories.id })
+      .from(pimSchema.productCategories)
+      .where(
+        parentId
+          ? eq(pimSchema.productCategories.parentId, parentId)
+          : isNull(pimSchema.productCategories.parentId),
+      )
+      .orderBy(asc(pimSchema.productCategories.sortOrder), asc(pimSchema.productCategories.name));
+
+    return siblings.map((sibling) => sibling.id);
+  }
+
+  /**
    * Enqueue CategoryChanged event
    */
   private async publishCategoryEvent(
@@ -902,6 +958,7 @@ export class ProductCategoriesService {
     changeType: 'created' | 'updated' | 'deleted' | 'moved',
     snapshot: CategorySnapshot | null,
     tx: DbTransaction,
+    siblingOrder?: string[],
   ): Promise<void> {
     const payload: CategoryChangedPayload = {
       categoryId,
@@ -909,6 +966,7 @@ export class ProductCategoriesService {
       timestamp: new Date().toISOString(),
       category: snapshot,
       ancestors: snapshot ? await this.buildAncestorSnapshots(snapshot, tx) : undefined,
+      ...(siblingOrder && { siblingOrder }),
     };
 
     await this.productPublisher.enqueue({ eventType: 'CategoryChanged', aggregateId: categoryId, payload }, tx);

--- a/apps/core/src/modules/catalog/core/categories/categories.service.ts
+++ b/apps/core/src/modules/catalog/core/categories/categories.service.ts
@@ -113,8 +113,7 @@ export class ProductCategoriesService {
           await this._linkTagGroups(newCategory.id, tagGroupLinks, client);
         }
 
-        // sortOrder 를 명시한 경우에만 형제 순서를 함께 보낸다.
-        // 생략했다면 위치에 뜻이 없으므로 소비자 기본값(맨 뒤)에 맡긴다.
+        // sortOrder 를 명시했을 때만 순서를 보낸다. 생략 = 위치에 뜻 없음(맨 뒤).
         const snapshot = this.buildCategorySnapshot(newCategory);
         await this.publishCategoryEvent(
           newCategory.id,
@@ -157,8 +156,7 @@ export class ProductCategoriesService {
       // 현재 값을 payload 에 실어 보내는데, undefined 만 보고 판단하면 저장 한 번에
       // 자손 전체(수십~수백 건)가 큐로 쏟아진다.
       let membersOnlyChanged = false;
-      // 어드민 폼은 정렬값을 건드리지 않아도 현재 값을 그대로 실어 보낸다.
-      // undefined 만 보고 판단하면 이름 한 글자 수정에도 형제 전체가 재정렬된다.
+      // 어드민 폼은 정렬값을 안 건드려도 현재 값을 실어 보낸다. 값 비교가 필요한 이유.
       let sortOrderChanged = false;
       if (categoryData.sortOrder !== undefined) {
         const [current] = await client
@@ -800,8 +798,7 @@ export class ProductCategoriesService {
         }
       }
 
-      // 4. 각 카테고리에 대해 CategoryChanged 이벤트 enqueue.
-      //    형제 순서는 첫 이벤트에만 싣는다 (배열 하나로 형제 전체가 정렬되므로).
+      // 4. CategoryChanged enqueue. 형제 순서는 첫 이벤트에만 (배열 하나로 전체가 정렬된다).
       const siblingOrder = await this.loadSiblingOrder(parentId || null, txn);
       for (const [index, category] of updatedCategories.entries()) {
         const snapshot = this.buildCategorySnapshot(category);
@@ -932,10 +929,7 @@ export class ProductCategoriesService {
     return ancestors;
   }
 
-  /**
-   * 형제 전체의 최종 순서를 PIM 카테고리 ID 배열로 만든다.
-   * sortOrder 는 중복될 수 있어 name 으로 갈라 결정적인 순서를 만든다.
-   */
+  /** 형제 순서를 ID 배열로. sortOrder 는 중복되므로 name 으로 갈라 결정적으로 만든다. */
   private async loadSiblingOrder(parentId: string | null, tx: DbTransaction): Promise<string[]> {
     const siblings = await tx
       .select({ id: pimSchema.productCategories.id })

--- a/packages/event-contracts/streams/product.stream.ts
+++ b/packages/event-contracts/streams/product.stream.ts
@@ -200,6 +200,14 @@ export interface CategoryChangedPayload {
    * 자식이 최상위로 잘못 붙지 않는다(이벤트 순서와 무관하게 트리 유지).
    */
   ancestors?: CategorySnapshot[];
+  /**
+   * 형제 전체의 최종 순서(PIM 카테고리 ID 배열). 순서가 실제로 바뀐 변경에만 실린다.
+   *
+   * 소비자의 rank 는 절대값이 아니라 형제 목록 안의 삽입 위치라, 한 건만 보내면 그
+   * 카테고리가 남의 자리를 뺏고 나머지를 밀어낸다. 순서는 형제 전체를 아는 PIM 이
+   * 배열째 넘긴다.
+   */
+  siblingOrder?: string[];
 }
 
 export interface CategorySnapshot {
@@ -423,6 +431,7 @@ const CategoryChangedSchema = z.object({
    * 추가는 additive 라 옛 producer 를 깨지 않는다.
    */
   ancestors: z.array(CategorySnapshotSchema).optional(),
+  siblingOrder: z.array(z.string().uuid()).optional(),
 });
 
 // ===== Stream Config =====

--- a/packages/event-contracts/streams/product.stream.ts
+++ b/packages/event-contracts/streams/product.stream.ts
@@ -202,10 +202,7 @@ export interface CategoryChangedPayload {
   ancestors?: CategorySnapshot[];
   /**
    * 형제 전체의 최종 순서(PIM 카테고리 ID 배열). 순서가 실제로 바뀐 변경에만 실린다.
-   *
-   * 소비자의 rank 는 절대값이 아니라 형제 목록 안의 삽입 위치라, 한 건만 보내면 그
-   * 카테고리가 남의 자리를 뺏고 나머지를 밀어낸다. 순서는 형제 전체를 아는 PIM 이
-   * 배열째 넘긴다.
+   * 소비자의 rank 는 삽입 위치라 한 건만 보내면 나머지가 밀린다 — 배열째 넘겨야 한다.
    */
   siblingOrder?: string[];
 }


### PR DESCRIPTION
## 무슨 일이 있었나

어드민에서 카테고리 **이름만 고쳐도** 스토어프론트의 카테고리 순서가 제멋대로 바뀌었습니다.

정렬값은 그대로인데(전체상품 보기 0, 최저가 해외직구 1) 스토어프론트에서는
전체상품 보기가 아래로 밀려 있었습니다. 라이브 DB를 열어보니 순서가 통째로
어긋나 있었습니다.

```
Core PIM (sort_order)          Medusa (rank, 스토어프론트 정렬 기준)
0  전체상품 보기                0  엠버래쉬(비활성)
1  최저가 해외직구               1  최저가 해외직구
1  NEW 신제품                   3  NEW 신제품
                               3  전체상품 보기   ← 밀려남. 게다가 동률
                               ...
                               32 가 4개, 2 는 빔
```

## 원인 1 — `sort_order` 를 `rank` 에 그대로 밀어넣고 있었다

두 값은 의미가 다릅니다.

- Core PIM 의 `sort_order` 는 **절대값**입니다. `default(0)` 이라 중복도 구멍도 흔합니다.
- Medusa 의 `rank` 는 **형제 목록 안의 삽입 위치**입니다. update 에 `rank` 가 실려 오면
  Medusa 가 형제 전체를 ±1 시프트합니다.

그런데 `ensureCategoryFromSnapshot` 이 **모든** 카테고리 갱신에 `rank` 를 함께 보내고
있었습니다. 그래서 이름 한 글자만 고쳐도 그 카테고리가 남의 자리를 뺏고 뒤쪽 형제를
전부 한 칸씩 밀어냈습니다. 대부분의 카테고리가 `sort_order` 0~1 근처라, 아무거나
수정할 때마다 앞자리를 뺏는 일이 반복됐습니다.

**고친 방법.** 순서는 형제 전체를 아는 쪽만 정할 수 있습니다. 그래서

- 단건 갱신 경로에서는 `rank` 를 아예 보내지 않습니다.
- 대신 `CategoryChangedPayload` 에 `siblingOrder?: string[]` 를 신설해, PIM 이 형제
  순서를 배열째 넘깁니다.
- 소비자는 `MedusaClient.syncSiblingRanks` 로 그 배열대로 rank 0..n-1 을 **순차** 적용합니다.
  (병렬로 보내면 시프트가 서로를 덮어씁니다.)

`siblingOrder` 는 **순서가 실제로 바뀐 변경에만** 싣습니다. 어드민 폼은 정렬값을
건드리지 않아도 현재 값을 그대로 실어 보내기 때문에, `undefined` 여부만 보고 판단하면
같은 버그로 되돌아갑니다.

## 원인 2 — 루트 카테고리에 `parent_category_id: null` 재전송

원인 1을 고치고 나서 드러난 결함입니다.

루트 카테고리에 `parent_category_id: null` 을 보내면 Medusa 가 이를 **"부모 이동"으로
오판**해 그 카테고리를 형제 맨 뒤로 재배치합니다. 값이 바뀌지 않았어도 키가 있기만 하면
그렇습니다.

원래부터 있던 결함인데, 예전에는 `rank` 를 같이 보내서 지정 rank 가 덮어쓰는 바람에
증상이 가려져 있었습니다. rank 전송을 없애자 맨 뒤로 밀리는 게 드러났습니다.

로컬 Medusa 실측:

```
parent_category_id: null 포함  →  왁싱 rank  9 → 30,  형제 21건 동반 이동
parent 키 자체를 뺌            →  왁싱 rank 30 → 30,  형제  0건
```

**고친 방법.** 부모가 실제로 바뀔 때만 payload 에 넣습니다.

## 검증

로컬 Medusa 에 격리된 트리를 만들어 실제 Admin API 로 태웠습니다. mock 이 아니라 실측입니다.

```
이름만 수정 (rank 미전송)     A B C D E  →  A B C D E        변화 없음
rank:0 동봉 (옛 동작)         A B C D E  →  C A B D E        원인 재현
순차 push [E D C B A]         A B C D E  →  E D C B A        의도대로
목표 [E, (없음), C]                      →  E C A            구멍 없이 당김
```

마지막 항목에서 처음 구현이 배열 index 를 rank 로 쓰는 바람에 `E A C` 가 나왔습니다.
Medusa 에 아직 없는 카테고리 자리에 구멍이 남아 남의 카테고리가 그 자리를 차지한
것입니다. 실제로 적용한 횟수로 세도록 고쳤습니다.

회귀 검증으로, 로컬에서 rank 를 실제로 망가뜨렸던 바로 그 이벤트를 재처리했습니다.
순서 변동 0건입니다.

유닛 테스트는 8개 추가했습니다. `type-check` 와 `jest` 는 develop 기준선과 동일합니다
(기존 실패 5 스위트 / 27건은 `@google-analytics/data` 미설치 등으로 develop 에서도 동일).

## 배포 후 할 일

이 PR 은 재발을 막을 뿐, **이미 어긋난 rank 를 되돌리지는 않습니다.**

라이브는 2026-08-26 에 403행을 Core `sort_order` 기준으로 재정렬해 한 번 복구했습니다
(백업: `~/db-backups/medusa_product_category_rank_20260826.csv`). 다만 배포 전까지
카테고리를 수정하면 다시 밀릴 수 있으니, **배포 후 라이브 루트 순서를 한 번 더
확인**하는 편이 안전합니다.

```sql
SELECT rank, name FROM product_category
WHERE parent_category_id IS NULL AND deleted_at IS NULL
ORDER BY rank LIMIT 10;
```

배포 대상은 **core 와 channel-adapter 둘 다**입니다. 스키마 변경은 없습니다
(이벤트 계약에 optional 필드 하나 추가라 additive 이며, 옛 producer 를 깨지 않습니다).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
