### PR TITLE
fix(search): 붙여 친 검색어·로마자 검색어를 잡고, 무관한 벡터 결과를 줄인다

### DIFF
--- a/apps/search/src/product-index.service.spec.ts
+++ b/apps/search/src/product-index.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
-import { ProductIndexService } from './product-index.service';
+import { ProductIndexService, VECTOR_FILL_KEYWORD_LIMIT, VECTOR_FILL_LIMIT } from './product-index.service';
 import { OpenSearchService } from './opensearch.service';
 import { EmbeddingService } from './embedding.service';
 import { SpellCorrectionService } from './spell-correction.service';
@@ -552,6 +552,35 @@ describe('ProductIndexService.searchProducts - RRF 융합', () => {
     // 키워드에 없고 벡터에만 있는 c 는 맨 뒤로 간다.
     expect(order.indexOf('c')).toBe(order.length - 1);
     expect(order.slice(0, 2).sort()).toEqual(['a', 'b']);
+  });
+
+  it('키워드가 한 화면을 채우면 벡터를 섞지 않는다', async () => {
+    const keywordHits = Array.from({ length: VECTOR_FILL_KEYWORD_LIMIT }, (_, i) => hit(`k${i}`));
+    const { service } = await buildService(makeEmbeddingService([0.1, 0.2]), keywordHits, [hit('vector-only')]);
+
+    const result = await service.searchProducts({ q: '유키반 테이프', sort: 'relevance', page: 1, size: 100 } as any);
+
+    expect(result.items.map((item) => item.productId)).not.toContain('vector-only');
+    expect(result.items).toHaveLength(VECTOR_FILL_KEYWORD_LIMIT);
+  });
+
+  it('키워드가 한 화면에 못 미치면 벡터로 채운다', async () => {
+    const keywordHits = Array.from({ length: VECTOR_FILL_KEYWORD_LIMIT - 1 }, (_, i) => hit(`k${i}`));
+    const { service } = await buildService(makeEmbeddingService([0.1, 0.2]), keywordHits, [hit('vector-only')]);
+
+    const result = await service.searchProducts({ q: '유키반 테이프', sort: 'relevance', page: 1, size: 100 } as any);
+
+    expect(result.items.map((item) => item.productId)).toContain('vector-only');
+  });
+
+  it('벡터로 덧붙이는 건 상한까지다 — 키워드 3 건에 99 건이 붙던 걸 막는다', async () => {
+    const keywordHits = [hit('k0'), hit('k1'), hit('k2')];
+    const vectorHits = Array.from({ length: 99 }, (_, i) => hit(`v${i}`));
+    const { service } = await buildService(makeEmbeddingService([0.1, 0.2]), keywordHits, vectorHits);
+
+    const result = await service.searchProducts({ q: '니치반', sort: 'relevance', page: 1, size: 100 } as any);
+
+    expect(result.items).toHaveLength(keywordHits.length + VECTOR_FILL_LIMIT);
   });
 
   it('관련도 정렬이 아니면 벡터를 섞지 않는다', async () => {

--- a/apps/search/src/product-index.service.ts
+++ b/apps/search/src/product-index.service.ts
@@ -349,7 +349,6 @@ export class ProductIndexService implements OnModuleInit {
                 { wildcard: { name_compact: { value: `*${compact}*` } } },
                 { wildcard: { 'brand.keyword': { value: `*${escapeWildcard(keyword)}*` } } },
                 { match_phrase: { brand: keyword } },
-                { match_phrase: { seo_keywords: keyword } },
                 { match_phrase: { tags: keyword } },
               ],
               minimum_should_match: 1,
@@ -810,7 +809,7 @@ export class ProductIndexService implements OnModuleInit {
           {
             multi_match: {
               query: q,
-              fields: ['name^8', 'brand^5', 'category_names^3', 'tags^3', 'seo_keywords^2', 'description'],
+              fields: ['name^8', 'brand^5', 'category_names^3', 'tags^3', 'description'],
               operator: 'or',
               minimum_should_match: '100%',
             },
@@ -822,7 +821,7 @@ export class ProductIndexService implements OnModuleInit {
             multi_match: {
               query: q,
               type: 'cross_fields',
-              fields: ['name^8', 'brand^5', 'category_names^3', 'tags^3', 'seo_keywords^2'],
+              fields: ['name^8', 'brand^5', 'category_names^3', 'tags^3'],
               operator: 'and',
               boost: 20,
             },
@@ -839,7 +838,7 @@ export class ProductIndexService implements OnModuleInit {
 
     const multiMatch: Record<string, unknown> = {
       query: q,
-      fields: ['name^6', 'brand^4', 'category_names^2', 'tags^2', 'seo_keywords^2', 'description'],
+      fields: ['name^6', 'brand^4', 'category_names^2', 'tags^2', 'description'],
       analyzer: 'nori_search_synonym',
       operator: 'or',
       minimum_should_match: minimumShouldMatch,
@@ -948,7 +947,7 @@ export class ProductIndexService implements OnModuleInit {
       {
         multi_match: {
           query: hangul,
-          fields: ['name^8', 'brand^5', 'category_names^3', 'tags^3', 'seo_keywords^2'],
+          fields: ['name^8', 'brand^5', 'category_names^3', 'tags^3'],
           operator: 'and',
           boost: 2,
         },

--- a/apps/search/src/product-index.service.ts
+++ b/apps/search/src/product-index.service.ts
@@ -46,6 +46,13 @@ function extractHitNames(response: any): string[] {
 // nori 토큰 총 길이가 원문의 이 비율 미만이면 "뭉갬"으로 보고 nori 기반 절을 통째로 뺀다.
 // (측정: 오샤레 0.33 / 타사와라 0.75 / 그 외 대표 키워드 1.00 — 임계 0.6 은 양쪽에 여유가 있다.)
 const NORI_COLLAPSE_RATIO_THRESHOLD = 0.6;
+
+// 벡터는 키워드가 이만큼도 못 찾았을 때만 보강으로 태운다. 한 화면(20 건) 기준.
+export const VECTOR_FILL_KEYWORD_LIMIT = 20;
+
+// 그때도 덧붙이는 건 이만큼까지다. k-NN 은 유사도 하한이 없어 항상 k 개를 채워 오므로
+// ("니치반" 키워드 3 건 + 벡터 99 건) 개수로 막지 않으면 무관 상품이 화면을 덮는다.
+export const VECTOR_FILL_LIMIT = 10;
 // 1~2음절 쿼리는 정상이어도 비율이 튀기 쉬워 감지 대상에서 뺀다.
 const NORI_COLLAPSE_MIN_LENGTH = 3;
 const NORI_ANALYZE_CACHE_LIMIT = 2000;
@@ -246,12 +253,17 @@ export class ProductIndexService implements OnModuleInit {
       const fallbackHits = fallbackResponse.body.hits.hits as any[];
       const keywordHits = this.mergeHitsWithPriority(strictHits, fallbackHits, this.keywordResultPoolLimit);
 
-      // 키워드가 한 건도 못 찾았으면 벡터로 채우지 않는다. 안 파는 상품을 뜻만 닮은 100 건으로
-      // 덮으면 화면이 거짓말을 하고, result_count 도 0 이 아니게 되어 소싱 리포트에서 사라진다.
-      const mergedHits =
-        keywordHits.length > 0 && vectorHits.length > 0
-          ? this.fuseWithRrf(keywordHits, vectorHits, this.keywordResultPoolLimit)
-          : keywordHits;
+      // 벡터는 키워드가 부족할 때 채우는 용도다. 양쪽 끝에서는 태우지 않는다 — 0 건이면 안 파는
+      // 상품을 뜻만 닮은 100 건으로 덮어 화면이 거짓말을 하고 result_count 도 0 이 아니게 되어
+      // 소싱 리포트에서 사라진다. 반대로 키워드가 이미 한 화면을 채웠으면 꼬리에 무관 상품만
+      // 붙는다 ("유키반 테이프" 106 건의 뒤쪽이 전부 맥반석가루·슈가링왁스 같은 벡터 이웃이었다).
+      const fillWithVector =
+        vectorHits.length > 0 &&
+        keywordHits.length > 0 &&
+        keywordHits.length < VECTOR_FILL_KEYWORD_LIMIT;
+      const mergedHits = fillWithVector
+        ? this.fuseWithRrf(keywordHits, vectorHits.slice(0, VECTOR_FILL_LIMIT), this.keywordResultPoolLimit)
+        : keywordHits;
 
       keywordMatchCount = keywordHits.length;
       total = mergedHits.length;

--- a/apps/search/src/spell-correction.service.spec.ts
+++ b/apps/search/src/spell-correction.service.spec.ts
@@ -27,6 +27,7 @@ const CATALOG = [
   '일자형 네일 클리퍼 손톱깎이',
   '래쉬몬스터 하이드로겔 아이패치',
   '속눈썹 롯드 보관함 30구',
+  'TAT After 탯 에프터 허슬 버터 타투 탯 밤 30g / 100g',
 ];
 
 describe('SpellCorrectionService', () => {
@@ -49,6 +50,12 @@ describe('SpellCorrectionService', () => {
   it('조합하다 만 낱자가 섞여도 되돌린다', () => {
     expect(service.suggest('롤리ㅣㅇ')).toBe('롤리킹');
     expect(service.suggest('롤리킹ㅇ')).toBe('롤리킹');
+  });
+
+  // 상품명은 "탯 에프터"로 띄어져 있는데 고객은 "텟에프터"로 붙여 친다.
+  it('띄어 쓴 두 단어를 붙여 친 오타도 되돌린다', () => {
+    expect(service.suggest('텟에프터')).toBe('탯에프터');
+    expect(service.suggest('탯빔')).toBe('탯밤');
   });
 
   it('상품명에 그대로 있는 말은 교정하지 않는다', () => {

--- a/apps/search/src/spell-correction.service.spec.ts
+++ b/apps/search/src/spell-correction.service.spec.ts
@@ -28,6 +28,7 @@ const CATALOG = [
   '래쉬몬스터 하이드로겔 아이패치',
   '속눈썹 롯드 보관함 30구',
   'TAT After 탯 에프터 허슬 버터 타투 탯 밤 30g / 100g',
+  '카레 베이스 컬러',
 ];
 
 describe('SpellCorrectionService', () => {
@@ -56,6 +57,20 @@ describe('SpellCorrectionService', () => {
   it('띄어 쓴 두 단어를 붙여 친 오타도 되돌린다', () => {
     expect(service.suggest('텟에프터')).toBe('탯에프터');
     expect(service.suggest('탯빔')).toBe('탯밤');
+  });
+
+  // 한글 발음을 영어로 옮겨 친 검색어. 자판만 안 바꾼 영타(dkdlvocl)와는 다른 문제다.
+  it('발음을 영어로 옮겨 친 검색어를 한글로 되돌린다', () => {
+    expect(service.suggest('taetbam')).toBe('탯밤');
+    expect(service.suggest('tatbam')).toBe('탯밤');
+    expect(service.suggest('nichiban')).toBe('니치반');
+  });
+
+  it('짧은 영문 약어는 되돌리지 않는다 — 브랜드·규격이 엉뚱한 한글로 끌려가면 안 된다', () => {
+    // 라이브 영문 검색어 상위. 4 글자에 거리 1 을 주면 "bare" 가 "카레"(kare)로 끌려갔다.
+    expect(service.suggest('led')).toBeNull();
+    expect(service.suggest('tat')).toBeNull();
+    expect(service.suggest('bare')).toBeNull();
   });
 
   it('상품명에 그대로 있는 말은 교정하지 않는다', () => {

--- a/apps/search/src/spell-correction.service.ts
+++ b/apps/search/src/spell-correction.service.ts
@@ -228,6 +228,7 @@ export class SpellCorrectionService {
   /** 상품명을 교정 후보로 쓸 단어로 자른다. 규격·모델번호는 후보가 될 이유가 없다. */
   private tokenize(name: string): string[] {
     const words = name
+      .normalize('NFC')
       .split(/[\s/,()[\]+&]+/)
       .map((word) => word.trim().toLowerCase())
       .filter(

--- a/apps/search/src/spell-correction.service.ts
+++ b/apps/search/src/spell-correction.service.ts
@@ -177,17 +177,30 @@ export class SpellCorrectionService {
 
   /** 상품명을 교정 후보로 쓸 단어로 자른다. 규격·모델번호는 후보가 될 이유가 없다. */
   private tokenize(name: string): string[] {
-    return name
+    const words = name
       .split(/[\s/,()[\]+&]+/)
       .map((word) => word.trim().toLowerCase())
       .filter(
         (word) =>
-          word.length >= MIN_CANDIDATE_LENGTH &&
+          word.length > 0 &&
           word.length <= MAX_CANDIDATE_LENGTH &&
           // 한글이 하나라도 있어야 한다. 영문·숫자 모델번호는 자모 편집 거리로 다룰 대상이 아니다.
           /[가-힣]/.test(word) &&
           !/\d/.test(word),
       );
+
+    const candidates = words.filter((word) => word.length >= MIN_CANDIDATE_LENGTH);
+
+    // 붙여 친 검색어("텟에프터")는 상품명이 "탯 에프터"로 띄어져 있으면 어느 단어와도
+    // 가깝지 않다. 인접한 두 단어를 붙인 말도 후보로 넣어야 걸린다.
+    for (let i = 0; i + 1 < words.length; i++) {
+      const joined = words[i] + words[i + 1];
+      if (joined.length >= MIN_CANDIDATE_LENGTH && joined.length <= MAX_CANDIDATE_LENGTH) {
+        candidates.push(joined);
+      }
+    }
+
+    return candidates;
   }
 
   private message(error: unknown): string {

--- a/apps/search/src/spell-correction.service.ts
+++ b/apps/search/src/spell-correction.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { OpenSearchService } from './opensearch.service';
-import { toJamo } from './utils/text.utils';
+import { toJamo, toRoman } from './utils/text.utils';
 
 // 자모 기준 편집 거리 상한. "나찌반"↔"니치반"이 2(ㅏ↔ㅣ, ㅉ↔ㅊ)라 2까지 본다.
 // 3 을 넘기면 "글루"↔"클립" 같은 무관한 쌍이 붙는다.
@@ -8,6 +8,12 @@ const MAX_DISTANCE = 2;
 // 짧은 검색어는 편집 거리 2 가 곧 절반이라 다른 단어가 된다. 음절 수로 상한을 조인다.
 const MAX_DISTANCE_BY_SYLLABLE: Record<number, number> = { 1: 0, 2: 1, 3: 2 };
 // 상품명에서 뽑은 후보 중 이 길이 미만은 버린다 — "1개", "대" 같은 조각이 교정 대상이 되면 안 된다.
+// 로마자 기준 상한. "탯밤"→taetbam 을 고객은 tatbam 으로 친다(거리 1). 2 를 주면
+// 정답이 없는 검색어가 엉뚱한 말로 끌려간다 — tatbam 이 "풋밤"(putbam, 거리 2)이 됐다.
+// 짧은 검색어는 거리 1 도 다른 말이 되므로 길이로 더 조인다 — 4 글자에 1 을 주면
+// 브랜드 "bare" 가 "카레"(kare)가 된다. 5 글자부터 열어야 "perma"→"퍼마"(peoma)가 산다.
+const MAX_ROMAN_DISTANCE = 1;
+const MAX_ROMAN_DISTANCE_BY_LENGTH: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 1 };
 const MIN_CANDIDATE_LENGTH = 2;
 const MAX_CANDIDATE_LENGTH = 12;
 // 사전 구축 시 훑을 상품 수 상한. 부팅이 색인 크기에 끌려가지 않게 막는다.
@@ -17,8 +23,16 @@ const SUGGEST_CACHE_LIMIT = 2000;
 interface Candidate {
   word: string;
   jamo: string;
+  // 로마자 표기. 고객이 한글 발음을 영어로 옮겨 치는 경우("탯밤"→tatbam)를 되돌린다.
+  roman: string;
   // 이 단어를 이름에 가진 상품 수. 동점일 때 흔한 쪽을 고른다.
   freq: number;
+}
+
+// 자판만 한글로 안 바꾼 영타(dkdlvocl)는 qwertyToHangul 이 따로 잡는다. 여기는 발음을
+// 옮겨 적은 검색어라 알파벳만으로 이뤄진다.
+function isRomanQuery(value: string): boolean {
+  return /^[a-z]+$/i.test(value);
 }
 
 @Injectable()
@@ -26,6 +40,7 @@ export class SpellCorrectionService {
   private readonly logger = new Logger(SpellCorrectionService.name);
   // 자모 길이별로 나눠 담는다. 편집 거리 d 이내면 길이 차도 d 이내라 그 구간만 보면 된다.
   private readonly byJamoLength = new Map<number, Candidate[]>();
+  private readonly byRomanLength = new Map<number, Candidate[]>();
   private readonly suggestCache = new Map<string, string | null>();
   private ready = false;
 
@@ -78,11 +93,18 @@ export class SpellCorrectionService {
     }
 
     this.byJamoLength.clear();
+    this.byRomanLength.clear();
     for (const [word, count] of freq) {
-      const jamo = toJamo(word);
-      const bucket = this.byJamoLength.get(jamo.length) ?? [];
-      bucket.push({ word, jamo, freq: count });
-      this.byJamoLength.set(jamo.length, bucket);
+      const candidate: Candidate = { word, jamo: toJamo(word), roman: toRoman(word), freq: count };
+      const jamoBucket = this.byJamoLength.get(candidate.jamo.length) ?? [];
+      jamoBucket.push(candidate);
+      this.byJamoLength.set(candidate.jamo.length, jamoBucket);
+
+      if (candidate.roman) {
+        const romanBucket = this.byRomanLength.get(candidate.roman.length) ?? [];
+        romanBucket.push(candidate);
+        this.byRomanLength.set(candidate.roman.length, romanBucket);
+      }
     }
 
     this.ready = true;
@@ -104,7 +126,7 @@ export class SpellCorrectionService {
       return cached;
     }
 
-    const result = this.findNearest(trimmed);
+    const result = isRomanQuery(trimmed) ? this.findNearestRoman(trimmed) : this.findNearest(trimmed);
     if (this.suggestCache.size >= SUGGEST_CACHE_LIMIT) {
       const oldest = this.suggestCache.keys().next().value;
       if (oldest !== undefined) {
@@ -133,6 +155,34 @@ export class SpellCorrectionService {
         }
 
         const distance = this.boundedDistance(jamo, candidate.jamo, limit);
+        if (distance > limit) {
+          continue;
+        }
+        if (!best || distance < best.distance || (distance === best.distance && candidate.freq > best.freq)) {
+          best = { word: candidate.word, distance, freq: candidate.freq };
+        }
+      }
+    }
+
+    return best?.word ?? null;
+  }
+
+  /**
+   * 발음을 영어로 옮겨 친 검색어를 되돌린다. "tatbam" → "탯밤"(taetbam, 거리 1).
+   * 로마자 표기법은 사람마다 흔들리므로(ae↔a, eo↔u) 편집 거리로 흡수한다.
+   */
+  private findNearestRoman(query: string): string | null {
+    const roman = query.toLowerCase();
+    const limit = MAX_ROMAN_DISTANCE_BY_LENGTH[roman.length] ?? MAX_ROMAN_DISTANCE;
+    if (limit === 0) {
+      return null;
+    }
+
+    let best: { word: string; distance: number; freq: number } | null = null;
+
+    for (let length = roman.length - limit; length <= roman.length + limit; length++) {
+      for (const candidate of this.byRomanLength.get(length) ?? []) {
+        const distance = this.boundedDistance(roman, candidate.roman, limit);
         if (distance > limit) {
           continue;
         }

--- a/apps/search/src/utils/text.utils.ts
+++ b/apps/search/src/utils/text.utils.ts
@@ -1,4 +1,4 @@
-import { convertQwertyToHangul, disassemble } from 'es-hangul';
+import { convertQwertyToHangul, disassemble, romanize } from 'es-hangul';
 
 export function compactText(value: string): string {
   return value.replace(/\s+/g, '');
@@ -36,6 +36,19 @@ export function qwertyToHangul(value: string): string {
     return '';
   }
   return /^[가-힣\s]+$/.test(converted) ? converted : '';
+}
+
+// "탯밤" → "taetbam". 고객이 한글 발음을 영어로 옮겨 치는 검색어("tatbam")를 되돌리는 데 쓴다.
+// 한글이 없는 말은 되돌릴 것도 없으므로 빈 문자열을 준다.
+export function toRoman(value: string): string {
+  if (!/[가-힣]/.test(value)) {
+    return '';
+  }
+  try {
+    return romanize(normalizeHangul(value)).toLowerCase();
+  } catch {
+    return '';
+  }
 }
 
 // 임베딩용 상품명 정제. 용량·모델번호가 섞이면 벡터가 흐려진다 —

--- a/scripts/ops/search-zero-hit/collect.py
+++ b/scripts/ops/search-zero-hit/collect.py
@@ -63,7 +63,6 @@ def index_match(keywords):
                 {"wildcard": {"name_compact": {"value": f"*{c}*"}}},
                 {"wildcard": {"brand.keyword": {"value": f"*{kw}*"}}},
                 {"match_phrase": {"brand": kw}},
-                {"match_phrase": {"seo_keywords": kw}},
                 {"match_phrase": {"tags": kw}},
             ], "minimum_should_match": 1}},
                 "_source": ["name", "brand", "is_visible_to_members_only", "status"]}, ensure_ascii=False))


### PR DESCRIPTION
고객이 실제로 친 검색어 3종이 0건이거나 엉뚱한 결과를 주던 걸 고칩니다. 서로 독립된 문제라 커밋도 나눠져 있습니다.

## 1. 붙여 친 검색어가 0건 — `텟에프터`

상품명은 `탯 에프터`로 띄어져 있는데 고객은 붙여 칩니다. 오타 교정 사전이 **단어 단위**로 만들어져서 `탯에프터`라는 후보가 아예 없었습니다.

→ 사전에 인접한 두 단어를 붙인 후보를 함께 넣습니다. 색인 변경 없음, 재색인 불필요.

라이브 사전(상품 20,000건)으로 검증:

| 검색어 | 결과 |
|---|---|
| `텟에프터` | → `탯에프터` ✅ |
| `탯빔` | → `탯밤` ✅ |
| `나찌반` `헨나` `아이패티` `롤리ㅣㅇ` | 기존 그대로 ✅ |
| `니치반` `속눈썹` `셀프네일` | null (정상 검색어는 안 건드림) ✅ |

## 2. 소리대로 영어로 친 검색어가 0건 — `tatbam`

`탯밤`을 발음대로 옮겨 친 검색어입니다. 자판만 안 바꾼 영타(`dkdlvocl`→아이패치)는 기존 `qwertyToHangul`이 잡고 있었지만, 발음 표기는 잡는 장치가 없었습니다. 상품 어디에도 `tatbam`이라는 문자열이 없으니 구조적으로 0건입니다.

→ 교정 사전이 후보마다 로마자 표기(`탯밤` → `taetbam`)를 함께 들고 있다가, 알파벳만으로 된 검색어가 0건이면 로마자 편집거리로 되돌립니다. **색인 변경 없음, 재색인 불필요.**

| 검색어 | 결과 | |
|---|---|---|
| `tatbam` `tetbam` | → `탯밤` | 목표 케이스 |
| `perma` | → `퍼마` | 라이브 58회 중 42회가 0건이던 검색어 |
| `nichiban` `yukiban` `rolliking` `aipaechi` | → 니치반 / 유키반 / 롤리킹 / 아이패치 | |
| `led` `ph` `md` `smp` `tat` `qa` | null | 짧은 약어는 안 건드림 |
| `vetus` `envy` `evenflo` `permablend` `bare` | null | 진짜 영문 브랜드는 보존 |

**임계값 근거**: 편집거리 2를 주면 정답이 인덱스에 없을 때 엉뚱한 말로 끌려갑니다(`tatbam` → `풋밤`, putbam, 거리 2). 4글자에 거리 1을 주면 브랜드 `bare`가 `카레`(kare)가 됩니다. 그래서 거리 1 + 5글자부터 허용으로 잡았고, 이 조합에서 위 표의 오탐이 전부 사라지면서 정답은 유지됩니다.

⚠️ 이 값들은 사례 기반이라 근거가 얇습니다. 자모 오타 때처럼 오타쌍 벤치로 스윕해서 확정하는 게 맞고, 후속으로 남겨둡니다.

## 3. 무관 상품이 결과 꼬리에 붙음 — `유키반 테이프`

벡터(임베딩) 검색은 유사도 하한이 없어 **항상 100건을 채워 옵니다.** 그런데 키워드 결과 뒤에 무조건 붙이고 있었습니다.

| 검색어 | 키워드 | 총계 | 벡터가 얹은 양 |
|---|---|---|---|
| 유키반 테이프 | 13 | 106 | +93 |
| 니치반 | 3 | 102 | +99 |
| 펌지 | 345 | 379 | +34 |

`유키반 테이프` 결과의 꼬리는 점수가 전부 0.69로 균일했고(RRF 융합 점수), 맥반석가루·송진가루·슈가링왁스 같은 완전 무관 상품이었습니다.

→ 키워드가 한 화면(20건)을 채우면 벡터를 안 쓰고, 쓰더라도 10건까지만 덧붙입니다.

예상 변화: 유키반 테이프 106 → 23건, 니치반 102 → 13건. 펌지·속눈썹은 벡터를 건너뜁니다.

**근본 해결은 아닙니다.** 원래는 k-NN에 유사도 하한을 줘서 무관한 이웃을 애초에 안 가져오는 게 맞는데, 코사인 점수가 몇 점부터 무관해지는지 실측 데이터가 없어 값을 못 정했습니다. 개수 제한은 거친 대신 틀릴 위험이 없습니다(최악이라도 덜 보여줄 뿐).

## 곁가지: SEO 키워드 매칭 제거

키워드 오염도 우려로 빼기로 했던 게 코드에 남아 있었습니다. 검색 쿼리 4곳에서 `seo_keywords^2`를 제거했습니다.

0건 리포트의 "이 키워드가 색인에 있나" 근거 조회 2곳(`getKeywordMatchEvidence`, `collect.py`)도 같이 뺐습니다 — 검색이 seo_keywords를 안 태우는데 근거에만 남겨두면, seo_keywords로만 걸리는 상품을 "이미 취급 중"으로 오판해 소싱 후보에서 빠지기 때문입니다.

색인 필드는 그대로 두었으니 재색인 불필요하고, 되돌리려면 필드명 복구로 끝납니다.

## 검증

- `npx jest apps/search` — 107 passed (실패 1건 `search.module.spec.ts`는 Kafka 배선 스펙으로 이 브랜치 이전부터 실패)
- `npm run type-check` — search 앱 0건 (남은 4건은 analytics의 `@google-analytics/data` 미설치)
- 라이브 사전·라이브 인덱스로 위 표의 before/after 실측
- 로컬 스토어프론트에서 화면 확인

## 배포

search가 묶인 `--target ServicesBundleB`. 재색인 불필요합니다.
