### PR TITLE
refactor(coupon): 죽은 컬럼 둘을 지운다 — order_id·issued_count contract 단계 (#488, ADR-0034 결정 6)

### DIFF
--- a/apps/medusa/src/api/store/customers/me/promotions/__tests__/format-promotion.unit.spec.ts
+++ b/apps/medusa/src/api/store/customers/me/promotions/__tests__/format-promotion.unit.spec.ts
@@ -213,7 +213,6 @@ describe('usable_count — 지금 쓸 수 있는 장 수 (#488 Task 8)', () => {
         expires_at: null,
         used_at: null,
         cart_id: null,
-        order_id: null,
         revoked_at: null,
       },
       {
@@ -226,7 +225,6 @@ describe('usable_count — 지금 쓸 수 있는 장 수 (#488 Task 8)', () => {
         expires_at: null,
         used_at: new Date(),
         cart_id: null,
-        order_id: 'o1',
         revoked_at: null,
       },
     ];
@@ -251,7 +249,6 @@ describe('usable_count — 지금 쓸 수 있는 장 수 (#488 Task 8)', () => {
         expires_at: '2026-06-01T00:00:00.000Z',
         used_at: null,
         cart_id: null,
-        order_id: null,
         revoked_at: null,
       },
     ];

--- a/apps/medusa/src/modules/promotion-meta/__tests__/grants.unit.spec.ts
+++ b/apps/medusa/src/modules/promotion-meta/__tests__/grants.unit.spec.ts
@@ -20,7 +20,6 @@ function grant(over: Partial<CouponGrantRow> & { id: string }): CouponGrantRow {
     expires_at: null,
     used_at: null,
     cart_id: null,
-    order_id: null,
     revoked_at: null,
     ...over,
   };

--- a/apps/medusa/src/modules/promotion-meta/__tests__/service.integration.spec.ts
+++ b/apps/medusa/src/modules/promotion-meta/__tests__/service.integration.spec.ts
@@ -534,57 +534,6 @@ moduleIntegrationTestRunner<PromotionMetaModuleService>({
         expect(new Date(second as string).getTime()).toBe(new Date(first as string).getTime());
       });
 
-      // `issued_count` 는 이 PR 이 읽기를 COUNT 로 옮겼지만 컬럼은 후속 contract PR 까지 남는다.
-      // 그동안 옛 태스크(롤링·롤백)가 이 컬럼으로 상한을 집행하므로, expand 단계 규약대로
-      // 쓰기를 **미러**한다 — 안 하면 동결된 카운터가 실제 장수 아래로 내려가 롤백 즉시
-      // 상한이 새는 fail-open 이 된다. 의미는 옛 코드와 같다: 상한 있는 프로모션만 센다.
-      describe('issued_count 미러 — expand 단계 dual write (롤백 안전망)', () => {
-        const issuedCountOf = async (promotionId: string) =>
-          Number((await service.getByPromotionId(promotionId))?.issued_count);
-
-        it('상한 있는 프로모션은 발급·중복·소진·force·회수마다 issued_count 가 장수를 따라간다', async () => {
-          await service.upsert({ promotion_id: 'promo_mirror', max_claims: 2 });
-          expect(await issuedCountOf('promo_mirror')).toBe(0);
-
-          expect(await issue('promo_mirror', 'cus_m', 'k1', 2)).toBe('created');
-          expect(await issuedCountOf('promo_mirror')).toBe(1);
-
-          expect(await issue('promo_mirror', 'cus_m', 'k1', 2)).toBe('duplicate');
-          expect(await issuedCountOf('promo_mirror')).toBe(1);
-
-          expect(await issue('promo_mirror', 'cus_m', 'k2', 2)).toBe('created');
-          expect(await issue('promo_mirror', 'cus_m', 'k3', 2)).toBe('exhausted');
-          expect(await issuedCountOf('promo_mirror')).toBe(2);
-
-          // force 는 상한을 넘겨도 센다 — 옛 `incrementIssuedCount` 와 같은 규칙.
-          expect(await issue('promo_mirror', 'cus_m', 'k4', 2, false)).toBe('created');
-          expect(await issuedCountOf('promo_mirror')).toBe(3);
-
-          expect(await service.revokeGrants('promo_mirror', 'cus_m')).toEqual({ revoked: 3, remaining: 0 });
-          expect(await issuedCountOf('promo_mirror')).toBe(0);
-        });
-
-        it('상한 없는 프로모션은 issued_count 를 건드리지 않는다 (옛 코드와 같은 의미)', async () => {
-          await service.upsert({ promotion_id: 'promo_mirror_free', max_claims: null });
-          await issue('promo_mirror_free', 'cus_mf', 'k1', null);
-          expect(await issuedCountOf('promo_mirror_free')).toBe(0);
-          await service.revokeGrants('promo_mirror_free', 'cus_mf');
-          expect(await issuedCountOf('promo_mirror_free')).toBe(0);
-        });
-
-        it('보상(revokeGrantsByIssueKeys) 도 실제로 치운 장수만큼만 되돌린다', async () => {
-          await service.upsert({ promotion_id: 'promo_mirror_comp', max_claims: 5 });
-          await issue('promo_mirror_comp', 'cus_mc', 'k1', 5);
-          await issue('promo_mirror_comp', 'cus_mc', 'k2', 5);
-          expect(await issuedCountOf('promo_mirror_comp')).toBe(2);
-          const k1 = (await service.listGrantsForCustomer('cus_mc')).find((g) => g.issue_key === 'k1')!;
-          await service.consumeGrantIfUnused(k1.id, 'cart_mc', new Date());
-
-          await service.revokeGrantsByIssueKeys('promo_mirror_comp', 'cus_mc', ['k1', 'k2']);
-          expect(await issuedCountOf('promo_mirror_comp')).toBe(1);
-        });
-      });
-
       // ── PR-2 결정 1 → PR-3 결정 5: 소모는 모듈 안에서 「고르기 + CAS」 한 문장이고, 그 문장이 곧 «검사»다 ──
       // 옛 구조는 훅이 장을 «읽어서 검사»하고(hasUsableGrant) 열 스텝 뒤 다른 훅이 «썼다». 그 사이가
       // 같은 고객의 두 카트가 장 하나로 둘 다 통과하는 창이었다. 이제 소모 결과가 판정이다:

--- a/apps/medusa/src/modules/promotion-meta/migrations/Migration20260904150000.ts
+++ b/apps/medusa/src/modules/promotion-meta/migrations/Migration20260904150000.ts
@@ -1,0 +1,35 @@
+import { Migration } from '@medusajs/framework/mikro-orm/migrations';
+
+/**
+ * contract 단계 — 죽은 컬럼 둘을 지운다 (ADR-0034 결정 6, expand-contract).
+ *
+ * `coupon_grant.order_id` — 소모의 키가 카트로 옮겨가며(2026-09-04 개정) 읽기·쓰기가 모두 끊겼다.
+ * `promotion_meta.issued_count` — 상한의 정본이 `coupon_grant` COUNT 가 되며 표시도 COUNT 에서 온다.
+ *
+ * **선행 조건 3개를 라이브에서 실측하고 나서 지운다** (2026-09-04, PR-3 배포 직후):
+ *   (ⅰ) 배포 시각 이후 `order_id` 가 쓰인 행 0 · (ⅱ) 그 컬럼을 읽는 프로덕션 코드 0 ·
+ *   (ⅲ) 롤링 창 사각지대 집합(`used_at NOT NULL AND cart_id IS NULL AND order_id NOT NULL`) 0행.
+ *
+ * `issued_count` 는 컬럼과 미러 쓰기(`mirrorIssuedCount`)를 **같은 PR 에서** 지운다. 롤링 중 옛
+ * 태스크의 미러 UPDATE 가 없는 컬럼을 만나 발급 트랜잭션이 던질 수 있는데, 그건 fail-closed 고
+ * (과다 발급이 아니라 발급 실패) 라이브 발급량이 사실상 0이라 감수한다. 쪼개면 그 사이 롤백이
+ * 났을 때 옛 코드가 «동결된» 카운터로 상한을 집행해 fail-open 이 된다(#778 리뷰 F5) — 그쪽이 나쁘다.
+ *
+ * 🔴 `down()` 은 스키마만 되돌린다. 지워진 값은 복구되지 않는다 — `order_id` 는 `order_cart`
+ *    링크로 다시 구할 수 있지만 `issued_count` 는 `coupon_grant` COUNT 로 다시 세야 한다.
+ */
+export class Migration20260904150000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(`DROP INDEX IF EXISTS "idx_coupon_grant_order";`);
+    this.addSql(`ALTER TABLE "coupon_grant" DROP COLUMN IF EXISTS "order_id";`);
+    this.addSql(`ALTER TABLE "promotion_meta" DROP COLUMN IF EXISTS "issued_count";`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`ALTER TABLE "promotion_meta" ADD COLUMN IF NOT EXISTS "issued_count" integer NOT NULL DEFAULT 0;`);
+    this.addSql(`ALTER TABLE "coupon_grant" ADD COLUMN IF NOT EXISTS "order_id" text NULL;`);
+    this.addSql(
+      `CREATE INDEX IF NOT EXISTS "idx_coupon_grant_order" ON "coupon_grant" ("order_id") WHERE "deleted_at" IS NULL;`,
+    );
+  }
+}

--- a/apps/medusa/src/modules/promotion-meta/models/coupon-grant.ts
+++ b/apps/medusa/src/modules/promotion-meta/models/coupon-grant.ts
@@ -32,8 +32,6 @@ const CouponGrant = model
        * 주문은 Medusa 의 `order_cart` 링크로 닿는다. 백필된 옛 장은 null 이다(카트가 없었다).
        */
       cart_id: model.text().nullable(),
-      /** 옛 키. 읽기·쓰기 모두 끊겼다 — DROP 은 다음 배포 뒤 별도 PR (ADR-0034 결정 6, expand-contract). */
-      order_id: model.text().nullable(),
       /** 어드민이 이 장을 회수한 시각. 사용된 장은 soft delete 되지 않으므로 이 열이 회수의 유일한 표지다. */
       revoked_at: model.dateTime().nullable(),
     },
@@ -58,8 +56,6 @@ const CouponGrant = model
     // 벗어난 값은 통합 스펙에서 안 걸린다.
     { on: ['customer_id'], name: 'idx_coupon_grant_customer' },
     { on: ['promotion_id'], name: 'idx_coupon_grant_promotion' },
-    // 옛 키의 인덱스. 컬럼과 함께 다음 배포 뒤 별도 PR 에서 지운다.
-    { on: ['order_id'], name: 'idx_coupon_grant_order' },
     // `restoreGrantsByCart`(주문 취소) 와 스위퍼(`listStuckConsumptions`) 가 이 컬럼으로 조회한다.
     // 테이블은 발급 1건당 1행으로 자란다 — 인덱스 없이는 취소마다 풀스캔이다.
     { on: ['cart_id'], name: 'idx_coupon_grant_cart' },

--- a/apps/medusa/src/modules/promotion-meta/models/promotion-meta.ts
+++ b/apps/medusa/src/modules/promotion-meta/models/promotion-meta.ts
@@ -11,7 +11,6 @@ const PromotionMeta = model
       created_by: model.text().nullable(),
       visibility: model.text().default('public'),
       max_claims: model.number().nullable(),
-      issued_count: model.number().default(0),
       auto_issue_trigger: model.text().nullable(),
       // 유효기간 «정책 축» (#488 결정 1). 인스턴스 축은 customer↔promotion 링크 행의 expires_at 이다.
       // claimable/assigned_only 에겐 발급 가능 구간, public 에겐 사용 가능 구간으로 읽힌다.

--- a/apps/medusa/src/modules/promotion-meta/service.ts
+++ b/apps/medusa/src/modules/promotion-meta/service.ts
@@ -40,7 +40,6 @@ export type CouponGrantRow = {
   used_at: Date | string | null;
   /** 이 장을 소모한 카트. 백필된 옛 장은 null. */
   cart_id: string | null;
-  order_id: string | null;
   revoked_at: Date | string | null;
 };
 
@@ -347,12 +346,6 @@ class PromotionMetaModuleService extends MedusaService({
       if (issued > Number(input.max_claims)) throw new ExhaustedSignal();
     }
 
-    // (3) 옛 카운터 미러 — 상한의 정본은 위 COUNT 지만, 컬럼이 살아 있는 동안 옛 태스크가
-    //     그걸로 집행하므로 같은 트랜잭션에서 따라가게 한다(`mirrorIssuedCount` 주석).
-    if (input.max_claims !== null) {
-      await this.mirrorIssuedCount(input.promotion_id, 1, sharedContext);
-    }
-
     return 'created';
   }
 
@@ -484,8 +477,7 @@ class PromotionMetaModuleService extends MedusaService({
    * 취소 구독자는 `restoreGrantsByCart` 가 만료·회수를 걸러 넘기고, 스위퍼는
    * `listStuckConsumptions` 가 고른다. 셋이 각자 UPDATE 를 들면 PR-2 가 걷어낸 쌍둥이가 되돌아온다.
    *
-   * `used_at IS NOT NULL` 술어 덕에 두 번 불려도 두 번째는 0 이다. `order_id` 는 만지지 않는다 —
-   * 읽는 곳이 없고, 컬럼은 다음 배포 뒤 지운다.
+   * `used_at IS NOT NULL` 술어 덕에 두 번 불려도 두 번째는 0 이다.
    */
   async restoreGrants(ids: string[], sharedContext?: Context<EntityManager>): Promise<number> {
     if (ids.length === 0) return 0;
@@ -628,41 +620,10 @@ class PromotionMetaModuleService extends MedusaService({
 
     const unused = rows.filter((g) => g.used_at == null);
     if (unused.length > 0) {
+      // soft delete 가 곧 슬롯 반환이다 — 상한은 `coupon_grant` COUNT 로 세므로 카운터가 따로 없다.
       await (this as any).softDeleteCouponGrants(unused.map((g) => g.id), {}, sharedContext);
-      // soft delete 가 곧 슬롯 반환이다 — 옛 카운터도 같은 트랜잭션에서 따라간다.
-      await this.mirrorIssuedCount(promotionId, -unused.length, sharedContext);
     }
     return { revoked: unused.length, remaining: rows.length - unused.length };
-  }
-
-  /**
-   * 옛 `issued_count` 컬럼을 «따라가게» 한다 — expand 단계의 dual write.
-   *
-   * 상한의 정본은 `coupon_grant` COUNT 다(설계 결정 1). 그런데 컬럼은 후속 contract PR 이
-   * 지울 때까지 남고, 그동안 롤링 중인 옛 태스크와 롤백된 배포는 **이 컬럼으로** 상한을
-   * 집행한다(`UPDATE … WHERE issued_count < max_claims`). 쓰기를 멈춘 채 두면 카운터가 실제
-   * 장수 아래로 동결돼, 롤백 즉시 상한을 넘겨 발급하는 fail-open 이 된다(PR #778 리뷰 F5).
-   * 그래서 장을 만들고 지우는 그 트랜잭션에서 같은 델타를 컬럼에도 적는다.
-   *
-   * 의미는 옛 코드와 같게 둔다 — **상한 있는 프로모션만** 센다(`max_claims IS NOT NULL`).
-   * 옛 `reserveClaimSlot`/`incrementIssuedCount` 가 그랬고, 무제한 프로모션까지 세면 발급마다
-   * `promotion_meta` 행 락을 잡아 「상한 없으면 잠그지도 세지도 않는다」는 최적화를 버리게 된다.
-   * 롤백 안전에 필요한 것은 상한 집행이 맞는 것이지 표시가 맞는 것이 아니다.
-   *
-   * 이 미러는 contract PR 이 컬럼과 함께 지운다. 그때까지 카운터와 COUNT 가 어긋나면
-   * (예: 컬럼 쓰기가 없던 창에서 발급된 장) PR 본문의 정합화 SQL 한 방이 맞춘다.
-   */
-  private async mirrorIssuedCount(
-    promotionId: string,
-    delta: number,
-    sharedContext?: Context<EntityManager>,
-  ): Promise<void> {
-    await this.txEm(sharedContext).execute(
-      `UPDATE "promotion_meta"
-          SET "issued_count" = GREATEST("issued_count" + ?, 0), "updated_at" = now()
-        WHERE "promotion_id" = ? AND "max_claims" IS NOT NULL AND "deleted_at" IS NULL`,
-      [delta, promotionId],
-    );
   }
 }
 

--- a/apps/medusa/src/scripts/backfill-coupon-grants.ts
+++ b/apps/medusa/src/scripts/backfill-coupon-grants.ts
@@ -142,7 +142,7 @@ export default async function backfillCouponGrants({ container }: ExecArgs) {
       // 유일한 호출자였다. 키로 찾고 「미사용일 때만」은 `consumeGrantIfUnused` 의 SQL
       // 술어가 지킨다(조회를 믿고 덮어쓰지 않는다). 키가 안 맞는 쌍(개통 후 발급분)은
       // 조용히 지나가고 이미 채워진 값은 건드리지 않으므로 몇 번을 불러도 안전하다.
-      // `order_id` 는 옮기지 않는다 — 읽는 곳이 없고 컬럼은 다음 배포 뒤 지운다(ADR-0034 결정 6).
+      // 옛 링크의 `order_id` 는 옮기지 않는다 — 그 컬럼은 contract PR 이 지웠다(ADR-0034 결정 6).
       const [grant] = (await promotionMetaService.listCouponGrants({
         promotion_id: l.promotion_id,
         customer_id: l.customer_id,

--- a/docs/adr/0034-coupon-issuance-writes-go-through-workflows.md
+++ b/docs/adr/0034-coupon-issuance-writes-go-through-workflows.md
@@ -390,7 +390,8 @@ consumeOneUsableGrantForCart({ promotion_id, customer_id, cart_id, now })
 4. 스위퍼 — `scripts/restore-stuck-coupon-consumptions.ts` + `jobs/restore-stuck-coupon-consumptions.ts`
    (매시 23분, `COUPON_STUCK_MIN_AGE_MINUTES` 기본 60).
 5. HTTP 스펙 — `integration-tests/http/coupon-consume.spec.ts` ①~⑦(⑦ = 측정 4 실측 겸용).
-6. (다음 배포 뒤, 별도 PR) `order_id` DROP COLUMN — 선행 조건은 결정 6 의 count 0.
+6. ✅ **실행됨 (2026-09-04, 별도 PR)** `order_id` DROP COLUMN — 선행 조건 3개를 라이브에서 확인하고
+   지웠다. 기록은 아래 «2026-09-04 contract 실행» 절.
 
 배포 제약: additive 마이그레이션 1건, Medusa 컨테이너가 부팅 시 자체 migrate 하므로(CLAUDE.md) 순서
 제약 없음. 옛 태스크는 새 컬럼을 무시한다. 배포 직후 스위퍼의 첫 회는 0건이어야 한다 — 옛 행은
@@ -414,3 +415,40 @@ consumeOneUsableGrantForCart({ promotion_id, customer_id, cart_id, now })
 - 2026-09-03 보강 절의 결정 1 문단 — `consumeOneUsableGrant` 는 `consumeOneUsableGrantForCart` 로
   바뀌었다(키가 주문에서 카트로, 결과가 세 값으로). 그 문단 자체는 09-03 시점의 기록이라 다시
   쓰지 않고, 문장 뒤에 이 개정을 가리키는 포인터만 붙였다.
+
+---
+
+## 2026-09-04 contract 실행 — 옛 컬럼 둘을 지웠다
+
+PR-3(#784)이 라이브에 나간 날(태스크 08:29:56 KST 시작, 08:33:32 rollout COMPLETED) **선행 조건 셋을
+전부 실측**하고 `Migration20260904150000` 으로 contract 단계를 밟았다.
+
+| 선행 조건 | 실측 |
+|---|---|
+| (ⅰ) 배포 시각 이후 `order_id` 가 쓰인 행 | `count(*) WHERE order_id IS NOT NULL AND updated_at > '2026-09-03 23:29:56+00'` = **0** |
+| (ⅱ) `coupon_grant.order_id` 를 읽는 프로덕션 코드 | **0** — 남은 `order_id` 문자열은 전부 Medusa 의 `order_cart` 링크이거나 `customer_promotion` 링크의 `extraColumns` 다 |
+| (ⅲ) 롤링 창 사각지대(`used_at NOT NULL AND cart_id IS NULL AND order_id NOT NULL`) | **0행** |
+
+배포 직후 스위퍼도 함께 확인했다 — 00:23·01:23·02:23 UTC 세 회차 전부 0건. 🔴 스위퍼는 `restored > 0`
+일 때만 로그를 내므로 **무음이 「안 돌았다」와 구별되지 않는다.** 형제 잡 `[membership-price-audit]`
+(`40 0 * * *`)이 같은 컨테이너에서 00:40:02 에 찍힌 것으로 크론 생존을 먼저 증명한 뒤 0건으로 읽었다.
+
+### `promotion_meta.issued_count` 를 같은 PR 에서 지운 이유
+
+미러(`mirrorIssuedCount`)는 «컬럼이 살아 있는 동안 옛 태스크가 그걸로 상한을 집행한다»는 이유로
+존재했다. 컬럼을 지우면 그 이유도 사라지므로 **미러 쓰기와 컬럼을 함께** 걷었다. 쪼개는 쪽(먼저 미러만
+제거 → 다음 사이클에 컬럼 DROP)도 검토했으나 기각했다 — 그 사이에 롤백이 나면 옛 코드가 **동결된**
+카운터로 상한을 집행해 fail-open(#778 리뷰 F5)이 된다. 함께 지울 때의 대가는 롤링 창(수 분) 안에 발급이
+일어나면 옛 태스크의 미러 UPDATE 가 없는 컬럼을 만나 **발급이 실패**하는 것인데, 방향이 fail-closed 고
+라이브 발급량이 사실상 0이라 이쪽을 골랐다.
+
+표시는 영향이 없다 — 어드민 응답의 `metadata.issued_count` 는 이미 `coupon_grant` 실측 COUNT 에서
+오고(`toMetadataShape(record, issuedCount)`), 컬럼을 읽지 않는다.
+
+### 이 PR 이 **하지 않은** 것 — 다음 contract 대상
+
+`links/customer-promotion.ts`(링크 테이블 + `extraColumns` 4개)는 그대로 뒀다. 「읽는 코드도 쓰는 코드도
+없다」는 판정은 유효하지만 **선행 확인이 하나 남아 있다** — `scripts/backfill-coupon-grants.ts` 가 그 링크를
+읽어 `coupon_grant` 로 옮기는 1회성 이관인데, **라이브에 아직 링크 행이 남아 있다**(2026-09-04
+`detach-coupon-campaigns` dry-run 이 `expires_at` 빈 링크 1건을 보고했다). 지우기 전에 그 행이 이미
+`coupon_grant` 로 옮겨졌는지 확인할 것. 링크 테이블 삭제는 데이터 손실이 되돌릴 수 없는 쪽이다.


### PR DESCRIPTION
PR-3(#784)이 라이브에 나간 뒤 expand-contract 의 **contract** 쪽을 밟는다. 죽은 컬럼 둘과 그것을 먹여 살리던 미러 쓰기를 걷는다.

## 무엇을 지우나

| 대상 | 왜 죽었나 |
|---|---|
| `coupon_grant.order_id` (+ `idx_coupon_grant_order`) | 소모의 키가 주문에서 **카트**로 옮겨가며(ADR-0034 2026-09-04 개정, 결정 6) 읽기·쓰기가 모두 끊겼다. 「어느 주문이 썼나」는 이제 `order_cart` 조인이 답한다 |
| `promotion_meta.issued_count` + `mirrorIssuedCount` | 상한의 정본이 `coupon_grant` COUNT 가 되며(#778 설계 결정 1) 컬럼을 읽는 곳이 사라졌다 |

**API 계약은 안 바뀐다** — 어드민 응답의 `metadata.issued_count` 는 이미 실측 COUNT 를 인자로 받아 싣는다(`toMetadataShape(record, issuedCount)`). 컬럼을 읽은 적이 없다.

## 선행 조건 — 라이브에서 실측하고 지웠다

PR-3 배포(태스크 `2026-09-04 08:29:56 KST` 시작, `08:33:32` rollout COMPLETED) 직후 ADR-0034 가 요구한 셋을 전부 확인했다.

| 조건 | 실측 |
|---|---|
| (ⅰ) 배포 시각 이후 `order_id` 가 쓰인 행 | `count(*) WHERE order_id IS NOT NULL AND updated_at > '2026-09-03 23:29:56+00'` = **0** |
| (ⅱ) `coupon_grant.order_id` 를 읽는 프로덕션 코드 | **0** — 남은 `order_id` 문자열은 전부 Medusa `order_cart` 링크이거나 `customer_promotion` 링크의 `extraColumns` 다 |
| (ⅲ) 롤링 창 사각지대 (`used_at NOT NULL AND cart_id IS NULL AND order_id NOT NULL`) | **0행** |

같은 자리에서 스위퍼도 확인했다 — 배포 후 00:23·01:23·02:23 UTC 세 회차 전부 0건. 🔴 스위퍼는 `restored > 0` 일 때만 로그를 내므로 **무음이 「안 돌았다」와 구별되지 않는다.** 형제 잡 `[membership-price-audit]`(`40 0 * * *`)이 같은 컨테이너에서 `00:40:02` 에 찍힌 것으로 크론 생존을 먼저 증명한 뒤 0건으로 읽었다.

## `issued_count` 를 왜 같은 PR 에서 지우나

미러는 «컬럼이 살아 있는 동안 옛 태스크가 그걸로 상한을 집행한다»는 이유로 존재했다. 컬럼이 사라지면 그 이유도 사라진다. 쪼개는 안(먼저 미러만 제거 → 다음 사이클에 DROP)도 검토했고 **기각**했다 — 그 사이에 롤백이 나면 옛 코드가 **동결된** 카운터로 상한을 집행해 fail-open 이 된다(#778 리뷰 F5).

함께 지울 때의 대가는 롤링 창(수 분) 안에 발급이 일어나면 옛 태스크의 미러 UPDATE 가 없는 컬럼을 만나 **발급이 실패**하는 것이다. 방향이 fail-closed 이고(과다 발급이 아니라 발급 실패) 라이브 발급량이 사실상 0이라 이쪽을 골랐다. 근거는 ADR-0034 「2026-09-04 contract 실행」 절에 남겼다.

## 하지 않은 것 — 다음 contract 대상

`links/customer-promotion.ts`(링크 테이블 + `extraColumns` 4개)는 **그대로 뒀다.** 「읽는 코드도 쓰는 코드도 없다」는 판정은 유효하지만 선행 확인이 하나 남았다 — `scripts/backfill-coupon-grants.ts` 가 그 링크를 읽어 `coupon_grant` 로 옮기는 1회성 이관인데, **라이브에 아직 링크 행이 남아 있다**(같은 날 `detach-coupon-campaigns` dry-run 이 `expires_at` 빈 링크 1건을 보고했다). 그 행이 이미 옮겨졌는지 보고 나서 지운다 — 링크 테이블 삭제는 되돌릴 수 없는 쪽이다.

## 배포

마이그레이션 1건(DROP 둘 + 인덱스 하나). Medusa 컨테이너가 부팅하며 스스로 migrate 하므로 **순서 제약 없음** — 이 PR 자체가 2-PR 규칙의 두 번째 단계다. `down()` 은 스키마만 되돌리고 값은 복구하지 않는다.

## 게이트

| 게이트 | 결과 |
|---|---|
| `npx tsc --noEmit -p apps/medusa/tsconfig.json` | 선재 3건 그대로 (`admin/lib/sdk.ts` ×2, `confirm-purchase.unit.spec.ts` ×1) |
| medusa 유닛 | **38 suites / 373 tests** |
| medusa 모듈 통합 | **8 suites / 152 tests** |
| medusa HTTP 통합 | **11 suites / 148 tests** — 이 러너가 마이그레이션을 실제로 실행하므로 DROP SQL 의 검증을 겸한다 |
| 루트 `npm run type-check` | 0 |

SoT: #488 · 결정 근거: `docs/adr/0034-coupon-issuance-writes-go-through-workflows.md`

https://claude.ai/code/session_01WMT9N3JF3JeZr8p93Cxbtn
