### PR TITLE
fix(deploy): search 판매량 색인용 내부 키를 배선한다

### DIFF
--- a/deployments/lcnine/services/infra/services.ts
+++ b/deployments/lcnine/services/infra/services.ts
@@ -70,6 +70,12 @@ export function setup(infra: SharedInfra) {
   // UGC — 서버 간(internal) 라우트 인증 키 (medusa 구매확정 → ugc 리뷰자격 등록)
   const ugcInternalKey = new sst.Secret('UgcInternalKey');
 
+  // Search — 서버 간(internal) 라우트 인증 키 (medusa 주문/백필 → search 판매량 색인)
+  // 아래 searchEnv 와 Medusa **양쪽**에 같은 값이 들어가야 한다. search 쪽 라우트는
+  // 키가 비면 아예 잠기므로(fail-closed), 한쪽만 배포되면 판매량이 색인에 안 실린다 —
+  // 장애는 아니고 랭킹의 판매량 항이 조용히 0 이 된다.
+  const searchInternalKey = new sst.Secret('SearchInternalKey');
+
   // Core — 서버 간(internal) 라우트 인증 키 (channel-adapter 수집 게이트 → core /internal/channels/*)
   // 아래 Core 와 channelAdapterEnv **양쪽**에 같은 값이 들어가야 한다. 한쪽만 배포되면 401 이고,
   // 수집 게이트는 fail-closed 라 주문 수집이 멈춘다 (#654).
@@ -330,6 +336,7 @@ export function setup(infra: SharedInfra) {
     AUTH_SECRET: authSecret.value,
     OIDC_ISSUER_URL: idpUserServiceUrl,
     OPENAI_API_KEY: openAiApiKey.value,
+    SEARCH_INTERNAL_KEY: searchInternalKey.value,
   });
 
   // 태스크 A: analytics + channel-adapter + membership (타깃그룹 3개 ≤ 5)
@@ -602,6 +609,8 @@ export function setup(infra: SharedInfra) {
       MEMBERSHIP_INTERNAL_KEY: membershipInternalKey.value,
       UGC_SERVICE_URL: url('ugc'),
       UGC_INTERNAL_KEY: ugcInternalKey.value,
+      SEARCH_SERVICE_URL: url('search'),
+      SEARCH_INTERNAL_KEY: searchInternalKey.value,
       MEDUSA_MEMBERSHIP_GROUP_ID: 'cusgroup_01KFZ12A1M344F6HKGDV35J28A',
       // 타임세일 시작·종료 경계에서 storefront 캐시를 비우는 크론이 쓴다.
       // channel-adapter 와 같은 엔드포인트·시크릿을 공유한다.


### PR DESCRIPTION
#773 이 `SEARCH_INTERNAL_KEY` 를 코드에서만 읽고 인프라(`infra/services.ts`)에 넣지 않았습니다. 그대로 배포하면 판매량이 색인에 안 실려 **랭킹의 판매량 항이 조용히 0** 이 됩니다.

장애는 아닙니다 — search 쪽 내부 라우트는 키가 비면 아예 잠기고(fail-closed), medusa 는 warn 만 남기고 건너뜁니다. 다만 기능이 아무 일도 안 합니다.

Medusa 의 `SEARCH_SERVICE_URL` 도 빠져 있었습니다. AdminWeb 에만 있어서 medusa 는 `localhost:3060` 폴백으로 떨어졌습니다.

## 변경

```
+  const searchInternalKey = new sst.Secret('SearchInternalKey')
+  searchEnv → SEARCH_INTERNAL_KEY
+  Medusa    → SEARCH_SERVICE_URL
+  Medusa    → SEARCH_INTERNAL_KEY
```

`coreInternalKey`(#654) 와 같은 형식으로, 양쪽에 같은 값이 들어가야 한다는 것과 한쪽만 배포됐을 때 무슨 일이 나는지를 주석에 적었습니다.

## 배포 절차

```bash
npx sst secret set SearchInternalKey <값> --stage live
npx sst deploy --stage live --target ServicesBundleB   # search
npx sst deploy --stage live --target Medusa
npx sst deploy --stage live --target Storefront

# 백필 1회 — 안 하면 판매량이 전부 0이라 랭킹 영향이 없다
cd apps/medusa && npx medusa exec ./src/scripts/sync-sales-count-to-search.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAPCj3ek9j6vAowau7b2iL