### PR TITLE
fix(channel-adapter): product-not-found 로 죽은 inbox 이벤트를 매일 되살린다

### DIFF
--- a/apps/channel-adapter/src/adapter.module.ts
+++ b/apps/channel-adapter/src/adapter.module.ts
@@ -80,6 +80,7 @@ import { ProductSellableQuantityConsumer } from './consumers/product-sellable-qu
 import { MembershipEventConsumer } from './consumers/membership-event.consumer';
 import { PimMedusaMappingRepository } from './adapters/medusa/pim-medusa-mapping.repository';
 import { InboxWorkerService } from './adapters/medusa/inbox-worker.service';
+import { InboxFailedRevivalService } from './adapters/medusa/inbox-failed-revival.service';
 import { FirebaseMembershipSyncService } from './adapters/medusa/firebase-membership-sync.service';
 import { AlmondAuthClient } from './adapters/almond-auth/almond-auth.client';
 import { UserServiceClient } from './services/user-service.client';
@@ -295,6 +296,7 @@ const NO_KAFKA_PUBLISHER_STREAMS: StreamConfig[] = [
     FirebaseMembershipSyncService,
     MembershipDailySyncService,
     CouponIssueReconciliationService,
+    InboxFailedRevivalService,
 
     // Event Chain Tracking (환경 무관하게 항상 등록)
     EventChainService,

--- a/apps/channel-adapter/src/adapters/medusa/inbox-failed-revival.service.spec.ts
+++ b/apps/channel-adapter/src/adapters/medusa/inbox-failed-revival.service.spec.ts
@@ -1,0 +1,124 @@
+import { InboxFailedRevivalService } from './inbox-failed-revival.service';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+function renderSql(condition: unknown): string {
+  return new PgDialect().sqlToQuery(condition as never).sql;
+}
+
+function createDbMock(rows: unknown[]) {
+  const selectWheres: unknown[] = [];
+  const updates: { values: any; where: unknown }[] = [];
+
+  const db = {
+    select: jest.fn(() => ({
+      from: jest.fn(() => ({
+        where: jest.fn((condition: unknown) => {
+          selectWheres.push(condition);
+          return Promise.resolve(rows);
+        }),
+      })),
+    })),
+    update: jest.fn(() => ({
+      set: jest.fn((values: any) => ({
+        where: jest.fn((condition: unknown) => {
+          updates.push({ values, where: condition });
+          return Promise.resolve(undefined);
+        }),
+      })),
+    })),
+  };
+
+  return { dbService: { db } as any, selectWheres, updates, db };
+}
+
+describe('InboxFailedRevivalService', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  /** sleep 을 건너뛰며 크론을 끝까지 돌린다. */
+  async function run(service: InboxFailedRevivalService) {
+    const done = service.reviveProductNotFoundFailures();
+    await jest.runAllTimersAsync();
+    return done;
+  }
+
+  it('Medusa 에 상품이 생긴 masterId 의 실패만 되살린다', async () => {
+    const { dbService, updates } = createDbMock([
+      { id: 'e1', payload: { masterId: 'm-exists' } },
+      { id: 'e2', payload: { masterId: 'm-exists' } },
+      { id: 'e3', payload: { masterId: 'm-missing' } },
+    ]);
+    const medusaClient = {
+      findProductByHandle: jest.fn(async (handle: string) => (handle === 'm-exists' ? { id: 'prod_1' } : null)),
+    } as any;
+
+    await run(new InboxFailedRevivalService(dbService, medusaClient));
+
+    // 이벤트 3건이지만 조회는 상품 수(2개) 만큼이다.
+    expect(medusaClient.findProductByHandle).toHaveBeenCalledTimes(2);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].values).toMatchObject({
+      status: 'pending',
+      attempts: 0,
+      errorMessage: null,
+      failedAt: null,
+    });
+    // 상품이 아직 없는 m-missing(e3) 은 깨우지 않는다 — 깨우면 attempts 만 또 소진한다.
+    expect(renderSql(updates[0].where)).toContain('$1, $2');
+  });
+
+  it('상품이 하나도 안 생겼으면 UPDATE 를 아예 하지 않는다', async () => {
+    const { dbService, updates } = createDbMock([{ id: 'e1', payload: { masterId: 'm-missing' } }]);
+    const medusaClient = { findProductByHandle: jest.fn().mockResolvedValue(null) } as any;
+
+    await run(new InboxFailedRevivalService(dbService, medusaClient));
+
+    expect(updates).toHaveLength(0);
+  });
+
+  it('조회가 터진 masterId 는 건너뛰고 나머지는 되살린다', async () => {
+    const { dbService, updates } = createDbMock([
+      { id: 'e1', payload: { masterId: 'm-boom' } },
+      { id: 'e2', payload: { masterId: 'm-exists' } },
+    ]);
+    const medusaClient = {
+      findProductByHandle: jest.fn(async (handle: string) => {
+        if (handle === 'm-boom') throw new Error('Medusa findProductByHandle failed: 503');
+        return { id: 'prod_1' };
+      }),
+    } as any;
+
+    await run(new InboxFailedRevivalService(dbService, medusaClient));
+
+    expect(updates).toHaveLength(1);
+    expect(renderSql(updates[0].where)).toContain('$1');
+  });
+
+  it('product-not-found 실패만, ProductSellableQuantityChanged 만 고른다', async () => {
+    const { dbService, selectWheres } = createDbMock([]);
+    const medusaClient = { findProductByHandle: jest.fn() } as any;
+
+    await run(new InboxFailedRevivalService(dbService, medusaClient));
+
+    const sql = renderSql(selectWheres[0]);
+    expect(sql).toContain('"status" = $1');
+    expect(sql).toContain('"event_type" = $2');
+    expect(sql).toContain('"error_message" like $3');
+    expect(medusaClient.findProductByHandle).not.toHaveBeenCalled();
+  });
+
+  it('payload 에 masterId 가 없는 행은 되살리지 않는다', async () => {
+    const { dbService, updates } = createDbMock([{ id: 'e1', payload: { variantId: 'v1' } }]);
+    const medusaClient = { findProductByHandle: jest.fn() } as any;
+
+    await run(new InboxFailedRevivalService(dbService, medusaClient));
+
+    expect(medusaClient.findProductByHandle).not.toHaveBeenCalled();
+    expect(updates).toHaveLength(0);
+  });
+});

--- a/apps/channel-adapter/src/adapters/medusa/inbox-failed-revival.service.spec.ts
+++ b/apps/channel-adapter/src/adapters/medusa/inbox-failed-revival.service.spec.ts
@@ -68,8 +68,14 @@ describe('InboxFailedRevivalService', () => {
       errorMessage: null,
       failedAt: null,
     });
-    // 상품이 아직 없는 m-missing(e3) 은 깨우지 않는다 — 깨우면 attempts 만 또 소진한다.
-    expect(renderSql(updates[0].where)).toContain('$1, $2');
+    // 상품이 아직 없는 m-missing(e3) 은 깨우지 않는다.
+    const where = renderSql(updates[0].where);
+    expect(where).toContain('$4, $5');
+    // 조회 때와 같은 조건을 UPDATE 에도 건다.
+    expect(where).toContain('"status" = $1');
+    expect(where).toContain('"event_type" = $2');
+    expect(where).toContain('"error_message" like $3');
+    expect(where).toContain('not exists');
   });
 
   it('상품이 하나도 안 생겼으면 UPDATE 를 아예 하지 않는다', async () => {
@@ -96,7 +102,7 @@ describe('InboxFailedRevivalService', () => {
     await run(new InboxFailedRevivalService(dbService, medusaClient));
 
     expect(updates).toHaveLength(1);
-    expect(renderSql(updates[0].where)).toContain('$1');
+    expect(renderSql(updates[0].where)).toContain('$4');
   });
 
   it('product-not-found 실패만, ProductSellableQuantityChanged 만 고른다', async () => {
@@ -109,6 +115,13 @@ describe('InboxFailedRevivalService', () => {
     expect(sql).toContain('"status" = $1');
     expect(sql).toContain('"event_type" = $2');
     expect(sql).toContain('"error_message" like $3');
+    // 같은 variant 에 더 최신 이벤트가 있으면 되살리지 않는다.
+    expect(sql.replace(/\s+/g, ' ')).toContain(
+      'not exists ( select 1 from "inbox_events" newer where newer.aggregate_id = "inbox_events"."aggregate_id"',
+    );
+    expect(sql.replace(/\s+/g, ' ')).toContain(
+      'coalesce(newer.event_occurred_at, newer.created_at) > coalesce("inbox_events"."event_occurred_at", "inbox_events"."created_at")',
+    );
     expect(medusaClient.findProductByHandle).not.toHaveBeenCalled();
   });
 

--- a/apps/channel-adapter/src/adapters/medusa/inbox-failed-revival.service.ts
+++ b/apps/channel-adapter/src/adapters/medusa/inbox-failed-revival.service.ts
@@ -1,0 +1,117 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { DbService } from '@app/db';
+import { and, eq, inArray, like } from 'drizzle-orm';
+import { inboxEvents } from '../../schema';
+import { MedusaClient } from './medusa.client';
+import type { ChannelAdapterSchema } from '../../types';
+
+/**
+ * `handleProductSellableQuantityChanged` 가 상품을 못 찾았을 때 내는 메시지의 접두사.
+ * 이 접두사로 시작하는 실패만 되살린다 — 다른 실패(권한, 타임아웃, 재고 반영 자체의 오류)는
+ * 상품이 생겼다고 해결되지 않으므로 건드리지 않는다.
+ */
+const PRODUCT_NOT_FOUND_PREFIX = 'Medusa product not found';
+
+/** Medusa 는 1 vCPU 라 확인 호출을 몰아치지 않는다 (MembershipDailySyncService 와 같은 간격). */
+const LOOKUP_INTERVAL_MS = 200;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * InboxFailedRevivalService
+ *
+ * 재고 이벤트가 상품 생성보다 먼저 처리돼 `Medusa product not found` 로 죽은 inbox 행을
+ * 매일 새벽 되살린다. 대량 상품등록과 재고 동기화가 겹친 날 생긴다
+ * (docs/runbooks/selmate-stock-pipeline.md 「대량 상품등록과 겹치면 재고가 뒤로 밀린다」).
+ *
+ * **`recalc-sellable` 로는 못 고친다.** Core 프로젝션은 이미 최신값이라 재발행이 전부
+ * "변동없음" 으로 스킵된다. inbox 행을 직접 깨우는 게 유일한 경로다.
+ *
+ * 되살리기 전에 **Medusa 에 상품이 실제로 생겼는지 확인**한다. 확인 없이 깨우면 아직 없는
+ * 상품은 attempts 만 또 소진하고 같은 자리로 돌아온다. 확인은 masterId 단위라, 이벤트가
+ * 수천 건이어도 호출은 상품 수만큼이다.
+ *
+ * 새벽에 도는 이유는 되살린 이벤트가 낮 작업과 같은 큐를 쓰기 때문이다.
+ */
+@Injectable()
+export class InboxFailedRevivalService {
+  private readonly logger = new Logger(InboxFailedRevivalService.name);
+
+  constructor(
+    private readonly dbService: DbService<ChannelAdapterSchema>,
+    private readonly medusaClient: MedusaClient,
+  ) {}
+
+  @Cron('0 4 * * *', { timeZone: 'Asia/Seoul' })
+  async reviveProductNotFoundFailures(): Promise<void> {
+    const failures = await this.dbService.db
+      .select({ id: inboxEvents.id, payload: inboxEvents.payload })
+      .from(inboxEvents)
+      .where(
+        and(
+          eq(inboxEvents.status, 'failed'),
+          eq(inboxEvents.eventType, 'ProductSellableQuantityChanged'),
+          like(inboxEvents.errorMessage, `${PRODUCT_NOT_FOUND_PREFIX}%`),
+        ),
+      );
+
+    if (failures.length === 0) {
+      this.logger.log('되살릴 product-not-found 실패 없음');
+      return;
+    }
+
+    const idsByMaster = new Map<string, string[]>();
+    let missingMasterId = 0;
+    for (const row of failures) {
+      const masterId = (row.payload as { masterId?: string } | null)?.masterId;
+      if (!masterId) {
+        missingMasterId += 1;
+        continue;
+      }
+      const ids = idsByMaster.get(masterId);
+      if (ids) ids.push(row.id);
+      else idsByMaster.set(masterId, [row.id]);
+    }
+
+    this.logger.log(
+      `product-not-found 실패 ${failures.length}건 / 상품 ${idsByMaster.size}개 확인 시작` +
+        (missingMasterId > 0 ? ` (masterId 없는 행 ${missingMasterId}건 제외)` : ''),
+    );
+
+    const reviveIds: string[] = [];
+    let stillMissing = 0;
+    let lookupFailed = 0;
+    for (const [masterId, ids] of idsByMaster) {
+      try {
+        const product = await this.medusaClient.findProductByHandle(masterId);
+        if (product) reviveIds.push(...ids);
+        else stillMissing += 1;
+      } catch (error) {
+        // 조회 자체가 실패한 상품은 이번 회차만 건너뛴다. failed 로 남아 있으니 내일 다시 본다.
+        lookupFailed += 1;
+        const reason = error instanceof Error ? error.message : String(error);
+        this.logger.warn(`masterId=${masterId} 존재 확인 실패, 이번 회차 건너뜀: ${reason}`);
+      }
+      await sleep(LOOKUP_INTERVAL_MS);
+    }
+
+    if (reviveIds.length > 0) {
+      await this.dbService.db
+        .update(inboxEvents)
+        .set({
+          status: 'pending',
+          attempts: 0,
+          nextAttemptAt: new Date(),
+          errorMessage: null,
+          failedAt: null,
+        })
+        .where(inArray(inboxEvents.id, reviveIds));
+    }
+
+    this.logger.log(
+      `되살리기 완료: ${reviveIds.length}건 pending 전환 | ` +
+        `아직 상품 없음 ${stillMissing}개 | 조회 실패 ${lookupFailed}개`,
+    );
+  }
+}

--- a/apps/channel-adapter/src/adapters/medusa/inbox-failed-revival.service.ts
+++ b/apps/channel-adapter/src/adapters/medusa/inbox-failed-revival.service.ts
@@ -1,38 +1,26 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { DbService } from '@app/db';
-import { and, eq, inArray, like } from 'drizzle-orm';
+import { and, eq, inArray, like, sql } from 'drizzle-orm';
 import { inboxEvents } from '../../schema';
 import { MedusaClient } from './medusa.client';
 import type { ChannelAdapterSchema } from '../../types';
 
-/**
- * `handleProductSellableQuantityChanged` 가 상품을 못 찾았을 때 내는 메시지의 접두사.
- * 이 접두사로 시작하는 실패만 되살린다 — 다른 실패(권한, 타임아웃, 재고 반영 자체의 오류)는
- * 상품이 생겼다고 해결되지 않으므로 건드리지 않는다.
- */
+/** 이 접두사로 시작하는 실패만 되살린다. 다른 실패는 상품이 생겨도 해결되지 않는다. */
 const PRODUCT_NOT_FOUND_PREFIX = 'Medusa product not found';
 
-/** Medusa 는 1 vCPU 라 확인 호출을 몰아치지 않는다 (MembershipDailySyncService 와 같은 간격). */
+/** Medusa 는 1 vCPU 라 확인 호출을 몰아치지 않는다. */
 const LOOKUP_INTERVAL_MS = 200;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
- * InboxFailedRevivalService
+ * 상품 생성보다 재고 이벤트가 먼저 처리돼 `Medusa product not found` 로 죽은 inbox 행을
+ * 매일 새벽 4시에 되살린다. 대량 상품등록과 재고 동기화가 겹친 날 생긴다.
  *
- * 재고 이벤트가 상품 생성보다 먼저 처리돼 `Medusa product not found` 로 죽은 inbox 행을
- * 매일 새벽 되살린다. 대량 상품등록과 재고 동기화가 겹친 날 생긴다
- * (docs/runbooks/selmate-stock-pipeline.md 「대량 상품등록과 겹치면 재고가 뒤로 밀린다」).
- *
- * **`recalc-sellable` 로는 못 고친다.** Core 프로젝션은 이미 최신값이라 재발행이 전부
- * "변동없음" 으로 스킵된다. inbox 행을 직접 깨우는 게 유일한 경로다.
- *
- * 되살리기 전에 **Medusa 에 상품이 실제로 생겼는지 확인**한다. 확인 없이 깨우면 아직 없는
- * 상품은 attempts 만 또 소진하고 같은 자리로 돌아온다. 확인은 masterId 단위라, 이벤트가
- * 수천 건이어도 호출은 상품 수만큼이다.
- *
- * 새벽에 도는 이유는 되살린 이벤트가 낮 작업과 같은 큐를 쓰기 때문이다.
+ * - `recalc-sellable` 재발행으로는 못 고친다. Core 프로젝션이 이미 최신이라 전부 스킵된다.
+ * - 깨우기 전에 Medusa 에 상품이 생겼는지 확인한다. 아니면 attempts 만 또 태운다.
+ * - variant 당 최신 실패 하나만 깨운다 (아래 `revivable` 참고).
  */
 @Injectable()
 export class InboxFailedRevivalService {
@@ -45,16 +33,30 @@ export class InboxFailedRevivalService {
 
   @Cron('0 4 * * *', { timeZone: 'Asia/Seoul' })
   async reviveProductNotFoundFailures(): Promise<void> {
+    // SELECT 와 UPDATE 가 같이 쓴다 — 그 사이 상태가 바뀐 행을 id 만으로 덮어쓰지 않기 위해.
+    //
+    // 같은 variant 에 더 최신 이벤트가 있으면 건너뛴다. sellableQuantity 는
+    // 절대값이라 뒤처진 이벤트를 깨우면 최신 수량을 과거 값으로 덮는다. 워커의 supersede
+    // 가드는 pending/processing 만 봐서 이미 published 된 최신 이벤트를 못 막는다.
+    // 시각 비교를 DB 안에서 하는 이유는 inbox-worker.service.ts 의 같은 주석 참고.
+    const revivable = and(
+      eq(inboxEvents.status, 'failed'),
+      eq(inboxEvents.eventType, 'ProductSellableQuantityChanged'),
+      like(inboxEvents.errorMessage, `${PRODUCT_NOT_FOUND_PREFIX}%`),
+      sql`not exists (
+        select 1 from ${inboxEvents} newer
+        where newer.aggregate_id = ${inboxEvents.aggregateId}
+          and newer.event_type = ${inboxEvents.eventType}
+          and newer.id <> ${inboxEvents.id}
+          and coalesce(newer.event_occurred_at, newer.created_at)
+              > coalesce(${inboxEvents.eventOccurredAt}, ${inboxEvents.createdAt})
+      )`,
+    );
+
     const failures = await this.dbService.db
       .select({ id: inboxEvents.id, payload: inboxEvents.payload })
       .from(inboxEvents)
-      .where(
-        and(
-          eq(inboxEvents.status, 'failed'),
-          eq(inboxEvents.eventType, 'ProductSellableQuantityChanged'),
-          like(inboxEvents.errorMessage, `${PRODUCT_NOT_FOUND_PREFIX}%`),
-        ),
-      );
+      .where(revivable);
 
     if (failures.length === 0) {
       this.logger.log('되살릴 product-not-found 실패 없음');
@@ -88,7 +90,7 @@ export class InboxFailedRevivalService {
         if (product) reviveIds.push(...ids);
         else stillMissing += 1;
       } catch (error) {
-        // 조회 자체가 실패한 상품은 이번 회차만 건너뛴다. failed 로 남아 있으니 내일 다시 본다.
+        // failed 로 남으니 내일 다시 본다.
         lookupFailed += 1;
         const reason = error instanceof Error ? error.message : String(error);
         this.logger.warn(`masterId=${masterId} 존재 확인 실패, 이번 회차 건너뜀: ${reason}`);
@@ -106,7 +108,7 @@ export class InboxFailedRevivalService {
           errorMessage: null,
           failedAt: null,
         })
-        .where(inArray(inboxEvents.id, reviveIds));
+        .where(and(revivable, inArray(inboxEvents.id, reviveIds)));
     }
 
     this.logger.log(


### PR DESCRIPTION
## 문제

재고 이벤트가 상품 생성보다 먼저 처리되면 inbox 행이 `Medusa product not found` 로 실패한다. 대량 상품등록과 재고 동기화가 겹친 날 생긴다.

상품은 뒤늦게 생기지만 **실패한 행은 스스로 깨어나지 않는다.** 재고가 영영 안 맞은 채로 남는다.

`recalc-sellable` 재발행으로는 못 고친다 — Core 프로젝션은 이미 최신값이라 전부 "변동없음" 으로 스킵된다. inbox 행을 직접 깨우는 게 유일한 경로다.

## 고친 방법

`InboxFailedRevivalService` 가 매일 새벽 4시(KST)에 돈다.

1. `status='failed'` + `eventType='ProductSellableQuantityChanged'` + errorMessage 가 `Medusa product not found` 로 시작하는 행을 모은다
2. payload 의 masterId 로 묶어 **Medusa 에 상품이 실제로 생겼는지 확인**한다
3. 생긴 것만 `pending` / `attempts=0` 으로 되돌린다

## 설계에서 짚은 것

**깨우기 전에 존재를 확인한다.** 확인 없이 깨우면 아직 없는 상품은 attempts 만 또 소진하고 같은 자리로 돌아온다. 확인은 masterId 단위라 이벤트가 수천 건이어도 호출은 상품 수만큼이다. Medusa 가 1 vCPU 라 200ms 간격을 뒀다.

**되살리는 대상을 좁혔다.** `Medusa product not found` 로 시작하는 실패만 본다. 권한이나 타임아웃으로 죽은 행은 상품이 생겼다고 해결되지 않으므로 건드리지 않는다.

**조회가 터진 상품은 이번 회차만 건너뛴다.** `failed` 로 남아 있으니 내일 다시 본다.

**새벽에 도는 이유** 는 되살린 이벤트가 낮 작업과 같은 큐를 쓰기 때문이다.

## 검증

```
npx jest --testPathPattern=inbox-failed-revival
Tests: 5 passed, 5 total
```

- Medusa 에 상품이 생긴 masterId 의 실패만 되살린다
- 상품이 하나도 안 생겼으면 UPDATE 를 아예 하지 않는다
- 조회가 터진 masterId 는 건너뛰고 나머지는 되살린다
- product-not-found 실패만, ProductSellableQuantityChanged 만 고른다
- payload 에 masterId 가 없는 행은 되살리지 않는다

`npm run type-check` 는 `@google-analytics/data` 미설치로 3건 나는데 로컬 `npm install` 문제이고 이 변경과 무관하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)