### PR TITLE
fix(search): 0건 키워드 자동 분류 제거 — 색인 근거 표시 + 인라인 상태 지정

### DIFF
--- a/apps/admin-web/src/features/statistics/template/keywords.tsx
+++ b/apps/admin-web/src/features/statistics/template/keywords.tsx
@@ -12,7 +12,6 @@ import {
   YAxis,
 } from 'recharts';
 import {
-  KeywordAutoCause,
   KeywordDetail,
   KeywordIssueStatus,
   ZeroHitKeywordRow,
@@ -44,16 +43,40 @@ const STATUS_LABELS: Record<KeywordIssueStatus, string> = {
   ignored: '무시',
 };
 
-const CAUSE_LABELS: Record<KeywordAutoCause, string> = {
-  engine: '검색엔진(개발)',
-  sourcing: '소싱 부재(MD)',
-  unclassified: '미분류',
-};
-
-function causeBadgeClass(cause: KeywordAutoCause): string {
-  if (cause === 'engine') return 'bg-blue-50 text-blue-700 border-blue-200';
-  if (cause === 'sourcing') return 'bg-purple-50 text-purple-700 border-purple-200';
-  return 'bg-gray-50 text-gray-500 border-gray-200';
+/** 색인 대조 근거 — 자동 판정 없이 재료만 보여준다. 개발/MD 판단은 사람이 상태로 지정. */
+function IndexEvidence({
+  matchedProductsCount,
+  matchedProductNames,
+  similarProductNames,
+  correctedQuery,
+}: {
+  matchedProductsCount: number;
+  matchedProductNames: string[];
+  similarProductNames: string[];
+  correctedQuery: string | null;
+}) {
+  if (matchedProductsCount === 0 && similarProductNames.length === 0 && !correctedQuery) {
+    return <span className="text-gray-400">색인 일치 없음</span>;
+  }
+  return (
+    <div className="space-y-0.5">
+      {matchedProductsCount > 0 ? (
+        <p title={matchedProductNames.join(' · ')}>
+          <span className="font-medium text-blue-700">색인 일치 {formatCount(matchedProductsCount)}건</span>
+          {matchedProductNames.length > 0 ? (
+            <span className="ml-1 text-gray-500">{matchedProductNames[0]}{matchedProductsCount > 1 ? ' 외' : ''}</span>
+          ) : null}
+        </p>
+      ) : null}
+      {similarProductNames.length > 0 ? (
+        <p className="text-gray-500" title={similarProductNames.join(' · ')}>
+          유사: {similarProductNames.slice(0, 2).join(', ')}
+          {similarProductNames.length > 2 ? ' 외' : ''}
+        </p>
+      ) : null}
+      {correctedQuery ? <p className="text-gray-500">영타 교정: {correctedQuery}</p> : null}
+    </div>
+  );
 }
 
 /** "N일 지연" 배지 — 방치가 길수록 진한 경고색 */
@@ -224,7 +247,7 @@ export default function KeywordStatisticsTemplate() {
 
           <ChartCard
             title="결과 0건 검색어 운영"
-            description="찾는 사람은 있는데 결과가 없던 키워드입니다. 지연 배지는 마지막으로 결과가 있었던 날(없으면 최초 0건일)부터의 일수 — 검색엔진 문제는 개발팀, 소싱 부재는 MD팀이 해결하도록 담당을 지정하세요. 검색어를 클릭하면 상세·담당·메모 편집이 열립니다."
+            description="찾는 사람은 있는데 결과가 없던 키워드입니다. 지연 배지는 마지막으로 결과가 있었던 날(없으면 최초 0건일)부터의 일수. 색인 근거(일치·유사 상품명)를 참고해 검색엔진 문제면 개발팀, 소싱 부재면 MD팀으로 상태를 지정하세요 — 자동 판정은 오탐이 있어 하지 않습니다. 검색어를 클릭하면 상세·담당·메모 편집이 열립니다."
             isLoading={zeroHit.isLoading}
             isEmpty={!zeroHit.data || zeroHit.data.totalItems === 0}
             emptyText="조회 기간에 결과 0건 검색이 없습니다"
@@ -241,7 +264,7 @@ export default function KeywordStatisticsTemplate() {
                         <th className="py-1.5 text-left">검색어</th>
                         <th className="py-1.5 text-left">지연</th>
                         <th className="py-1.5 text-right">0건 검색</th>
-                        <th className="py-1.5 text-left pl-4">자동 분류</th>
+                        <th className="py-1.5 text-left pl-4">색인 근거</th>
                         <th className="py-1.5 text-left">상태</th>
                         <th className="py-1.5 text-left">담당자</th>
                         <th className="py-1.5 text-left">메모</th>
@@ -388,6 +411,12 @@ function ZeroHitRow({
   rowNumber: number;
   onSelect: () => void;
 }) {
+  const upsert = useUpsertKeywordIssue();
+  // 상태만 바꾼다 — 서버 upsert 는 미전달 필드(담당·메모)를 보존한다
+  const changeStatus = (status: KeywordIssueStatus) => {
+    upsert.mutate({ keywordNorm: row.keywordNorm, keyword: row.keyword, status });
+  };
+
   return (
     <tr className="border-b last:border-0">
       <td className="py-1.5 text-gray-400">{rowNumber}</td>
@@ -395,24 +424,32 @@ function ZeroHitRow({
         <button type="button" onClick={onSelect} className="font-medium text-gray-900 hover:underline">
           {row.keyword}
         </button>
-        {row.correctedQuery ? (
-          <span className="ml-1 text-[11px] text-gray-400">→ {row.correctedQuery}</span>
-        ) : null}
       </td>
       <td className="py-1.5">
         <NeglectBadge days={row.neglectDays} resolved={row.resolvedByIndex} />
       </td>
       <td className="py-1.5 text-right tabular-nums">{formatCount(row.zeroCount)}</td>
-      <td className="py-1.5 pl-4">
-        <span className={cn('inline-block rounded border px-1.5 py-0.5 text-[11px]', causeBadgeClass(row.autoCause))}>
-          {CAUSE_LABELS[row.autoCause]}
-        </span>
-        {row.matchedProductsCount > 0 ? (
-          <span className="ml-1 text-[11px] text-gray-400">색인 {formatCount(row.matchedProductsCount)}개</span>
-        ) : null}
+      <td className="py-1.5 pl-4 text-[11px]">
+        <IndexEvidence
+          matchedProductsCount={row.matchedProductsCount}
+          matchedProductNames={row.matchedProductNames}
+          similarProductNames={row.similarProductNames}
+          correctedQuery={row.correctedQuery}
+        />
       </td>
       <td className="py-1.5">
-        {row.issue ? STATUS_LABELS[row.issue.status] : <span className="text-gray-400">신규</span>}
+        <select
+          value={row.issue?.status ?? 'new'}
+          onChange={(event) => changeStatus(event.target.value as KeywordIssueStatus)}
+          disabled={upsert.isPending}
+          className="rounded border border-gray-200 bg-white px-1.5 py-1 text-[11px] disabled:opacity-40"
+        >
+          {(Object.keys(STATUS_LABELS) as KeywordIssueStatus[]).map((value) => (
+            <option key={value} value={value}>
+              {STATUS_LABELS[value]}
+            </option>
+          ))}
+        </select>
       </td>
       <td className="py-1.5">
         {row.issue?.assigneeName ?? <span className="text-gray-400">미지정</span>}
@@ -432,17 +469,14 @@ function KeywordDetailPanel({ detail }: { detail: KeywordDetail }) {
       <div className="flex flex-wrap items-center gap-2 text-xs">
         <span className="text-sm font-semibold text-gray-900">{detail.keyword}</span>
         {detail.neglectDays != null ? <NeglectBadge days={detail.neglectDays} resolved={false} /> : null}
-        <span
-          className={cn('inline-block rounded border px-1.5 py-0.5 text-[11px]', causeBadgeClass(detail.autoCause))}
-        >
-          {CAUSE_LABELS[detail.autoCause]}
-        </span>
-        {detail.correctedQuery ? (
-          <span className="text-gray-500">영타 교정: {detail.correctedQuery}</span>
-        ) : null}
-        {detail.matchedProductsCount > 0 ? (
-          <span className="text-gray-500">색인 일치 상품 {formatCount(detail.matchedProductsCount)}개</span>
-        ) : null}
+      </div>
+      <div className="text-xs">
+        <IndexEvidence
+          matchedProductsCount={detail.matchedProductsCount}
+          matchedProductNames={detail.matchedProductNames}
+          similarProductNames={detail.similarProductNames}
+          correctedQuery={detail.correctedQuery}
+        />
       </div>
       {detail.count === 0 ? (
         <p className="text-xs text-gray-500">조회 기간에 이 키워드의 검색 이력이 없습니다.</p>

--- a/apps/admin-web/src/lib/api/domains/search/index.ts
+++ b/apps/admin-web/src/lib/api/domains/search/index.ts
@@ -49,7 +49,6 @@ export interface KeywordStatistics {
 
 export const KEYWORD_ISSUE_STATUSES = ['new', 'dev', 'md', 'in_progress', 'resolved', 'ignored'] as const;
 export type KeywordIssueStatus = (typeof KEYWORD_ISSUE_STATUSES)[number];
-export type KeywordAutoCause = 'engine' | 'sourcing' | 'unclassified';
 
 export interface KeywordIssue {
   keywordNorm: string;
@@ -72,8 +71,11 @@ export interface ZeroHitKeywordRow {
   neglectDays: number;
   /** 0건 이후 결과가 다시 나오기 시작했으면 true (자동 해소) */
   resolvedByIndex: boolean;
-  autoCause: KeywordAutoCause;
+  /** 색인 대조 근거 — 자동 판정 없음, 개발/MD 판단 재료 */
   matchedProductsCount: number;
+  matchedProductNames: string[];
+  /** 자모 유사(오타 후보) 상품명 — 무관 상품이 섞일 수 있는 참고 정보 */
+  similarProductNames: string[];
   correctedQuery: string | null;
   issue: KeywordIssue | null;
 }
@@ -120,8 +122,9 @@ export interface KeywordDetail {
   lastPositiveAt: string | null;
   firstZeroAt: string | null;
   neglectDays: number | null;
-  autoCause: KeywordAutoCause;
   matchedProductsCount: number;
+  matchedProductNames: string[];
+  similarProductNames: string[];
   correctedQuery: string | null;
   issue: KeywordIssue | null;
 }

--- a/apps/search/src/dto/admin-keyword-ops.dto.ts
+++ b/apps/search/src/dto/admin-keyword-ops.dto.ts
@@ -6,9 +6,6 @@ import { DateRangeDto, KeywordVolumeBucketDto } from './admin-keyword-statistics
 export const KEYWORD_ISSUE_STATUSES = ['new', 'dev', 'md', 'in_progress', 'resolved', 'ignored'] as const;
 export type KeywordIssueStatus = (typeof KEYWORD_ISSUE_STATUSES)[number];
 
-/** 0건 검색어의 자동 원인 분류 — 수동 상태(status)가 항상 우선한다 */
-export type KeywordAutoCause = 'engine' | 'sourcing' | 'unclassified';
-
 export class AdminZeroHitKeywordsQueryDto {
   @Validate(IsCalendarDateConstraint, { message: 'from 은 달력에 존재하는 YYYY-MM-DD 여야 합니다' })
   from: string;
@@ -53,10 +50,14 @@ export class ZeroHitKeywordRowDto {
   neglectDays: number;
   /** 0건 이후 다시 결과가 나오기 시작했으면 true (자동 해소 표시) */
   resolvedByIndex: boolean;
-  /** 자동 원인 분류 — engine: 색인엔 있는데 검색 0건(개발), sourcing: 색인에도 없음(MD) */
-  autoCause: KeywordAutoCause;
-  /** 문자열 포함 대조로 색인에서 찾은 상품 수 */
+  /**
+   * 색인 대조 근거 — 자동 판정 없음. 개발/MD 판단은 사람이 이 재료와 함께 status 로 지정한다.
+   * matchedProductsCount>0 이면 색인엔 있는데 검색이 0건이었다는 뜻(검색엔진·노출 쪽 신호),
+   * similarProductNames 는 오타 후보(무관 상품이 섞일 수 있는 참고 정보).
+   */
   matchedProductsCount: number;
+  matchedProductNames: string[];
+  similarProductNames: string[];
   /** 영타 교정 결과 ("vjak"→"퍼마") — 교정 불가면 null */
   correctedQuery: string | null;
   issue: KeywordIssueDto | null;
@@ -109,8 +110,9 @@ export class AdminKeywordDetailResponseDto {
   firstZeroAt: string | null;
   /** 현재 0건 방치 중일 때만 값이 있다 */
   neglectDays: number | null;
-  autoCause: KeywordAutoCause;
   matchedProductsCount: number;
+  matchedProductNames: string[];
+  similarProductNames: string[];
   correctedQuery: string | null;
   issue: KeywordIssueDto | null;
 }

--- a/apps/search/src/product-index.service.ts
+++ b/apps/search/src/product-index.service.ts
@@ -19,6 +19,25 @@ import { compactText, qwertyToHangul, toJamo } from './utils/text.utils';
 
 type SearchStage = 'strict' | 'fallback';
 
+/** 키워드 ↔ 상품 색인 대조 근거 — 판정 없이 재료만 */
+export interface KeywordMatchEvidence {
+  /** 문자열 포함 정확 일치 상품 수 */
+  exactCount: number;
+  /** 정확 일치 상품명 샘플 */
+  exactNames: string[];
+  /** 자모 유사(오타 후보) 상품명 샘플 — 무관 상품이 섞일 수 있는 참고 정보 */
+  similarNames: string[];
+}
+
+const EVIDENCE_SAMPLE_SIZE = 3;
+
+function extractHitNames(response: any): string[] {
+  const hits: any[] = response?.hits?.hits ?? [];
+  return hits
+    .map((hit) => hit?._source?.name)
+    .filter((name): name is string => typeof name === 'string' && name.length > 0);
+}
+
 // nori 가 미등록 고유명사를 동사 활용형으로 오분석해 토큰을 통째로 날려버리는 경우가 있다.
 // 예: "오샤레" → 오(VV 동사어간) + 샤(E 어미) + 레(E 어미) → posfilter 가 E 를 버려 ["오"] 만 남는다.
 // 남은 "오" 는 "타사와라"("와라"→"오") 같은 무관 상품과 name^8 로 매칭돼 정답을 랭킹 밖으로 밀어낸다.
@@ -231,12 +250,14 @@ export class ProductIndexService implements OnModuleInit {
   }
 
   /**
-   * 키워드 문자열을 실제로 담고 있는 상품 수 — 오타보정·fuzzy 없는 문자열 포함 대조.
-   * 0건 검색어 원인 분류용: 색인에 상품이 있는데 검색이 0건이면 검색엔진/노출 문제,
-   * 색인에도 없으면 소싱 부재다. (scripts/ops/search-zero-hit/collect.py 의 index_match 와 같은 절)
+   * 키워드 ↔ 상품 색인 대조 **근거** — 자동 "판정"에 쓰지 않는다.
+   * 사람이 개발/MD 를 판단할 재료로, (1) 문자열 포함 정확 일치(오타보정·fuzzy 없음 —
+   * scripts/ops/search-zero-hit/collect.py 의 index_match 와 같은 절)와 (2) 자모 유사
+   * 상품명(검색 엔진의 오타 절과 같은 name_jamo/brand_jamo fuzzy)을 함께 돌려준다.
+   * 유사 매칭은 무관 상품이 걸릴 수 있으므로 화면에서 "유사" 라벨로만 보여줄 것.
    */
-  async countKeywordMatches(keywords: string[]): Promise<Map<string, number>> {
-    const result = new Map<string, number>();
+  async getKeywordMatchEvidence(keywords: string[]): Promise<Map<string, KeywordMatchEvidence>> {
+    const result = new Map<string, KeywordMatchEvidence>();
     if (keywords.length === 0) return result;
 
     const client = this.openSearchService.getClient();
@@ -244,16 +265,19 @@ export class ProductIndexService implements OnModuleInit {
     await this.ensureProductsIndex();
 
     const escapeWildcard = (value: string) => value.replace(/([*?\\])/g, '\\$1');
-    const batchSize = 40;
+    // 키워드당 msearch 2건(정확·유사)이라 배치를 절반으로 줄인다.
+    const batchSize = 20;
     for (let start = 0; start < keywords.length; start += batchSize) {
       const chunk = keywords.slice(start, start + batchSize);
       const lines: Record<string, unknown>[] = [];
       for (const keyword of chunk) {
-        const compact = escapeWildcard(compactText(keyword).toLowerCase());
+        const compactRaw = compactText(keyword).toLowerCase();
+        const compact = escapeWildcard(compactRaw);
         lines.push({ index });
         lines.push({
-          size: 0,
+          size: EVIDENCE_SAMPLE_SIZE,
           track_total_hits: true,
+          _source: ['name'],
           query: {
             bool: {
               should: [
@@ -267,13 +291,40 @@ export class ProductIndexService implements OnModuleInit {
             },
           },
         });
+        lines.push({ index });
+        // 자모 유사 — 검색 엔진의 buildJamoTypoClauses 와 같은 필드·fuzziness 규칙.
+        // 너무 짧은 키워드는 편집거리 1도 헐거워서 아예 안 돌린다 (match_none).
+        lines.push({
+          size: EVIDENCE_SAMPLE_SIZE,
+          _source: ['name'],
+          query:
+            compactRaw.length >= JAMO_TYPO_MIN_LENGTH
+              ? {
+                  multi_match: {
+                    query: toJamo(keyword),
+                    fields: ['name_jamo^6', 'brand_jamo^4'],
+                    fuzziness: compactRaw.length >= JAMO_FUZZY2_MIN_LENGTH ? 2 : 1,
+                    prefix_length: 0,
+                    max_expansions: 25,
+                    minimum_should_match: '100%',
+                  },
+                }
+              : { match_none: {} },
+        });
       }
       const response = await client.msearch({ body: lines });
       const responses: any[] = (response.body as any)?.responses ?? [];
       chunk.forEach((keyword, offset) => {
-        const hits = responses[offset]?.hits?.total;
-        const total = typeof hits === 'number' ? hits : (hits?.value ?? 0);
-        result.set(keyword, Number(total ?? 0));
+        const exact = responses[offset * 2];
+        const similar = responses[offset * 2 + 1];
+        const totalRaw = exact?.hits?.total;
+        const exactNames = extractHitNames(exact);
+        result.set(keyword, {
+          exactCount: Number((typeof totalRaw === 'number' ? totalRaw : totalRaw?.value) ?? 0),
+          exactNames,
+          // 정확 일치에 이미 나온 이름은 유사 목록에서 뺀다 — 화면 중복 방지
+          similarNames: extractHitNames(similar).filter((name) => !exactNames.includes(name)),
+        });
       });
     }
     return result;

--- a/apps/search/src/search-keyword-ops.service.spec.ts
+++ b/apps/search/src/search-keyword-ops.service.spec.ts
@@ -27,13 +27,20 @@ function buildIssueRepository(rows: SearchKeywordIssue[] = []): KeywordIssueRepo
   } as unknown as KeywordIssueRepository;
 }
 
-function buildProductIndex(matches: Record<string, number> = {}): ProductIndexService {
+type EvidenceStub = { exactCount: number; exactNames: string[]; similarNames: string[] };
+
+function buildProductIndex(evidence: Record<string, Partial<EvidenceStub>> = {}): ProductIndexService {
   return {
-    countKeywordMatches: jest
-      .fn()
-      .mockImplementation((keywords: string[]) =>
-        Promise.resolve(new Map(keywords.map((keyword) => [keyword, matches[keyword] ?? 0]))),
+    getKeywordMatchEvidence: jest.fn().mockImplementation((keywords: string[]) =>
+      Promise.resolve(
+        new Map(
+          keywords.map((keyword) => [
+            keyword,
+            { exactCount: 0, exactNames: [], similarNames: [], ...evidence[keyword] },
+          ]),
+        ),
       ),
+    ),
   } as unknown as ProductIndexService;
 }
 
@@ -104,29 +111,40 @@ describe('SearchKeywordOpsService.getZeroHitKeywords', () => {
     expect(result.items.map((item) => item.keywordNorm)).toEqual(['b']);
     expect(result.totalItems).toBe(2);
     expect(issueRepository.findByNorms).toHaveBeenCalledWith(['b']);
-    expect(productIndex.countKeywordMatches).toHaveBeenCalledWith(['b']);
+    expect(productIndex.getKeywordMatchEvidence).toHaveBeenCalledWith(['b']);
   });
 
-  it('색인 대조 결과로 원인을 분류한다 — 색인에 있으면 engine, 없으면 sourcing, 조회 실패면 unclassified', async () => {
+  it('색인 대조는 판정 없이 근거만 싣는다 — 정확 일치 수·이름과 유사 상품명', async () => {
     const repository = buildRepository({
       getZeroHitKeywords: jest.fn().mockResolvedValue([
         zeroRow('퍼마색소', 5, '2026-08-26T01:00:00Z'),
-        zeroRow('경이로운', 3, '2026-08-26T01:00:00Z'),
+        zeroRow('로리킹', 3, '2026-08-26T01:00:00Z'),
       ]),
     });
     const service = new SearchKeywordOpsService(
       repository,
       buildIssueRepository(),
-      buildProductIndex({ 퍼마색소: 53 }),
+      buildProductIndex({
+        퍼마색소: { exactCount: 53, exactNames: ['퍼마 색소 30ml'] },
+        // 오타 키워드 — 정확 일치는 없지만 자모 유사로 실제 상품명이 잡힌다
+        로리킹: { similarNames: ['롤리킹 롤러'] },
+      }),
     );
 
     const result = await service.getZeroHitKeywords('2026-08-01', '2026-08-27', 1, 20);
     const byNorm = new Map(result.items.map((item) => [item.keywordNorm, item]));
-    expect(byNorm.get('퍼마색소')).toMatchObject({ autoCause: 'engine', matchedProductsCount: 53 });
-    expect(byNorm.get('경이로운')).toMatchObject({ autoCause: 'sourcing', matchedProductsCount: 0 });
+    expect(byNorm.get('퍼마색소')).toMatchObject({
+      matchedProductsCount: 53,
+      matchedProductNames: ['퍼마 색소 30ml'],
+      similarProductNames: [],
+    });
+    expect(byNorm.get('로리킹')).toMatchObject({
+      matchedProductsCount: 0,
+      similarProductNames: ['롤리킹 롤러'],
+    });
 
     const failingIndex = {
-      countKeywordMatches: jest.fn().mockRejectedValue(new Error('opensearch down')),
+      getKeywordMatchEvidence: jest.fn().mockRejectedValue(new Error('opensearch down')),
     } as unknown as ProductIndexService;
     const degraded = await new SearchKeywordOpsService(repository, buildIssueRepository(), failingIndex).getZeroHitKeywords(
       '2026-08-01',
@@ -134,21 +152,27 @@ describe('SearchKeywordOpsService.getZeroHitKeywords', () => {
       1,
       20,
     );
-    expect(degraded.items.every((item) => item.autoCause === 'unclassified')).toBe(true);
+    // 색인 조회가 죽어도 목록은 나온다 — 근거만 비어 있다
+    expect(degraded.items).toHaveLength(2);
+    expect(degraded.items.every((item) => item.matchedProductsCount === 0 && item.similarProductNames.length === 0)).toBe(true);
   });
 
-  it('영타 검색어는 교정 결과가 색인에 있으면 engine 으로 분류한다', async () => {
+  it('영타 검색어는 교정어의 일치 상품명을 유사 근거로 합친다', async () => {
     const repository = buildRepository({
       getZeroHitKeywords: jest.fn().mockResolvedValue([zeroRow('vjak', 4, '2026-08-26T01:00:00Z')]),
     });
     const service = new SearchKeywordOpsService(
       repository,
       buildIssueRepository(),
-      buildProductIndex({ 퍼마: 12 }),
+      buildProductIndex({ 퍼마: { exactCount: 12, exactNames: ['퍼마 블렌드'] } }),
     );
 
     const result = await service.getZeroHitKeywords('2026-08-01', '2026-08-27', 1, 20);
-    expect(result.items[0]).toMatchObject({ autoCause: 'engine', correctedQuery: '퍼마', matchedProductsCount: 0 });
+    expect(result.items[0]).toMatchObject({
+      correctedQuery: '퍼마',
+      matchedProductsCount: 0,
+      similarProductNames: ['퍼마 블렌드'],
+    });
   });
 });
 

--- a/apps/search/src/search-keyword-ops.service.ts
+++ b/apps/search/src/search-keyword-ops.service.ts
@@ -2,7 +2,6 @@ import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import {
   AdminKeywordDetailResponseDto,
   AdminZeroHitKeywordsResponseDto,
-  KeywordAutoCause,
   KeywordIssueDto,
   UpsertKeywordIssueDto,
   ZeroHitKeywordRowDto,
@@ -108,13 +107,13 @@ export class SearchKeywordOpsService {
     };
 
     const pageRows = enriched.slice((page - 1) * limit, (page - 1) * limit + limit);
-    const [issues, classification] = await Promise.all([
+    const [issues, evidence] = await Promise.all([
       this.keywordIssueRepository.findByNorms(pageRows.map((row) => row.keywordNorm)),
-      this.classifyKeywords(pageRows.map((row) => row.keyword)),
+      this.gatherEvidence(pageRows.map((row) => row.keyword)),
     ]);
 
     const items: ZeroHitKeywordRowDto[] = pageRows.map((row) => {
-      const cls = classification.get(row.keyword);
+      const ev = evidence.get(row.keyword);
       const issue = issues.get(row.keywordNorm);
       return {
         keyword: row.keyword,
@@ -125,9 +124,10 @@ export class SearchKeywordOpsService {
         firstZeroAt: row.firstZeroAt,
         neglectDays: row.neglectDays,
         resolvedByIndex: row.resolvedByIndex,
-        autoCause: cls?.autoCause ?? 'unclassified',
-        matchedProductsCount: cls?.matchedProductsCount ?? 0,
-        correctedQuery: cls?.correctedQuery ?? null,
+        matchedProductsCount: ev?.matchedProductsCount ?? 0,
+        matchedProductNames: ev?.matchedProductNames ?? [],
+        similarProductNames: ev?.similarProductNames ?? [],
+        correctedQuery: ev?.correctedQuery ?? null,
         issue: issue ? toIssueDto(issue) : null,
       };
     });
@@ -145,7 +145,7 @@ export class SearchKeywordOpsService {
     const fromIso = kstDayStartIso(from);
     const toExclusiveIso = kstDayStartIso(addDays(to, 1));
 
-    const [detail, activityMap, previousCounts, issues, classification] = await Promise.all([
+    const [detail, activityMap, previousCounts, issues, evidence] = await Promise.all([
       this.repository.getKeywordDetail({ keywordNorm, fromIso, toExclusiveIso }),
       this.repository.getKeywordActivity({ keywordNorms: [keywordNorm] }),
       this.repository.getKeywordCounts({
@@ -154,7 +154,7 @@ export class SearchKeywordOpsService {
         keywordNorms: [keywordNorm],
       }),
       this.keywordIssueRepository.findByNorms([keywordNorm]),
-      this.classifyKeywords([keyword]),
+      this.gatherEvidence([keyword]),
     ]);
 
     const activity = activityMap.get(keywordNorm);
@@ -163,7 +163,7 @@ export class SearchKeywordOpsService {
     const lastZeroAt = activity?.lastZeroAt ?? null;
     const neglecting = Boolean(lastZeroAt && (!lastPositiveAt || lastPositiveAt < lastZeroAt));
     const anchorIso = lastPositiveAt ?? firstZeroAt;
-    const cls = classification.get(keyword);
+    const ev = evidence.get(keyword);
     const issue = issues.get(keywordNorm);
 
     return {
@@ -179,9 +179,10 @@ export class SearchKeywordOpsService {
       lastPositiveAt,
       firstZeroAt,
       neglectDays: neglecting && anchorIso ? daysBetween(kstDateOf(anchorIso), todayKst()) : null,
-      autoCause: cls?.autoCause ?? 'unclassified',
-      matchedProductsCount: cls?.matchedProductsCount ?? 0,
-      correctedQuery: cls?.correctedQuery ?? null,
+      matchedProductsCount: ev?.matchedProductsCount ?? 0,
+      matchedProductNames: ev?.matchedProductNames ?? [],
+      similarProductNames: ev?.similarProductNames ?? [],
+      correctedQuery: ev?.correctedQuery ?? null,
       issue: issue ? toIssueDto(issue) : null,
     };
   }
@@ -203,14 +204,31 @@ export class SearchKeywordOpsService {
   }
 
   /**
-   * 원인 자동 분류 — 색인 문자열 대조(+영타 교정 재대조).
-   * 색인에 상품이 있으면 검색엔진/노출 문제(engine, 개발), 없으면 소싱 부재(sourcing, MD).
-   * 색인 조회가 실패하면 unclassified 로 남긴다 — 목록 조회 자체를 막지 않는다.
+   * 색인 대조 **근거** 수집 — 자동 판정을 내리지 않는다 (판정은 오탐이 잦아 제거,
+   * 개발/MD 판단은 사람이 status 로 지정한다). 정확 일치 상품 수·이름, 자모 유사
+   * 상품명(오타 후보), 영타 교정어를 재료로 돌려준다. 영타 교정어의 정확 일치
+   * 상품명은 유사 목록에 합친다. 색인 조회가 실패해도 목록 조회는 막지 않는다.
    */
-  private async classifyKeywords(
-    keywords: string[],
-  ): Promise<Map<string, { autoCause: KeywordAutoCause; matchedProductsCount: number; correctedQuery: string | null }>> {
-    const result = new Map<string, { autoCause: KeywordAutoCause; matchedProductsCount: number; correctedQuery: string | null }>();
+  private async gatherEvidence(keywords: string[]): Promise<
+    Map<
+      string,
+      {
+        matchedProductsCount: number;
+        matchedProductNames: string[];
+        similarProductNames: string[];
+        correctedQuery: string | null;
+      }
+    >
+  > {
+    const result = new Map<
+      string,
+      {
+        matchedProductsCount: number;
+        matchedProductNames: string[];
+        similarProductNames: string[];
+        correctedQuery: string | null;
+      }
+    >();
     const unique = [...new Set(keywords.filter((keyword) => keyword.length > 0))];
     if (unique.length === 0) return result;
 
@@ -221,24 +239,33 @@ export class SearchKeywordOpsService {
     }
 
     try {
-      const matches = await this.productIndexService.countKeywordMatches([
+      const evidence = await this.productIndexService.getKeywordMatchEvidence([
         ...new Set([...unique, ...correctedBy.values()]),
       ]);
       for (const keyword of unique) {
-        const matched = matches.get(keyword) ?? 0;
+        const own = evidence.get(keyword);
         const corrected = correctedBy.get(keyword) ?? null;
-        const correctedMatched = corrected ? (matches.get(corrected) ?? 0) : 0;
+        const correctedEvidence = corrected ? evidence.get(corrected) : undefined;
+        const similar = [
+          ...new Set([
+            ...(own?.similarNames ?? []),
+            ...(correctedEvidence?.exactNames ?? []),
+            ...(correctedEvidence?.similarNames ?? []),
+          ]),
+        ].filter((name) => !(own?.exactNames ?? []).includes(name));
         result.set(keyword, {
-          autoCause: matched > 0 || correctedMatched > 0 ? 'engine' : 'sourcing',
-          matchedProductsCount: matched,
+          matchedProductsCount: own?.exactCount ?? 0,
+          matchedProductNames: own?.exactNames ?? [],
+          similarProductNames: similar,
           correctedQuery: corrected,
         });
       }
     } catch {
       for (const keyword of unique) {
         result.set(keyword, {
-          autoCause: 'unclassified',
           matchedProductsCount: 0,
+          matchedProductNames: [],
+          similarProductNames: [],
           correctedQuery: correctedBy.get(keyword) ?? null,
         });
       }


### PR DESCRIPTION
## 배경

#751 배포 후 실사용 피드백: 0건 검색어의 자동 원인 분류(검색엔진/소싱 부재)가 부정확하다. 예: "로리킹"은 "롤리킹"의 오타라 검색엔진 쪽 문제인데, 문자열 포함 대조는 이를 못 잡아 소싱 부재로 오판했다. 정확한 자동 판정은 이 데이터만으로는 불가능하다 — 오프라인 소싱 리포트조차 사람 판정 사전(verdicts)을 두고 오탐을 계속 정정하는 이유다.

## 변경

**틀릴 수 있는 "판정"을 없애고, 사람이 판단할 "근거"만 보여준다.**

- `autoCause` 제거. 대신 키워드마다:
  - **정확 일치**: 문자열 포함 대조 상품 수 + 상품명 샘플 (색인엔 있는데 검색 0건 → 검색엔진·노출 신호)
  - **유사 상품명**: 자모 fuzzy 매칭(검색 엔진의 오타 절과 같은 `name_jamo`/`brand_jamo` 규칙) — "로리킹" 옆에 "롤리킹 아이롤러"가 뜬다. 무관 상품이 섞일 수 있어 라벨을 "유사"로만 단다
  - **영타 교정어** + 그 교정어의 일치 상품명(유사 목록에 병합)
- 화면: 분류 배지 → "색인 근거" 컬럼. 개발/MD 지정이 빨라지도록 **테이블 행에서 바로 상태를 바꾸는 인라인 셀렉트** 추가 (상태만 전송 — 서버 upsert가 담당·메모를 보존).
- 색인 조회가 실패해도 목록은 뜬다(근거만 빈 값).

## 검증

- type-check 0 / 전체 jest 실패 0 / admin-web 테스트 606 통과
- 실부팅 E2E: 색인에 "롤리킹" 상품만 있는 상태에서 0건 키워드 "로리킹" 조회 → 정확 일치 0건 + 유사 "롤리킹 아이롤러" 표시 확인

## 참고

`autoCause` 응답 필드 제거는 #751 이 오늘 배포된 admin-web 전용 API 라 외부 소비자가 없다.
