### PR TITLE
test(medusa): 배송비 그룹 입력 스펙을 carrier·description 계약에 맞춘다

### DIFF
--- a/apps/medusa/src/modules/almond-fulfillment/__tests__/parse-shipping-group-input.unit.spec.ts
+++ b/apps/medusa/src/modules/almond-fulfillment/__tests__/parse-shipping-group-input.unit.spec.ts
@@ -15,7 +15,10 @@ describe('parseShippingGroupInput', () => {
       name: '간편식 배송',
       policy: { type: 'conditional_free', baseFee: 3000, freeThreshold: 30000 },
       areaTemplateCode: 'default',
-      delivery: { method: '택배', area: '전국지역', leadTimeMinDays: 2, leadTimeMaxDays: 3 },
+      // carrier·description 은 입력이 없어도 빈 문자열로 항상 채운다. data 갱신이 JSON 병합이라
+      // 키를 빠뜨리면 옛 값이 남아 '지우기' 가 동작하지 않는다.
+      delivery: { method: '택배', area: '전국지역', leadTimeMinDays: 2, leadTimeMaxDays: 3, carrier: '' },
+      description: '',
     });
   });
 
@@ -26,7 +29,37 @@ describe('parseShippingGroupInput', () => {
       area: '전국지역',
       leadTimeMinDays: 2,
       leadTimeMaxDays: 3,
+      carrier: '',
     });
+  });
+
+  it('택배사와 안내 문구는 앞뒤 공백을 떼고 담는다', () => {
+    const parsed = parseShippingGroupInput({
+      ...valid,
+      delivery: { ...valid.delivery, carrier: '  한진택배  ' },
+      description: '  주문 후 2~3일 내 발송합니다.  ',
+    });
+    expect(parsed.delivery.carrier).toBe('한진택배');
+    expect(parsed.description).toBe('주문 후 2~3일 내 발송합니다.');
+  });
+
+  // 비운 값도 키를 남겨야 JSON 병합에서 옛 값이 되살아나지 않는다.
+  it.each<[string, unknown]>([
+    ['빈 문자열', ''],
+    ['null', null],
+    ['생략', undefined],
+  ])('안내 문구가 %s 이면 빈 문자열로 지운다', (_label, description) => {
+    expect(parseShippingGroupInput({ ...valid, description })).toHaveProperty('description', '');
+  });
+
+  it('공백뿐인 택배사는 빈 문자열로 지운다', () => {
+    const parsed = parseShippingGroupInput({ ...valid, delivery: { ...valid.delivery, carrier: '   ' } });
+    expect(parsed.delivery).toHaveProperty('carrier', '');
+  });
+
+  it('안내 문구는 500자까지 허용한다', () => {
+    const description = '가'.repeat(500);
+    expect(parseShippingGroupInput({ ...valid, description }).description).toBe(description);
   });
 
   it('배송기간 시작일이 종료일보다 크면 거부한다', () => {
@@ -54,6 +87,7 @@ describe('parseShippingGroupInput', () => {
     ['소수점 금액', { ...valid, policy: { type: 'flat', baseFee: 1000.5 } }, /baseFee/],
     ['조건부 무료인데 기준금액 없음', { ...valid, policy: { type: 'conditional_free', baseFee: 3000 } }, /freeThreshold/],
     ['유료인데 배송비 0원', { ...valid, policy: { type: 'flat', baseFee: 0 } }, /baseFee/],
+    ['500자를 넘는 안내 문구', { ...valid, description: '가'.repeat(501) }, /description/],
   ])('%s 은 거부한다', (_label, input, pattern) => {
     expect(() => parseShippingGroupInput(input)).toThrow(pattern as RegExp);
   });


### PR DESCRIPTION
## 왜

Medusa 유닛 워크플로가 **2026-08-18 부터 develop 에서 계속 빨갰다**. 실패는 209건 중 2건, 전부 `parse-shipping-group-input.unit.spec.ts` 한 파일이다.

`parseShippingGroupInput()` 이 `delivery.carrier: ''` 와 `description: ''` 을 더 반환하는데 스펙이 `toEqual`(엄격 심층 비교)이라 "예상에 없는 키"로 깨진다.

| | |
|---|---|
| 두 필드를 넣은 커밋 | `79343a43d` (2026-08-18, #661) |
| 스펙 마지막 수정 | `abc20af81` (2026-08-06, #568) |

그 사이 두 파일 모두 변경이 0건이라, 08-18 · 08-20(2건) · 08-29(2건) 실패는 전부 같은 한 가지 원인이다. 최근 PR 들이 물려받은 빨강은 그 PR 탓이 아니다.

## 코드가 아니라 스펙이 낡았다

`carrier`·`description` 을 빈 문자열로라도 **항상** 내보내는 것은 의도된 설계다. `79343a43d` 의 커밋 본문이 이유를 적고 있다 — shipping option 의 `data` 갱신이 JSON 병합이라 키를 빠뜨리면 옛 값이 남아 '지우기' 가 동작하지 않는다. 스펙 파일 자체도 같은 논리의 주석(`policy.freeThreshold` 를 0 으로 덮어쓰는 이유)을 이미 갖고 있었다.

기능은 `types.ts` 계약 · 어드민 그룹 폼 입력란 · 스토어프론트 툴팁/택배사 폴백 · E2E 까지 배선돼 있다. 스펙에 맞추려고 두 필드를 빼면 그게 회귀다.

## 무엇을

낡은 단언 2건을 계약에 맞추고, 드리프트가 생긴 지점이 곧 커버리지 구멍이었으므로 같이 채웠다 (+7건).

- 값 전달과 앞뒤 공백 제거
- 빈 문자열 / `null` / 생략 일 때 **키를 남긴 채** `''` 로 지우기 — `toHaveProperty` 로 키 존재까지 검사
- `description` 500자 경계 (통과 / 초과 거부)

구현 변경 없음. 마이그레이션 없음.

## 검증

- `npm run test:unit` — 24 suites / **216 tests 통과** (209 → +7)
- `npx tsc --noEmit -p tsconfig.instrumentation.json` — 통과
- **변이 테스트**: 구현에서 `carrier` 반환 · `description` 반환 · 500자 가드를 각각 들어내자 **9건(고친 2건 + 새 7건) 전부 빨강**. 통과만 하고 아무것도 지키지 않는 테스트는 없다.

루트 검증 게이트는 영향 없다 — 루트 jest 는 `modulePathIgnorePatterns`, 루트 tsconfig 는 `exclude` 로 각각 `apps/medusa` 를 제외한다.

## 남는 과제 (이 PR 범위 밖)

`79343a43d` 는 부모가 하나인 커밋이고 연결된 PR 이 없다 — **PR 없이 develop 에 직접 푸시**됐다. PR 게이트를 통과한 적이 없고 머지 후 `push` 실행만 떠서 11일간 방치됐다. 여기에 `medusa-unit-tests.yml` 이 `paths: apps/medusa/**` 로만 도는 탓에 대부분의 PR 에서는 빨강이 보이지도 않는다. 브랜치 보호와 `paths` 필터를 어떻게 볼지는 별도로 다뤄야 한다.

https://claude.ai/code/session_01LjUmHiLiePVXUYpbzJasRw
