### PR TITLE
fix(archive): 다른 문서 갔다 오면 본문이 사라지던 구멍

### DIFF
--- a/apps/admin-web/src/lib/services/archive/mutations.spec.ts
+++ b/apps/admin-web/src/lib/services/archive/mutations.spec.ts
@@ -1,0 +1,99 @@
+import { QueryClient } from '@tanstack/react-query';
+import { writeBackSavedPage } from './mutations';
+import { archiveQueryKeys } from './query-keys';
+import type {
+  ArchivePageDetailDto,
+  ArchivePageSaveResultDto,
+} from '@/lib/types/dto/archive';
+
+const PAGE_ID = 'page-1';
+
+function detail(
+  overrides: Partial<ArchivePageDetailDto> = {}
+): ArchivePageDetailDto {
+  return {
+    id: PAGE_ID,
+    parentId: null,
+    space: 'team',
+    title: '옛 제목',
+    icon: null,
+    coverUrl: null,
+    content: [],
+    contentMarkdown: '',
+    createdBy: null,
+    updatedBy: null,
+    createdAt: '2026-09-03T00:00:00.000Z',
+    updatedAt: '2026-09-03T00:00:00.000Z',
+    isFavorite: false,
+    breadcrumbs: [],
+    ...overrides,
+  };
+}
+
+function saveResult(): ArchivePageSaveResultDto {
+  return {
+    id: PAGE_ID,
+    title: '새 제목',
+    icon: '📄',
+    coverUrl: null,
+    updatedBy: 'user-1',
+    updatedAt: '2026-09-03T05:00:00.000Z',
+  };
+}
+
+function makeClient(seed?: ArchivePageDetailDto) {
+  const queryClient = new QueryClient();
+  if (seed) queryClient.setQueryData(archiveQueryKeys.page(PAGE_ID), seed);
+  return queryClient;
+}
+
+describe('writeBackSavedPage', () => {
+  it('본문 저장분을 캐시에 넣는다 — 안 넣으면 돌아왔을 때 빈 문서가 뜨고 그게 서버를 덮는다', () => {
+    const queryClient = makeClient(detail());
+    const content = [{ id: 'b1', type: 'paragraph' }];
+
+    writeBackSavedPage(
+      queryClient,
+      PAGE_ID,
+      { content, contentMarkdown: '안녕' },
+      saveResult()
+    );
+
+    const cached = queryClient.getQueryData<ArchivePageDetailDto>(
+      archiveQueryKeys.page(PAGE_ID)
+    );
+    expect(cached?.content).toEqual(content);
+    expect(cached?.contentMarkdown).toBe('안녕');
+  });
+
+  it('제목만 저장한 요청은 본문을 건드리지 않는다', () => {
+    const content = [{ id: 'b1', type: 'paragraph' }];
+    const queryClient = makeClient(
+      detail({ content, contentMarkdown: '원래 본문' })
+    );
+
+    writeBackSavedPage(queryClient, PAGE_ID, { title: '새 제목' }, saveResult());
+
+    const cached = queryClient.getQueryData<ArchivePageDetailDto>(
+      archiveQueryKeys.page(PAGE_ID)
+    );
+    expect(cached?.content).toEqual(content);
+    expect(cached?.contentMarkdown).toBe('원래 본문');
+    expect(cached?.title).toBe('새 제목');
+  });
+
+  it('캐시에 없는 페이지는 만들어 내지 않는다 — 부분 문서가 진짜 문서 행세를 하면 안 된다', () => {
+    const queryClient = makeClient();
+
+    writeBackSavedPage(
+      queryClient,
+      PAGE_ID,
+      { content: [], contentMarkdown: '' },
+      saveResult()
+    );
+
+    expect(
+      queryClient.getQueryData(archiveQueryKeys.page(PAGE_ID))
+    ).toBeUndefined();
+  });
+});

--- a/apps/admin-web/src/lib/services/archive/mutations.ts
+++ b/apps/admin-web/src/lib/services/archive/mutations.ts
@@ -4,6 +4,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { archiveClient } from '@/lib/api/domains/archive';
 import type {
   ArchivePageDetailDto,
+  ArchivePageSaveResultDto,
   ArchiveSpace,
   CreateArchivePageDto,
   MoveArchivePageDto,
@@ -22,6 +23,46 @@ function invalidateLists(
 }
 
 /**
+ * 저장한 값을 상세 캐시에 그대로 되써 넣는다.
+ *
+ * 서버 응답에는 본문이 없고(`ArchivePageSaveResultDto`), 상세 조회는 `staleTime: Infinity` 라
+ * 여기서 안 넣으면 캐시의 `content` 가 «문서를 처음 연 순간의 값»에 영원히 묶인다.
+ * 그러면 다른 문서에 갔다 돌아왔을 때 방금 쓴 본문이 없는 편집기가 뜨고,
+ * 거기서 한 글자만 쳐도 그 빈 본문이 서버의 진짜 본문을 덮는다.
+ */
+export function writeBackSavedPage(
+  queryClient: ReturnType<typeof useQueryClient>,
+  id: string,
+  dto: UpdateArchivePageDto,
+  result?: ArchivePageSaveResultDto
+): void {
+  queryClient.setQueryData<ArchivePageDetailDto>(
+    archiveQueryKeys.page(id),
+    (previous) => {
+      if (!previous) return previous;
+
+      const next: ArchivePageDetailDto = result
+        ? {
+            ...previous,
+            title: result.title,
+            icon: result.icon,
+            coverUrl: result.coverUrl,
+            updatedAt: result.updatedAt,
+            updatedBy: result.updatedBy,
+          }
+        : { ...previous };
+
+      // 보낸 것만 반영한다 — 제목만 저장한 요청이 본문을 건드리면 안 된다.
+      if (dto.content !== undefined) next.content = dto.content;
+      if (dto.contentMarkdown !== undefined)
+        next.contentMarkdown = dto.contentMarkdown;
+
+      return next;
+    }
+  );
+}
+
+/**
  * 컴포넌트가 사라지는 순간의 저장.
  * useMutation 의 콜백은 옵저버가 이미 떨어져 나갔을 수 있으므로, 요청과 캐시 정리를
  * 직접 부른다 — «떠나면서 마지막 한 글자를 잃는» 경로를 훅 수명에 맡기지 않는다.
@@ -33,11 +74,12 @@ export async function flushArchivePageUpdate(
   dto: UpdateArchivePageDto
 ): Promise<void> {
   try {
-    await archiveClient.update(id, dto);
-    queryClient.invalidateQueries({ queryKey: archiveQueryKeys.page(id) });
+    const result = await archiveClient.update(id, dto);
+    writeBackSavedPage(queryClient, id, dto, result);
     invalidateLists(queryClient, space);
   } catch {
-    // 화면이 이미 없어 알릴 곳이 없다. 다음 조회에서 서버 값이 정답이 된다.
+    // 화면이 이미 없어 알릴 곳이 없다. 캐시가 서버와 갈렸을 수 있으니 다음 조회에서 다시 읽는다.
+    queryClient.invalidateQueries({ queryKey: archiveQueryKeys.page(id) });
   }
 }
 
@@ -54,8 +96,8 @@ export const useCreateArchivePage = () => {
 };
 
 /**
- * 자동 저장. 서버가 돌려주는 건 저장 결과(제목·수정시각)뿐이라 본문 캐시는 그대로 두고
- * 메타데이터만 손본다 — 편집 중인 블록을 서버 응답으로 덮으면 커서가 튄다.
+ * 자동 저장. 서버가 돌려주는 건 저장 결과(제목·수정시각)뿐이므로, 본문은 서버 응답이 아니라
+ * «방금 보낸 것»으로 캐시를 맞춘다 — 편집 중인 블록을 다시 조회한 값으로 덮으면 커서가 튄다.
  */
 export const useUpdateArchivePage = (space: ArchiveSpace) => {
   const queryClient = useQueryClient();
@@ -63,21 +105,8 @@ export const useUpdateArchivePage = (space: ArchiveSpace) => {
   return useMutation({
     mutationFn: ({ id, dto }: { id: string; dto: UpdateArchivePageDto }) =>
       archiveClient.update(id, dto),
-    onSuccess: (result) => {
-      queryClient.setQueryData<ArchivePageDetailDto>(
-        archiveQueryKeys.page(result.id),
-        (previous) =>
-          previous
-            ? {
-                ...previous,
-                title: result.title,
-                icon: result.icon,
-                coverUrl: result.coverUrl,
-                updatedAt: result.updatedAt,
-                updatedBy: result.updatedBy,
-              }
-            : previous
-      );
+    onSuccess: (result, variables) => {
+      writeBackSavedPage(queryClient, result.id, variables.dto, result);
       invalidateLists(queryClient, space);
     },
   });


### PR DESCRIPTION
자동 저장은 잘 되고 있었다 — PATCH 는 200 이고 새로고침하면 본문이 나온다.
문제는 화면이 그걸 다시 안 읽는 것이었다.

상세 조회 캐시는 편집 중 커서가 튀지 않게 staleTime: Infinity 로 잡혀 있어 명시적 무효화 전에는 서버를 다시 읽지 않는다. 그런데 저장 뮤테이션은 서버 응답
(ArchivePageSaveResultDto — 제목·아이콘·커버·수정시각뿐)에 있는 필드만 캐시에 되써 넣었다. 응답에 본문이 없으니 캐시의 content 는 «문서를 처음 연 순간의 값»에 영원히 묶였고, 앱 안에서 다른 문서에 갔다 돌아오면 그 빈 본문으로 편집기가 떴다.

거기서 한 글자만 치면 그 빈 본문이 800ms 뒤 서버의 진짜 본문을 덮는다.
표시 결함이 아니라 유실 경로다.

되쓰기의 원본을 응답이 아니라 «방금 보낸 요청»으로 바꿨다. 보내지 않은 필드는
건드리지 않는다 — 제목만 저장한 요청이 본문을 지우면 안 된다.