### PR TITLE
feat(statistics): 이익 탭 — 상품별 마진, 수수료율 설정, 수입 2분리

### DIFF
--- a/apps/admin-web/src/app/(admin)/statistics/profit/page.tsx
+++ b/apps/admin-web/src/app/(admin)/statistics/profit/page.tsx
@@ -1,0 +1,12 @@
+import RouteGuard from '@/components/layout/route-guard';
+import ProfitStatisticsTemplate from '@/features/statistics/template/profit';
+
+export default function StatisticsProfitPage() {
+  return (
+    <RouteGuard requireRole={['admin', 'master']}>
+      <div className="flex w-full max-w-[1600px] flex-col gap-y-2 p-3">
+        <ProfitStatisticsTemplate />
+      </div>
+    </RouteGuard>
+  );
+}

--- a/apps/admin-web/src/features/statistics/components/shell.tsx
+++ b/apps/admin-web/src/features/statistics/components/shell.tsx
@@ -19,6 +19,7 @@ import { defaultRange, useStatisticsRange } from '../shared';
 
 const TABS = [
   { href: '/statistics/sales', label: '매출' },
+  { href: '/statistics/profit', label: '이익' },
   { href: '/statistics/products', label: '상품' },
   { href: '/statistics/customers', label: '고객·멤버십' },
   { href: '/statistics/keywords', label: '검색 키워드' },

--- a/apps/admin-web/src/features/statistics/template/profit.tsx
+++ b/apps/admin-web/src/features/statistics/template/profit.tsx
@@ -14,9 +14,36 @@ import {
 } from 'recharts';
 import { ProfitSort } from '@/lib/api/domains/analytics';
 import { useProfitStatistics } from '@/lib/services/analytics';
+import { useFeeRates, useFeeSummary, useMembershipRevenue } from '@/lib/services/wallet/queries';
+import { useCreateFeeRate, useDeleteFeeRate } from '@/lib/services/wallet/mutations';
+import type { FeeSummaryDto, MembershipRevenueDto, WalletPaymentMethodType } from '@/lib/types/dto/wallet';
 import { StatisticsShell } from '../components/shell';
-import { ChartCard, KpiTile } from '../components/widgets';
+import { ChartCard, HorizontalBarList, KpiTile } from '../components/widgets';
 import { formatCount, formatKrw, formatKrwAxis, formatPercent, SERIES_COLORS, useStatisticsRange } from '../shared';
+
+const METHOD_LABELS: Record<string, string> = {
+  POINTS: '포인트',
+  CARD: '카드',
+  BANK_TRANSFER: '무통장입금',
+  BNPL: 'BNPL',
+  TOSS: '토스페이먼츠',
+  NICEPAY: '나이스페이',
+  TOSS_BILLING: '토스 정기결제',
+  NICEPAY_BILLING: '나이스페이 정기결제',
+  CMS_BATCH: '효성 CMS',
+};
+
+const METHOD_TYPES = Object.keys(METHOD_LABELS) as WalletPaymentMethodType[];
+
+function methodLabel(methodType: string): string {
+  return METHOD_LABELS[methodType] ?? methodType;
+}
+
+/** 만분율 → 표시용 퍼센트 (2.75% 같은 소수 둘째 자리 유지) */
+function formatBp(bp: number | null): string {
+  if (bp == null) return '미설정';
+  return `${(bp / 100).toLocaleString('ko-KR', { maximumFractionDigits: 2 })}%`;
+}
 
 const SORT_OPTIONS: ReadonlyArray<{ value: ProfitSort; label: string }> = [
   { value: 'margin', label: '마진순' },
@@ -67,6 +94,11 @@ export default function ProfitStatisticsTemplate() {
   const prev = data?.previousTotals;
   const totalPages = data ? Math.max(1, Math.ceil(data.totalItems / PAGE_SIZE)) : 1;
 
+  // 수수료·멤버십 수입은 wallet 원장 기준 전사 값이다 — 채널 필터와 무관.
+  const feeQuery = useFeeSummary(range.from, range.to);
+  const membershipQuery = useMembershipRevenue(range.from, range.to);
+  const walletScopeMismatch = Boolean(range.channel);
+
   return (
     <StatisticsShell>
       {isError ? (
@@ -113,6 +145,21 @@ export default function ProfitStatisticsTemplate() {
               커버리지가 올라갑니다.
             </p>
           ) : null}
+
+          <CombinedProfitSection
+            commerceNetRevenue={totals?.netRevenue}
+            commerceEstimatedMargin={totals?.estimatedMargin}
+            fee={feeQuery.data}
+            membership={membershipQuery.data}
+            isLoading={isLoading || feeQuery.isLoading || membershipQuery.isLoading}
+            channelFiltered={walletScopeMismatch}
+          />
+
+          <FeeSection
+            fee={feeQuery.data}
+            isLoading={feeQuery.isLoading}
+            isError={feeQuery.isError}
+          />
 
           <ChartCard
             title="마진 추이"
@@ -255,5 +302,323 @@ export default function ProfitStatisticsTemplate() {
         </div>
       )}
     </StatisticsShell>
+  );
+}
+
+/** 수입 구성(멤버십/커머스) + 수수료까지 반영한 종합 손익 요약 */
+function CombinedProfitSection({
+  commerceNetRevenue,
+  commerceEstimatedMargin,
+  fee,
+  membership,
+  isLoading,
+  channelFiltered,
+}: {
+  commerceNetRevenue: number | undefined;
+  commerceEstimatedMargin: number | undefined;
+  fee: FeeSummaryDto | undefined;
+  membership: MembershipRevenueDto | undefined;
+  isLoading: boolean;
+  channelFiltered: boolean;
+}) {
+  const membershipAmount = membership?.totalAmount;
+  const estimatedFee = fee?.totals.estimatedFee;
+  const ready =
+    commerceNetRevenue != null && commerceEstimatedMargin != null && membershipAmount != null && estimatedFee != null;
+  const totalRevenue = ready ? commerceNetRevenue + membershipAmount : undefined;
+  const combinedProfit = ready ? commerceEstimatedMargin + membershipAmount - estimatedFee : undefined;
+
+  return (
+    <ChartCard
+      title="수입 구성과 종합 손익"
+      description="멤버십 구독료(청구 확정일 기준)와 결제 수수료는 결제 원장 기준 전사 값입니다. 종합 이익 = 커머스 추정 마진 + 멤버십 구독료 − 추정 수수료."
+      isLoading={isLoading}
+      isEmpty={false}
+    >
+      <div className="space-y-4">
+        {channelFiltered ? (
+          <p className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800">
+            채널 필터가 걸려 있습니다 — 커머스 순매출은 선택 채널 기준이지만 멤버십 구독료·수수료는 전
+            채널 합계라서, 이 섹션의 종합 수치는 채널 필터와 정확히 대응하지 않습니다.
+          </p>
+        ) : null}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <KpiTile label="총수입" value={formatKrw(totalRevenue)} hint="커머스 순매출 + 멤버십 구독료" />
+          <KpiTile
+            label="멤버십 구독료"
+            value={formatKrw(membershipAmount)}
+            hint={membership ? `PAID 인보이스 ${formatCount(membership.invoiceCount)}건` : undefined}
+          />
+          <KpiTile
+            label="추정 결제수수료"
+            value={formatKrw(estimatedFee)}
+            hint={
+              fee && fee.totals.uncoveredAmount > 0
+                ? `요율 미설정 결제액 ${formatKrw(fee.totals.uncoveredAmount)} 제외`
+                : '결제수단별 캡처 금액 × 설정 요율'
+            }
+          />
+          <KpiTile
+            label="추정 종합 이익"
+            value={formatKrw(combinedProfit)}
+            hint="원가 미입력·요율 미설정 몫은 빠진 근사치"
+          />
+        </div>
+        <div>
+          <p className="mb-2 text-xs font-medium text-gray-500">수입 구성</p>
+          <HorizontalBarList
+            items={[
+              { label: '커머스 상품판매 (순매출)', value: commerceNetRevenue ?? 0 },
+              { label: '멤버십 구독료', value: membershipAmount ?? 0 },
+            ]}
+            formatValue={formatKrw}
+          />
+        </div>
+      </div>
+    </ChartCard>
+  );
+}
+
+/** 결제수단별 추정 수수료 표 + 수수료율 설정(이력) 관리 */
+function FeeSection({
+  fee,
+  isLoading,
+  isError,
+}: {
+  fee: FeeSummaryDto | undefined;
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  return (
+    <ChartCard
+      title="결제 수수료"
+      description="거래별 실 수수료 원천이 없어 결제수단별 설정 요율로 근사 계산합니다. 요율은 적용 시작일 이력으로 관리되며, 과거 기간을 조회하면 그 시점 요율이 적용됩니다."
+      isLoading={isLoading}
+      isEmpty={false}
+    >
+      {isError ? (
+        <p className="py-6 text-center text-sm text-red-500">수수료 요약을 불러오지 못했습니다.</p>
+      ) : (
+        <div className="space-y-3">
+          {fee && fee.totals.uncoveredAmount > 0 ? (
+            <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+              요율이 설정되지 않은 시점의 결제액 {formatKrw(fee.totals.uncoveredAmount)}은 수수료를 계산하지
+              못했습니다. 아래 &lsquo;수수료율 설정&rsquo;에서 결제수단별 요율을 입력하세요.
+            </p>
+          ) : null}
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b text-gray-500">
+                  <th className="py-1.5 text-left">결제수단</th>
+                  <th className="py-1.5 text-right">결제액 (캡처)</th>
+                  <th className="py-1.5 text-right">건수</th>
+                  <th className="py-1.5 text-right">적용 요율</th>
+                  <th className="py-1.5 text-right">추정 수수료</th>
+                  <th className="py-1.5 text-right">환불액</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(fee?.methods ?? []).map((row) => (
+                  <tr key={row.methodType} className="border-b last:border-0">
+                    <td className="py-1.5 font-medium text-gray-900">{methodLabel(row.methodType)}</td>
+                    <td className="py-1.5 text-right tabular-nums">{formatKrw(row.capturedAmount)}</td>
+                    <td className="py-1.5 text-right tabular-nums">{formatCount(row.capturedCount)}</td>
+                    <td className="py-1.5 text-right tabular-nums">
+                      {row.appliedFeeRateBp == null ? (
+                        <span className="text-amber-600">미설정</span>
+                      ) : (
+                        formatBp(row.appliedFeeRateBp)
+                      )}
+                    </td>
+                    <td className="py-1.5 text-right tabular-nums">
+                      {row.uncoveredAmount > 0 && row.coveredAmount === 0 ? (
+                        <span className="text-gray-400">계산 불가</span>
+                      ) : (
+                        formatKrw(row.estimatedFee)
+                      )}
+                    </td>
+                    <td className="py-1.5 text-right tabular-nums">{formatKrw(row.refundedAmount)}</td>
+                  </tr>
+                ))}
+                {fee && fee.methods.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="py-6 text-center text-gray-400">
+                      조회 기간에 결제가 없습니다
+                    </td>
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          </div>
+          <div>
+            <button
+              type="button"
+              onClick={() => setSettingsOpen((open) => !open)}
+              className="rounded border border-gray-200 px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-50"
+            >
+              수수료율 설정 {settingsOpen ? '접기' : '열기'}
+            </button>
+          </div>
+          {settingsOpen ? <FeeRateSettings /> : null}
+        </div>
+      )}
+    </ChartCard>
+  );
+}
+
+/** 수수료율 설정 — 변경은 새 적용일 행 추가(이력 보존), 잘못 넣은 행만 삭제 */
+function FeeRateSettings() {
+  const { data, isLoading, isError } = useFeeRates();
+  const createFeeRate = useCreateFeeRate();
+  const deleteFeeRate = useDeleteFeeRate();
+
+  const [methodType, setMethodType] = useState<WalletPaymentMethodType>('CARD');
+  const [ratePercent, setRatePercent] = useState('');
+  const [effectiveFrom, setEffectiveFrom] = useState('');
+  const [memo, setMemo] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const submit = () => {
+    const percent = Number(ratePercent);
+    if (!ratePercent || Number.isNaN(percent) || percent < 0 || percent > 100) {
+      setFormError('요율은 0~100 사이 %로 입력하세요 (예: 2.9)');
+      return;
+    }
+    if (!effectiveFrom) {
+      setFormError('적용 시작일을 선택하세요');
+      return;
+    }
+    setFormError(null);
+    createFeeRate.mutate(
+      {
+        methodType,
+        feeRateBp: Math.round(percent * 100),
+        effectiveFrom,
+        memo: memo.trim() || undefined,
+      },
+      {
+        onSuccess: () => {
+          setRatePercent('');
+          setMemo('');
+        },
+        onError: () => setFormError('등록에 실패했습니다. 같은 결제수단·적용일의 요율이 이미 있는지 확인하세요.'),
+      }
+    );
+  };
+
+  return (
+    <div className="space-y-3 rounded-md border border-gray-200 bg-gray-50 p-3">
+      <div className="flex flex-wrap items-end gap-2 text-xs">
+        <label className="flex flex-col gap-1">
+          <span className="text-gray-500">결제수단</span>
+          <select
+            value={methodType}
+            onChange={(event) => setMethodType(event.target.value as WalletPaymentMethodType)}
+            className="rounded border border-gray-200 bg-white px-2 py-1.5"
+          >
+            {METHOD_TYPES.map((type) => (
+              <option key={type} value={type}>
+                {METHOD_LABELS[type]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-gray-500">요율 (%)</span>
+          <input
+            type="number"
+            step="0.01"
+            min="0"
+            max="100"
+            value={ratePercent}
+            onChange={(event) => setRatePercent(event.target.value)}
+            placeholder="2.9"
+            className="w-24 rounded border border-gray-200 bg-white px-2 py-1.5"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-gray-500">적용 시작일 (KST)</span>
+          <input
+            type="date"
+            value={effectiveFrom}
+            onChange={(event) => setEffectiveFrom(event.target.value)}
+            className="rounded border border-gray-200 bg-white px-2 py-1.5"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-gray-500">메모</span>
+          <input
+            type="text"
+            value={memo}
+            onChange={(event) => setMemo(event.target.value)}
+            placeholder="예: 인하 협상 반영"
+            maxLength={255}
+            className="w-44 rounded border border-gray-200 bg-white px-2 py-1.5"
+          />
+        </label>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={createFeeRate.isPending}
+          className="rounded bg-gray-800 px-3 py-1.5 text-xs font-medium text-white disabled:opacity-40"
+        >
+          등록
+        </button>
+      </div>
+      {formError ? <p className="text-xs text-red-500">{formError}</p> : null}
+      <p className="text-xs text-gray-400">
+        요율 변경은 기존 행 수정이 아니라 새 적용 시작일로 등록하세요 — 과거 기간 조회에 그 시점 요율이
+        유지됩니다.
+      </p>
+      {isError ? (
+        <p className="text-xs text-red-500">요율 목록을 불러오지 못했습니다.</p>
+      ) : isLoading ? (
+        <p className="text-xs text-gray-400">불러오는 중…</p>
+      ) : (
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b text-gray-500">
+              <th className="py-1.5 text-left">결제수단</th>
+              <th className="py-1.5 text-right">요율</th>
+              <th className="py-1.5 text-left pl-4">적용 시작일 (KST)</th>
+              <th className="py-1.5 text-left">메모</th>
+              <th className="py-1.5 text-right"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {(data?.items ?? []).map((rate) => (
+              <tr key={rate.id} className="border-b last:border-0">
+                <td className="py-1.5">{methodLabel(rate.methodType)}</td>
+                <td className="py-1.5 text-right tabular-nums">{formatBp(rate.feeRateBp)}</td>
+                <td className="py-1.5 pl-4 tabular-nums">
+                  {new Date(rate.effectiveFrom).toLocaleDateString('ko-KR', { timeZone: 'Asia/Seoul' })}
+                </td>
+                <td className="py-1.5 text-gray-500">{rate.memo ?? ''}</td>
+                <td className="py-1.5 text-right">
+                  <button
+                    type="button"
+                    onClick={() => deleteFeeRate.mutate(rate.id)}
+                    disabled={deleteFeeRate.isPending}
+                    className="rounded border border-gray-200 px-2 py-0.5 text-gray-500 hover:bg-white disabled:opacity-40"
+                  >
+                    삭제
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {data && data.items.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="py-4 text-center text-gray-400">
+                  등록된 요율이 없습니다 — 위에서 결제수단별 요율을 입력하세요
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      )}
+    </div>
   );
 }

--- a/apps/admin-web/src/features/statistics/template/profit.tsx
+++ b/apps/admin-web/src/features/statistics/template/profit.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSearchParams, usePathname, useRouter } from 'next/navigation';
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { ProfitSort } from '@/lib/api/domains/analytics';
+import { useProfitStatistics } from '@/lib/services/analytics';
+import { StatisticsShell } from '../components/shell';
+import { ChartCard, KpiTile } from '../components/widgets';
+import { formatCount, formatKrw, formatKrwAxis, formatPercent, SERIES_COLORS, useStatisticsRange } from '../shared';
+
+const SORT_OPTIONS: ReadonlyArray<{ value: ProfitSort; label: string }> = [
+  { value: 'margin', label: '마진순' },
+  { value: 'marginRate', label: '마진율순' },
+  { value: 'revenue', label: '순매출순' },
+  { value: 'quantity', label: '판매량순' },
+];
+
+const ORDER_OPTIONS = [
+  { value: 'desc', label: '상위' },
+  { value: 'asc', label: '하위' },
+] as const;
+
+const PAGE_SIZE = 50;
+
+export default function ProfitStatisticsTemplate() {
+  const range = useStatisticsRange();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const sort = (searchParams.get('sort') as ProfitSort) ?? 'margin';
+  const order = searchParams.get('order') === 'asc' ? 'asc' : 'desc';
+  const [page, setPage] = useState(1);
+
+  // 조회 조건이 바뀌면 페이지가 범위를 벗어날 수 있다 — 1페이지로 되돌린다
+  useEffect(() => {
+    setPage(1);
+  }, [range.from, range.to, range.channel]);
+
+  const { data, isLoading, isError } = useProfitStatistics({
+    from: range.from,
+    to: range.to,
+    channel: range.channel,
+    sort,
+    order,
+    page,
+    limit: PAGE_SIZE,
+  });
+
+  const setParam = (key: string, value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set(key, value);
+    setPage(1);
+    router.replace(`${pathname}?${params.toString()}`);
+  };
+
+  const totals = data?.totals;
+  const prev = data?.previousTotals;
+  const totalPages = data ? Math.max(1, Math.ceil(data.totalItems / PAGE_SIZE)) : 1;
+
+  return (
+    <StatisticsShell>
+      {isError ? (
+        <p className="py-10 text-center text-sm text-red-500">
+          통계를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <KpiTile
+              label="추정 마진"
+              value={formatKrw(totals?.estimatedMargin)}
+              previous={
+                totals && prev ? { current: totals.estimatedMargin, previous: prev.estimatedMargin } : undefined
+              }
+              hint="원가가 입력된 상품 기준 · 순매출 − 추정 원가"
+              isLoading={isLoading}
+            />
+            <KpiTile
+              label="마진율"
+              value={formatPercent(totals?.marginRate)}
+              hint="추정 마진 ÷ 계산 가능 순매출"
+              isLoading={isLoading}
+            />
+            <KpiTile
+              label="추정 원가"
+              value={formatKrw(totals?.estimatedCost)}
+              previous={totals && prev ? { current: totals.estimatedCost, previous: prev.estimatedCost } : undefined}
+              hint="게시 공급가 × 판매수량 (취소·환불 금액 비례 보정)"
+              isLoading={isLoading}
+            />
+            <KpiTile
+              label="원가 커버리지"
+              value={formatPercent(totals?.costCoverageRate)}
+              hint="순매출 중 원가가 입력된 상품의 비중"
+              isLoading={isLoading}
+            />
+          </div>
+
+          {totals && totals.uncomputedNetRevenue > 0 ? (
+            <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+              원가 미입력 상품 {formatCount(totals.uncomputedProductsCount)}개(순매출{' '}
+              {formatKrw(totals.uncomputedNetRevenue)})는 마진 계산에서 제외됐습니다. 상품 등록의 공급가를 채우면
+              커버리지가 올라갑니다.
+            </p>
+          ) : null}
+
+          <ChartCard
+            title="마진 추이"
+            description="마진·원가는 원가가 입력된 상품 몫만 반영합니다. 취소·환불이 발생일에 귀속되므로 순매출·마진이 음수인 날이 있을 수 있습니다."
+            isLoading={isLoading}
+            isEmpty={!data || data.series.length === 0}
+          >
+            <ResponsiveContainer width="100%" height={280}>
+              <LineChart data={data?.series ?? []} margin={{ top: 8, right: 16, bottom: 0, left: 8 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#eee" />
+                <XAxis dataKey="bucket" tick={{ fontSize: 11 }} stroke="#999" />
+                <YAxis tick={{ fontSize: 11 }} stroke="#999" tickFormatter={formatKrwAxis} />
+                <Tooltip formatter={(value: number) => formatKrw(value)} />
+                <Legend />
+                <Line
+                  type="monotone"
+                  dataKey="netRevenue"
+                  name="순매출"
+                  stroke={SERIES_COLORS[0]}
+                  strokeWidth={2}
+                  dot={false}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="estimatedMargin"
+                  name="추정 마진"
+                  stroke={SERIES_COLORS[1]}
+                  strokeWidth={2}
+                  dot={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </ChartCard>
+
+          <ChartCard
+            title="상품별 마진"
+            description="기간 내 판매된 전 상품입니다. 원가 미입력 상품은 마진을 계산하지 않고 '계산 불가'로 표시합니다 — 마진 정렬에서는 항상 뒤로 갑니다."
+            isLoading={isLoading}
+            isEmpty={!data || data.totalItems === 0}
+          >
+            <div className="mb-3 flex flex-wrap items-center gap-1">
+              {SORT_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setParam('sort', option.value)}
+                  className={
+                    sort === option.value
+                      ? 'rounded-full bg-orange-500 px-3 py-1 text-xs font-medium text-white'
+                      : 'rounded-full border border-gray-200 px-3 py-1 text-xs text-gray-600 hover:bg-gray-50'
+                  }
+                >
+                  {option.label}
+                </button>
+              ))}
+              <span className="mx-1 h-4 w-px bg-gray-200" />
+              {ORDER_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setParam('order', option.value)}
+                  className={
+                    order === option.value
+                      ? 'rounded-full bg-gray-800 px-3 py-1 text-xs font-medium text-white'
+                      : 'rounded-full border border-gray-200 px-3 py-1 text-xs text-gray-600 hover:bg-gray-50'
+                  }
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b text-gray-500">
+                    <th className="py-1.5 text-left">#</th>
+                    <th className="py-1.5 text-left">상품</th>
+                    <th className="py-1.5 text-right">판매량</th>
+                    <th className="py-1.5 text-right">순매출</th>
+                    <th className="py-1.5 text-right">공급가</th>
+                    <th className="py-1.5 text-right">추정 원가</th>
+                    <th className="py-1.5 text-right">추정 마진</th>
+                    <th className="py-1.5 text-right">마진율</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(data?.items ?? []).map((row, index) => (
+                    <tr key={row.masterId} className="border-b last:border-0">
+                      <td className="py-1.5 text-gray-400">{(page - 1) * PAGE_SIZE + index + 1}</td>
+                      <td className="py-1.5">
+                        <span className="font-medium text-gray-900">{row.name ?? row.masterId}</span>
+                      </td>
+                      <td className="py-1.5 text-right tabular-nums">{formatCount(row.quantitySold)}</td>
+                      <td className="py-1.5 text-right tabular-nums">{formatKrw(row.netRevenue)}</td>
+                      <td className="py-1.5 text-right tabular-nums">
+                        {row.supplyPrice == null ? <span className="text-gray-400">미입력</span> : formatKrw(row.supplyPrice)}
+                      </td>
+                      <td className="py-1.5 text-right tabular-nums">
+                        {row.estimatedCost == null ? <span className="text-gray-400">-</span> : formatKrw(row.estimatedCost)}
+                      </td>
+                      <td className="py-1.5 text-right tabular-nums font-medium">
+                        {row.estimatedMargin == null ? (
+                          <span className="font-normal text-gray-400">계산 불가</span>
+                        ) : (
+                          <span className={row.estimatedMargin >= 0 ? undefined : 'text-red-600'}>
+                            {formatKrw(row.estimatedMargin)}
+                          </span>
+                        )}
+                      </td>
+                      <td className="py-1.5 text-right tabular-nums">{formatPercent(row.marginRate)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="mt-3 flex items-center justify-between text-xs text-gray-600">
+              <span>
+                전체 {formatCount(data?.totalItems)}개 상품 · {page}/{totalPages} 페이지
+              </span>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  disabled={page <= 1}
+                  onClick={() => setPage((current) => Math.max(1, current - 1))}
+                  className="rounded border border-gray-200 px-2.5 py-1 disabled:opacity-40"
+                >
+                  이전
+                </button>
+                <button
+                  type="button"
+                  disabled={page >= totalPages}
+                  onClick={() => setPage((current) => Math.min(totalPages, current + 1))}
+                  className="rounded border border-gray-200 px-2.5 py-1 disabled:opacity-40"
+                >
+                  다음
+                </button>
+              </div>
+            </div>
+          </ChartCard>
+        </div>
+      )}
+    </StatisticsShell>
+  );
+}

--- a/apps/admin-web/src/lib/api/domains/analytics/index.ts
+++ b/apps/admin-web/src/lib/api/domains/analytics/index.ts
@@ -235,6 +235,65 @@ export interface BehaviorStatistics {
   }>;
 }
 
+export type ProfitSort = 'revenue' | 'margin' | 'marginRate' | 'quantity';
+
+export interface ProfitStatisticsQuery extends StatisticsRangeQuery {
+  sort?: ProfitSort;
+  order?: 'desc' | 'asc';
+  page?: number;
+  limit?: number;
+}
+
+export interface ProfitTotals {
+  grossRevenue: number;
+  cancelledAmount: number;
+  refundedAmount: number;
+  netRevenue: number;
+  quantitySold: number;
+  productsCount: number;
+  computedNetRevenue: number;
+  estimatedCost: number;
+  estimatedMargin: number;
+  marginRate: number | null;
+  uncomputedNetRevenue: number;
+  uncomputedProductsCount: number;
+  costCoverageRate: number | null;
+}
+
+export interface ProfitProductRow {
+  masterId: string;
+  name: string | null;
+  quantitySold: number;
+  grossRevenue: number;
+  cancelledAmount: number;
+  refundedAmount: number;
+  netRevenue: number;
+  supplyPrice: number | null;
+  estimatedCost: number | null;
+  estimatedMargin: number | null;
+  marginRate: number | null;
+}
+
+export interface ProfitSeriesPoint {
+  bucket: string;
+  netRevenue: number;
+  computedNetRevenue: number;
+  estimatedCost: number;
+  estimatedMargin: number;
+}
+
+export interface ProfitStatistics {
+  range: { from: string; to: string };
+  previousRange: { from: string; to: string };
+  totals: ProfitTotals;
+  previousTotals: ProfitTotals;
+  series: ProfitSeriesPoint[];
+  items: ProfitProductRow[];
+  page: number;
+  limit: number;
+  totalItems: number;
+}
+
 export interface DailyRevenueSummary extends RevenueTotals {
   date: string;
   avgOrderValue: number | null;
@@ -280,6 +339,17 @@ export const analyticsApi = {
     const params = new URLSearchParams(rangeQs(query));
     if (query.limit) params.set('limit', String(query.limit));
     const res = await client.get(`${ANALYTICS_SERVICE_BASE_URL}/statistics/products/unsold?${params.toString()}`);
+    return res.data;
+  },
+
+  getProfitStatistics: async (query: ProfitStatisticsQuery): Promise<ProfitStatistics> => {
+    const params = new URLSearchParams({ from: query.from, to: query.to });
+    if (query.channel) params.set('channel', query.channel);
+    if (query.sort) params.set('sort', query.sort);
+    if (query.order) params.set('order', query.order);
+    if (query.page) params.set('page', String(query.page));
+    if (query.limit) params.set('limit', String(query.limit));
+    const res = await client.get(`${ANALYTICS_SERVICE_BASE_URL}/statistics/profit?${params.toString()}`);
     return res.data;
   },
 

--- a/apps/admin-web/src/lib/api/domains/wallet/index.ts
+++ b/apps/admin-web/src/lib/api/domains/wallet/index.ts
@@ -30,6 +30,10 @@ import {
   PutRegionMethodItem,
   AdminCashReceiptDto,
   IssueCashReceiptPayload,
+  FeeRateDto,
+  CreateFeeRatePayload,
+  FeeSummaryDto,
+  MembershipRevenueDto,
 } from '@/lib/types/dto/wallet';
 import { client } from '../../client';
 
@@ -479,6 +483,44 @@ export const walletApi = {
       `${BASE}/v1/admin/regions/${encodeURIComponent(code)}/payment-methods`,
       { items },
       idempotencyConfig()
+    );
+    return res.data;
+  },
+
+  // ── 통계 (수수료율·수수료 요약·멤버십 수입) ─────────────────────────────────
+
+  listFeeRates: async (): Promise<{ items: FeeRateDto[] }> => {
+    const res = await client.get(`${BASE}/v1/admin/statistics/fee-rates`);
+    return res.data;
+  },
+
+  createFeeRate: async (payload: CreateFeeRatePayload): Promise<{ id: string }> => {
+    const res = await client.post(
+      `${BASE}/v1/admin/statistics/fee-rates`,
+      payload,
+      idempotencyConfig()
+    );
+    return res.data;
+  },
+
+  deleteFeeRate: async (id: string): Promise<{ deleted: true }> => {
+    const res = await client.delete(
+      `${BASE}/v1/admin/statistics/fee-rates/${encodeURIComponent(id)}`,
+      idempotencyConfig()
+    );
+    return res.data;
+  },
+
+  getFeeSummary: async (from: string, to: string): Promise<FeeSummaryDto> => {
+    const res = await client.get(
+      `${BASE}/v1/admin/statistics/fees?${buildQueryString({ from, to })}`
+    );
+    return res.data;
+  },
+
+  getMembershipRevenue: async (from: string, to: string): Promise<MembershipRevenueDto> => {
+    const res = await client.get(
+      `${BASE}/v1/admin/statistics/membership-revenue?${buildQueryString({ from, to })}`
     );
     return res.data;
   },

--- a/apps/admin-web/src/lib/services/analytics/queries.ts
+++ b/apps/admin-web/src/lib/services/analytics/queries.ts
@@ -6,6 +6,7 @@ import {
   BehaviorStatisticsQuery,
   CustomerInsightsQuery,
   ProductStatisticsQuery,
+  ProfitStatisticsQuery,
   StatisticsRangeQuery,
   TrafficStatisticsQuery,
 } from '@/lib/api/domains/analytics';
@@ -36,6 +37,15 @@ export const useUnsoldProducts = (query: StatisticsRangeQuery & { limit?: number
   return useQuery({
     queryKey: analyticsQueryKeys.unsoldProducts(query),
     queryFn: () => analyticsApi.getUnsoldProducts(query),
+  });
+};
+
+export const useProfitStatistics = (query: ProfitStatisticsQuery) => {
+  return useQuery({
+    queryKey: analyticsQueryKeys.profit(query),
+    queryFn: () => analyticsApi.getProfitStatistics(query),
+    // 페이지 이동 시 이전 페이지를 유지해 테이블이 깜빡이지 않게 한다
+    placeholderData: (previous) => previous,
   });
 };
 

--- a/apps/admin-web/src/lib/services/analytics/query-keys.ts
+++ b/apps/admin-web/src/lib/services/analytics/query-keys.ts
@@ -1,6 +1,7 @@
 import {
   BehaviorStatisticsQuery,
   CustomerInsightsQuery,
+  ProfitStatisticsQuery,
   StatisticsRangeQuery,
   TrafficStatisticsQuery,
 } from '@/lib/api/domains/analytics';
@@ -14,6 +15,7 @@ export const analyticsQueryKeys = {
   unsoldProducts: (query: StatisticsRangeQuery & { limit?: number }) =>
     [...analyticsQueryKeys.all, 'unsold-products', query] as const,
   customers: (query: StatisticsRangeQuery) => [...analyticsQueryKeys.all, 'customers', query] as const,
+  profit: (query: ProfitStatisticsQuery) => [...analyticsQueryKeys.all, 'profit', query] as const,
   traffic: (query: TrafficStatisticsQuery) => [...analyticsQueryKeys.all, 'traffic', query] as const,
   customerInsights: (query: CustomerInsightsQuery) => [...analyticsQueryKeys.all, 'customer-insights', query] as const,
   behavior: (query: BehaviorStatisticsQuery) => [...analyticsQueryKeys.all, 'behavior', query] as const,

--- a/apps/admin-web/src/lib/services/wallet/mutations.ts
+++ b/apps/admin-web/src/lib/services/wallet/mutations.ts
@@ -5,6 +5,7 @@ import { salesOrders } from '@/lib/api/domains/orders';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { walletQueryKeys } from './query-keys';
 import type {
+  CreateFeeRatePayload,
   CreateRegionPayload,
   PutRegionMethodItem,
   UpdateCatalogPayload,
@@ -277,6 +278,28 @@ export const usePutRegionPaymentMethods = () => {
         queryKey: walletQueryKeys.regionMethods(variables.code),
       });
       queryClient.invalidateQueries({ queryKey: walletQueryKeys.regions() });
+    },
+  });
+};
+
+// ── 통계 — 수수료율 설정 ─────────────────────────────────────────────────────
+
+export const useCreateFeeRate = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: CreateFeeRatePayload) => walletApi.createFeeRate(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: walletQueryKeys.statistics() });
+    },
+  });
+};
+
+export const useDeleteFeeRate = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => walletApi.deleteFeeRate(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: walletQueryKeys.statistics() });
     },
   });
 };

--- a/apps/admin-web/src/lib/services/wallet/queries.ts
+++ b/apps/admin-web/src/lib/services/wallet/queries.ts
@@ -154,6 +154,34 @@ export const useRegions = () => {
   });
 };
 
+// ── 통계 (수수료율·수수료 요약·멤버십 수입) ─────────────────────────────────
+
+export const useFeeRates = () => {
+  return useQuery({
+    queryKey: walletQueryKeys.feeRates(),
+    queryFn: () => walletApi.listFeeRates(),
+    staleTime: 30 * 1000,
+  });
+};
+
+export const useFeeSummary = (from: string, to: string) => {
+  return useQuery({
+    queryKey: walletQueryKeys.feeSummary(from, to),
+    queryFn: () => walletApi.getFeeSummary(from, to),
+    staleTime: 60 * 1000,
+    placeholderData: keepPreviousData,
+  });
+};
+
+export const useMembershipRevenue = (from: string, to: string) => {
+  return useQuery({
+    queryKey: walletQueryKeys.membershipRevenue(from, to),
+    queryFn: () => walletApi.getMembershipRevenue(from, to),
+    staleTime: 60 * 1000,
+    placeholderData: keepPreviousData,
+  });
+};
+
 export const useRegionPaymentMethods = (code: string | null) => {
   return useQuery({
     queryKey: walletQueryKeys.regionMethods(code ?? ''),

--- a/apps/admin-web/src/lib/services/wallet/query-keys.ts
+++ b/apps/admin-web/src/lib/services/wallet/query-keys.ts
@@ -49,4 +49,12 @@ export const walletQueryKeys = {
   regions: () => [...walletQueryKeys.all, 'regions'] as const,
   regionMethods: (code: string) =>
     [...walletQueryKeys.regions(), code, 'payment-methods'] as const,
+
+  // 통계 (수수료율·수수료 요약·멤버십 수입)
+  statistics: () => [...walletQueryKeys.all, 'statistics'] as const,
+  feeRates: () => [...walletQueryKeys.statistics(), 'fee-rates'] as const,
+  feeSummary: (from: string, to: string) =>
+    [...walletQueryKeys.statistics(), 'fees', { from, to }] as const,
+  membershipRevenue: (from: string, to: string) =>
+    [...walletQueryKeys.statistics(), 'membership-revenue', { from, to }] as const,
 } as const;

--- a/apps/admin-web/src/lib/types/dto/wallet.ts
+++ b/apps/admin-web/src/lib/types/dto/wallet.ts
@@ -458,3 +458,63 @@ export interface IssueCashReceiptPayload {
   type: AdminCashReceiptType;
   customerIdentityNumber: string;
 }
+
+// ── 통계 (수수료율 설정·수수료 요약·멤버십 수입) ─────────────────────────────
+export type WalletPaymentMethodType =
+  | 'POINTS'
+  | 'CARD'
+  | 'BANK_TRANSFER'
+  | 'BNPL'
+  | 'TOSS'
+  | 'NICEPAY'
+  | 'TOSS_BILLING'
+  | 'NICEPAY_BILLING'
+  | 'CMS_BATCH';
+
+export interface FeeRateDto {
+  id: string;
+  methodType: WalletPaymentMethodType;
+  /** 만분율(basis point): 2.9% = 290 */
+  feeRateBp: number;
+  effectiveFrom: string;
+  memo: string | null;
+  createdAt: string;
+}
+
+export interface CreateFeeRatePayload {
+  methodType: WalletPaymentMethodType;
+  feeRateBp: number;
+  /** KST 적용 시작일, YYYY-MM-DD */
+  effectiveFrom: string;
+  memo?: string;
+}
+
+export interface FeeMethodSummaryDto {
+  methodType: string;
+  capturedAmount: number;
+  capturedCount: number;
+  refundedAmount: number;
+  coveredAmount: number;
+  uncoveredAmount: number;
+  estimatedFee: number;
+  appliedFeeRateBp: number | null;
+}
+
+export interface FeeSummaryDto {
+  range: { from: string; to: string };
+  methods: FeeMethodSummaryDto[];
+  totals: {
+    capturedAmount: number;
+    refundedAmount: number;
+    coveredAmount: number;
+    uncoveredAmount: number;
+    estimatedFee: number;
+  };
+}
+
+export interface MembershipRevenueDto {
+  range: { from: string; to: string };
+  totalAmount: number;
+  invoiceCount: number;
+  series: Array<{ bucket: string; amount: number; count: number }>;
+}

--- a/apps/analytics/drizzle/20260826070711_add-dim-master-supply-price.sql
+++ b/apps/analytics/drizzle/20260826070711_add-dim-master-supply-price.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "dim_product_masters" ADD COLUMN "supply_price" bigint;

--- a/apps/analytics/drizzle/meta/20260826070711_snapshot.json
+++ b/apps/analytics/drizzle/meta/20260826070711_snapshot.json
@@ -1,0 +1,2284 @@
+{
+  "id": "9ea37e75-3bf3-49f4-ba40-49cabe1fb250",
+  "prevId": "c52709f4-4d5c-4734-8a51-c4ed617a0d18",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agg_channel_daily": {
+      "name": "agg_channel_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agg_date": {
+          "name": "agg_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_channel": {
+          "name": "sales_channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orders_count": {
+          "name": "orders_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "gross_revenue": {
+          "name": "gross_revenue",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cancelled_amount": {
+          "name": "cancelled_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "refunded_amount": {
+          "name": "refunded_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_agg_channel_daily": {
+          "name": "uq_agg_channel_daily",
+          "columns": [
+            {
+              "expression": "agg_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sales_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_channel_daily_date": {
+          "name": "idx_agg_channel_daily_date",
+          "columns": [
+            {
+              "expression": "agg_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agg_customer_lifetime": {
+      "name": "agg_customer_lifetime",
+      "schema": "",
+      "columns": {
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_order_at": {
+          "name": "first_order_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_order_at": {
+          "name": "last_order_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orders_count": {
+          "name": "orders_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_revenue": {
+          "name": "total_revenue",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agg_customer_lifetime_first_order": {
+          "name": "idx_agg_customer_lifetime_first_order",
+          "columns": [
+            {
+              "expression": "first_order_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agg_membership_daily": {
+      "name": "agg_membership_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agg_date": {
+          "name": "agg_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UNKNOWN'"
+        },
+        "members_count": {
+          "name": "members_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_agg_membership_daily": {
+          "name": "uq_agg_membership_daily",
+          "columns": [
+            {
+              "expression": "agg_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_membership_daily_date": {
+          "name": "idx_agg_membership_daily_date",
+          "columns": [
+            {
+              "expression": "agg_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agg_product_order_daily": {
+      "name": "agg_product_order_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agg_date": {
+          "name": "agg_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_channel": {
+          "name": "sales_channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orders_count": {
+          "name": "orders_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "quantity_sold": {
+          "name": "quantity_sold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "gross_revenue": {
+          "name": "gross_revenue",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cancelled_amount": {
+          "name": "cancelled_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "refunded_amount": {
+          "name": "refunded_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_agg_product_order_daily": {
+          "name": "uq_agg_product_order_daily",
+          "columns": [
+            {
+              "expression": "agg_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sales_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_product_order_daily_date": {
+          "name": "idx_agg_product_order_daily_date",
+          "columns": [
+            {
+              "expression": "agg_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_product_order_daily_master": {
+          "name": "idx_agg_product_order_daily_master",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_product_order_daily_channel": {
+          "name": "idx_agg_product_order_daily_channel",
+          "columns": [
+            {
+              "expression": "sales_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agg_user_product_purchase": {
+      "name": "agg_user_product_purchase",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_product_id": {
+          "name": "channel_product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchase_count": {
+          "name": "purchase_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_quantity": {
+          "name": "total_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_purchased_at": {
+          "name": "last_purchased_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_purchased_at": {
+          "name": "first_purchased_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_agg_user_product": {
+          "name": "uq_agg_user_product",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_user_product_customer": {
+          "name": "idx_agg_user_product_customer",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_user_product_master": {
+          "name": "idx_agg_user_product_master",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_user_product_count": {
+          "name": "idx_agg_user_product_count",
+          "columns": [
+            {
+              "expression": "purchase_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agg_variant_order_daily": {
+      "name": "agg_variant_order_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agg_date": {
+          "name": "agg_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sales_channel": {
+          "name": "sales_channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity_sold": {
+          "name": "quantity_sold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "gross_revenue": {
+          "name": "gross_revenue",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_agg_variant_order_daily": {
+          "name": "uq_agg_variant_order_daily",
+          "columns": [
+            {
+              "expression": "agg_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "variant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sales_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_variant_order_daily_date": {
+          "name": "idx_agg_variant_order_daily_date",
+          "columns": [
+            {
+              "expression": "agg_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agg_variant_order_daily_master": {
+          "name": "idx_agg_variant_order_daily_master",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dim_customer_membership": {
+      "name": "dim_customer_membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UNKNOWN'"
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_to": {
+          "name": "valid_to",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_dim_customer_membership": {
+          "name": "uq_dim_customer_membership",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_customer_membership_user": {
+          "name": "idx_dim_customer_membership_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_customer_membership_valid_to": {
+          "name": "idx_dim_customer_membership_valid_to",
+          "columns": [
+            {
+              "expression": "valid_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dim_product_categories": {
+      "name": "dim_product_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_name": {
+          "name": "category_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_dim_product_categories_master_category": {
+          "name": "uq_dim_product_categories_master_category",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_product_categories_master": {
+          "name": "idx_dim_product_categories_master",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_product_categories_category": {
+          "name": "idx_dim_product_categories_category",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_product_categories_primary": {
+          "name": "idx_dim_product_categories_primary",
+          "columns": [
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dim_product_masters": {
+      "name": "dim_product_masters",
+      "schema": "",
+      "columns": {
+        "master_id": {
+          "name": "master_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_change_reason": {
+          "name": "last_change_reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supply_price": {
+          "name": "supply_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_dim_product_masters_active": {
+          "name": "idx_dim_product_masters_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_product_masters_name": {
+          "name": "idx_dim_product_masters_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_product_masters_updated_at": {
+          "name": "idx_dim_product_masters_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dim_product_variants": {
+      "name": "dim_product_variants",
+      "schema": "",
+      "columns": {
+        "variant_id": {
+          "name": "variant_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variant_name": {
+          "name": "variant_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventory_management": {
+          "name": "inventory_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_stock_sellable": {
+          "name": "pre_stock_sellable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "always_sellable_zero_stock": {
+          "name": "always_sellable_zero_stock",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_dim_product_variants_master": {
+          "name": "idx_dim_product_variants_master",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_product_variants_status": {
+          "name": "idx_dim_product_variants_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_dim_product_variants_updated_at": {
+          "name": "idx_dim_product_variants_updated_at",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fact_membership_events": {
+      "name": "fact_membership_events",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(26)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier_id": {
+          "name": "tier_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_text": {
+          "name": "reason_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fact_membership_events_user": {
+          "name": "idx_fact_membership_events_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_membership_events_occurred_at": {
+          "name": "idx_fact_membership_events_occurred_at",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_membership_events_status": {
+          "name": "idx_fact_membership_events_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_membership_events_reason": {
+          "name": "idx_fact_membership_events_reason",
+          "columns": [
+            {
+              "expression": "reason_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fact_order_events": {
+      "name": "fact_order_events",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(26)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_version": {
+          "name": "message_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "message_kind": {
+          "name": "message_kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "varchar(26)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "causation_id": {
+          "name": "causation_id",
+          "type": "varchar(26)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregate_type": {
+          "name": "aggregate_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_service": {
+          "name": "source_service",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_channel": {
+          "name": "sales_channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_fact_order_events_type": {
+          "name": "idx_fact_order_events_type",
+          "columns": [
+            {
+              "expression": "message_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_order_events_occurred_at": {
+          "name": "idx_fact_order_events_occurred_at",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_order_events_order": {
+          "name": "idx_fact_order_events_order",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_order_events_external_order": {
+          "name": "idx_fact_order_events_external_order",
+          "columns": [
+            {
+              "expression": "external_order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fact_order_items": {
+      "name": "fact_order_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(26)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_order_id": {
+          "name": "external_order_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_channel": {
+          "name": "sales_channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_item_id": {
+          "name": "order_item_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "master_id": {
+          "name": "master_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variant_id": {
+          "name": "variant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sku_id": {
+          "name": "sku_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_product_id": {
+          "name": "channel_product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_fact_order_items_order_item": {
+          "name": "uq_fact_order_items_order_item",
+          "columns": [
+            {
+              "expression": "order_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sales_channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_order_items_master": {
+          "name": "idx_fact_order_items_master",
+          "columns": [
+            {
+              "expression": "master_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_order_items_occurred_at": {
+          "name": "idx_fact_order_items_occurred_at",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_order_items_order_key": {
+          "name": "idx_fact_order_items_order_key",
+          "columns": [
+            {
+              "expression": "order_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_fact_order_items_customer": {
+          "name": "idx_fact_order_items_customer",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "event.outbox_events": {
+      "name": "outbox_events",
+      "schema": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_type": {
+          "name": "aggregate_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "partition_key": {
+          "name": "partition_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "outbox_status_idx": {
+          "name": "outbox_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_processing_started_idx": {
+          "name": "outbox_processing_started_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processing_started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_topic_idx": {
+          "name": "outbox_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_status_next_attempt_idx": {
+          "name": "outbox_status_next_attempt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_partition_created_idx": {
+          "name": "outbox_partition_created_idx",
+          "columns": [
+            {
+              "expression": "partition_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_event_outbox_topic_event_idempotency": {
+          "name": "uq_event_outbox_topic_event_idempotency",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "event.event_resource_links": {
+      "name": "event_resource_links",
+      "schema": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(26)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "erl_chain_idx": {
+          "name": "erl_chain_idx",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "erl_resource_idx": {
+          "name": "erl_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "erl_event_idx": {
+          "name": "erl_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.role_scope_mapping": {
+      "name": "role_scope_mapping",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_scope_unique_idx": {
+          "name": "role_scope_unique_idx",
+          "columns": [
+            {
+              "expression": "role_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_scope_mapping_scope_id_scopes_id_fk": {
+          "name": "role_scope_mapping_scope_id_scopes_id_fk",
+          "tableFrom": "role_scope_mapping",
+          "tableTo": "scopes",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.scopes": {
+      "name": "scopes",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microservice_name": {
+          "name": "microservice_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scopes_key_unique": {
+          "name": "scopes_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "event": "event",
+    "auth": "auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/analytics/drizzle/meta/_journal.json
+++ b/apps/analytics/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1787622224208,
       "tag": "20260825014344_add-dim-category-name",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1787728031557,
+      "tag": "20260826070711_add-dim-master-supply-price",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/analytics/src/analytics.module.ts
+++ b/apps/analytics/src/analytics.module.ts
@@ -27,6 +27,8 @@ import { StatisticsController } from './features/statistics/api/statistics.contr
 import { StatisticsQuery } from './features/statistics/read-model/statistics.query';
 import { CustomerInsightsController } from './features/statistics/api/customer-insights.controller';
 import { CustomerInsightsQuery } from './features/statistics/read-model/customer-insights.query';
+import { ProfitController } from './features/statistics/api/profit.controller';
+import { ProfitQuery } from './features/statistics/read-model/profit.query';
 import { TrafficController } from './features/traffic/api/traffic.controller';
 import { BehaviorController } from './features/traffic/api/behavior.controller';
 import { TrafficQuery } from './features/traffic/read-model/traffic.query';
@@ -76,6 +78,7 @@ import { SCHEDULE_ROOT } from '@app/shared/schedule/schedule-root';
     AnalyticsController,
     StatisticsController,
     CustomerInsightsController,
+    ProfitController,
     TrafficController,
     BehaviorController,
     OrderEventsConsumer,
@@ -98,6 +101,7 @@ import { SCHEDULE_ROOT } from '@app/shared/schedule/schedule-root';
     MembershipDailySnapshotService,
     StatisticsQuery,
     CustomerInsightsQuery,
+    ProfitQuery,
     Ga4Client,
     TrafficQuery,
     BehaviorQuery,

--- a/apps/analytics/src/datasets/products/dimensions/product-dimensions.service.ts
+++ b/apps/analytics/src/datasets/products/dimensions/product-dimensions.service.ts
@@ -19,6 +19,7 @@ type MasterPatch = {
   activeVersionId?: string | null;
   isActive?: boolean | null;
   lastChangeReason?: string | null;
+  supplyPrice?: number | null;
   deletedAt?: Date | null;
   eventAt?: Date;
 };
@@ -158,6 +159,8 @@ export class ProductDimensionsService {
           activeVersionId: payload.versionId,
           isActive: payload.versionId !== null,
           lastChangeReason: payload.changeReason,
+          // 키 부재(구버전 이벤트·미게시)는 기존 원가 유지, null 은 "원가 지움"으로 반영
+          ...(payload.supplyPrice !== undefined ? { supplyPrice: payload.supplyPrice } : {}),
           eventAt,
         },
         executor,
@@ -200,6 +203,7 @@ export class ProductDimensionsService {
       activeVersionId: patch.activeVersionId ?? null,
       isActive: patch.isActive ?? null,
       lastChangeReason: patch.lastChangeReason ?? null,
+      supplyPrice: patch.supplyPrice ?? null,
       createdAt: now,
       updatedAt: now,
       deletedAt: patch.deletedAt ?? null,
@@ -225,6 +229,10 @@ export class ProductDimensionsService {
 
     if (Object.prototype.hasOwnProperty.call(patch, 'lastChangeReason')) {
       set.lastChangeReason = patch.lastChangeReason ?? null;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(patch, 'supplyPrice')) {
+      set.supplyPrice = patch.supplyPrice ?? null;
     }
 
     if (Object.prototype.hasOwnProperty.call(patch, 'deletedAt')) {

--- a/apps/analytics/src/datasets/products/dimensions/product-dimensions.supply-price.integration.spec.ts
+++ b/apps/analytics/src/datasets/products/dimensions/product-dimensions.supply-price.integration.spec.ts
@@ -1,0 +1,74 @@
+import { randomUUID } from 'crypto';
+import * as postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { eq } from 'drizzle-orm';
+import type { DbService } from '@app/db';
+import { analyticsSchema, dimProductMasters } from '../../../schema';
+import { ProductDimensionsService } from './product-dimensions.service';
+
+/**
+ * dim 원가 갱신 의미론: supplyPrice 키 부재(구버전 이벤트·미게시)는 기존 값을 유지하고,
+ * null 은 "원가 지움"으로 반영해야 한다 — 스테일 원가로 마진이 계산되는 사고 방지.
+ *
+ * 실행: DATABASE_URL=postgresql://postgres:postgres@localhost:5432/analytics \
+ *   npx jest --testPathPattern="product-dimensions.supply-price.integration"
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+
+describeIfDb('ProductDimensionsService supplyPrice (실 Postgres)', () => {
+  jest.setTimeout(120_000);
+
+  const masterId = `itest-master-${randomUUID().slice(0, 8)}`;
+
+  let sql: postgres.Sql;
+  let db: ReturnType<typeof drizzle<typeof analyticsSchema>>;
+  let service: ProductDimensionsService;
+
+  const basePayload = {
+    masterId,
+    name: '원가 시맨틱 테스트',
+    previousActiveVersionId: null,
+    changeReason: 'published' as const,
+    changedAt: new Date().toISOString(),
+  };
+
+  const readSupplyPrice = async () => {
+    const rows = await db
+      .select({ supplyPrice: dimProductMasters.supplyPrice })
+      .from(dimProductMasters)
+      .where(eq(dimProductMasters.masterId, masterId));
+    return rows[0]?.supplyPrice;
+  };
+
+  beforeAll(() => {
+    sql = postgres(DATABASE_URL as string, { max: 1 });
+    db = drizzle(sql, { schema: analyticsSchema });
+    const dbService = {
+      db,
+      run: <T>(fn: (t: unknown) => Promise<T>, tx?: unknown): Promise<T> =>
+        tx ? fn(tx) : (db.transaction((t) => fn(t)) as Promise<T>),
+    } as unknown as DbService<typeof analyticsSchema>;
+    service = new ProductDimensionsService(dbService);
+  });
+
+  afterAll(async () => {
+    await db?.delete(dimProductMasters).where(eq(dimProductMasters.masterId, masterId));
+    await sql?.end();
+  });
+
+  it('게시 이벤트의 supplyPrice 를 저장한다', async () => {
+    await service.recordMasterActiveVersionChanged({ ...basePayload, versionId: `${masterId}-v1`, supplyPrice: 3000 });
+    expect(await readSupplyPrice()).toBe(3000);
+  });
+
+  it('키가 없는 이벤트(구버전·미게시)는 기존 원가를 유지한다', async () => {
+    await service.recordMasterActiveVersionChanged({ ...basePayload, versionId: null, changeReason: 'unpublished' });
+    expect(await readSupplyPrice()).toBe(3000);
+  });
+
+  it('null 은 "원가 지움"으로 반영한다', async () => {
+    await service.recordMasterActiveVersionChanged({ ...basePayload, versionId: `${masterId}-v2`, supplyPrice: null });
+    expect(await readSupplyPrice()).toBeNull();
+  });
+});

--- a/apps/analytics/src/features/statistics/api/profit.controller.ts
+++ b/apps/analytics/src/features/statistics/api/profit.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { AdminRealmGuard, JwtAuthGuard } from '@app/authorization';
+import { ProfitQuery, ProfitStatistics } from '../read-model/profit.query';
+import { ProfitStatisticsQueryDto } from './statistics-query.dto';
+
+/**
+ * 이익(수익성) 통계. admin-web 프록시를 통해서만 호출된다.
+ * 신설 라우트 관례대로 AdminRealmGuard 로 staff 를 강제한다.
+ */
+@ApiTags('Statistics')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, AdminRealmGuard)
+@Controller('statistics')
+export class ProfitController {
+  constructor(private readonly profitQuery: ProfitQuery) {}
+
+  @Get('profit')
+  @ApiOperation({
+    summary: '이익(수익성) 통계',
+    description:
+      '기간 내 상품별 순매출·추정 원가·마진과 전사 요약. 원가는 게시 시점 공급가 × 판매수량을 ' +
+      '순매출 비율로 보정한 근사치이며, 원가 미입력 상품은 마진을 계산하지 않고 별도 몫으로 내려준다. ' +
+      '상품 목록은 페이지네이션 전체 조회.',
+  })
+  getProfit(@Query() query: ProfitStatisticsQueryDto): Promise<ProfitStatistics> {
+    return this.profitQuery.getProfit(
+      query.from,
+      query.to,
+      query.channel,
+      query.sort,
+      query.order,
+      query.page,
+      query.limit,
+    );
+  }
+}

--- a/apps/analytics/src/features/statistics/api/statistics-query.dto.ts
+++ b/apps/analytics/src/features/statistics/api/statistics-query.dto.ts
@@ -61,6 +61,37 @@ export class CustomerInsightsQueryDto extends StatisticsRangeQueryDto {
   minBuyers?: number = 5;
 }
 
+export class ProfitStatisticsQueryDto extends StatisticsRangeQueryDto {
+  @ApiPropertyOptional({
+    enum: ['revenue', 'margin', 'marginRate', 'quantity'],
+    default: 'revenue',
+    description: '상품 목록 정렬 기준 — 마진 정렬에서 원가 미입력(계산 불가) 상품은 항상 뒤로 간다',
+  })
+  @IsOptional()
+  @IsIn(['revenue', 'margin', 'marginRate', 'quantity'])
+  sort?: 'revenue' | 'margin' | 'marginRate' | 'quantity' = 'revenue';
+
+  @ApiPropertyOptional({ enum: ['desc', 'asc'], default: 'desc' })
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  order?: 'asc' | 'desc' = 'desc';
+
+  @ApiPropertyOptional({ example: 1, default: 1, description: '페이지 (1부터)' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ example: 50, default: 50, description: '페이지 크기' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  limit?: number = 50;
+}
+
 export class UnsoldProductsQueryDto extends StatisticsRangeQueryDto {
   @ApiPropertyOptional({ example: 50, default: 50, description: '최대 행 수' })
   @IsOptional()

--- a/apps/analytics/src/features/statistics/read-model/profit.query.integration.spec.ts
+++ b/apps/analytics/src/features/statistics/read-model/profit.query.integration.spec.ts
@@ -1,0 +1,182 @@
+import { randomUUID } from 'crypto';
+import * as postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { eq } from 'drizzle-orm';
+import type { DbService } from '@app/db';
+import { aggProductOrderDaily, analyticsSchema, dimProductMasters, factOrderItems } from '../../../schema';
+import { ProfitQuery } from './profit.query';
+
+/**
+ * 이익 read-model 을 실 Postgres 로 검증한다 — 검증 대상이 SQL(그룹핑·서브쿼리·FILTER) 자체다.
+ * 시드는 고유 채널 값으로 격리하고 끝나면 지운다.
+ *
+ * 실행: DATABASE_URL=postgresql://postgres:postgres@localhost:5432/analytics \
+ *   npx jest --testPathPattern="profit.query.integration"
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+
+if (process.env.REQUIRE_ANALYTICS_DB === '1' && !DATABASE_URL) {
+  throw new Error('REQUIRE_ANALYTICS_DB=1 인데 DATABASE_URL 이 없습니다');
+}
+
+describeIfDb('ProfitQuery (실 Postgres)', () => {
+  jest.setTimeout(120_000);
+
+  const channel = `itest-${randomUUID().slice(0, 8)}`;
+  const masterCost = `itest-master-${randomUUID().slice(0, 8)}`; // 원가 있음, 취소 있음
+  const masterNoCost = `itest-master-${randomUUID().slice(0, 8)}`; // 원가 없음 — 계산 불가 몫
+  const masterCheap = `itest-master-${randomUUID().slice(0, 8)}`; // 원가 있음, 저마진
+  const masterNameless = `itest-master-${randomUUID().slice(0, 8)}`; // dim 없음 — 이름 폴백
+
+  let sql: postgres.Sql;
+  let db: ReturnType<typeof drizzle<typeof analyticsSchema>>;
+  let query: ProfitQuery;
+
+  beforeAll(async () => {
+    sql = postgres(DATABASE_URL as string, { max: 1 });
+    db = drizzle(sql, { schema: analyticsSchema });
+    const dbService = {
+      db,
+      run: <T>(fn: (t: unknown) => Promise<T>, tx?: unknown): Promise<T> =>
+        tx ? fn(tx) : (db.transaction((t) => fn(t)) as Promise<T>),
+    } as unknown as DbService<typeof analyticsSchema>;
+    query = new ProfitQuery(dbService);
+
+    await db.insert(dimProductMasters).values([
+      { masterId: masterCost, name: '이익테스트 원가상품', supplyPrice: 3000 },
+      { masterId: masterNoCost, name: '이익테스트 원가없음' },
+      { masterId: masterCheap, name: '이익테스트 저마진', supplyPrice: 900 },
+    ]);
+
+    await db.insert(aggProductOrderDaily).values([
+      // masterCost: 8/1 10개×1만원, 8/2 취소 2만원 → 순매출 8만, 원가 3만×0.8=2.4만
+      { aggDate: '2026-08-01', masterId: masterCost, salesChannel: channel, ordersCount: 2, quantitySold: 10, grossRevenue: 100_000, cancelledAmount: 0, refundedAmount: 0 },
+      { aggDate: '2026-08-02', masterId: masterCost, salesChannel: channel, ordersCount: 0, quantitySold: 0, grossRevenue: 0, cancelledAmount: 20_000, refundedAmount: 0 },
+      // masterNoCost: 순매출 5만 — 계산 불가 몫으로 분리돼야 한다
+      { aggDate: '2026-08-01', masterId: masterNoCost, salesChannel: channel, ordersCount: 1, quantitySold: 5, grossRevenue: 50_000, cancelledAmount: 0, refundedAmount: 0 },
+      // masterCheap: 순매출 1만, 원가 10개×900=9000 → 마진 1000 (10%)
+      { aggDate: '2026-08-03', masterId: masterCheap, salesChannel: channel, ordersCount: 1, quantitySold: 10, grossRevenue: 10_000, cancelledAmount: 0, refundedAmount: 0 },
+      // masterNameless: dim 자체가 없다 — 이름은 주문 라인 폴백, 원가는 계산 불가
+      { aggDate: '2026-08-03', masterId: masterNameless, salesChannel: channel, ordersCount: 1, quantitySold: 1, grossRevenue: 1_000, cancelledAmount: 0, refundedAmount: 0 },
+      // 직전 기간(7월) — previousTotals 산출용
+      { aggDate: '2026-07-05', masterId: masterCost, salesChannel: channel, ordersCount: 1, quantitySold: 2, grossRevenue: 20_000, cancelledAmount: 0, refundedAmount: 0 },
+    ]);
+
+    await db.insert(factOrderItems).values([
+      {
+        messageId: `IT${randomUUID().replace(/-/g, '').slice(0, 24)}`,
+        orderKey: `${masterNameless}-o1`,
+        salesChannel: channel,
+        masterId: masterNameless,
+        productName: '폴백 이름',
+        quantity: 1,
+        occurredAt: new Date('2026-08-03T10:00:00+09:00'),
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    if (db) {
+      await db.delete(aggProductOrderDaily).where(eq(aggProductOrderDaily.salesChannel, channel));
+      await db.delete(dimProductMasters).where(eq(dimProductMasters.masterId, masterCost));
+      await db.delete(dimProductMasters).where(eq(dimProductMasters.masterId, masterNoCost));
+      await db.delete(dimProductMasters).where(eq(dimProductMasters.masterId, masterCheap));
+      await db.delete(factOrderItems).where(eq(factOrderItems.masterId, masterNameless));
+    }
+    await sql?.end();
+  });
+
+  it('전사 요약이 계산 가능/불가 몫을 분리해 손계산과 일치한다', async () => {
+    const result = await query.getProfit('2026-08-01', '2026-08-31', channel);
+
+    // 순매출: 8만(원가상품) + 5만(원가없음) + 1만(저마진) + 1천(dim없음) = 14.1만
+    expect(result.totals).toMatchObject({
+      grossRevenue: 161_000,
+      cancelledAmount: 20_000,
+      refundedAmount: 0,
+      netRevenue: 141_000,
+      quantitySold: 26,
+      productsCount: 4,
+      // 계산 가능: 원가상품 8만 + 저마진 1만
+      computedNetRevenue: 90_000,
+      // 원가상품 10×3000×(8만/10만)=24000 + 저마진 10×900=9000
+      estimatedCost: 33_000,
+      estimatedMargin: 57_000,
+      uncomputedNetRevenue: 51_000,
+      uncomputedProductsCount: 2,
+    });
+    expect(result.totals.marginRate).toBeCloseTo(57_000 / 90_000);
+    expect(result.totals.costCoverageRate).toBeCloseTo(90_000 / 141_000);
+
+    // 직전 기간(7월 동일 길이): 원가상품 2만, 원가 2×3000
+    expect(result.previousTotals).toMatchObject({
+      netRevenue: 20_000,
+      computedNetRevenue: 20_000,
+      estimatedCost: 6_000,
+    });
+  });
+
+  it('일별 추이의 원가·마진은 계산 가능 몫만 반영한다', async () => {
+    const result = await query.getProfit('2026-08-01', '2026-08-31', channel);
+    const byBucket = new Map(result.series.map((point) => [point.bucket, point]));
+
+    expect(byBucket.get('2026-08-01')).toMatchObject({
+      netRevenue: 150_000,
+      computedNetRevenue: 100_000,
+      estimatedCost: 30_000, // 8/1 단독으로는 취소가 없다 — 취소는 8/2 에 귀속
+      estimatedMargin: 70_000,
+    });
+    expect(byBucket.get('2026-08-02')).toMatchObject({
+      netRevenue: -20_000,
+      computedNetRevenue: -20_000,
+      estimatedCost: 0, // 수량 0 — 음수 원가로 내려가면 안 된다
+    });
+  });
+
+  it('상품 목록: 원가 없는 행은 계산 불가(null), 이름은 주문 라인 폴백', async () => {
+    const result = await query.getProfit('2026-08-01', '2026-08-31', channel, 'revenue', 'desc', 1, 50);
+    expect(result.totalItems).toBe(4);
+
+    const byMaster = new Map(result.items.map((item) => [item.masterId, item]));
+    expect(byMaster.get(masterCost)).toMatchObject({
+      netRevenue: 80_000,
+      supplyPrice: 3000,
+      estimatedCost: 24_000,
+      estimatedMargin: 56_000,
+    });
+    expect(byMaster.get(masterCost)?.marginRate).toBeCloseTo(0.7);
+    expect(byMaster.get(masterNoCost)).toMatchObject({
+      netRevenue: 50_000,
+      supplyPrice: null,
+      estimatedCost: null,
+      estimatedMargin: null,
+      marginRate: null,
+    });
+    expect(byMaster.get(masterNameless)?.name).toBe('폴백 이름');
+  });
+
+  it('마진 정렬은 계산 불가 행을 방향과 무관하게 끝으로 보낸다', async () => {
+    const desc = await query.getProfit('2026-08-01', '2026-08-31', channel, 'margin', 'desc', 1, 50);
+    expect(desc.items.map((item) => item.masterId).slice(0, 2)).toEqual([masterCost, masterCheap]);
+    expect(desc.items.slice(2).every((item) => item.estimatedMargin === null)).toBe(true);
+
+    const asc = await query.getProfit('2026-08-01', '2026-08-31', channel, 'margin', 'asc', 1, 50);
+    expect(asc.items.map((item) => item.masterId).slice(0, 2)).toEqual([masterCheap, masterCost]);
+    expect(asc.items.slice(2).every((item) => item.estimatedMargin === null)).toBe(true);
+  });
+
+  it('페이지네이션: 페이지를 이어 붙이면 전체가 겹침 없이 나온다', async () => {
+    const page1 = await query.getProfit('2026-08-01', '2026-08-31', channel, 'revenue', 'desc', 1, 3);
+    const page2 = await query.getProfit('2026-08-01', '2026-08-31', channel, 'revenue', 'desc', 2, 3);
+    expect(page1.totalItems).toBe(4);
+    expect(page1.items).toHaveLength(3);
+    expect(page2.items).toHaveLength(1);
+    const all = [...page1.items, ...page2.items].map((item) => item.masterId);
+    expect(new Set(all).size).toBe(4);
+  });
+
+  it('기간이 뒤집히면 400', async () => {
+    await expect(query.getProfit('2026-08-31', '2026-08-01', channel)).rejects.toThrow('조회 기간이 뒤집혔습니다');
+  });
+});

--- a/apps/analytics/src/features/statistics/read-model/profit.query.spec.ts
+++ b/apps/analytics/src/features/statistics/read-model/profit.query.spec.ts
@@ -1,0 +1,46 @@
+import { estimateCost, marginRateOf } from './profit.query';
+
+describe('estimateCost', () => {
+  it('원가 미입력이면 null — 0 으로 뭉개지 않는다', () => {
+    expect(estimateCost(10, null, 100_000, 100_000)).toBeNull();
+  });
+
+  it('취소·환불이 없으면 판매수량 × 공급가 그대로', () => {
+    expect(estimateCost(10, 3_000, 100_000, 100_000)).toBe(30_000);
+  });
+
+  it('취소·환불 금액만큼 순매출 비율로 원가를 덜어낸다', () => {
+    expect(estimateCost(10, 3_000, 100_000, 50_000)).toBe(15_000);
+  });
+
+  it('환불이 총매출을 넘어 순매출이 음수여도 원가는 0 밑으로 내려가지 않는다', () => {
+    expect(estimateCost(10, 3_000, 100_000, -20_000)).toBe(0);
+  });
+
+  it('순매출이 총매출보다 커도(비정상 데이터) 원가는 전량 원가를 넘지 않는다', () => {
+    expect(estimateCost(10, 3_000, 100_000, 120_000)).toBe(30_000);
+  });
+
+  it('총매출 0(취소만 있는 기간)이면 비율 보정 없이 전량 원가 — 수량 0 이면 0', () => {
+    expect(estimateCost(0, 3_000, 0, -5_000)).toBe(0);
+  });
+
+  it('공급가 0 원은 유효한 원가다 — null 과 구분된다', () => {
+    expect(estimateCost(10, 0, 100_000, 100_000)).toBe(0);
+  });
+});
+
+describe('marginRateOf', () => {
+  it('마진 미계산(null)이면 null', () => {
+    expect(marginRateOf(null, 100_000)).toBeNull();
+  });
+
+  it('순매출이 0 이하이면 비율을 만들지 않는다', () => {
+    expect(marginRateOf(1_000, 0)).toBeNull();
+    expect(marginRateOf(-1_000, -5_000)).toBeNull();
+  });
+
+  it('마진 / 순매출', () => {
+    expect(marginRateOf(30_000, 100_000)).toBeCloseTo(0.3);
+  });
+});

--- a/apps/analytics/src/features/statistics/read-model/profit.query.ts
+++ b/apps/analytics/src/features/statistics/read-model/profit.query.ts
@@ -1,0 +1,386 @@
+import { Injectable } from '@nestjs/common';
+import { InjectTypedDb } from '@app/db/decorators';
+import { DbService } from '@app/db';
+import { BadRequestError } from '@app/shared';
+import { and, eq, gte, inArray, lte, sql, SQL } from 'drizzle-orm';
+import { aggProductOrderDaily, analyticsSchema, dimProductMasters, factOrderItems } from '../../../schema';
+
+export type ProfitSort = 'revenue' | 'margin' | 'marginRate' | 'quantity';
+
+/**
+ * 기간 전사 이익 요약. 원가가 있는 상품(computed)과 없는 상품(uncomputed)을 항상 분리해
+ * 내려준다 — 없는 쪽을 0 으로 뭉개면 이익이 과대/과소로 보이기 때문.
+ */
+export interface ProfitTotals {
+  grossRevenue: number;
+  cancelledAmount: number;
+  refundedAmount: number;
+  netRevenue: number;
+  quantitySold: number;
+  productsCount: number;
+  /** 원가가 입력된 상품들의 순매출 합 — 마진 계산의 분모 */
+  computedNetRevenue: number;
+  /** 원가 추정치 합 (판매수량×공급가를 순매출 비율로 보정) */
+  estimatedCost: number;
+  /** computedNetRevenue - estimatedCost */
+  estimatedMargin: number;
+  /** estimatedMargin / computedNetRevenue. 분모 0 이하이면 null. */
+  marginRate: number | null;
+  /** 원가 미입력 상품들의 순매출 합 — "계산 불가" 몫 */
+  uncomputedNetRevenue: number;
+  uncomputedProductsCount: number;
+  /** computedNetRevenue / netRevenue. 분모 0 이하이면 null. */
+  costCoverageRate: number | null;
+}
+
+export interface ProfitProductRow {
+  masterId: string;
+  name: string | null;
+  quantitySold: number;
+  grossRevenue: number;
+  cancelledAmount: number;
+  refundedAmount: number;
+  netRevenue: number;
+  /** null = 원가 미입력 → 아래 세 값도 전부 null ("계산 불가") */
+  supplyPrice: number | null;
+  estimatedCost: number | null;
+  estimatedMargin: number | null;
+  marginRate: number | null;
+}
+
+export interface ProfitSeriesPoint {
+  bucket: string;
+  netRevenue: number;
+  computedNetRevenue: number;
+  estimatedCost: number;
+  estimatedMargin: number;
+}
+
+export interface ProfitStatistics {
+  range: { from: string; to: string };
+  previousRange: { from: string; to: string };
+  totals: ProfitTotals;
+  previousTotals: ProfitTotals;
+  series: ProfitSeriesPoint[];
+  items: ProfitProductRow[];
+  page: number;
+  limit: number;
+  totalItems: number;
+}
+
+/**
+ * 원가 추정: 판매수량 × 공급가에 순매출/총매출 비율(0~1 클램프)을 곱한다.
+ * 취소·환불은 금액만 있고 수량이 없어서, 취소분 원가를 금액 비례로 덜어내는 근사다 —
+ * 환불 금액을 master 별로 비례 배분하는 기존 파이프라인과 같은 정신.
+ */
+export function estimateCost(
+  quantitySold: number,
+  supplyPrice: number | null,
+  grossRevenue: number,
+  netRevenue: number,
+): number | null {
+  if (supplyPrice == null) {
+    return null;
+  }
+  const fullCost = quantitySold * supplyPrice;
+  if (grossRevenue <= 0) {
+    return fullCost;
+  }
+  const ratio = Math.min(Math.max(netRevenue / grossRevenue, 0), 1);
+  return Math.round(fullCost * ratio);
+}
+
+export function marginRateOf(margin: number | null, netRevenue: number): number | null {
+  if (margin == null || netRevenue <= 0) {
+    return null;
+  }
+  return margin / netRevenue;
+}
+
+function previousRange(from: string, to: string): { from: string; to: string } {
+  const fromDate = new Date(`${from}T00:00:00Z`);
+  const toDate = new Date(`${to}T00:00:00Z`);
+  const days = Math.round((toDate.getTime() - fromDate.getTime()) / 86_400_000) + 1;
+  const prevTo = new Date(fromDate.getTime() - 86_400_000);
+  const prevFrom = new Date(prevTo.getTime() - (days - 1) * 86_400_000);
+  const fmt = (d: Date) => d.toISOString().slice(0, 10);
+  return { from: fmt(prevFrom), to: fmt(prevTo) };
+}
+
+const EMPTY_TOTALS: ProfitTotals = {
+  grossRevenue: 0,
+  cancelledAmount: 0,
+  refundedAmount: 0,
+  netRevenue: 0,
+  quantitySold: 0,
+  productsCount: 0,
+  computedNetRevenue: 0,
+  estimatedCost: 0,
+  estimatedMargin: 0,
+  marginRate: null,
+  uncomputedNetRevenue: 0,
+  uncomputedProductsCount: 0,
+  costCoverageRate: null,
+};
+
+@Injectable()
+export class ProfitQuery {
+  constructor(
+    @InjectTypedDb<typeof analyticsSchema>()
+    private readonly dbService: DbService<typeof analyticsSchema>,
+  ) {}
+
+  private get db() {
+    return this.dbService.db;
+  }
+
+  async getProfit(
+    from: string,
+    to: string,
+    channel?: string,
+    sort: ProfitSort = 'revenue',
+    order: 'asc' | 'desc' = 'desc',
+    page = 1,
+    limit = 50,
+  ): Promise<ProfitStatistics> {
+    if (from > to) {
+      throw new BadRequestError(`조회 기간이 뒤집혔습니다: ${from} > ${to}`);
+    }
+    const prev = previousRange(from, to);
+
+    const [totals, previousTotals, series, pageResult] = await Promise.all([
+      this.totals(from, to, channel),
+      this.totals(prev.from, prev.to, channel),
+      this.series(from, to, channel),
+      this.pagedItems(from, to, channel, sort, order, page, limit),
+    ]);
+
+    return {
+      range: { from, to },
+      previousRange: prev,
+      totals,
+      previousTotals,
+      series,
+      items: pageResult.items,
+      page,
+      limit,
+      totalItems: pageResult.totalItems,
+    };
+  }
+
+  private rangeWhere(from: string, to: string, channel?: string): SQL | undefined {
+    const parts: SQL[] = [gte(aggProductOrderDaily.aggDate, from), lte(aggProductOrderDaily.aggDate, to)];
+    if (channel) {
+      parts.push(eq(aggProductOrderDaily.salesChannel, channel));
+    }
+    return and(...parts);
+  }
+
+  /** 행 하나(그룹)의 순매출 비율 보정 원가 — SQL 판. estimateCost 와 같은 식이어야 한다. */
+  private costExpr(qty: SQL, gross: SQL, net: SQL): SQL {
+    return sql`ROUND(${qty} * ${dimProductMasters.supplyPrice} * CASE WHEN ${gross} > 0 THEN LEAST(GREATEST(${net}::numeric / ${gross}, 0), 1) ELSE 1 END)`;
+  }
+
+  private async totals(from: string, to: string, channel?: string): Promise<ProfitTotals> {
+    const qty = sql`SUM(${aggProductOrderDaily.quantitySold})`;
+    const gross = sql`SUM(${aggProductOrderDaily.grossRevenue})`;
+    const net = sql`SUM(${aggProductOrderDaily.grossRevenue} - ${aggProductOrderDaily.cancelledAmount} - ${aggProductOrderDaily.refundedAmount})`;
+
+    const perMaster = this.db
+      .select({
+        masterId: aggProductOrderDaily.masterId,
+        quantitySold: sql<string>`${qty}`.as('quantity_sold'),
+        grossRevenue: sql<string>`${gross}`.as('gross_revenue'),
+        cancelledAmount: sql<string>`SUM(${aggProductOrderDaily.cancelledAmount})`.as('cancelled_amount'),
+        refundedAmount: sql<string>`SUM(${aggProductOrderDaily.refundedAmount})`.as('refunded_amount'),
+        netRevenue: sql<string>`${net}`.as('net_revenue'),
+        supplyPrice: dimProductMasters.supplyPrice,
+        estimatedCost: sql<string>`${this.costExpr(qty, gross, net)}`.as('estimated_cost'),
+      })
+      .from(aggProductOrderDaily)
+      .leftJoin(dimProductMasters, eq(dimProductMasters.masterId, aggProductOrderDaily.masterId))
+      .where(this.rangeWhere(from, to, channel))
+      .groupBy(aggProductOrderDaily.masterId, dimProductMasters.supplyPrice)
+      .as('per_master');
+
+    const rows = await this.db
+      .select({
+        grossRevenue: sql<string>`COALESCE(SUM(${perMaster.grossRevenue}), 0)`,
+        cancelledAmount: sql<string>`COALESCE(SUM(${perMaster.cancelledAmount}), 0)`,
+        refundedAmount: sql<string>`COALESCE(SUM(${perMaster.refundedAmount}), 0)`,
+        netRevenue: sql<string>`COALESCE(SUM(${perMaster.netRevenue}), 0)`,
+        quantitySold: sql<string>`COALESCE(SUM(${perMaster.quantitySold}), 0)`,
+        productsCount: sql<string>`COUNT(*)`,
+        computedNetRevenue: sql<string>`COALESCE(SUM(${perMaster.netRevenue}) FILTER (WHERE ${perMaster.supplyPrice} IS NOT NULL), 0)`,
+        estimatedCost: sql<string>`COALESCE(SUM(${perMaster.estimatedCost}) FILTER (WHERE ${perMaster.supplyPrice} IS NOT NULL), 0)`,
+        uncomputedNetRevenue: sql<string>`COALESCE(SUM(${perMaster.netRevenue}) FILTER (WHERE ${perMaster.supplyPrice} IS NULL), 0)`,
+        uncomputedProductsCount: sql<string>`COUNT(*) FILTER (WHERE ${perMaster.supplyPrice} IS NULL)`,
+      })
+      .from(perMaster);
+
+    const row = rows[0];
+    if (!row || Number(row.productsCount) === 0) {
+      return EMPTY_TOTALS;
+    }
+
+    const netRevenue = Number(row.netRevenue);
+    const computedNetRevenue = Number(row.computedNetRevenue);
+    const estimatedCost = Number(row.estimatedCost);
+    const estimatedMargin = computedNetRevenue - estimatedCost;
+    return {
+      grossRevenue: Number(row.grossRevenue),
+      cancelledAmount: Number(row.cancelledAmount),
+      refundedAmount: Number(row.refundedAmount),
+      netRevenue,
+      quantitySold: Number(row.quantitySold),
+      productsCount: Number(row.productsCount),
+      computedNetRevenue,
+      estimatedCost,
+      estimatedMargin,
+      marginRate: marginRateOf(estimatedMargin, computedNetRevenue),
+      uncomputedNetRevenue: Number(row.uncomputedNetRevenue),
+      uncomputedProductsCount: Number(row.uncomputedProductsCount),
+      costCoverageRate: netRevenue > 0 ? computedNetRevenue / netRevenue : null,
+    };
+  }
+
+  /** 일별 마진 추이 — 원가 있는 상품 부분만 cost/margin 에 반영된다. */
+  private async series(from: string, to: string, channel?: string): Promise<ProfitSeriesPoint[]> {
+    const qty = sql`SUM(${aggProductOrderDaily.quantitySold})`;
+    const gross = sql`SUM(${aggProductOrderDaily.grossRevenue})`;
+    const net = sql`SUM(${aggProductOrderDaily.grossRevenue} - ${aggProductOrderDaily.cancelledAmount} - ${aggProductOrderDaily.refundedAmount})`;
+
+    const perMasterDay = this.db
+      .select({
+        aggDate: aggProductOrderDaily.aggDate,
+        netRevenue: sql<string>`${net}`.as('net_revenue'),
+        supplyPrice: dimProductMasters.supplyPrice,
+        estimatedCost: sql<string>`${this.costExpr(qty, gross, net)}`.as('estimated_cost'),
+      })
+      .from(aggProductOrderDaily)
+      .leftJoin(dimProductMasters, eq(dimProductMasters.masterId, aggProductOrderDaily.masterId))
+      .where(this.rangeWhere(from, to, channel))
+      .groupBy(aggProductOrderDaily.aggDate, aggProductOrderDaily.masterId, dimProductMasters.supplyPrice)
+      .as('per_master_day');
+
+    const rows = await this.db
+      .select({
+        bucket: sql<string>`${perMasterDay.aggDate}::text`,
+        netRevenue: sql<string>`COALESCE(SUM(${perMasterDay.netRevenue}), 0)`,
+        computedNetRevenue: sql<string>`COALESCE(SUM(${perMasterDay.netRevenue}) FILTER (WHERE ${perMasterDay.supplyPrice} IS NOT NULL), 0)`,
+        estimatedCost: sql<string>`COALESCE(SUM(${perMasterDay.estimatedCost}) FILTER (WHERE ${perMasterDay.supplyPrice} IS NOT NULL), 0)`,
+      })
+      .from(perMasterDay)
+      .groupBy(sql`1`)
+      .orderBy(sql`1`);
+
+    return rows.map((row) => {
+      const computedNetRevenue = Number(row.computedNetRevenue);
+      const estimatedCost = Number(row.estimatedCost);
+      return {
+        bucket: row.bucket,
+        netRevenue: Number(row.netRevenue),
+        computedNetRevenue,
+        estimatedCost,
+        estimatedMargin: computedNetRevenue - estimatedCost,
+      };
+    });
+  }
+
+  private async pagedItems(
+    from: string,
+    to: string,
+    channel: string | undefined,
+    sort: ProfitSort,
+    order: 'asc' | 'desc',
+    page: number,
+    limit: number,
+  ): Promise<{ items: ProfitProductRow[]; totalItems: number }> {
+    const where = this.rangeWhere(from, to, channel);
+
+    const qty = sql`SUM(${aggProductOrderDaily.quantitySold})`;
+    const gross = sql`SUM(${aggProductOrderDaily.grossRevenue})`;
+    const net = sql`SUM(${aggProductOrderDaily.grossRevenue} - ${aggProductOrderDaily.cancelledAmount} - ${aggProductOrderDaily.refundedAmount})`;
+    const cost = this.costExpr(qty, gross, net);
+    const margin = sql`${net} - ${cost}`;
+
+    const sortExpr =
+      sort === 'quantity'
+        ? qty
+        : sort === 'margin'
+          ? sql`CASE WHEN ${dimProductMasters.supplyPrice} IS NULL THEN NULL ELSE ${margin} END`
+          : sort === 'marginRate'
+            ? sql`CASE WHEN ${dimProductMasters.supplyPrice} IS NULL OR ${net} <= 0 THEN NULL ELSE (${margin})::numeric / ${net} END`
+            : net;
+    // 마진 정렬에서 "계산 불가" 행은 방향과 무관하게 항상 끝으로 보낸다
+    const orderExpr = order === 'asc' ? sql`${sortExpr} ASC NULLS LAST` : sql`${sortExpr} DESC NULLS LAST`;
+
+    const [countRows, rows] = await Promise.all([
+      this.db
+        .select({ value: sql<string>`COUNT(DISTINCT ${aggProductOrderDaily.masterId})` })
+        .from(aggProductOrderDaily)
+        .where(where),
+      this.db
+        .select({
+          masterId: aggProductOrderDaily.masterId,
+          name: dimProductMasters.name,
+          quantitySold: sql<string>`${qty}`,
+          grossRevenue: sql<string>`${gross}`,
+          cancelledAmount: sql<string>`SUM(${aggProductOrderDaily.cancelledAmount})`,
+          refundedAmount: sql<string>`SUM(${aggProductOrderDaily.refundedAmount})`,
+          supplyPrice: dimProductMasters.supplyPrice,
+        })
+        .from(aggProductOrderDaily)
+        .leftJoin(dimProductMasters, eq(dimProductMasters.masterId, aggProductOrderDaily.masterId))
+        .where(where)
+        .groupBy(aggProductOrderDaily.masterId, dimProductMasters.name, dimProductMasters.supplyPrice)
+        .orderBy(orderExpr, sql`${aggProductOrderDaily.masterId} ASC`)
+        .limit(limit)
+        .offset((page - 1) * limit),
+    ]);
+
+    const items = rows.map((row) => {
+      const quantitySold = Number(row.quantitySold);
+      const grossRevenue = Number(row.grossRevenue);
+      const cancelledAmount = Number(row.cancelledAmount);
+      const refundedAmount = Number(row.refundedAmount);
+      const netRevenue = grossRevenue - cancelledAmount - refundedAmount;
+      const supplyPrice = row.supplyPrice ?? null;
+      const estimatedCost = estimateCost(quantitySold, supplyPrice, grossRevenue, netRevenue);
+      const estimatedMargin = estimatedCost == null ? null : netRevenue - estimatedCost;
+      return {
+        masterId: row.masterId,
+        name: row.name ?? null,
+        quantitySold,
+        grossRevenue,
+        cancelledAmount,
+        refundedAmount,
+        netRevenue,
+        supplyPrice,
+        estimatedCost,
+        estimatedMargin,
+        marginRate: marginRateOf(estimatedMargin, netRevenue),
+      };
+    });
+
+    const nameless = items.filter((item) => !item.name).map((item) => item.masterId);
+    if (nameless.length > 0) {
+      const fallbackRows = await this.db
+        .selectDistinctOn([factOrderItems.masterId], {
+          masterId: factOrderItems.masterId,
+          productName: factOrderItems.productName,
+        })
+        .from(factOrderItems)
+        .where(and(inArray(factOrderItems.masterId, nameless), sql`${factOrderItems.productName} IS NOT NULL`))
+        .orderBy(factOrderItems.masterId, sql`${factOrderItems.occurredAt} DESC`);
+      const nameByMaster = new Map(fallbackRows.map((row) => [row.masterId, row.productName]));
+      for (const item of items) {
+        if (!item.name) {
+          item.name = nameByMaster.get(item.masterId) ?? null;
+        }
+      }
+    }
+
+    return { items, totalItems: Number(countRows[0]?.value ?? 0) };
+  }
+}

--- a/apps/analytics/src/schema.ts
+++ b/apps/analytics/src/schema.ts
@@ -110,6 +110,8 @@ export const dimProductMasters = pgTable(
     activeVersionId: varchar('active_version_id', { length: 255 }),
     isActive: boolean('is_active'),
     lastChangeReason: varchar('last_change_reason', { length: 50 }),
+    /** 게시 시점 매입 원가(공급가, 원). null = 원가 미입력 — 마진은 "계산 불가"로 구분한다. */
+    supplyPrice: bigint('supply_price', { mode: 'number' }),
     createdAt: timestamp('created_at').defaultNow(),
     updatedAt: timestamp('updated_at').defaultNow(),
     deletedAt: timestamp('deleted_at'),

--- a/apps/core/src/modules/catalog/core/products/services/product-versions.service.ts
+++ b/apps/core/src/modules/catalog/core/products/services/product-versions.service.ts
@@ -1169,6 +1169,8 @@ export class ProductVersionsService {
           primaryCategoryId,
           changeReason,
           changedAt: new Date().toISOString(),
+          // 원가 미상(null 저장)과 키 부재(미게시)를 구분해 소비 측이 기존 값을 안 지우게 한다
+          ...(changeReason === 'unpublished' ? {} : { supplyPrice: newVersion.supplyPrice ?? null }),
           snapshot,
           // 출처가 없으면 키를 만들지 않는다 — 단건 게시의 payload 를 그대로 두기 위해서다.
           ...(options?.origin ? { origin: options.origin } : {}),

--- a/apps/wallet/drizzle/20260826080857_add-payment-fee-rates.sql
+++ b/apps/wallet/drizzle/20260826080857_add-payment-fee-rates.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "payment_fee_rates" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"method_type" "payment_method_type" NOT NULL,
+	"fee_rate_bp" integer NOT NULL,
+	"effective_from" timestamp with time zone NOT NULL,
+	"memo" varchar(255),
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "payment_fee_rates_bp_range" CHECK ("payment_fee_rates"."fee_rate_bp" >= 0 AND "payment_fee_rates"."fee_rate_bp" <= 10000)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_payment_fee_rates_method_effective" ON "payment_fee_rates" USING btree ("method_type","effective_from");

--- a/apps/wallet/drizzle/meta/20260826080857_snapshot.json
+++ b/apps/wallet/drizzle/meta/20260826080857_snapshot.json
@@ -1,0 +1,5218 @@
+{
+  "id": "6e0bc39c-1842-44b8-b87e-1a3226357950",
+  "prevId": "c1772b5f-2995-477f-9641-b09508354e11",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.billing_agreements": {
+      "name": "billing_agreements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_method_id": {
+          "name": "billing_method_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriber_ref": {
+          "name": "subscriber_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriber_type": {
+          "name": "subscriber_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "billing_agreement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_billing_agreements_subscriber": {
+          "name": "uq_billing_agreements_subscriber",
+          "columns": [
+            {
+              "expression": "subscriber_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscriber_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_billing_agreements_user_id": {
+          "name": "idx_billing_agreements_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_billing_agreements_billing_method_id": {
+          "name": "idx_billing_agreements_billing_method_id",
+          "columns": [
+            {
+              "expression": "billing_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_agreements_billing_method_id_billing_methods_id_fk": {
+          "name": "billing_agreements_billing_method_id_billing_methods_id_fk",
+          "tableFrom": "billing_agreements",
+          "tableTo": "billing_methods",
+          "columnsFrom": [
+            "billing_method_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_methods": {
+      "name": "billing_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_key": {
+          "name": "billing_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_key": {
+          "name": "customer_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cms_member_id": {
+          "name": "cms_member_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "billing_method_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_billing_methods_user_id": {
+          "name": "idx_billing_methods_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_billing_methods_user_provider_status": {
+          "name": "idx_billing_methods_user_provider_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cash_receipts": {
+      "name": "cash_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "charge_id": {
+          "name": "charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "cash_receipt_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customer_identity_number": {
+          "name": "customer_identity_number",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cash_receipt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canceled_amount": {
+          "name": "canceled_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "receipt_key": {
+          "name": "receipt_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_payload": {
+          "name": "request_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_payload": {
+          "name": "response_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canceled_at": {
+          "name": "canceled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_cash_receipts_active_charge": {
+          "name": "uq_cash_receipts_active_charge",
+          "columns": [
+            {
+              "expression": "charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"cash_receipts\".\"status\" = 'ISSUED'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cash_receipts_intent": {
+          "name": "idx_cash_receipts_intent",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cash_receipts_user_created_at": {
+          "name": "idx_cash_receipts_user_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cash_receipts_charge_id_charges_id_fk": {
+          "name": "cash_receipts_charge_id_charges_id_fk",
+          "tableFrom": "cash_receipts",
+          "tableTo": "charges",
+          "columnsFrom": [
+            "charge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cash_receipts_intent_id_payment_intents_id_fk": {
+          "name": "cash_receipts_intent_id_payment_intents_id_fk",
+          "tableFrom": "cash_receipts",
+          "tableTo": "payment_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "cash_receipts_amount_positive": {
+          "name": "cash_receipts_amount_positive",
+          "value": "\"cash_receipts\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.charges": {
+      "name": "charges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "charge_operation",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "charge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_transaction_id": {
+          "name": "provider_transaction_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_idempotency_key": {
+          "name": "provider_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_payload": {
+          "name": "request_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_payload": {
+          "name": "response_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_charges_provider_idempotency_key": {
+          "name": "uq_charges_provider_idempotency_key",
+          "columns": [
+            {
+              "expression": "provider_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_charges_active_intent_operation": {
+          "name": "uq_charges_active_intent_operation",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"charges\".\"status\" in ('CREATED', 'PENDING', 'REQUIRES_ACTION')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_charges_intent_created_at": {
+          "name": "idx_charges_intent_created_at",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_charges_status_created_at": {
+          "name": "idx_charges_status_created_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "charges_intent_id_payment_intents_id_fk": {
+          "name": "charges_intent_id_payment_intents_id_fk",
+          "tableFrom": "charges",
+          "tableTo": "payment_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "charges_payment_method_id_payment_methods_id_fk": {
+          "name": "charges_payment_method_id_payment_methods_id_fk",
+          "tableFrom": "charges",
+          "tableTo": "payment_methods",
+          "columnsFrom": [
+            "payment_method_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "charges_amount_positive": {
+          "name": "charges_amount_positive",
+          "value": "\"charges\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.checkout_sessions": {
+      "name": "checkout_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "intent_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "success_url": {
+          "name": "success_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_url": {
+          "name": "cancel_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allow_composite": {
+          "name": "allow_composite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "checkout_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_checkout_sessions_user_status": {
+          "name": "idx_checkout_sessions_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_checkout_sessions_status_expires_at": {
+          "name": "idx_checkout_sessions_status_expires_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "checkout_sessions_intent_id_payment_intents_id_fk": {
+          "name": "checkout_sessions_intent_id_payment_intents_id_fk",
+          "tableFrom": "checkout_sessions",
+          "tableTo": "payment_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cms_agreements": {
+      "name": "cms_agreements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cms_member_id": {
+          "name": "cms_member_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_key": {
+          "name": "agreement_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_extension": {
+          "name": "file_extension",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_code": {
+          "name": "result_code",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_message": {
+          "name": "result_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_cms_agreements_cms_member_id": {
+          "name": "idx_cms_agreements_cms_member_id",
+          "columns": [
+            {
+              "expression": "cms_member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cms_members": {
+      "name": "cms_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "billing_method_id": {
+          "name": "billing_method_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cms_member_id": {
+          "name": "cms_member_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_company": {
+          "name": "payment_company",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_name": {
+          "name": "payer_name",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_number": {
+          "name": "payer_number",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cms_member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "result_code": {
+          "name": "result_code",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_message": {
+          "name": "result_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_cms_members_cms_member_id": {
+          "name": "uq_cms_members_cms_member_id",
+          "columns": [
+            {
+              "expression": "cms_member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cms_members_billing_method_id": {
+          "name": "idx_cms_members_billing_method_id",
+          "columns": [
+            {
+              "expression": "billing_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cms_members_user_id": {
+          "name": "idx_cms_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cms_members_status": {
+          "name": "idx_cms_members_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cms_members_billing_method_id_billing_methods_id_fk": {
+          "name": "cms_members_billing_method_id_billing_methods_id_fk",
+          "tableFrom": "cms_members",
+          "tableTo": "billing_methods",
+          "columnsFrom": [
+            "billing_method_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cms_withdrawals": {
+      "name": "cms_withdrawals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cms_member_id": {
+          "name": "cms_member_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "charge_id": {
+          "name": "charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_date": {
+          "name": "payment_date",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "cms_withdrawal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REQUESTED'"
+        },
+        "result_code": {
+          "name": "result_code",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_message": {
+          "name": "result_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actual_amount": {
+          "name": "actual_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee": {
+          "name": "fee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_cms_withdrawals_transaction_id": {
+          "name": "uq_cms_withdrawals_transaction_id",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cms_withdrawals_intent_id": {
+          "name": "idx_cms_withdrawals_intent_id",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cms_withdrawals_status_payment_date": {
+          "name": "idx_cms_withdrawals_status_payment_date",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cms_withdrawals_charge_id_charges_id_fk": {
+          "name": "cms_withdrawals_charge_id_charges_id_fk",
+          "tableFrom": "cms_withdrawals",
+          "tableTo": "charges",
+          "columnsFrom": [
+            "charge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cms_withdrawals_intent_id_payment_intents_id_fk": {
+          "name": "cms_withdrawals_intent_id_payment_intents_id_fk",
+          "tableFrom": "cms_withdrawals",
+          "tableTo": "payment_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_path": {
+          "name": "request_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subscriber_type": {
+          "name": "subscriber_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriber_ref": {
+          "name": "subscriber_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_method_id": {
+          "name": "billing_method_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_due": {
+          "name": "amount_due",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "retry_interval_hours": {
+          "name": "retry_interval_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 72
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_invoices_idempotency_key": {
+          "name": "uq_invoices_idempotency_key",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_subscriber": {
+          "name": "idx_invoices_subscriber",
+          "columns": [
+            {
+              "expression": "subscriber_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscriber_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_status_next_attempt_at": {
+          "name": "idx_invoices_status_next_attempt_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"invoices\".\"next_attempt_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_billing_method_id_billing_methods_id_fk": {
+          "name": "invoices_billing_method_id_billing_methods_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "billing_methods",
+          "columnsFrom": [
+            "billing_method_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoices_amount_due_positive": {
+          "name": "invoices_amount_due_positive",
+          "value": "\"invoices\".\"amount_due\" > 0"
+        },
+        "invoices_period_valid": {
+          "name": "invoices_period_valid",
+          "value": "\"invoices\".\"period_end\" >= \"invoices\".\"period_start\""
+        },
+        "invoices_attempt_count_non_negative": {
+          "name": "invoices_attempt_count_non_negative",
+          "value": "\"invoices\".\"attempt_count\" >= 0"
+        },
+        "invoices_max_attempts_positive": {
+          "name": "invoices_max_attempts_positive",
+          "value": "\"invoices\".\"max_attempts\" > 0"
+        },
+        "invoices_retry_interval_hours_positive": {
+          "name": "invoices_retry_interval_hours_positive",
+          "value": "\"invoices\".\"retry_interval_hours\" > 0"
+        },
+        "invoices_terminal_finalized_consistency": {
+          "name": "invoices_terminal_finalized_consistency",
+          "value": "(\"invoices\".\"status\" IN ('PAID', 'UNCOLLECTIBLE', 'MANDATE_REJECTED', 'VOID')) = (\"invoices\".\"finalized_at\" IS NOT NULL)"
+        },
+        "invoices_next_attempt_status_consistency": {
+          "name": "invoices_next_attempt_status_consistency",
+          "value": "(\n        (\"invoices\".\"status\" IN ('OPEN', 'MANDATE_PENDING', 'PAST_DUE') AND \"invoices\".\"next_attempt_at\" IS NOT NULL)\n        OR (\"invoices\".\"status\" IN ('PAID', 'UNCOLLECTIBLE', 'MANDATE_REJECTED', 'VOID') AND \"invoices\".\"next_attempt_at\" IS NULL)\n        OR \"invoices\".\"status\" IN ('DRAFT', 'ATTEMPTING')\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_fee_rates": {
+      "name": "payment_fee_rates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "method_type": {
+          "name": "method_type",
+          "type": "payment_method_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_rate_bp": {
+          "name": "fee_rate_bp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memo": {
+          "name": "memo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_payment_fee_rates_method_effective": {
+          "name": "uq_payment_fee_rates_method_effective",
+          "columns": [
+            {
+              "expression": "method_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payment_fee_rates_bp_range": {
+          "name": "payment_fee_rates_bp_range",
+          "value": "\"payment_fee_rates\".\"fee_rate_bp\" >= 0 AND \"payment_fee_rates\".\"fee_rate_bp\" <= 10000"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_intent_item_discounts": {
+      "name": "payment_intent_item_discounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_ref_id": {
+          "name": "discount_ref_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "payment_intent_item_discount_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_intent_item_discounts_intent": {
+          "name": "idx_payment_intent_item_discounts_intent",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_intent_item_discounts_item": {
+          "name": "idx_payment_intent_item_discounts_item",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_intent_item_discounts_intent_id_payment_intents_id_fk": {
+          "name": "payment_intent_item_discounts_intent_id_payment_intents_id_fk",
+          "tableFrom": "payment_intent_item_discounts",
+          "tableTo": "payment_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_intent_item_discounts_item_id_payment_intent_items_id_fk": {
+          "name": "payment_intent_item_discounts_item_id_payment_intent_items_id_fk",
+          "tableFrom": "payment_intent_item_discounts",
+          "tableTo": "payment_intent_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payment_intent_item_discounts_amount_positive": {
+          "name": "payment_intent_item_discounts_amount_positive",
+          "value": "\"payment_intent_item_discounts\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_intent_items": {
+      "name": "payment_intent_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_id": {
+          "name": "line_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "payment_intent_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_ref_id": {
+          "name": "item_ref_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_amount": {
+          "name": "base_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_discount_per_unit_total": {
+          "name": "item_discount_per_unit_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "item_discount_flat_total": {
+          "name": "item_discount_flat_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "payable_amount": {
+          "name": "payable_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_payment_intent_items_intent_line": {
+          "name": "uq_payment_intent_items_intent_line",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "line_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_intent_items_intent_created_at": {
+          "name": "idx_payment_intent_items_intent_created_at",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_intent_items_intent_id_payment_intents_id_fk": {
+          "name": "payment_intent_items_intent_id_payment_intents_id_fk",
+          "tableFrom": "payment_intent_items",
+          "tableTo": "payment_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payment_intent_items_unit_price_non_negative": {
+          "name": "payment_intent_items_unit_price_non_negative",
+          "value": "\"payment_intent_items\".\"unit_price\" >= 0"
+        },
+        "payment_intent_items_quantity_positive": {
+          "name": "payment_intent_items_quantity_positive",
+          "value": "\"payment_intent_items\".\"quantity\" > 0"
+        },
+        "payment_intent_items_base_amount_non_negative": {
+          "name": "payment_intent_items_base_amount_non_negative",
+          "value": "\"payment_intent_items\".\"base_amount\" >= 0"
+        },
+        "payment_intent_items_discount_per_unit_non_negative": {
+          "name": "payment_intent_items_discount_per_unit_non_negative",
+          "value": "\"payment_intent_items\".\"item_discount_per_unit_total\" >= 0"
+        },
+        "payment_intent_items_discount_flat_non_negative": {
+          "name": "payment_intent_items_discount_flat_non_negative",
+          "value": "\"payment_intent_items\".\"item_discount_flat_total\" >= 0"
+        },
+        "payment_intent_items_payable_amount_non_negative": {
+          "name": "payment_intent_items_payable_amount_non_negative",
+          "value": "\"payment_intent_items\".\"payable_amount\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_intent_order_discounts": {
+      "name": "payment_intent_order_discounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_ref_id": {
+          "name": "discount_ref_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "payment_intent_order_discount_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ORDER'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_intent_order_discounts_intent": {
+          "name": "idx_payment_intent_order_discounts_intent",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_intent_order_discounts_intent_id_payment_intents_id_fk": {
+          "name": "payment_intent_order_discounts_intent_id_payment_intents_id_fk",
+          "tableFrom": "payment_intent_order_discounts",
+          "tableTo": "payment_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payment_intent_order_discounts_amount_positive": {
+          "name": "payment_intent_order_discounts_amount_positive",
+          "value": "\"payment_intent_order_discounts\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_intents": {
+      "name": "payment_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "payable_amount": {
+          "name": "payable_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_intent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "intent_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PURCHASE'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_url": {
+          "name": "return_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_expires_at": {
+          "name": "action_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_payment_intents_client_secret": {
+          "name": "uq_payment_intents_client_secret",
+          "columns": [
+            {
+              "expression": "client_secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_intents_status_expires_at": {
+          "name": "idx_payment_intents_status_expires_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_intents_status_action_expires_at": {
+          "name": "idx_payment_intents_status_action_expires_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_intents_user_created_at": {
+          "name": "idx_payment_intents_user_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_intents_invoice_id": {
+          "name": "idx_payment_intents_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"payment_intents\".\"invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_payment_intents_live_invoice": {
+          "name": "uq_payment_intents_live_invoice",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_intents\".\"invoice_id\" IS NOT NULL AND \"payment_intents\".\"status\" IN ('CREATED', 'PROCESSING', 'PENDING_SETTLEMENT')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_intents_billing_idempotency_key": {
+          "name": "idx_payment_intents_billing_idempotency_key",
+          "columns": [
+            {
+              "expression": "(\"metadata\"->>'idempotencyKey')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_intents\".\"metadata\"->>'idempotencyKey' IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_intents_payment_method_id_payment_methods_id_fk": {
+          "name": "payment_intents_payment_method_id_payment_methods_id_fk",
+          "tableFrom": "payment_intents",
+          "tableTo": "payment_methods",
+          "columnsFrom": [
+            "payment_method_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_intents_invoice_id_invoices_id_fk": {
+          "name": "payment_intents_invoice_id_invoices_id_fk",
+          "tableFrom": "payment_intents",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "payment_intents_payable_amount_non_negative": {
+          "name": "payment_intents_payable_amount_non_negative",
+          "value": "\"payment_intents\".\"payable_amount\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.payment_method_catalog": {
+      "name": "payment_method_catalog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_payment_method_catalog_code": {
+          "name": "uq_payment_method_catalog_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "payment_method_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_reusable": {
+          "name": "is_reusable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_data": {
+          "name": "provider_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_methods_user_id": {
+          "name": "idx_payment_methods_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_methods_user_type": {
+          "name": "idx_payment_methods_user_type",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_state_transitions": {
+      "name": "payment_state_transitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "payment_state_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_status": {
+          "name": "previous_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_message": {
+          "name": "reason_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_type": {
+          "name": "triggered_by_type",
+          "type": "payment_state_trigger_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by_id": {
+          "name": "triggered_by_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "causation_id": {
+          "name": "causation_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payment_state_transitions_entity": {
+          "name": "idx_payment_state_transitions_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_state_transitions_correlation": {
+          "name": "idx_payment_state_transitions_correlation",
+          "columns": [
+            {
+              "expression": "correlation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.point_event_details": {
+      "name": "point_event_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "point_event_id": {
+          "name": "point_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "point_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_event_detail_id": {
+          "name": "earned_event_detail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_event_detail_id": {
+          "name": "original_event_detail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_point_event_details_user_earned_created_at": {
+          "name": "idx_point_event_details_user_earned_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_event_detail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_point_event_details_point_event_created_at": {
+          "name": "idx_point_event_details_point_event_created_at",
+          "columns": [
+            {
+              "expression": "point_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "point_event_details_point_event_id_point_events_id_fk": {
+          "name": "point_event_details_point_event_id_point_events_id_fk",
+          "tableFrom": "point_event_details",
+          "tableTo": "point_events",
+          "columnsFrom": [
+            "point_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "point_event_details_earned_event_detail_id_point_event_details_id_fk": {
+          "name": "point_event_details_earned_event_detail_id_point_event_details_id_fk",
+          "tableFrom": "point_event_details",
+          "tableTo": "point_event_details",
+          "columnsFrom": [
+            "earned_event_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "point_event_details_original_event_detail_id_point_event_details_id_fk": {
+          "name": "point_event_details_original_event_detail_id_point_event_details_id_fk",
+          "tableFrom": "point_event_details",
+          "tableTo": "point_event_details",
+          "columnsFrom": [
+            "original_event_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "point_event_details_amount_non_zero": {
+          "name": "point_event_details_amount_non_zero",
+          "value": "\"point_event_details\".\"amount\" <> 0"
+        },
+        "point_event_details_type_amount_consistency": {
+          "name": "point_event_details_type_amount_consistency",
+          "value": "(\n        (\"point_event_details\".\"event_type\" in ('EARN', 'REDEEM_CANCEL') and \"point_event_details\".\"amount\" > 0)\n        or\n        (\"point_event_details\".\"event_type\" in ('REDEEM', 'EARN_CANCEL') and \"point_event_details\".\"amount\" < 0)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.point_events": {
+      "name": "point_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "point_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_event_id": {
+          "name": "original_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leg_id": {
+          "name": "leg_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_idempotency_key": {
+          "name": "provider_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_transaction_id": {
+          "name": "provider_transaction_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_message": {
+          "name": "reason_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_point_events_provider_idempotency_key": {
+          "name": "uq_point_events_provider_idempotency_key",
+          "columns": [
+            {
+              "expression": "provider_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_point_events_user_created_at": {
+          "name": "idx_point_events_user_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_point_events_intent_leg_created_at": {
+          "name": "idx_point_events_intent_leg_created_at",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "leg_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_point_events_expires_at": {
+          "name": "idx_point_events_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "point_events_amount_non_zero": {
+          "name": "point_events_amount_non_zero",
+          "value": "\"point_events\".\"amount\" <> 0"
+        },
+        "point_events_type_amount_consistency": {
+          "name": "point_events_type_amount_consistency",
+          "value": "(\n        (\"point_events\".\"event_type\" in ('EARN', 'REDEEM_CANCEL') and \"point_events\".\"amount\" > 0)\n        or\n        (\"point_events\".\"event_type\" in ('REDEEM', 'EARN_CANCEL') and \"point_events\".\"amount\" < 0)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.point_hold_details": {
+      "name": "point_hold_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "hold_id": {
+          "name": "hold_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_event_detail_id": {
+          "name": "earned_event_detail_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_point_hold_details_hold_earned_detail": {
+          "name": "uq_point_hold_details_hold_earned_detail",
+          "columns": [
+            {
+              "expression": "hold_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "earned_event_detail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_point_hold_details_earned_event_detail_id": {
+          "name": "idx_point_hold_details_earned_event_detail_id",
+          "columns": [
+            {
+              "expression": "earned_event_detail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "point_hold_details_hold_id_point_holds_id_fk": {
+          "name": "point_hold_details_hold_id_point_holds_id_fk",
+          "tableFrom": "point_hold_details",
+          "tableTo": "point_holds",
+          "columnsFrom": [
+            "hold_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "point_hold_details_earned_event_detail_id_point_event_details_id_fk": {
+          "name": "point_hold_details_earned_event_detail_id_point_event_details_id_fk",
+          "tableFrom": "point_hold_details",
+          "tableTo": "point_event_details",
+          "columnsFrom": [
+            "earned_event_detail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "point_hold_details_amount_positive": {
+          "name": "point_hold_details_amount_positive",
+          "value": "\"point_hold_details\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.point_holds": {
+      "name": "point_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leg_id": {
+          "name": "leg_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorize_attempt_id": {
+          "name": "authorize_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorize_provider_idempotency_key": {
+          "name": "authorize_provider_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "point_hold_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_event_id": {
+          "name": "captured_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_attempt_id": {
+          "name": "capture_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_provider_idempotency_key": {
+          "name": "capture_provider_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_attempt_id": {
+          "name": "cancel_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_provider_idempotency_key": {
+          "name": "cancel_provider_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_point_holds_authorize_provider_idempotency_key": {
+          "name": "uq_point_holds_authorize_provider_idempotency_key",
+          "columns": [
+            {
+              "expression": "authorize_provider_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_point_holds_capture_provider_idempotency_key": {
+          "name": "uq_point_holds_capture_provider_idempotency_key",
+          "columns": [
+            {
+              "expression": "capture_provider_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"point_holds\".\"capture_provider_idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_point_holds_cancel_provider_idempotency_key": {
+          "name": "uq_point_holds_cancel_provider_idempotency_key",
+          "columns": [
+            {
+              "expression": "cancel_provider_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"point_holds\".\"cancel_provider_idempotency_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_point_holds_leg_authorized": {
+          "name": "uq_point_holds_leg_authorized",
+          "columns": [
+            {
+              "expression": "leg_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"point_holds\".\"status\" = 'AUTHORIZED'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_point_holds_user_status_created_at": {
+          "name": "idx_point_holds_user_status_created_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_point_holds_leg_created_at": {
+          "name": "idx_point_holds_leg_created_at",
+          "columns": [
+            {
+              "expression": "leg_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "point_holds_captured_event_id_point_events_id_fk": {
+          "name": "point_holds_captured_event_id_point_events_id_fk",
+          "tableFrom": "point_holds",
+          "tableTo": "point_events",
+          "columnsFrom": [
+            "captured_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "point_holds_amount_positive": {
+          "name": "point_holds_amount_positive",
+          "value": "\"point_holds\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.provider_webhook_receipts": {
+      "name": "provider_webhook_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "provider_webhook_receipt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_provider_webhook_receipts_provider_event": {
+          "name": "uq_provider_webhook_receipts_provider_event",
+          "columns": [
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_webhook_receipts_status_received_at": {
+          "name": "idx_provider_webhook_receipts_status_received_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refund_requests": {
+      "name": "refund_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "charge_id": {
+          "name": "charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_code": {
+          "name": "bank_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bank_name": {
+          "name": "bank_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holder_name": {
+          "name": "holder_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "refund_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REQUESTED'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refund_id": {
+          "name": "refund_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_by": {
+          "name": "processed_by",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_refund_requests_intent_id": {
+          "name": "idx_refund_requests_intent_id",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refund_requests_status_created_at": {
+          "name": "idx_refund_requests_status_created_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_refund_requests_intent_active": {
+          "name": "uq_refund_requests_intent_active",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"refund_requests\".\"status\" = 'REQUESTED'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refund_requests_intent_id_payment_intents_id_fk": {
+          "name": "refund_requests_intent_id_payment_intents_id_fk",
+          "tableFrom": "refund_requests",
+          "tableTo": "payment_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "refund_requests_charge_id_charges_id_fk": {
+          "name": "refund_requests_charge_id_charges_id_fk",
+          "tableFrom": "refund_requests",
+          "tableTo": "charges",
+          "columnsFrom": [
+            "charge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "refund_requests_refund_id_refunds_id_fk": {
+          "name": "refund_requests_refund_id_refunds_id_fk",
+          "tableFrom": "refund_requests",
+          "tableTo": "refunds",
+          "columnsFrom": [
+            "refund_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "refund_requests_amount_positive": {
+          "name": "refund_requests_amount_positive",
+          "value": "\"refund_requests\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.refunds": {
+      "name": "refunds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "charge_id": {
+          "name": "charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent_id": {
+          "name": "intent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "refund_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason_code": {
+          "name": "reason_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason_message": {
+          "name": "reason_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_refund_id": {
+          "name": "provider_refund_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_refunds_charge_id": {
+          "name": "idx_refunds_charge_id",
+          "columns": [
+            {
+              "expression": "charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refunds_intent_id": {
+          "name": "idx_refunds_intent_id",
+          "columns": [
+            {
+              "expression": "intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refunds_status_created_at": {
+          "name": "idx_refunds_status_created_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refunds_charge_id_charges_id_fk": {
+          "name": "refunds_charge_id_charges_id_fk",
+          "tableFrom": "refunds",
+          "tableTo": "charges",
+          "columnsFrom": [
+            "charge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "refunds_intent_id_payment_intents_id_fk": {
+          "name": "refunds_intent_id_payment_intents_id_fk",
+          "tableFrom": "refunds",
+          "tableTo": "payment_intents",
+          "columnsFrom": [
+            "intent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "refunds_amount_positive": {
+          "name": "refunds_amount_positive",
+          "value": "\"refunds\".\"amount\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.region_payment_methods": {
+      "name": "region_payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_id": {
+          "name": "catalog_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_region_payment_methods_region_catalog": {
+          "name": "uq_region_payment_methods_region_catalog",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "catalog_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_region_payment_methods_region": {
+          "name": "idx_region_payment_methods_region",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "region_payment_methods_region_id_regions_id_fk": {
+          "name": "region_payment_methods_region_id_regions_id_fk",
+          "tableFrom": "region_payment_methods",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "region_payment_methods_catalog_id_payment_method_catalog_id_fk": {
+          "name": "region_payment_methods_catalog_id_payment_method_catalog_id_fk",
+          "tableFrom": "region_payment_methods",
+          "tableTo": "payment_method_catalog",
+          "columnsFrom": [
+            "catalog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_regions_code": {
+          "name": "uq_regions_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "regions_code_lowercase": {
+          "name": "regions_code_lowercase",
+          "value": "\"regions\".\"code\" = lower(\"regions\".\"code\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscription_billing_methods": {
+      "name": "subscription_billing_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subscriber_type": {
+          "name": "subscriber_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscriber_ref": {
+          "name": "subscriber_ref",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_method_id": {
+          "name": "billing_method_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "subscription_billing_method_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRIMARY'"
+        },
+        "status": {
+          "name": "status",
+          "type": "subscription_billing_method_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING_MANDATE'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_subscription_billing_methods_active_primary": {
+          "name": "uq_subscription_billing_methods_active_primary",
+          "columns": [
+            {
+              "expression": "subscriber_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscriber_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"subscription_billing_methods\".\"role\" = 'PRIMARY' AND \"subscription_billing_methods\".\"status\" = 'ACTIVE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_subscription_billing_methods_pending_primary": {
+          "name": "uq_subscription_billing_methods_pending_primary",
+          "columns": [
+            {
+              "expression": "subscriber_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscriber_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"subscription_billing_methods\".\"role\" = 'PRIMARY' AND \"subscription_billing_methods\".\"status\" = 'PENDING_MANDATE'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_subscription_billing_methods_live_method": {
+          "name": "uq_subscription_billing_methods_live_method",
+          "columns": [
+            {
+              "expression": "subscriber_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscriber_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "billing_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"subscription_billing_methods\".\"status\" IN ('ACTIVE', 'PENDING_MANDATE')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_subscription_billing_methods_live_backup_priority": {
+          "name": "uq_subscription_billing_methods_live_backup_priority",
+          "columns": [
+            {
+              "expression": "subscriber_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscriber_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"subscription_billing_methods\".\"role\" = 'BACKUP' AND \"subscription_billing_methods\".\"status\" IN ('ACTIVE', 'PENDING_MANDATE')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscription_billing_methods_subscriber": {
+          "name": "idx_subscription_billing_methods_subscriber",
+          "columns": [
+            {
+              "expression": "subscriber_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscriber_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_subscription_billing_methods_billing_method_id": {
+          "name": "idx_subscription_billing_methods_billing_method_id",
+          "columns": [
+            {
+              "expression": "billing_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_billing_methods_billing_method_id_billing_methods_id_fk": {
+          "name": "subscription_billing_methods_billing_method_id_billing_methods_id_fk",
+          "tableFrom": "subscription_billing_methods",
+          "tableTo": "billing_methods",
+          "columnsFrom": [
+            "billing_method_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "event.outbox_events": {
+      "name": "outbox_events",
+      "schema": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_type": {
+          "name": "aggregate_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "partition_key": {
+          "name": "partition_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processing_started_at": {
+          "name": "processing_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "outbox_status_idx": {
+          "name": "outbox_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_processing_started_idx": {
+          "name": "outbox_processing_started_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processing_started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_topic_idx": {
+          "name": "outbox_topic_idx",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_status_next_attempt_idx": {
+          "name": "outbox_status_next_attempt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbox_partition_created_idx": {
+          "name": "outbox_partition_created_idx",
+          "columns": [
+            {
+              "expression": "partition_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_event_outbox_topic_event_idempotency": {
+          "name": "uq_event_outbox_topic_event_idempotency",
+          "columns": [
+            {
+              "expression": "topic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "event.event_resource_links": {
+      "name": "event_resource_links",
+      "schema": "event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(26)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "erl_chain_idx": {
+          "name": "erl_chain_idx",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "erl_resource_idx": {
+          "name": "erl_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "erl_event_idx": {
+          "name": "erl_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.role_scope_mapping": {
+      "name": "role_scope_mapping",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role_name": {
+          "name": "role_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "role_scope_unique_idx": {
+          "name": "role_scope_unique_idx",
+          "columns": [
+            {
+              "expression": "role_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_scope_mapping_scope_id_scopes_id_fk": {
+          "name": "role_scope_mapping_scope_id_scopes_id_fk",
+          "tableFrom": "role_scope_mapping",
+          "tableTo": "scopes",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.scopes": {
+      "name": "scopes",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microservice_name": {
+          "name": "microservice_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scopes_key_unique": {
+          "name": "scopes_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.billing_agreement_status": {
+      "name": "billing_agreement_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "SUSPENDED",
+        "REVOKED"
+      ]
+    },
+    "public.billing_method_status": {
+      "name": "billing_method_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "REVOKED",
+        "DELETED",
+        "EXPIRED"
+      ]
+    },
+    "public.cash_receipt_status": {
+      "name": "cash_receipt_status",
+      "schema": "public",
+      "values": [
+        "ISSUED",
+        "CANCELED",
+        "FAILED"
+      ]
+    },
+    "public.cash_receipt_type": {
+      "name": "cash_receipt_type",
+      "schema": "public",
+      "values": [
+        "소득공제",
+        "지출증빙"
+      ]
+    },
+    "public.charge_operation": {
+      "name": "charge_operation",
+      "schema": "public",
+      "values": [
+        "AUTHORIZE",
+        "CAPTURE",
+        "CANCEL",
+        "REFUND"
+      ]
+    },
+    "public.charge_status": {
+      "name": "charge_status",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "PENDING",
+        "SUCCEEDED",
+        "FAILED",
+        "CANCELED",
+        "REFUNDED",
+        "REQUIRES_ACTION"
+      ]
+    },
+    "public.checkout_session_status": {
+      "name": "checkout_session_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "COMPLETED",
+        "EXPIRED",
+        "CANCELED"
+      ]
+    },
+    "public.cms_member_status": {
+      "name": "cms_member_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "REGISTERED",
+        "FAILED",
+        "DELETED"
+      ]
+    },
+    "public.cms_withdrawal_status": {
+      "name": "cms_withdrawal_status",
+      "schema": "public",
+      "values": [
+        "REQUESTED",
+        "PROCESSING",
+        "SUCCEEDED",
+        "FAILED",
+        "DELETED"
+      ]
+    },
+    "public.intent_purpose": {
+      "name": "intent_purpose",
+      "schema": "public",
+      "values": [
+        "PURCHASE",
+        "SUBSCRIPTION",
+        "REPAYMENT",
+        "PAYOUT"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "OPEN",
+        "MANDATE_PENDING",
+        "ATTEMPTING",
+        "PAST_DUE",
+        "PAID",
+        "UNCOLLECTIBLE",
+        "MANDATE_REJECTED",
+        "VOID"
+      ]
+    },
+    "public.payment_intent_item_discount_kind": {
+      "name": "payment_intent_item_discount_kind",
+      "schema": "public",
+      "values": [
+        "ITEM_PER_UNIT",
+        "ITEM_FLAT"
+      ]
+    },
+    "public.payment_intent_item_type": {
+      "name": "payment_intent_item_type",
+      "schema": "public",
+      "values": [
+        "PRODUCT",
+        "SUBSCRIPTION",
+        "SHIPPING_FEE",
+        "OTHER"
+      ]
+    },
+    "public.payment_intent_order_discount_kind": {
+      "name": "payment_intent_order_discount_kind",
+      "schema": "public",
+      "values": [
+        "ORDER"
+      ]
+    },
+    "public.payment_intent_status": {
+      "name": "payment_intent_status",
+      "schema": "public",
+      "values": [
+        "CREATED",
+        "PROCESSING",
+        "REQUIRES_ACTION",
+        "AWAITING_DEPOSIT",
+        "AUTHORIZED",
+        "CAPTURED",
+        "SUCCEEDED",
+        "FAILED",
+        "CANCELED",
+        "PENDING_SETTLEMENT",
+        "PARTIALLY_CAPTURED"
+      ]
+    },
+    "public.payment_method_type": {
+      "name": "payment_method_type",
+      "schema": "public",
+      "values": [
+        "POINTS",
+        "CARD",
+        "BANK_TRANSFER",
+        "BNPL",
+        "TOSS",
+        "NICEPAY",
+        "TOSS_BILLING",
+        "NICEPAY_BILLING",
+        "CMS_BATCH"
+      ]
+    },
+    "public.payment_state_entity_type": {
+      "name": "payment_state_entity_type",
+      "schema": "public",
+      "values": [
+        "INTENT",
+        "CHARGE",
+        "REFUND"
+      ]
+    },
+    "public.payment_state_trigger_type": {
+      "name": "payment_state_trigger_type",
+      "schema": "public",
+      "values": [
+        "SYSTEM",
+        "USER",
+        "ADMIN",
+        "WEBHOOK",
+        "COMMAND"
+      ]
+    },
+    "public.point_event_type": {
+      "name": "point_event_type",
+      "schema": "public",
+      "values": [
+        "EARN",
+        "REDEEM",
+        "EARN_CANCEL",
+        "REDEEM_CANCEL"
+      ]
+    },
+    "public.point_hold_status": {
+      "name": "point_hold_status",
+      "schema": "public",
+      "values": [
+        "AUTHORIZED",
+        "CAPTURED",
+        "CANCELLED"
+      ]
+    },
+    "public.provider_webhook_receipt_status": {
+      "name": "provider_webhook_receipt_status",
+      "schema": "public",
+      "values": [
+        "RECEIVED",
+        "PROCESSED",
+        "IGNORED_DUPLICATE",
+        "FAILED"
+      ]
+    },
+    "public.refund_request_status": {
+      "name": "refund_request_status",
+      "schema": "public",
+      "values": [
+        "REQUESTED",
+        "APPROVED",
+        "REJECTED",
+        "CANCELED"
+      ]
+    },
+    "public.refund_status": {
+      "name": "refund_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "SUCCEEDED",
+        "FAILED"
+      ]
+    },
+    "public.subscription_billing_method_role": {
+      "name": "subscription_billing_method_role",
+      "schema": "public",
+      "values": [
+        "PRIMARY",
+        "BACKUP"
+      ]
+    },
+    "public.subscription_billing_method_status": {
+      "name": "subscription_billing_method_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "PENDING_MANDATE",
+        "REVOKED",
+        "FAILED"
+      ]
+    }
+  },
+  "schemas": {
+    "event": "event",
+    "auth": "auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/wallet/drizzle/meta/_journal.json
+++ b/apps/wallet/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1786312671957,
       "tag": "20260809215751_drop-legacy-wallet-outbox",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1787731737591,
+      "tag": "20260826080857_add-payment-fee-rates",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/wallet/src/admin/statistics-admin.controller.ts
+++ b/apps/wallet/src/admin/statistics-admin.controller.ts
@@ -1,0 +1,85 @@
+import { Body, Controller, Delete, Get, HttpCode, Param, ParseUUIDPipe, Post, Query } from '@nestjs/common';
+import { ApiOperation, ApiProperty, ApiPropertyOptional, ApiTags } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsIn, IsInt, IsOptional, IsString, Matches, Max, MaxLength, Min } from 'class-validator';
+import { paymentMethodTypeEnum, PaymentMethodType } from '../schema';
+import { StatisticsAdminService } from './statistics-admin.service';
+import { WalletAdminAuth } from '../wallet-admin-auth.decorator';
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+class CreateFeeRateDto {
+  @ApiProperty({ enum: paymentMethodTypeEnum.enumValues })
+  @IsIn(paymentMethodTypeEnum.enumValues)
+  methodType: PaymentMethodType;
+
+  @ApiProperty({ description: '수수료율(만분율). 2.9% = 290', minimum: 0, maximum: 10000 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  @Max(10000)
+  feeRateBp: number;
+
+  @ApiProperty({ description: '적용 시작일 (KST, YYYY-MM-DD)' })
+  @Matches(DATE_ONLY)
+  effectiveFrom: string;
+
+  @ApiPropertyOptional({ maxLength: 255 })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  memo?: string;
+}
+
+class StatisticsRangeQueryDto {
+  @ApiProperty({ description: '조회 시작일 (KST, YYYY-MM-DD)' })
+  @Matches(DATE_ONLY)
+  from: string;
+
+  @ApiProperty({ description: '조회 종료일 (KST, YYYY-MM-DD, inclusive)' })
+  @Matches(DATE_ONLY)
+  to: string;
+}
+
+@ApiTags('Admin - Statistics')
+@WalletAdminAuth()
+@Controller('v1/admin/statistics')
+export class StatisticsAdminController {
+  constructor(private readonly service: StatisticsAdminService) {}
+
+  @Get('fee-rates')
+  @ApiOperation({ summary: '결제수단별 수수료율 목록 (이력 포함)' })
+  async listFeeRates() {
+    return this.service.listFeeRates();
+  }
+
+  @Post('fee-rates')
+  @HttpCode(201)
+  @ApiOperation({ summary: '수수료율 등록 — 변경은 새 적용일 행 추가로(이력 보존)' })
+  async createFeeRate(@Body() dto: CreateFeeRateDto) {
+    return this.service.createFeeRate({
+      methodType: dto.methodType,
+      feeRateBp: dto.feeRateBp,
+      effectiveFrom: dto.effectiveFrom,
+      memo: dto.memo,
+    });
+  }
+
+  @Delete('fee-rates/:id')
+  @ApiOperation({ summary: '수수료율 삭제' })
+  async deleteFeeRate(@Param('id', ParseUUIDPipe) id: string) {
+    return this.service.deleteFeeRate(id);
+  }
+
+  @Get('fees')
+  @ApiOperation({ summary: '기간 결제수단별 추정 수수료 요약 (캡처 금액 × 시점 요율)' })
+  async getFeeSummary(@Query() query: StatisticsRangeQueryDto) {
+    return this.service.getFeeSummary(query.from, query.to);
+  }
+
+  @Get('membership-revenue')
+  @ApiOperation({ summary: '멤버십 구독료 수입 (PAID 인보이스, finalized_at KST 기준)' })
+  async getMembershipRevenue(@Query() query: StatisticsRangeQueryDto) {
+    return this.service.getMembershipRevenue(query.from, query.to);
+  }
+}

--- a/apps/wallet/src/admin/statistics-admin.integration.spec.ts
+++ b/apps/wallet/src/admin/statistics-admin.integration.spec.ts
@@ -1,0 +1,306 @@
+import { randomUUID } from 'crypto';
+import * as postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { inArray } from 'drizzle-orm';
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+import type { DbService } from '@app/db';
+import {
+  billingMethods,
+  charges,
+  invoices,
+  paymentFeeRates,
+  paymentIntents,
+  paymentMethods,
+  refunds,
+  walletSchema,
+  WalletSchema,
+} from '../schema';
+import { StatisticsAdminService } from './statistics-admin.service';
+
+/**
+ * 수수료·멤버십 수입 집계를 실 Postgres 로 검증한다 — 검증 대상이 KST 날짜 변환과
+ * 조인·그룹핑 SQL 자체다. 기간을 미래(2031-03)로 격리해 기존 데이터와 겹치지 않게 하고
+ * 끝나면 시드를 지운다. 빈 스크래치 DB 사용 권장.
+ *
+ * 실행: 스크래치 DB 에 wallet 마이그레이션 적용 후
+ *   DATABASE_URL=postgresql://postgres:postgres@localhost:5432/wallet_itest \
+ *     npx jest --testPathPattern="statistics-admin.integration"
+ */
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeIfDb = DATABASE_URL ? describe : describe.skip;
+
+if (process.env.REQUIRE_WALLET_DB === '1' && !DATABASE_URL) {
+  throw new Error('REQUIRE_WALLET_DB=1 인데 DATABASE_URL 이 없습니다');
+}
+
+describeIfDb('StatisticsAdminService (실 Postgres)', () => {
+  jest.setTimeout(120_000);
+
+  const FROM = '2031-03-01';
+  const TO = '2031-03-31';
+
+  let sql: postgres.Sql;
+  let db: ReturnType<typeof drizzle<WalletSchema>>;
+  let service: StatisticsAdminService;
+
+  const methodCardId = randomUUID();
+  const methodTossId = randomUUID();
+  const intentIds = [randomUUID(), randomUUID(), randomUUID(), randomUUID()];
+  const chargeIds = [randomUUID(), randomUUID(), randomUUID(), randomUUID(), randomUUID(), randomUUID()];
+  const refundIds = [randomUUID(), randomUUID()];
+  const billingMethodId = randomUUID();
+  const invoiceIds = [randomUUID(), randomUUID(), randomUUID(), randomUUID()];
+  const createdFeeRateIds: string[] = [];
+
+  beforeAll(async () => {
+    sql = postgres(DATABASE_URL as string, { max: 1 });
+    db = drizzle(sql, { schema: walletSchema });
+    service = new StatisticsAdminService({ db } as unknown as DbService<WalletSchema>);
+
+    await db.insert(paymentMethods).values([
+      { id: methodCardId, userId: 'itest-user', type: 'CARD' },
+      { id: methodTossId, userId: 'itest-user', type: 'TOSS' },
+    ]);
+
+    const expiresAt = new Date('2031-04-01T00:00:00+09:00');
+    await db.insert(paymentIntents).values(
+      intentIds.map((id) => ({
+        id,
+        payableAmount: 100_000,
+        currency: 'KRW',
+        status: 'SUCCEEDED' as const,
+        clientSecret: `itest-${id.slice(0, 20)}`,
+        expiresAt,
+      })),
+    );
+
+    await db.insert(charges).values([
+      // CARD: 3/10 KST 캡처 100,000 (요율 290bp 구간)
+      {
+        id: chargeIds[0],
+        intentId: intentIds[0],
+        paymentMethodId: methodCardId,
+        amount: 100_000,
+        currency: 'KRW',
+        operation: 'CAPTURE',
+        status: 'SUCCEEDED',
+        providerIdempotencyKey: `itest-${chargeIds[0]}`,
+        createdAt: new Date('2031-03-10T23:30:00+09:00'),
+      },
+      // CARD: 3/11 KST 00:10 (UTC 로는 3/10) 캡처 200,000 — KST 경계 검증, 요율 250bp 구간
+      {
+        id: chargeIds[1],
+        intentId: intentIds[1],
+        paymentMethodId: methodCardId,
+        amount: 200_000,
+        currency: 'KRW',
+        operation: 'CAPTURE',
+        status: 'SUCCEEDED',
+        providerIdempotencyKey: `itest-${chargeIds[1]}`,
+        createdAt: new Date('2031-03-11T00:10:00+09:00'),
+      },
+      // TOSS: 요율 미설정 — uncovered 로 나와야 한다
+      {
+        id: chargeIds[2],
+        intentId: intentIds[2],
+        paymentMethodId: methodTossId,
+        amount: 50_000,
+        currency: 'KRW',
+        operation: 'CAPTURE',
+        status: 'SUCCEEDED',
+        providerIdempotencyKey: `itest-${chargeIds[2]}`,
+        createdAt: new Date('2031-03-15T12:00:00+09:00'),
+      },
+      // 제외 대상: AUTHORIZE, 실패 캡처, 기간 밖 캡처
+      {
+        id: chargeIds[3],
+        intentId: intentIds[3],
+        paymentMethodId: methodCardId,
+        amount: 70_000,
+        currency: 'KRW',
+        operation: 'AUTHORIZE',
+        status: 'SUCCEEDED',
+        providerIdempotencyKey: `itest-${chargeIds[3]}`,
+        createdAt: new Date('2031-03-12T12:00:00+09:00'),
+      },
+      {
+        id: chargeIds[4],
+        intentId: intentIds[3],
+        paymentMethodId: methodCardId,
+        amount: 80_000,
+        currency: 'KRW',
+        operation: 'CAPTURE',
+        status: 'FAILED',
+        providerIdempotencyKey: `itest-${chargeIds[4]}`,
+        createdAt: new Date('2031-03-12T13:00:00+09:00'),
+      },
+      {
+        id: chargeIds[5],
+        intentId: intentIds[3],
+        paymentMethodId: methodCardId,
+        amount: 90_000,
+        currency: 'KRW',
+        operation: 'CAPTURE',
+        status: 'SUCCEEDED',
+        providerIdempotencyKey: `itest-${chargeIds[5]}`,
+        createdAt: new Date('2031-04-02T12:00:00+09:00'),
+      },
+    ]);
+
+    await db.insert(refunds).values([
+      {
+        id: refundIds[0],
+        chargeId: chargeIds[0],
+        intentId: intentIds[0],
+        amount: 30_000,
+        currency: 'KRW',
+        status: 'SUCCEEDED',
+        createdAt: new Date('2031-03-20T12:00:00+09:00'),
+      },
+      // FAILED 환불은 집계 제외
+      {
+        id: refundIds[1],
+        chargeId: chargeIds[1],
+        intentId: intentIds[1],
+        amount: 10_000,
+        currency: 'KRW',
+        status: 'FAILED',
+        createdAt: new Date('2031-03-21T12:00:00+09:00'),
+      },
+    ]);
+
+    await db.insert(billingMethods).values([{ id: billingMethodId, userId: 'itest-user', providerType: 'CMS' }]);
+
+    const invoiceBase = {
+      billingMethodId,
+      currency: 'KRW',
+      periodStart: '2031-03-01',
+      periodEnd: '2031-03-31',
+      dueDate: '2031-03-05',
+    };
+    await db.insert(invoices).values([
+      {
+        ...invoiceBase,
+        id: invoiceIds[0],
+        subscriberType: 'MEMBERSHIP',
+        subscriberRef: 'itest-m1',
+        amountDue: 9_900,
+        status: 'PAID',
+        finalizedAt: new Date('2031-03-05T10:00:00+09:00'),
+        idempotencyKey: `itest-${invoiceIds[0]}`,
+      },
+      {
+        ...invoiceBase,
+        id: invoiceIds[1],
+        subscriberType: 'MEMBERSHIP',
+        subscriberRef: 'itest-m2',
+        amountDue: 9_900,
+        status: 'PAID',
+        finalizedAt: new Date('2031-03-05T11:00:00+09:00'),
+        idempotencyKey: `itest-${invoiceIds[1]}`,
+      },
+      // 기간 밖 PAID — 제외
+      {
+        ...invoiceBase,
+        id: invoiceIds[2],
+        subscriberType: 'MEMBERSHIP',
+        subscriberRef: 'itest-m3',
+        amountDue: 9_900,
+        status: 'PAID',
+        finalizedAt: new Date('2031-04-01T10:00:00+09:00'),
+        idempotencyKey: `itest-${invoiceIds[2]}`,
+      },
+      // 다른 subscriberType — 제외
+      {
+        ...invoiceBase,
+        id: invoiceIds[3],
+        subscriberType: 'OTHER',
+        subscriberRef: 'itest-o1',
+        amountDue: 5_000,
+        status: 'PAID',
+        finalizedAt: new Date('2031-03-06T10:00:00+09:00'),
+        idempotencyKey: `itest-${invoiceIds[3]}`,
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    if (db) {
+      if (createdFeeRateIds.length > 0) {
+        await db.delete(paymentFeeRates).where(inArray(paymentFeeRates.id, createdFeeRateIds));
+      }
+      await db.delete(refunds).where(inArray(refunds.id, refundIds));
+      await db.delete(charges).where(inArray(charges.id, chargeIds));
+      await db.delete(paymentIntents).where(inArray(paymentIntents.id, intentIds));
+      await db.delete(paymentMethods).where(inArray(paymentMethods.id, [methodCardId, methodTossId]));
+      await db.delete(invoices).where(inArray(invoices.id, invoiceIds));
+      await db.delete(billingMethods).where(inArray(billingMethods.id, [billingMethodId]));
+    }
+    await sql?.end();
+  });
+
+  it('요율 CRUD — 등록·중복 거절·삭제·목록', async () => {
+    const first = await service.createFeeRate({ methodType: 'CARD', feeRateBp: 290, effectiveFrom: '2031-03-01' });
+    createdFeeRateIds.push(first.id);
+    const second = await service.createFeeRate({
+      methodType: 'CARD',
+      feeRateBp: 250,
+      effectiveFrom: '2031-03-11',
+      memo: '인하 협상',
+    });
+    createdFeeRateIds.push(second.id);
+
+    await expect(
+      service.createFeeRate({ methodType: 'CARD', feeRateBp: 300, effectiveFrom: '2031-03-01' }),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    const list = await service.listFeeRates();
+    const mine = list.items.filter((item) => createdFeeRateIds.includes(item.id));
+    expect(mine).toHaveLength(2);
+    // 같은 결제수단 안에서 적용일 내림차순
+    expect(mine[0].feeRateBp).toBe(250);
+    expect(mine[0].memo).toBe('인하 협상');
+
+    await expect(service.deleteFeeRate(randomUUID())).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('수수료 요약 — KST 경계·시점 요율·미설정 분리·환불 (손계산 대조)', async () => {
+    const result = await service.getFeeSummary(FROM, TO);
+
+    const card = result.methods.find((row) => row.methodType === 'CARD');
+    expect(card).toBeDefined();
+    // 100,000(3/10) + 200,000(3/11 KST — UTC 로는 3/10 이라 경계 검증) = 300,000
+    expect(card?.capturedAmount).toBe(300_000);
+    expect(card?.capturedCount).toBe(2);
+    // 100,000×2.9% + 200,000×2.5% = 2,900 + 5,000
+    expect(card?.estimatedFee).toBe(7_900);
+    expect(card?.coveredAmount).toBe(300_000);
+    expect(card?.uncoveredAmount).toBe(0);
+    expect(card?.refundedAmount).toBe(30_000);
+    expect(card?.appliedFeeRateBp).toBe(250);
+
+    const toss = result.methods.find((row) => row.methodType === 'TOSS');
+    expect(toss?.capturedAmount).toBe(50_000);
+    expect(toss?.coveredAmount).toBe(0);
+    expect(toss?.uncoveredAmount).toBe(50_000);
+    expect(toss?.estimatedFee).toBe(0);
+    expect(toss?.appliedFeeRateBp).toBeNull();
+
+    expect(result.totals.capturedAmount).toBe(350_000);
+    expect(result.totals.estimatedFee).toBe(7_900);
+    expect(result.totals.uncoveredAmount).toBe(50_000);
+    expect(result.totals.refundedAmount).toBe(30_000);
+  });
+
+  it('멤버십 수입 — PAID·MEMBERSHIP·기간 내만, 일별 시리즈', async () => {
+    const result = await service.getMembershipRevenue(FROM, TO);
+    expect(result.totalAmount).toBe(19_800);
+    expect(result.invoiceCount).toBe(2);
+    expect(result.series).toEqual([{ bucket: '2031-03-05', amount: 19_800, count: 2 }]);
+  });
+
+  it('기간 뒤집힘은 400', async () => {
+    await expect(service.getFeeSummary(TO, FROM)).rejects.toBeInstanceOf(BadRequestException);
+    await expect(service.getMembershipRevenue(TO, FROM)).rejects.toBeInstanceOf(BadRequestException);
+  });
+});

--- a/apps/wallet/src/admin/statistics-admin.service.spec.ts
+++ b/apps/wallet/src/admin/statistics-admin.service.spec.ts
@@ -1,0 +1,94 @@
+import { kstDayStart, resolveFeeRateBp, summarizeFees } from './statistics-admin.service';
+
+describe('kstDayStart', () => {
+  it('KST 날짜의 자정을 UTC 로 환산한다', () => {
+    expect(kstDayStart('2026-08-10').toISOString()).toBe('2026-08-09T15:00:00.000Z');
+  });
+});
+
+describe('resolveFeeRateBp', () => {
+  const rates = [
+    { methodType: 'CARD', feeRateBp: 290, effectiveFrom: kstDayStart('2026-08-01') },
+    { methodType: 'CARD', feeRateBp: 250, effectiveFrom: kstDayStart('2026-08-11') },
+    { methodType: 'TOSS', feeRateBp: 320, effectiveFrom: kstDayStart('2026-08-05') },
+  ];
+
+  it('시점 이하 중 가장 늦은 적용일의 요율을 고른다', () => {
+    expect(resolveFeeRateBp(rates, 'CARD', kstDayStart('2026-08-10'))).toBe(290);
+    expect(resolveFeeRateBp(rates, 'CARD', kstDayStart('2026-08-11'))).toBe(250);
+    expect(resolveFeeRateBp(rates, 'CARD', kstDayStart('2026-08-20'))).toBe(250);
+  });
+
+  it('적용 시작 전이거나 결제수단 요율이 없으면 null', () => {
+    expect(resolveFeeRateBp(rates, 'CARD', kstDayStart('2026-07-31'))).toBeNull();
+    expect(resolveFeeRateBp(rates, 'NICEPAY', kstDayStart('2026-08-10'))).toBeNull();
+    expect(resolveFeeRateBp([], 'CARD', kstDayStart('2026-08-10'))).toBeNull();
+  });
+});
+
+describe('summarizeFees', () => {
+  const rates = [
+    { methodType: 'CARD', feeRateBp: 290, effectiveFrom: kstDayStart('2026-08-01') },
+    { methodType: 'CARD', feeRateBp: 250, effectiveFrom: kstDayStart('2026-08-11') },
+  ];
+
+  it('요율 유무로 covered/uncovered 를 나누고 일별 요율을 적용한다', () => {
+    const daily = [
+      { methodType: 'CARD', day: '2026-08-10', amount: 100_000, count: 2 },
+      { methodType: 'CARD', day: '2026-08-11', amount: 200_000, count: 3 },
+      { methodType: 'TOSS', day: '2026-08-10', amount: 50_000, count: 1 },
+    ];
+    const result = summarizeFees(daily, new Map([['CARD', 30_000]]), rates, '2026-08-31');
+
+    const card = result.find((row) => row.methodType === 'CARD');
+    expect(card).toEqual({
+      methodType: 'CARD',
+      capturedAmount: 300_000,
+      capturedCount: 5,
+      refundedAmount: 30_000,
+      coveredAmount: 300_000,
+      uncoveredAmount: 0,
+      // 100,000×2.9% + 200,000×2.5%
+      estimatedFee: 2_900 + 5_000,
+      appliedFeeRateBp: 250,
+    });
+
+    const toss = result.find((row) => row.methodType === 'TOSS');
+    expect(toss).toEqual({
+      methodType: 'TOSS',
+      capturedAmount: 50_000,
+      capturedCount: 1,
+      refundedAmount: 0,
+      coveredAmount: 0,
+      uncoveredAmount: 50_000,
+      estimatedFee: 0,
+      appliedFeeRateBp: null,
+    });
+  });
+
+  it('요율 시행 전 날짜 몫은 uncovered 로 분리된다', () => {
+    const daily = [
+      { methodType: 'CARD', day: '2026-07-31', amount: 10_000, count: 1 },
+      { methodType: 'CARD', day: '2026-08-01', amount: 10_000, count: 1 },
+    ];
+    const [card] = summarizeFees(daily, new Map(), rates, '2026-08-01');
+    expect(card.coveredAmount).toBe(10_000);
+    expect(card.uncoveredAmount).toBe(10_000);
+    expect(card.estimatedFee).toBe(290);
+  });
+
+  it('환불만 있는 결제수단도 행으로 나오고, 캡처 금액 내림차순 정렬', () => {
+    const daily = [{ methodType: 'CARD', day: '2026-08-01', amount: 1_000, count: 1 }];
+    const result = summarizeFees(daily, new Map([['BANK_TRANSFER', 5_000]]), rates, '2026-08-01');
+    expect(result.map((row) => row.methodType)).toEqual(['CARD', 'BANK_TRANSFER']);
+    expect(result[1].refundedAmount).toBe(5_000);
+    expect(result[1].capturedAmount).toBe(0);
+  });
+
+  it('수수료는 일 단위 반올림 합', () => {
+    const daily = [{ methodType: 'CARD', day: '2026-08-01', amount: 999, count: 1 }];
+    const [card] = summarizeFees(daily, new Map(), rates, '2026-08-01');
+    // 999 × 290 / 10000 = 28.971 → 29
+    expect(card.estimatedFee).toBe(29);
+  });
+});

--- a/apps/wallet/src/admin/statistics-admin.service.ts
+++ b/apps/wallet/src/admin/statistics-admin.service.ts
@@ -1,0 +1,309 @@
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { and, asc, desc, eq, sql } from 'drizzle-orm';
+import { DbService } from '@app/db';
+import { charges, invoices, paymentFeeRates, paymentMethods, PaymentMethodType, refunds, WalletSchema } from '../schema';
+
+export interface FeeRateDto {
+  id: string;
+  methodType: PaymentMethodType;
+  feeRateBp: number;
+  effectiveFrom: string;
+  memo: string | null;
+  createdAt: string;
+}
+
+export interface FeeMethodSummary {
+  methodType: string;
+  capturedAmount: number;
+  capturedCount: number;
+  refundedAmount: number;
+  /** 요율이 설정된 시점의 캡처 금액 — 수수료 추정의 분모 */
+  coveredAmount: number;
+  /** 요율 미설정 시점의 캡처 금액 — "계산 불가" 몫 */
+  uncoveredAmount: number;
+  /** coveredAmount 에 요율을 적용한 추정 수수료 */
+  estimatedFee: number;
+  /** 기간 종료일 기준 적용 요율(표시용). 미설정이면 null. */
+  appliedFeeRateBp: number | null;
+}
+
+export interface FeeSummaryResponse {
+  range: { from: string; to: string };
+  methods: FeeMethodSummary[];
+  totals: {
+    capturedAmount: number;
+    refundedAmount: number;
+    coveredAmount: number;
+    uncoveredAmount: number;
+    estimatedFee: number;
+  };
+}
+
+export interface MembershipRevenuePoint {
+  bucket: string;
+  amount: number;
+  count: number;
+}
+
+export interface MembershipRevenueResponse {
+  range: { from: string; to: string };
+  totalAmount: number;
+  invoiceCount: number;
+  series: MembershipRevenuePoint[];
+}
+
+interface FeeRateLookupRow {
+  methodType: string;
+  feeRateBp: number;
+  effectiveFrom: Date;
+}
+
+/** KST 달력 날짜 문자열(YYYY-MM-DD)의 자정 시각 */
+export function kstDayStart(day: string): Date {
+  return new Date(`${day}T00:00:00+09:00`);
+}
+
+/** 해당 시각에 적용되는 요율(effective_from 이 가장 늦으면서 at 이하) — 없으면 null */
+export function resolveFeeRateBp(rates: FeeRateLookupRow[], methodType: string, at: Date): number | null {
+  let found: FeeRateLookupRow | null = null;
+  for (const rate of rates) {
+    if (rate.methodType !== methodType) continue;
+    if (rate.effectiveFrom.getTime() > at.getTime()) continue;
+    if (!found || rate.effectiveFrom.getTime() > found.effectiveFrom.getTime()) {
+      found = rate;
+    }
+  }
+  return found ? found.feeRateBp : null;
+}
+
+export interface DailyCapturedRow {
+  methodType: string;
+  day: string;
+  amount: number;
+  count: number;
+}
+
+/** 일×결제수단 캡처 금액에 그 날 적용 요율을 곱해 결제수단별로 합산한다. */
+export function summarizeFees(
+  daily: DailyCapturedRow[],
+  refundedByMethod: Map<string, number>,
+  rates: FeeRateLookupRow[],
+  rangeTo: string,
+): FeeMethodSummary[] {
+  const byMethod = new Map<string, FeeMethodSummary>();
+  const methodTypes = new Set<string>([...daily.map((row) => row.methodType), ...refundedByMethod.keys()]);
+  for (const methodType of methodTypes) {
+    byMethod.set(methodType, {
+      methodType,
+      capturedAmount: 0,
+      capturedCount: 0,
+      refundedAmount: refundedByMethod.get(methodType) ?? 0,
+      coveredAmount: 0,
+      uncoveredAmount: 0,
+      estimatedFee: 0,
+      appliedFeeRateBp: resolveFeeRateBp(rates, methodType, kstDayStart(rangeTo)),
+    });
+  }
+  for (const row of daily) {
+    const summary = byMethod.get(row.methodType);
+    if (!summary) continue;
+    summary.capturedAmount += row.amount;
+    summary.capturedCount += row.count;
+    const rateBp = resolveFeeRateBp(rates, row.methodType, kstDayStart(row.day));
+    if (rateBp == null) {
+      summary.uncoveredAmount += row.amount;
+    } else {
+      summary.coveredAmount += row.amount;
+      summary.estimatedFee += Math.round((row.amount * rateBp) / 10_000);
+    }
+  }
+  return [...byMethod.values()].sort((a, b) => b.capturedAmount - a.capturedAmount);
+}
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+function assertRange(from: string, to: string): void {
+  if (!DATE_ONLY.test(from) || !DATE_ONLY.test(to)) {
+    throw new BadRequestException('from/to 는 YYYY-MM-DD 형식이어야 합니다');
+  }
+  if (from > to) {
+    throw new BadRequestException(`조회 기간이 뒤집혔습니다: ${from} > ${to}`);
+  }
+}
+
+@Injectable()
+export class StatisticsAdminService {
+  constructor(private readonly dbService: DbService<WalletSchema>) {}
+
+  private get db() {
+    return this.dbService.db;
+  }
+
+  async listFeeRates(): Promise<{ items: FeeRateDto[] }> {
+    const rows = await this.db
+      .select()
+      .from(paymentFeeRates)
+      .orderBy(asc(paymentFeeRates.methodType), desc(paymentFeeRates.effectiveFrom));
+    return {
+      items: rows.map((row) => ({
+        id: row.id,
+        methodType: row.methodType,
+        feeRateBp: row.feeRateBp,
+        effectiveFrom: row.effectiveFrom.toISOString(),
+        memo: row.memo ?? null,
+        createdAt: row.createdAt.toISOString(),
+      })),
+    };
+  }
+
+  async createFeeRate(input: {
+    methodType: PaymentMethodType;
+    feeRateBp: number;
+    effectiveFrom: string;
+    memo?: string;
+  }): Promise<{ id: string }> {
+    if (!DATE_ONLY.test(input.effectiveFrom)) {
+      throw new BadRequestException('effectiveFrom 은 YYYY-MM-DD 형식이어야 합니다');
+    }
+    const effectiveFrom = kstDayStart(input.effectiveFrom);
+    const [existing] = await this.db
+      .select({ id: paymentFeeRates.id })
+      .from(paymentFeeRates)
+      .where(and(eq(paymentFeeRates.methodType, input.methodType), eq(paymentFeeRates.effectiveFrom, effectiveFrom)))
+      .limit(1);
+    if (existing) {
+      throw new ConflictException(`같은 결제수단·적용일의 요율이 이미 있습니다: ${input.methodType} ${input.effectiveFrom}`);
+    }
+    const [inserted] = await this.db
+      .insert(paymentFeeRates)
+      .values({
+        methodType: input.methodType,
+        feeRateBp: input.feeRateBp,
+        effectiveFrom,
+        memo: input.memo ?? null,
+      })
+      .returning({ id: paymentFeeRates.id });
+    return { id: inserted.id };
+  }
+
+  async deleteFeeRate(id: string): Promise<{ deleted: true }> {
+    const rows = await this.db.delete(paymentFeeRates).where(eq(paymentFeeRates.id, id)).returning({ id: paymentFeeRates.id });
+    if (rows.length === 0) {
+      throw new NotFoundException(`요율을 찾을 수 없습니다: ${id}`);
+    }
+    return { deleted: true };
+  }
+
+  /**
+   * 기간(KST 달력일) 내 결제수단별 캡처 금액 × 시점 요율 = 추정 수수료.
+   * 실 수수료 원천이 없으므로 어디까지나 근사치다 — 요율 미설정 구간은 "계산 불가"로 분리한다.
+   */
+  async getFeeSummary(from: string, to: string): Promise<FeeSummaryResponse> {
+    assertRange(from, to);
+
+    const chargeDay = sql<string>`((${charges.createdAt} AT TIME ZONE 'Asia/Seoul')::date)::text`;
+    const [capturedRows, refunded, rateRows] = await Promise.all([
+      this.db
+        .select({
+          methodType: paymentMethods.type,
+          day: chargeDay,
+          amount: sql<string>`SUM(${charges.amount})`,
+          count: sql<string>`COUNT(*)`,
+        })
+        .from(charges)
+        .innerJoin(paymentMethods, eq(paymentMethods.id, charges.paymentMethodId))
+        .where(
+          and(
+            eq(charges.operation, 'CAPTURE'),
+            eq(charges.status, 'SUCCEEDED'),
+            sql`(${charges.createdAt} AT TIME ZONE 'Asia/Seoul')::date BETWEEN ${from}::date AND ${to}::date`,
+          ),
+        )
+        .groupBy(paymentMethods.type, sql`(${charges.createdAt} AT TIME ZONE 'Asia/Seoul')::date`),
+      this.refundedByMethod(from, to),
+      this.db
+        .select({
+          methodType: paymentFeeRates.methodType,
+          feeRateBp: paymentFeeRates.feeRateBp,
+          effectiveFrom: paymentFeeRates.effectiveFrom,
+        })
+        .from(paymentFeeRates),
+    ]);
+
+    const daily: DailyCapturedRow[] = capturedRows.map((row) => ({
+      methodType: row.methodType,
+      day: row.day,
+      amount: Number(row.amount),
+      count: Number(row.count),
+    }));
+
+    const methods = summarizeFees(daily, refunded, rateRows, to);
+    const totals = methods.reduce(
+      (acc, method) => ({
+        capturedAmount: acc.capturedAmount + method.capturedAmount,
+        refundedAmount: acc.refundedAmount + method.refundedAmount,
+        coveredAmount: acc.coveredAmount + method.coveredAmount,
+        uncoveredAmount: acc.uncoveredAmount + method.uncoveredAmount,
+        estimatedFee: acc.estimatedFee + method.estimatedFee,
+      }),
+      { capturedAmount: 0, refundedAmount: 0, coveredAmount: 0, uncoveredAmount: 0, estimatedFee: 0 },
+    );
+
+    return { range: { from, to }, methods, totals };
+  }
+
+  private async refundedByMethod(from: string, to: string): Promise<Map<string, number>> {
+    const rows = await this.db
+      .select({
+        methodType: paymentMethods.type,
+        amount: sql<string>`SUM(${refunds.amount})`,
+      })
+      .from(refunds)
+      .innerJoin(charges, eq(charges.id, refunds.chargeId))
+      .innerJoin(paymentMethods, eq(paymentMethods.id, charges.paymentMethodId))
+      .where(
+        and(
+          eq(refunds.status, 'SUCCEEDED'),
+          sql`(${refunds.createdAt} AT TIME ZONE 'Asia/Seoul')::date BETWEEN ${from}::date AND ${to}::date`,
+        ),
+      )
+      .groupBy(paymentMethods.type);
+    return new Map(rows.map((row) => [row.methodType, Number(row.amount)]));
+  }
+
+  /** 멤버십 구독료 수입 — PAID 인보이스의 amount_due 를 finalized_at(KST 달력일) 기준으로 귀속 */
+  async getMembershipRevenue(from: string, to: string): Promise<MembershipRevenueResponse> {
+    assertRange(from, to);
+
+    const bucket = sql<string>`((${invoices.finalizedAt} AT TIME ZONE 'Asia/Seoul')::date)::text`;
+    const rows = await this.db
+      .select({
+        bucket,
+        amount: sql<string>`SUM(${invoices.amountDue})`,
+        count: sql<string>`COUNT(*)`,
+      })
+      .from(invoices)
+      .where(
+        and(
+          eq(invoices.subscriberType, 'MEMBERSHIP'),
+          eq(invoices.status, 'PAID'),
+          sql`(${invoices.finalizedAt} AT TIME ZONE 'Asia/Seoul')::date BETWEEN ${from}::date AND ${to}::date`,
+        ),
+      )
+      .groupBy(sql`1`)
+      .orderBy(sql`1`);
+
+    const series = rows.map((row) => ({
+      bucket: row.bucket,
+      amount: Number(row.amount),
+      count: Number(row.count),
+    }));
+
+    return {
+      range: { from, to },
+      totalAmount: series.reduce((sum, point) => sum + point.amount, 0),
+      invoiceCount: series.reduce((sum, point) => sum + point.count, 0),
+      series,
+    };
+  }
+}

--- a/apps/wallet/src/schema.ts
+++ b/apps/wallet/src/schema.ts
@@ -949,6 +949,29 @@ export const subscriptionBillingMethods = pgTable(
   ],
 );
 
+// ─── 결제수단별 수수료율 (관리자 입력) ────────────────────────────────────────
+// PG 거래별 실 수수료 원천이 없어(승인 응답 미저장) 관리자가 입력한 요율로 근사 계산한다.
+// 요율 변경은 UPDATE 가 아니라 새 effective_from 행 추가 — 과거 기간을 다시 조회해도
+// 그 시점 요율이 적용되도록 이력을 보존한다.
+
+export const paymentFeeRates = pgTable(
+  'payment_fee_rates',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    methodType: paymentMethodTypeEnum('method_type').notNull(),
+    // 만분율(basis point): 2.9% = 290
+    feeRateBp: integer('fee_rate_bp').notNull(),
+    // 이 요율이 적용되기 시작하는 시각(포함). 관리자는 KST 날짜로 입력하고 서버가 자정으로 변환.
+    effectiveFrom: timestamp('effective_from', { withTimezone: true }).notNull(),
+    memo: varchar('memo', { length: 255 }),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    check('payment_fee_rates_bp_range', sql`${table.feeRateBp} >= 0 AND ${table.feeRateBp} <= 10000`),
+    uniqueIndex('uq_payment_fee_rates_method_effective').on(table.methodType, table.effectiveFrom),
+  ],
+);
+
 // ─── Type exports ─────────────────────────────────────────────────────────────
 
 export type PaymentMethodType = (typeof paymentMethodTypeEnum.enumValues)[number];
@@ -1005,6 +1028,7 @@ export const walletSchema = {
   cmsAgreements,
   invoices,
   subscriptionBillingMethods,
+  paymentFeeRates,
 };
 
 export { idempotencyKeys };

--- a/apps/wallet/src/wallet.module.ts
+++ b/apps/wallet/src/wallet.module.ts
@@ -89,6 +89,8 @@ import { PointsController } from './points/points.controller';
 import { BankTransferAdminService } from './admin/bank-transfer-admin.service';
 import { RecurringBillingAdminService } from './admin/recurring-billing-admin.service';
 import { RecurringBillingAdminController } from './admin/recurring-billing-admin.controller';
+import { StatisticsAdminService } from './admin/statistics-admin.service';
+import { StatisticsAdminController } from './admin/statistics-admin.controller';
 
 // Messaging + Jobs
 import { ExpirationJob } from './jobs/expiration.job';
@@ -420,6 +422,7 @@ async function resolveCanActivate(result: boolean | Promise<boolean> | unknown):
     CheckoutSessionController,
     CmsAgreementController,
     RecurringBillingAdminController,
+    StatisticsAdminController,
     InvoiceController,
     MyInvoiceController,
     UgcCommandConsumer,
@@ -510,6 +513,7 @@ async function resolveCanActivate(result: boolean | Promise<boolean> | unknown):
     BankTransferAdminService,
     PaymentIntentAdminService,
     RecurringBillingAdminService,
+    StatisticsAdminService,
 
     // Billing
     BillingMethodService,

--- a/packages/event-contracts/streams/product.stream.ts
+++ b/packages/event-contracts/streams/product.stream.ts
@@ -77,6 +77,11 @@ export interface ProductMasterActiveVersionChangedPayload {
   primaryCategoryId?: string | null;
   changeReason: 'published' | 'unpublished' | 'rollback';
   changedAt: string;
+  /**
+   * 게시된 버전의 매입 원가(공급가, 원). 내부 통계 전용이라 Medusa 로 가는 snapshot 에는
+   * 넣지 않는다. 키가 없으면 원가 미상 — 소비 측은 기존 값을 유지해야 한다.
+   */
+  supplyPrice?: number | null;
   snapshot?: ProductSnapshot | null;
   /** 대량 작업이 낸 이벤트임을 표시한다. 단건 게시에는 키 자체가 없다. */
   origin?: ProductPublishOrigin;
@@ -385,6 +390,7 @@ const ProductMasterActiveVersionChangedSchema = z.object({
   primaryCategoryId: z.string().nullable().optional(),
   changeReason: z.enum(['published', 'unpublished', 'rollback']),
   changedAt: z.string().datetime(),
+  supplyPrice: z.number().int().nonnegative().nullable().optional(),
   snapshot: ProductSnapshotSchema.nullable().optional(),
   origin: z.literal('bulk_import').optional(),
   importSessionId: z.string().min(1).optional(),

--- a/scripts/ops/backfill-dim-supply-price.js
+++ b/scripts/ops/backfill-dim-supply-price.js
@@ -1,0 +1,72 @@
+// analytics dim_product_masters.supply_price 백필 — 게시(active) 버전의 공급가를 core 에서 읽어
+// analytics dim 에 채운다. 이벤트 계약에 supplyPrice 가 실리기 전에 게시된 상품들을 위한 1회성.
+//
+// 실행 (deployments/lcnine/services 에서, DB 터널 127.0.0.1:15432):
+//   DB_TUNNEL_HOST=127.0.0.1 DB_TUNNEL_PORT=15432 \
+//   npx sst shell --stage live -- node ../../../scripts/ops/backfill-dim-supply-price.js
+// DRY_RUN=1 이면 변경 건수만 보고하고 쓰지 않는다.
+const { Client } = require('pg');
+
+function resource(name) {
+  return JSON.parse(process.env[`SST_RESOURCE_${name}`]);
+}
+function dbUrl(name) {
+  const d = resource('Db');
+  return `postgresql://${d.username}:${d.password}@${process.env.DB_TUNNEL_HOST || d.host}:${process.env.DB_TUNNEL_PORT || d.port}/${name}?sslmode=disable`;
+}
+
+async function main() {
+  const dryRun = process.env.DRY_RUN === '1';
+  const core = new Client({ connectionString: process.env.CORE_DATABASE_URL || dbUrl('core') });
+  const analytics = new Client({ connectionString: process.env.ANALYTICS_DATABASE_URL || dbUrl('analytics') });
+  await core.connect();
+  await analytics.connect();
+
+  const { rows } = await core.query(`
+    SELECT v.master_id, v.name, v.supply_price
+    FROM product_master_versions v
+    JOIN product_masters m ON m.id = v.master_id AND m.deleted_at IS NULL
+    WHERE v.status = 'active' AND v.deleted_at IS NULL
+  `);
+  const withCost = rows.filter((r) => r.supply_price != null);
+  console.log(`core active 버전 ${rows.length}건, 원가 보유 ${withCost.length}건`);
+
+  let updated = 0;
+  let inserted = 0;
+  let unchanged = 0;
+  for (const row of withCost) {
+    if (dryRun) {
+      const existing = await analytics.query('SELECT supply_price FROM dim_product_masters WHERE master_id = $1', [
+        row.master_id,
+      ]);
+      if (existing.rowCount === 0) inserted += 1;
+      else if (String(existing.rows[0].supply_price) !== String(row.supply_price)) updated += 1;
+      else unchanged += 1;
+      continue;
+    }
+    // 이벤트가 이미 최신 원가를 실어 왔을 수 있다 — 값이 다를 때만 갱신해 updated_at 을 아낀다
+    const result = await analytics.query(
+      `INSERT INTO dim_product_masters (master_id, name, supply_price, created_at, updated_at)
+       VALUES ($1, $2, $3, now(), now())
+       ON CONFLICT (master_id) DO UPDATE
+         SET supply_price = EXCLUDED.supply_price, updated_at = now()
+         WHERE dim_product_masters.supply_price IS DISTINCT FROM EXCLUDED.supply_price
+       RETURNING (xmax = 0) AS is_insert`,
+      [row.master_id, row.name ?? null, row.supply_price],
+    );
+    if (result.rowCount === 0) unchanged += 1;
+    else if (result.rows[0].is_insert) inserted += 1;
+    else updated += 1;
+  }
+
+  console.log(
+    `${dryRun ? '[DRY_RUN] ' : ''}insert ${inserted}건, update ${updated}건, 변화 없음 ${unchanged}건 (원가 없는 상품 ${rows.length - withCost.length}건은 건드리지 않음)`,
+  );
+  await core.end();
+  await analytics.end();
+}
+
+main().catch((e) => {
+  console.error('FAILED:', e);
+  process.exit(1);
+});

--- a/scripts/security/idor-reviewed.spec.ts
+++ b/scripts/security/idor-reviewed.spec.ts
@@ -79,6 +79,12 @@ const IDOR_REVIEWED: Record<string, { verdict: Verdict; evidence: string; predic
     predicate: '@UseGuards(JwtAuthGuard, AdminRealmGuard)',
     note: '구매 기반 고객 분석(코호트·RFM·재구매·등급전환) — 쿼리 파라미터가 날짜/limit/minBuyers 뿐이고 응답도 버킷·집계 단위(개별 고객 식별자 없음)라 IDOR 대상 아님. 컨트롤러 클래스에 JwtAuthGuard + AdminRealmGuard(staff role 강제).',
   },
+  'analytics GET /statistics/profit': {
+    verdict: 'N/A',
+    evidence: 'apps/analytics/src/features/statistics/api/profit.controller.ts:13',
+    predicate: '@UseGuards(JwtAuthGuard, AdminRealmGuard)',
+    note: '이익(수익성) 통계 — 쿼리 파라미터가 날짜/채널/정렬/페이지 뿐이고 응답도 상품 단위 집계(개별 고객 식별자 없음)라 IDOR 대상 아님. 컨트롤러 클래스에 JwtAuthGuard + AdminRealmGuard(staff role 강제).',
+  },
   'analytics GET /statistics/traffic': {
     verdict: 'N/A',
     evidence: 'apps/analytics/src/features/traffic/api/traffic.controller.ts:15',
@@ -674,15 +680,15 @@ const keyOf = (r: AuditRow): string => `${r.app} ${r.verb} ${r.route}`;
 describe('IDOR 검사 대상 집합', () => {
   it('감사 스크립트가 idorTarget 을 내보낸다', () => {
     const targets = runAudit().filter((r) => r.idorTarget);
-    expect(targets).toHaveLength(105);
+    expect(targets).toHaveLength(106);
   });
 
   // search 와 analytics 가 둘 다 `GET /health` 다. `<VERB> <route>` 로 키를 만들면
   // 97건이 96개로 뭉개지고 스냅샷이 한 건을 조용히 잃는다.
   it('키에 app 이 들어가야 충돌하지 않는다', () => {
     const targets = runAudit().filter((r) => r.idorTarget);
-    expect(new Set(targets.map(keyOf)).size).toBe(105);
-    expect(new Set(targets.map((r) => `${r.verb} ${r.route}`)).size).toBe(104);
+    expect(new Set(targets.map(keyOf)).size).toBe(106);
+    expect(new Set(targets.map((r) => `${r.verb} ${r.route}`)).size).toBe(105);
   });
 
   it('감사 스크립트의 대상 집합과 명단이 정확히 일치한다', () => {


### PR DESCRIPTION
## 내용

통계에 이익(수익성) 축을 추가합니다. 두 커밋입니다.

### 1) 이익 탭 1차 — 상품별 마진과 전사 손익 요약
- `ProductMasterActiveVersionChanged` 이벤트에 톱레벨 `supplyPrice` 추가(additive, snapshot 밖) → analytics `dim_product_masters.supply_price` 소비(키 부재=유지, null=지움)
- `GET /statistics/profit` (JwtAuthGuard+AdminRealmGuard): 전사 손익 요약, 일별 마진 추이, 상품별 마진 **전체 페이지네이션**. 원가 미입력 상품은 0으로 뭉개지 않고 "계산 불가"로 분리
- admin-web "이익" 탭, 과거분 백필 스크립트

### 2) 수수료율 설정 + 수입 2분리
- PG 거래별 실 수수료 원천이 없어(승인 응답 미저장) **관리자가 입력하는 결제수단별 요율**로 근사: wallet `payment_fee_rates` (결제수단×만분율×적용 시작일, 변경은 새 행 추가로 이력 보존)
- `/v1/admin/statistics` (@WalletAdminAuth): 요율 CRUD, 기간 수수료 요약(KST 일별 캡처 금액 × 시점 요율, 요율 미설정 몫은 분리), 멤버십 구독료(PAID 인보이스 finalized_at KST 귀속)
- 이익 탭에 수입 구성(멤버십/커머스)·종합 손익 KPI·결제 수수료 카드 + 요율 설정 UI

## 설계 결정
- **수입 2분리 서빙은 wallet 요약 API + admin-web 병합**: analytics 집계 파이프라인을 건드리지 않고, 인보이스 유량이 작아 웨어하우스 적재가 과함. 교차 분석이 필요해지면 그때 analytics 신규 consumer 로 승격
- wallet 기존 결제 경로(intent/charge/refund/invoice)는 무변경 — 신규 테이블·조회 라우트만
- 마이그레이션 2건(analytics·wallet) 모두 additive (CREATE TABLE / ADD COLUMN)

## 검증
- type-check 0, 전체 jest 0실패, wallet·analytics·admin-web 빌드 통과
- 실 PG 통합스펙: analytics 9건 + wallet 4건 (KST 자정 경계 귀속, 요율 변경 전후 구간별 적용, 미설정 분리, 환불 FAILED 제외, 멤버십 기간·타입 필터 — 손계산 대조)
- 실부팅 E2E: 무토큰 401 / 고객 403 / admin Bearer·쿠키 200 / 기간 뒤집힘·형식 오류 400 / 생성 201·중복 409·삭제 재시도 404 / 기존 라우트 불변
- 라우트 감사: 신규 라우트 전부 가드 인식, IDOR 명단 불변
- 미확인: 브라우저 화면 실측, 라이브 실데이터

## 배포 주의
- expand 컨벤션: **migrate → deploy** (analytics, wallet 둘 다)
- 이벤트 계약 공유로 analytics·core·wallet·admin-web 이 같이 나가야 함. 배포 후 dim 백필 1회(DRY_RUN 먼저)
- wallet 쓰기 라우트는 멱등 인터셉터가 Idempotency-Key 를 요구(DELETE 포함) — admin-web 클라이언트는 반영됨