### PR TITLE
fix(inventory): dev 스모크로 잡은 발주 도메인 결함 4건 (#724 후속)

### DIFF
--- a/apps/core/src/modules/inventory/inbound/services/earliest-expected-date.ts
+++ b/apps/core/src/modules/inventory/inbound/services/earliest-expected-date.ts
@@ -1,7 +1,16 @@
 /**
- * 예정일은 더 이상 헤더 컬럼이 아니다 — 발주 헤더는 **라인 ETA 중 가장 이른 날짜**,
- * 입고 계획은 **아직 안 들어온 아이템 예정일 중 가장 이른 날짜**다. 두 자리가 같은
- * 규칙이라 함수 하나를 나눠 쓴다.
+ * 예정일은 더 이상 헤더 컬럼이 아니다. 발주 헤더와 입고 계획 둘 다 **"아직 안 들어온
+ * 것 중 가장 이른 날짜"** 라는 같은 규칙이라 함수 하나를 나눠 쓴다.
+ *
+ * 다만 *무엇이 "아직 안 들어온 것"인지*는 자리마다 다르고, **그 필터는 호출자가 건다**:
+ *
+ * - 입고 계획: 아직 `pending` 인 아이템 (`inbound.service.ts`)
+ * - 발주 헤더: 실제로 발주된(`ordered`) 라인 (`purchaseOrderExpectedArrival`)
+ *
+ * 예전 이 자리에는 발주 헤더가 *"라인 ETA 중 가장 이른 날짜"* 라고 적혀 있었다. 필터가
+ * 빠진 그 문장 자체가 버그였다 — 끝내 못 산(`unavailable`) 라인의 예정일이 발주 전체의
+ * 입고 예정일 행세를 해서, 같은 발주를 발주 목록과 입고 대기가 다른 날짜로 말했다
+ * (2026-08-26 dev 스모크에서 발견).
  *
  * 컬럼은 `date` + `mode:'string'` 이라 `'YYYY-MM-DD'` 로 온다. 이 모양은 사전순이
  * 곧 시간순이라 문자열 비교로 최소값을 고를 수 있고, `new Date()` 왕복이 없으니
@@ -15,4 +24,22 @@ export function earliestExpectedDate(dates: (string | null)[]): Date | null {
   if (present.length === 0) return null;
   const earliest = present.reduce((min, date) => (date < min ? date : min));
   return new Date(`${earliest}T00:00:00.000Z`);
+}
+
+/**
+ * 발주 헤더의 도착예정일. **실발주된(`ordered`) 라인만** 본다.
+ *
+ * `unavailable` 라인은 영영 오지 않고, `requested` 라인은 아직 주문조차 하지 않았다 —
+ * 둘 다 입고 계획에 아이템이 없다(`executeLineOrder` 만 아이템을 쓴다). 계획과 **같은
+ * 집합**을 보게 해서 발주 목록과 입고 대기가 갈리지 않도록 한다.
+ *
+ * 대가는 아직 한 라인도 실행 안 된 발주가 「입고 예정일」을 비운다는 것이다. 그건
+ * 이 도메인이 이미 택한 원칙과 같다 — *"계획은 첫 실행에서 생긴다. 발주서 생성
+ * 시점이 아니다 — 아직 주문 안 했으니 입고 예정도 없다"* (`orderLine` docstring).
+ *
+ * 산식이 한쪽만 바뀌는 것은 `purchase-order-line-execution` 통합 스펙의 파리티
+ * 단언(헤더 도착예정일 == 계획 예정일)이 막는다.
+ */
+export function purchaseOrderExpectedArrival(lines: { status: string; expectedArrival: string | null }[]): Date | null {
+  return earliestExpectedDate(lines.filter((line) => line.status === 'ordered').map((line) => line.expectedArrival));
 }

--- a/apps/core/src/modules/inventory/inbound/services/purchase-order-line-execution.integration.spec.ts
+++ b/apps/core/src/modules/inventory/inbound/services/purchase-order-line-execution.integration.spec.ts
@@ -458,12 +458,14 @@ describeIfDb('발주 라인 실행 (DB integration)', () => {
 
       expect(created.lines).toHaveLength(3);
       created.lines.forEach((line) => expect(line.expectedArrival).toBe('2026-11-03'));
-      // 헤더 값은 이제 라인에서 파생된다.
-      expect(created.expectedArrival?.toISOString()).toBe('2026-11-03T00:00:00.000Z');
+      // 헤더 값은 **실발주된 라인**에서만 파생된다. 아직 한 라인도 실행 안 했으므로
+      // 라인이 계획상 날짜를 들고 있어도 헤더는 비어 있다 — 입고 계획이 아직 없는 것과
+      // 같은 상태를 말해야 한다(purchaseOrderExpectedArrival docstring).
+      expect(created.expectedArrival).toBeNull();
     });
   });
 
-  it('헤더 도착예정일은 라인 중 가장 이른 날짜다', async () => {
+  it('헤더 도착예정일은 실발주된 라인 중 가장 이른 날짜다', async () => {
     await inRollbackTx(db, async (trx) => {
       const fx = await seedPoWithThreeLines(trx);
       const service = buildService(trx);
@@ -479,6 +481,95 @@ describeIfDb('발주 라인 실행 (DB integration)', () => {
       );
 
       expect(result.expectedArrival?.toISOString()).toBe('2026-09-15T00:00:00.000Z');
+    });
+  });
+
+  /**
+   * dev 스모크(2026-08-26)에서 잡힌 실제 발주(`0e687ae7…`)를 그대로 고정한다.
+   *
+   * 발주 목록·상세는 「2026-09-15」를, 입고 대기는 「2026-10-01」을 말했다. 09-15 는
+   * **단종되어 구매 불가**로 종결된 라인이 들고 있던 날짜다 — 영영 안 오는 물건의
+   * 예정일이 발주 전체의 입고 예정일 행세를 했다. 입고 계획 쪽은 애초에 불가 라인을
+   * 아이템으로 안 만들어서 맞게 나왔다.
+   */
+  it('발주불가 라인의 예정일은 헤더 도착예정일에 들어가지 않는다', async () => {
+    await inRollbackTx(db, async (trx) => {
+      // 세 라인 모두 생성 시 예정일 2026-09-15 를 물려받는다.
+      const fx = await seedPoWithThreeLines(trx, { lineExpectedArrival: '2026-09-15' });
+      const service = buildService(trx);
+
+      // 요청 10 → 실발주 6, 실제 도착은 10-01
+      await service.orderLine(fx.poId, fx.skuIds[0], { orderedQty: 6, expectedArrival: '2026-10-01' }, ACTOR, trx);
+      // 단종 — 09-15 를 든 채 종결된다
+      await service.markLineUnavailable(fx.poId, fx.skuIds[1], { reason: '단종되어 구매 불가' }, ACTOR, trx);
+      const result = await service.orderLine(
+        fx.poId,
+        fx.skuIds[2],
+        { orderedQty: 30, expectedArrival: '2026-11-01' },
+        ACTOR,
+        trx,
+      );
+
+      // 불가 라인은 09-15 를 그대로 들고 있다 — 지운 게 아니라 헤더 산식에서 뺀 것이다.
+      expect(result.lines.find((line) => line.skuId === fx.skuIds[1])).toMatchObject({
+        status: 'unavailable',
+        expectedArrival: '2026-09-15',
+      });
+      expect(result.expectedArrival?.toISOString()).toBe('2026-10-01T00:00:00.000Z');
+    });
+  });
+
+  /**
+   * 위 불일치를 구조적으로 막는다. 헤더 도착예정일과 입고 계획 예정일은 **같은 발주에
+   * 대해 같은 날짜**여야 한다 — 운영자가 발주 목록과 입고 대기를 번갈아 보기 때문이다.
+   *
+   * 두 값을 각각 손으로 계산해 비교하지 않는다. 실제 두 화면이 부르는 서비스 메서드의
+   * 응답끼리 맞춘다. 한쪽 산식만 바꾸면 여기가 빨개진다.
+   */
+  it('헤더 도착예정일이 그 발주에서 파생된 입고 계획의 예정일과 같다', async () => {
+    await inRollbackTx(db, async (trx) => {
+      const fx = await seedPoWithThreeLines(trx, { lineExpectedArrival: '2026-09-15' });
+      const service = buildService(trx);
+
+      await service.orderLine(fx.poId, fx.skuIds[0], { orderedQty: 6, expectedArrival: '2026-10-01' }, ACTOR, trx);
+      await service.markLineUnavailable(fx.poId, fx.skuIds[1], { reason: '단종되어 구매 불가' }, ACTOR, trx);
+      const header = await service.orderLine(
+        fx.poId,
+        fx.skuIds[2],
+        { orderedQty: 30, expectedArrival: '2026-11-01' },
+        ACTOR,
+        trx,
+      );
+
+      const pending = await buildInboundService(trx).getInboundPending(fx.warehouseId, trx);
+      const plan = pending.pendingPlans.find((p) => p.purchaseOrder?.id === fx.poId);
+
+      expect(plan).toBeDefined();
+      expect(header.expectedArrival?.toISOString()).toBe(plan?.expectedDate?.toISOString());
+      // 미입고 수량도 실발주분만 센다 — 불가 처리한 요청분은 빠진다.
+      expect(plan?.totalPendingQuantity).toBe(36);
+    });
+  });
+
+  /**
+   * 아직 실행 안 된 라인은 계획 아이템이 없다. 그 라인이 생성 시 물려받은 "계획상" 날짜를
+   * 헤더가 말하면, 위와 똑같이 두 화면이 갈린다 — 불가 라인만 빼는 것으로는 안 잠긴다.
+   */
+  it('아직 실행 안 된 라인의 예정일은 헤더 도착예정일에 들어가지 않는다', async () => {
+    await inRollbackTx(db, async (trx) => {
+      const fx = await seedPoWithThreeLines(trx, { lineExpectedArrival: '2026-09-01' });
+      const service = buildService(trx);
+
+      const result = await service.orderLine(
+        fx.poId,
+        fx.skuIds[0],
+        { orderedQty: 10, expectedArrival: '2026-10-01' },
+        ACTOR,
+        trx,
+      );
+
+      expect(result.lines.filter((line) => line.status === 'requested')).toHaveLength(2);
+      expect(result.expectedArrival?.toISOString()).toBe('2026-10-01T00:00:00.000Z');
     });
   });
 

--- a/apps/core/src/modules/inventory/inbound/services/purchase-order-status.rules.spec.ts
+++ b/apps/core/src/modules/inventory/inbound/services/purchase-order-status.rules.spec.ts
@@ -14,4 +14,18 @@ describe('발주 종결 전이', () => {
   it('이미 종결된 발주는 다시 종결되지 않는다', () => {
     expect(() => assertReceivedTransition('received')).toThrow(/received/);
   });
+
+  /**
+   * 두 거부는 같은 술어의 두 얼굴이지만 **원인이 반대**다. 한 문장을 돌려쓰면 운영자가
+   * 받는 409 가 자기 상황을 설명하지 못한다 — 이미 전 라인이 실행된 발주에게
+   * "라인을 먼저 실행하라" 고 말하는 식이다(2026-08-26 dev 스모크에서 발견).
+   */
+  it('created 거부는 아직 실행 안 된 라인을 지목한다', () => {
+    expect(() => assertReceivedTransition('created')).toThrow(/not executed yet/);
+  });
+
+  it('received 거부는 이미 종결됐음을 말한다 — 라인 실행을 요구하지 않는다', () => {
+    expect(() => assertReceivedTransition('received')).toThrow(/already received/);
+    expect(() => assertReceivedTransition('received')).not.toThrow(/executed/);
+  });
 });

--- a/apps/core/src/modules/inventory/inbound/services/purchase-order-status.rules.ts
+++ b/apps/core/src/modules/inventory/inbound/services/purchase-order-status.rules.ts
@@ -11,10 +11,16 @@ export type PurchaseOrderHeaderStatus = 'created' | 'confirmed' | 'received';
  * `created` 거부와 `received` 거부는 같은 술어의 두 얼굴이다 — 전자는 아직 발주하지
  * 않은 라인을 입고 처리하는 것을 막고, 후자는 #724 항목 3(#735)이 심사 게이트를
  * 걷어내며 열린 역방향 전이를 막는다.
+ *
+ * **두 얼굴이면 문장도 둘이어야 한다.** 한 문장을 돌려쓰던 때는 이미 전 라인이 실행된
+ * 발주에게 "라인을 먼저 실행하라" 고 답했다 — 원인과 반대되는 안내였다.
  */
 export function assertReceivedTransition(current: PurchaseOrderHeaderStatus): void {
   if (current === 'confirmed') return;
+  if (current === 'received') {
+    throw new ConflictError('Purchase order is already received; it cannot be received again');
+  }
   throw new ConflictError(
-    `Cannot mark purchase order as received from status '${current}' — every line must be executed first`,
+    `Cannot mark purchase order as received from status '${current}' — some lines are not executed yet`,
   );
 }

--- a/apps/core/src/modules/inventory/inbound/services/purchase-order.service.ts
+++ b/apps/core/src/modules/inventory/inbound/services/purchase-order.service.ts
@@ -22,7 +22,7 @@ import { TransactionService } from '../../shared/services/transaction.service';
 import { SupplierResponseDto } from '../../suppliers/dto/supplier-response.dto';
 import { InboundService } from './inbound.service';
 import { assertReceivedTransition } from './purchase-order-status.rules';
-import { earliestExpectedDate } from './earliest-expected-date';
+import { purchaseOrderExpectedArrival } from './earliest-expected-date';
 
 @Injectable()
 export class PurchaseOrderService {
@@ -554,7 +554,7 @@ export class PurchaseOrderService {
         id: po.id,
         type: po.type as PurchaseOrderType,
         supplierId: po.supplierId,
-        expectedArrival: earliestExpectedDate(lines.map((line) => line.expectedArrival)),
+        expectedArrival: purchaseOrderExpectedArrival(lines),
         status: po.status as PurchaseOrderStatus,
         createdAt: po.createdAt,
         updatedAt: po.updatedAt,
@@ -652,7 +652,7 @@ export class PurchaseOrderService {
         id: po.id,
         type: po.type as PurchaseOrderType,
         supplierId: po.supplierId,
-        expectedArrival: earliestExpectedDate(lines.map((line) => line.expectedArrival)),
+        expectedArrival: purchaseOrderExpectedArrival(lines),
         status: po.status as PurchaseOrderStatus,
         createdAt: po.createdAt,
         updatedAt: po.updatedAt,

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -155,6 +155,17 @@ npm run start:main:dev               # core :3100
 - **`npm run generate:token` 의 HS256 토큰은 curl 검증용이다.** 임의 역할로 발급할 수 있어 권한
   경계를 확인하기 좋지만, **warehouse-app 에는 토큰 주입 경로가 없다**(`src/app/config.ts` 가 OIDC
   로만 토큰을 얻는다). 앱 화면에서 역할을 바꿔 보려면 위처럼 라이브 계정이 필요하다.
+  - ⚠️ **그 토큰에 `iss` 를 넣으면 core 가 무조건 401 을 준다.** `JwtAccessStrategy.validate()` 는
+    *iss 가 있을 때만* issuer 를 검증하고, 그 분기는 RS256 OIDC 토큰용이다 — 로컬 core 의
+    `OIDC_ISSUER_URL` 은 `https://user.almondyoung.com` 이라 어떤 로컬 값을 넣어도 안 맞는다.
+    2026-08-26 이전의 `generate:token` 이 `iss: 'almondyoung-auth'` 를 박고 있어서 **이 문장이
+    사실이 아니었다** (스크립트가 발급한 토큰이 core 에 못 들어갔다). 직접 서명할 때도 페이로드는
+    `{ sub, userId, email, roles }` 까지만 둔다.
+  - 쿠키로도 같은 토큰을 쓴다. admin-web 프록시가 `accessToken` 쿠키를 그대로 업스트림에 넘긴다:
+
+    ```bash
+    curl --cookie "accessToken=$TOKEN" http://localhost:8002/api/proxy/api/purchase-orders
+    ```
 - 시드는 결정론적이다. SKU 코드 `DEV-SKU-0001…`, 바코드 `88000000001…`, 주문번호 `DEV-ORDER-0001…`,
   운송장번호 `DEV-WAYBILL-0001…` 이 리셋해도 그대로라 종이에 적어두고 스캔 테스트에 쓸 수 있다.
 - **출고작업(단순출고)이 시드만으로 바로 열린다.** 주문 10건 중 planned 인 5건이 배치

--- a/scripts/generate-jwt-token.js
+++ b/scripts/generate-jwt-token.js
@@ -14,18 +14,46 @@ const jwt = require('jsonwebtoken');
 const readline = require('readline');
 const { randomUUID } = require('crypto');
 
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout
-});
+// readline 은 **부를 때** 만든다. 모듈 로드 시점에 만들면 이 파일을 require 하는
+// 것만으로 stdin 이 열려 jest 가 종료하지 못한다.
+let rl = null;
 
 function question(query) {
+  if (!rl) {
+    rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    });
+  }
   return new Promise(resolve => rl.question(query, resolve));
+}
+
+function closeRl() {
+  if (rl) rl.close();
 }
 
 function isValidUUID(str) {
   const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   return uuidRegex.test(str);
+}
+
+/**
+ * HS256 legacy 토큰의 페이로드.
+ *
+ * **`iss`/`aud` 를 넣지 않는다.** `libs/authorization` 의 JwtAccessStrategy.validate()
+ * 는 *iss 가 있을 때만* issuer/audience 를 검증하는데, 그 분기는 RS256 OIDC 토큰을
+ * 위한 것이다. 여기서 iss 를 실으면 HS256 토큰이 그 분기로 끌려 들어가 `OIDC_ISSUER_URL`
+ * 과 대조당하고, 로컬 core 의 그 값은 `https://user.almondyoung.com` 이라 **어떤 값을
+ * 넣어도 401 이다.** 예전엔 `iss: 'almondyoung-auth'` 가 박혀 있어서 이 스크립트가
+ * 발급한 토큰이 core 에 아예 못 들어갔다.
+ */
+function buildTokenPayload({ userId, email, roles }) {
+  return {
+    sub: userId,
+    userId: userId,
+    email: email,
+    roles: roles,
+  };
 }
 
 async function main() {
@@ -37,7 +65,7 @@ async function main() {
   const authSecret = await question('AUTH_SECRET (필수): ');
   if (!authSecret || authSecret.trim() === '') {
     console.error('❌ AUTH_SECRET은 필수입니다.');
-    rl.close();
+    closeRl();
     process.exit(1);
   }
   
@@ -83,18 +111,12 @@ async function main() {
       expiresIn = '876000h';
   }
   
-  rl.close();
+  closeRl();
   
   console.log('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
   console.log('🔨 토큰 생성 중...\n');
   
-  const payload = {
-    sub: userId,
-    userId: userId,
-    email: email,
-    roles: roles,
-    iss: 'almondyoung-auth',
-  };
+  const payload = buildTokenPayload({ userId, email, roles });
   
   const token = jwt.sign(payload, authSecret, { expiresIn });
   
@@ -135,9 +157,13 @@ async function main() {
   console.log('');
 }
 
-main().catch(err => {
-  console.error('❌ 에러 발생:', err.message);
-  rl.close();
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch(err => {
+    console.error('❌ 에러 발생:', err.message);
+    closeRl();
+    process.exit(1);
+  });
+}
+
+module.exports = { buildTokenPayload };
 

--- a/scripts/generate-jwt-token.spec.ts
+++ b/scripts/generate-jwt-token.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * `npm run generate:token` 이 발급한 토큰이 **core 에 실제로 들어가는지**를 고정한다.
+ *
+ * 이 스크립트는 HS256 legacy 토큰을 만드는데 페이로드에 `iss` 를 박고 있었다. 그런데
+ * `libs/authorization` 의 `JwtAccessStrategy.validate()` 는 *iss 가 있을 때만* issuer 를
+ * 검증한다 — 그 분기는 RS256 OIDC 토큰을 위한 것이다(같은 파일 주석: "legacy HS256
+ * 토큰은 iss/aud claim 자체가 없으므로"). 로컬 core 의 `OIDC_ISSUER_URL` 은
+ * `https://user.almondyoung.com` 이라, 이 스크립트가 무슨 iss 를 넣든 401 이 났다.
+ *
+ * 즉 저장소에 있는 유일한 토큰 발급 도구가 저장소의 주 API 서버에 못 들어갔다
+ * (2026-08-26 dev 스모크에서 발견).
+ */
+// 대상이 `.ts` 가 아니라 `.js` 다 — `npm run generate:token` 이 ts-node 없이 `node` 로
+// 직접 부르는 스크립트라 그대로 둔다. 그래서 import 가 아니라 require 로 가져온다.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { buildTokenPayload } = require('./generate-jwt-token') as {
+  buildTokenPayload: (input: { userId: string; email: string; roles: string[] }) => Record<string, unknown>;
+};
+
+const INPUT = { userId: '00000000-0000-4000-8000-000000000001', email: 'dev@example.com', roles: ['admin'] };
+
+describe('generate-jwt-token 페이로드', () => {
+  it('iss 를 싣지 않는다 — 실으면 HS256 토큰이 OIDC issuer 검증에 걸린다', () => {
+    expect(buildTokenPayload(INPUT)).not.toHaveProperty('iss');
+  });
+
+  it('aud 도 싣지 않는다 — 같은 분기가 audience 까지 본다', () => {
+    expect(buildTokenPayload(INPUT)).not.toHaveProperty('aud');
+  });
+
+  it('core 가 사용자를 식별하는 claim 은 그대로 싣는다', () => {
+    expect(buildTokenPayload(INPUT)).toEqual({
+      sub: INPUT.userId,
+      userId: INPUT.userId,
+      email: INPUT.email,
+      roles: INPUT.roles,
+    });
+  });
+});

--- a/scripts/local/seed-dev-core/constants.ts
+++ b/scripts/local/seed-dev-core/constants.ts
@@ -22,6 +22,7 @@
  *   019d000b — outbound.ts    outboundBatchId (출고 배치 1개)
  *   019d000c — outbound.ts    workItemId (배치 work item 5개)
  *   019d000d — outbound.ts    waybillId (운송장 5개)
+ *   019d000e — constants.ts   SEED_IDS.supplier
  */
 export const SEED_IDS = {
   warehouseBucheon: '019d0001-0001-7000-a000-000000000001',
@@ -40,6 +41,8 @@ export const SEED_IDS = {
   holderSecondary: '019d0003-0002-7000-a000-000000000002',
 
   deliveryProfile: '019d0004-0001-7000-a000-000000000001',
+
+  supplier: '019d000e-0001-7000-a000-000000000001',
 } as const;
 
 /** 부천 일반 랙/빈 6개 — 이동·실사 대상. code 가 곧 라벨이다. */

--- a/scripts/local/seed-dev-core/inbound.ts
+++ b/scripts/local/seed-dev-core/inbound.ts
@@ -2,10 +2,30 @@ import { eq } from 'drizzle-orm';
 import { DbTx, wmsTables } from '../../../apps/core/src/modules/inventory/schema/inventory.schema';
 import { InboundService } from '../../../apps/core/src/modules/inventory/inbound/services/inbound.service';
 import { SEED_IDS, SEED_SKUS } from './constants';
+import { SEED_ACTOR } from './shipments';
 
 /** 리셋마다 같은 날짜가 나오도록 고정한다 (결정론 규약). */
 /** 예정일은 헤더/계획이 아니라 라인·아이템이 갖는다(#724 항목 9). date 컬럼이라 'YYYY-MM-DD'. */
 const EXPECTED_DATE = '2026-08-01';
+
+/**
+ * 실행된 라인의 공통 필드. **헤더를 `confirmed` 로 심으려면 라인이 종결돼 있어야 한다** —
+ * 헤더 status 는 라인에서 파생되고(`refreshHeaderStatus`), 계획 아이템은 `ordered` 라인에서만
+ * 생긴다(`executeLineOrder`). 라인을 기본값 `requested` 로 두면 실제 코드로는 만들 수 없는
+ * 상태가 되고, 그 순간 발주 헤더 도착예정일(실발주 라인 기준)과 입고 계획 예정일이 갈린다.
+ *
+ * `orderedAt` 은 결정론 규약에 따라 고정 시각이다 — 리셋마다 값이 흔들리면 안 된다.
+ */
+const ORDERED_AT = new Date('2026-07-25T00:00:00.000Z');
+function executedLine(quantity: number) {
+  return {
+    quantity,
+    status: 'ordered' as const,
+    orderedQty: quantity,
+    orderedAt: ORDERED_AT,
+    orderedBy: SEED_ACTOR.id,
+  };
+}
 
 /**
  * 국내 PO 1건(부천 단일 plan) + 해외 PO 1건(중국 source → 부천 destination 2-plan).
@@ -25,7 +45,7 @@ export async function seedInbound(inboundService: InboundService, tx: DbTx): Pro
     .insert(wmsTables.purchaseOrders)
     .values({
       type: 'domestic',
-      supplierId: null,
+      supplierId: SEED_IDS.supplier,
       sourceWarehouseId: SEED_IDS.warehouseBucheon,
       destinationWarehouseId: SEED_IDS.warehouseBucheon,
       requiresTransfer: false,
@@ -34,8 +54,20 @@ export async function seedInbound(inboundService: InboundService, tx: DbTx): Pro
     .returning();
 
   await tx.insert(wmsTables.purchaseOrderLines).values([
-    { poId: domesticPo.id, skuId: SEED_SKUS[0].id, quantity: 40, unitPrice: null, expectedArrival: EXPECTED_DATE },
-    { poId: domesticPo.id, skuId: SEED_SKUS[1].id, quantity: 25, unitPrice: null, expectedArrival: EXPECTED_DATE },
+    {
+      poId: domesticPo.id,
+      skuId: SEED_SKUS[0].id,
+      unitPrice: null,
+      expectedArrival: EXPECTED_DATE,
+      ...executedLine(40),
+    },
+    {
+      poId: domesticPo.id,
+      skuId: SEED_SKUS[1].id,
+      unitPrice: null,
+      expectedArrival: EXPECTED_DATE,
+      ...executedLine(25),
+    },
   ]);
 
   // 국내 plan: 입고 전혀 안 태움 — pending / receivedQty 0 그대로 유지.
@@ -74,7 +106,7 @@ export async function seedInbound(inboundService: InboundService, tx: DbTx): Pro
     .insert(wmsTables.purchaseOrders)
     .values({
       type: 'foreign',
-      supplierId: null,
+      supplierId: SEED_IDS.supplier,
       sourceWarehouseId: SEED_IDS.warehouseChina,
       destinationWarehouseId: SEED_IDS.warehouseBucheon,
       requiresTransfer: true,
@@ -82,11 +114,15 @@ export async function seedInbound(inboundService: InboundService, tx: DbTx): Pro
     })
     .returning();
 
-  await tx
-    .insert(wmsTables.purchaseOrderLines)
-    .values([
-      { poId: foreignPo.id, skuId: SEED_SKUS[2].id, quantity: 60, unitPrice: null, expectedArrival: EXPECTED_DATE },
-    ]);
+  await tx.insert(wmsTables.purchaseOrderLines).values([
+    {
+      poId: foreignPo.id,
+      skuId: SEED_SKUS[2].id,
+      unitPrice: null,
+      expectedArrival: EXPECTED_DATE,
+      ...executedLine(60),
+    },
+  ]);
 
   // source plan (중국): 시작은 pending / receivedQty 0.
   const [sourcePlan] = await tx

--- a/scripts/local/seed-dev-core/master-data.ts
+++ b/scripts/local/seed-dev-core/master-data.ts
@@ -26,6 +26,26 @@ export async function seedMasterData(tx: DbTx): Promise<void> {
     },
   ]);
 
+  // 공급처가 없으면 **발주를 아예 만들 수 없다** — CreatePurchaseOrderDto.supplierId 가
+  // @IsUUID() 필수라 발주 화면의 첫 걸음에서 막힌다.
+  //
+  // defaultWarehouseId 는 중국 물류창고다. 이 값이 비면 getSupplierDefaultWarehouseId 가
+  // 발주 생성을 400 으로 막고, 값이 있으면 그게 발주의 **출발 창고**가 된다. 중국을 출발로
+  // 두면 목적지(부천)와 달라 requiresTransfer=true 인 해외 발주 경로가 열린다 — 라이브의
+  // 실제 모양이고, 국내 발주만 시드하면 그 경로가 로컬에서 한 번도 안 밟힌다.
+  await tx.insert(wmsTables.suppliers).values([
+    {
+      id: SEED_IDS.supplier,
+      name: '개발용 공급처',
+      code: 'DEV-SUP',
+      defaultWarehouseId: SEED_IDS.warehouseChina,
+      email: 'supplier@example.com',
+      phone: '02-0000-0000',
+      isDirectDelivery: false,
+      paymentMethod: 'postpaid',
+    },
+  ]);
+
   await tx.insert(wmsTables.locations).values([
     {
       id: SEED_IDS.locBucheonReceiving,

--- a/scripts/local/seed-dev-core/seed.integration.spec.ts
+++ b/scripts/local/seed-dev-core/seed.integration.spec.ts
@@ -198,6 +198,25 @@ describeIfSeedDb('dev_core 시드', () => {
     expect(new Set(barcodes.map((b) => b.barcode)).size).toBe(20); // 바코드 유일성 (더블체크)
   });
 
+  /**
+   * 공급처가 없으면 **로컬에서 발주를 아예 만들 수 없다** — `CreatePurchaseOrderDto.supplierId`
+   * 가 `@IsUUID()` 필수라 발주 스모크 1번에서 바로 막힌다(2026-08-26 발견).
+   *
+   * `defaultWarehouseId` 는 중국 물류창고다. `getSupplierDefaultWarehouseId` 가 발주의
+   * 출발 창고를 여기서 파생하고, **비어 있으면 발주 생성이 400** 이다. 중국을 출발로 두면
+   * 목적지(부천)와 달라 `requiresTransfer=true` 인 해외 발주 경로가 열린다 — 라이브의
+   * 실제 모양이다.
+   */
+  it('공급처 1건이 중국 창고를 기본 창고로 들어간다', async () => {
+    const suppliers = await db.select().from(wmsTables.suppliers);
+    expect(suppliers).toHaveLength(1);
+
+    // 리터럴이다 — SEED_IDS 를 import 하면 상수 자체가 틀렸을 때도 통과한다(위 마스터 데이터 주석).
+    expect(suppliers[0].id).toBe('019d000e-0001-7000-a000-000000000001');
+    expect(suppliers[0].name).toBe('개발용 공급처');
+    expect(suppliers[0].defaultWarehouseId).toBe('019d0001-0002-7000-a000-000000000002');
+  });
+
   it('재고가 원장과 이벤트 양쪽에 정합하게 들어간다', async () => {
     const ledgers = await db
       .select({
@@ -383,6 +402,21 @@ describeIfSeedDb('dev_core 시드', () => {
     expect(poLineQtyByPoAndSku.get(`${domesticPo!.id}:${DEV_SKU_0001}`)).toBe(40);
     expect(poLineQtyByPoAndSku.get(`${domesticPo!.id}:${DEV_SKU_0002}`)).toBe(25);
     expect(poLineQtyByPoAndSku.get(`${foreignPo!.id}:${DEV_SKU_0003}`)).toBe(60);
+
+    // 라인 생명주기(#739/#742)를 시드도 지켜야 한다. 헤더 `confirmed` 는 **전 라인이 종결됐다**는
+    // 파생 결과이고(refreshHeaderStatus), 계획 아이템은 `ordered` 라인에서만 생긴다
+    // (executeLineOrder). 라인을 requested 로 두면 실제 코드로는 도달할 수 없는 상태가 되고,
+    // 그 순간 발주 헤더 도착예정일(실발주 라인 기준)과 입고 계획 예정일이 갈린다 —
+    // 발주 목록은 「—」, 입고 대기는 「2026-08-01」이 되는 식이다.
+    poLines.forEach((line) => {
+      expect(line.status).toBe('ordered');
+      expect(line.orderedQty).toBe(line.quantity);
+      expect(line.orderedAt).not.toBeNull();
+      expect(line.orderedBy).toBe('019d0008-0001-7000-a000-000000000001'); // SEED_ACTOR
+    });
+
+    // 발주에 공급처가 붙어 있어야 목록·상세의 공급처 열이 비지 않는다.
+    expect(orders.every((o) => o.supplierId === '019d000e-0001-7000-a000-000000000001')).toBe(true);
 
     const plans = await db.select().from(wmsTables.inboundPlans);
     expect(plans).toHaveLength(3);


### PR DESCRIPTION
`apps/core` 발주(Purchase Order) 도메인에서 **최초 dev 스모크**(2026-08-26, 백엔드 15항목 + UI 8항목)로 잡은 결함을 고친다. #724 의 후속이고 현황판에 없는 항목이라 번호는 붙이지 않는다.

라이브 `purchase_orders` 는 **0행**이다 — 이 도메인은 고장난 게 아니라 아직 개통되지 않았다. 아래 결함들은 지금 아무 피해도 안 내고 있고, **개통 첫날 전부 드러난다.**

---

## A. 구매 불가 라인의 ETA 가 발주 도착예정일에 샜다 (본체)

`purchase-order.service.ts` 의 헤더 도착예정일 산식에 `status` 필터가 없어서 **`unavailable` 로 종결된 라인의 ETA 까지** MIN 에 들어갔다.

**시스템이 스스로 모순을 드러냈다.** dev DB 의 재현 발주 `0e687ae7…`:

| 라인 | status | expectedArrival |
|---|---|---|
| 개발용 상품 0004 | `ordered` (요청 10 → 실발주 6) | 2026-10-01 |
| 개발용 상품 0005 | **`unavailable`** (사유: 단종되어 구매 불가) | 2026-09-15 |
| 개발용 상품 0006 | `ordered` (요청 30 → 실발주 30) | 2026-11-01 |

같은 발주를 두 화면이 다르게 말했다:

| 화면 | 수정 전 | 수정 후 |
|---|---|---|
| 발주 목록 · 발주 상세 | **2026-09-15** ← 불가 라인의 ETA | **2026-10-01** |
| 입고 대기 | 2026-10-01 | 2026-10-01 |

입고 계획 쪽은 `unavailable` 라인을 애초에 계획 아이템으로 안 만들어서 맞게 나왔다(미입고 수량도 **36 = 6 + 30** 으로 정확). **정답이 2026-10-01 이라는 걸 시스템이 옆 화면에서 이미 말하고 있었다.** 대조군도 같은 코드베이스에 있다 — `inbound.service.ts` 가 `eq(inboundPlanItems.status, 'pending')` 으로 이미 들어온 아이템을 뺀다. 발주 쪽만 비대칭이었다.

발주 상세 드로어는 한 장 안에서 자기모순이었다 — 상단 「입고 예정일 2026-09-15」 바로 밑에 그 날짜를 가진 라인이 빨간 **「불가」** 배지를 달고 있었다.

#742(항목 9의 3단계)가 헤더 컬럼을 드롭하고 파생으로 바꾸면서 생긴 구멍이다.

### 산식을 `ordered` 라인만으로 좁혔다

「불가만 제외」로는 **구조적으로 안 잠긴다.** 계획 아이템은 `ordered` 라인에서만 생기는데(`executeLineOrder`), `requested` 라인도 발주 생성 시 입력한 `expectedArrival` 을 들고 있다. 그래서 requested/ordered 혼재 발주에서 같은 불일치가 남는다:

| 라인 | status | ETA |
|---|---|---|
| A | `ordered` | 2026-10-01 |
| B, C | `requested` (생성 시 입력값) | 2026-09-01 |

→ 발주 목록 `2026-09-01`, 입고 대기 `2026-10-01`. 같은 종류의 불일치다.

`ordered` 만 보면 두 자리가 **같은 집합**을 본다. 대가는 아직 한 라인도 실행 안 된 발주가 「입고 예정일」을 비운다는 것인데(목록에 «—»), 그건 이 도메인이 이미 택한 원칙과 같다 — *"계획은 첫 실행에서 생긴다. 발주서 생성 시점이 아니다 — 아직 주문 안 했으니 입고 예정도 없다"* (`orderLine` docstring).

순수함수 `earliestExpectedDate` 자체는 멀쩡했다(배열의 MIN 을 낼 뿐이고 스펙도 다 통과했다). 고친 건 **호출자가 넘기는 라인 집합**과, *"발주 헤더는 라인 ETA 중 가장 이른 날짜"* 라고 적어 이 버그의 원인이던 **docstring** 이다.

### 스펙

이 도메인은 **게이트 초록이 실동작을 보장하지 못한 전력**이 있다(쿼리키 무효화 불발 · 목록 envelope 불일치 — 둘 다 게이트를 통과했고 후자는 리뷰 4번이 놓쳤다). A 도 같은 부류로, **순수함수 단위 테스트로는 절대 안 잡힌다.** 통합 스펙 3건을 걸었다:

1. 재현 발주(불가 라인 혼재)의 헤더 ETA 가 `2026-10-01` 인지 + 불가 라인은 09-15 를 **그대로 들고 있는지**(지운 게 아니라 산식에서 뺀 것)
2. **파리티 단언 — 발주 헤더 ETA == 그 발주에서 파생된 입고 계획의 예정일.** 두 값을 각각 손으로 계산해 비교하지 않고, **두 화면이 실제로 부르는 서비스 메서드의 응답끼리** 맞춘다. 한쪽 산식만 바뀌면 여기가 빨개진다
3. `requested` 라인의 계획상 날짜가 헤더에 안 새는지

`RED → GREEN` 을 실제로 봤다. RED 에서 파리티 스펙이 **두 화면 불일치(09-15 vs 10-01)를 그대로 재현**했다.

---

## B. `npm run generate:token` 이 core 에서 통하지 않았다

`scripts/generate-jwt-token.js` 가 페이로드에 `iss: 'almondyoung-auth'` 를 박았다. 그런데 `JwtAccessStrategy.validate()` 는 **`iss` 가 있을 때만** issuer 를 검증하고, 그 분기는 RS256 OIDC 토큰용이다(같은 파일 주석: *"legacy HS256 토큰은 iss/aud claim 자체가 없으므로"*). 로컬 core 의 `OIDC_ISSUER_URL` 은 `https://user.almondyoung.com` 이라 **어떤 로컬 iss 값을 넣어도 401** 이었다.

즉 저장소의 유일한 토큰 발급 도구가 저장소의 주 API 서버에 못 들어갔다. `docs/local-dev.md` 의 *"`npm run generate:token` 의 HS256 토큰은 curl 검증용이다"* 안내도 그래서 사실이 아니었다 — 문서도 같이 고쳤다.

곁들여: 페이로드 조립을 `buildTokenPayload` 로 뽑아 스펙을 걸었고, readline 을 lazy 로 돌렸다(모듈 로드 시점에 만들면 require 만으로 stdin 이 열려 jest 가 종료하지 못한다).

---

## C. 재종결 409 문구가 원인과 안 맞았다

`assertReceivedTransition` 이 `created` 와 `received` 두 경우에 같은 문장을 썼다:

> `Cannot mark purchase order as received from status 'received' — every line must be executed first`

`received` 인 발주는 라인이 **이미 전부 실행됐다.** 원인과 반대되는 안내다. docstring 은 *"같은 술어의 두 얼굴"* 이라고 정확히 적어놨는데 메시지가 한 얼굴만 말했다. 상태별로 갈랐다.

---

## E. 시드가 `suppliers` 를 만들지 않았다

`CreatePurchaseOrderDto.supplierId` 는 `@IsUUID()` **필수**인데 `scripts/local/seed-dev-core/` 전체에 `suppliers` 가 0회 등장했다 — **로컬에서 발주를 아예 만들 수 없어** 스모크 1번에서 바로 막혔다.

공급처 1건(`개발용 공급처`)을 추가했다. `defaultWarehouseId` 는 **중국 물류창고** — `getSupplierDefaultWarehouseId` 가 발주의 출발 창고를 여기서 파생하고 비어 있으면 400 이며, 중국을 출발로 두면 목적지(부천)와 달라 해외 발주 경로가 열린다.

### 곁들여 드러난 것

시드가 헤더를 `confirmed` 로 심으면서 라인은 기본값 `requested` 로 두고 계획 아이템은 만들었다. **실제 코드로는 도달할 수 없는 상태다** — 헤더 status 는 라인에서 파생되고 계획 아이템은 `ordered` 라인에서만 생긴다. 지금까지는 마이그레이션 백필이 기존 dev DB 의 라인을 `ordered` 로 메워줘 가려져 있었고, **갓 시드한 DB 에서만 드러난다.**

그 상태에 A 의 산식을 적용하면 시드 발주가 **헤더 「—」 / 입고 대기 「2026-08-01」** 로 갈린다 — 이번에 고친 바로 그 불일치가 시드 데이터로 재현된다. 라인에 `status='ordered'` · `orderedQty` · `orderedAt` · `orderedBy` 를 채우고 발주에 공급처를 붙였다.

---

## D. 백필된 라인의 `orderedAt` / `orderedBy` — 판단만

마이그레이션 `20260825010019` 이 기존 발주의 라인을 백필하며 `ordered_at`/`ordered_by` 는 안 채웠다(채울 값이 없다). **코드 변경 없음.** admin-web `line-list/index.tsx` 가 `{line.orderedAt && (…)}` 로 **span 자체를 안 그린다** — 빈칸이 남지 않아 깨져 보이지 않는다. "기록 없음" 명시는 있으면 좋은 정도이지 필수가 아니다.

---

## 검증

| 게이트 | 결과 |
|---|---|
| `npm run type-check` | **0** |
| `cd apps/admin-web && npx tsc --noEmit` | **0** |
| `npx jest --maxWorkers=2` | **489 suite / 4209 test 통과, 실패 0** |
| `npm run test:core:integration:local` | 8 suite / 12 test 실패 — **develop 에서 실측한 기준선과 동일**(develop 486 통과 → 이 브랜치 489 통과, 새 스펙 +3). 실패 스위트는 catalog · fulfillment · inventory-core · stocktaking · reservation 으로 **이 PR 이 건드린 파일 없음** |
| `npm run test:seed-dev-core:integration` | **11/11** |
| eslint (변경 파일) | 0 (`purchase-order.service.ts:5` 의 미사용 `asc` 는 develop 부터 있던 것이라 안 건드림) |

### 실동작 확인 (로컬 core + admin-web)

게이트만으로는 부족한 도메인이라 실제 화면까지 확인했다.

- **B 실증**: 고친 스크립트의 `buildTokenPayload` 로 토큰을 만들어 admin-web 프록시 → core 호출 → **200**(전에는 401).
- **A 실증** — 재현 발주를 API 로 다시 만들어 라인을 실행한 뒤:

  ```
  ── 발주 헤더 ──
  4c98487d | confirmed | 공급처 개발용 공급처 | ETA 2026-10-01
       개발용 상품 0004 | ordered     | ETA 2026-10-01
       개발용 상품 0005 | unavailable | ETA 2026-09-15
       개발용 상품 0006 | ordered     | ETA 2026-11-01
  01da3e32 | confirmed | 공급처 개발용 공급처 | ETA 2026-08-01
  c27751d1 | confirmed | 공급처 개발용 공급처 | ETA 2026-08-01

  ── 입고 대기 ──
  PO 01da3e32 | expectedDate 2026-08-01 | 미입고 65
  PO 4c98487d | expectedDate 2026-10-01 | 미입고 36
  ```

  전 발주에서 **헤더 ETA == 계획 예정일**. 시드 발주도 파리티가 성립한다(E 수정 전에는 헤더 `—` vs 계획 `2026-08-01`).
- **E 실증**: 공급처가 생긴 뒤 `POST /purchase-orders` 가 실제로 통했다 — 스모크 1번이 열렸다.
- **브라우저 눈검증**: 발주 목록 「입고 예정일」 `2026. 10. 1.`, 발주 상세 드로어 상단 「입고 예정일 2026-10-01」 + 「불가」 배지 라인만 09-15. 자기모순 해소.

## 마이그레이션 / 배포

**마이그레이션 0건. 시크릿 0건. env 0건. 이벤트 계약 변경 0건.**

`ordered`-only 산식은 API 응답 값이 바뀌므로(생성 직후 발주의 `expectedArrival` 이 `null`) core → admin-web 순서 의존은 없다. admin-web 은 이미 `null` 을 «—» 로 렌더한다.

## 하지 않은 것

- `transfer_orders` 와 발주를 링크하지 않았다 — 없는 FK 가 설계다(ADR-0032 로 문서화 예정).
- `PurchaseOrderService` 를 옮기거나 쪼개지 않았다 — #724 항목 5 의 몫이고 ADR-0032 가 선행이다.

참조: #724
