### PR TITLE
docs: 쿠폰 리허설 3차 지침 + 로컬 E2E 환경 핸드오프 (#775 R11 통과)

### DIFF
--- a/docs/local-e2e-environment.md
+++ b/docs/local-e2e-environment.md
@@ -1,0 +1,283 @@
+# 로컬 전 과정(E2E) 검증 환경 — 구축 핸드오프
+
+> **목적:** 관리자 액션 · 회원가입 · 장바구니 · 쿠폰 적용 · 결제 · 어드민 주문조회 · 매칭을
+> **한 로컬 스택에서, 크롬으로 사람이 하듯** 검증할 수 있게 세운다.
+>
+> **이 문서는 환경만 다룬다.** 쿠폰 도메인 절차는 `docs/superpowers/plans/2026-09-05-coupon-rehearsal-3.md`.
+>
+> 근거: 2026-09-05 쿠폰 리허설 3차. 그날 세션 시간의 대부분이 여기 적힌 것들을 하나씩 발견하는 데 들어갔다.
+> **정본은 `docs/local-dev.md` 이고, 이 문서는 거기에 없던 것만 모았다** — 안정화되면 접어 넣을 것.
+
+---
+
+## 0. 🔴 먼저 읽을 한 문단
+
+**「떠 있다」와 「최신이다」는 다르다.** 3차 착수 시 포트 8개가 전부 열려 있었지만 프로세스는 **4일 묵은 코드**였고
+Medusa 스키마는 **3주 밀려** 있었으며 `coupon_grant` 테이블 자체가 없었다. 그 상태로 검증을 돌렸으면
+판정 SQL 이 죽고 결과는 전부 무의미했다.
+
+**그래서 매 세션 시작은 이것이다:**
+
+```bash
+bash scripts/local/preflight-e2e.sh
+```
+
+컨테이너·포트·프로세스 신선도·스키마·시드·조용히 죽는 env 키·포트 충돌을 한 번에 잰다. ✗ 가 있으면 그것부터.
+
+---
+
+## 1. 앱 지도 — **11개다** (2차 지침서는 8개로 적었다)
+
+| 앱 | 포트 | 왜 필요한가 | 기동 |
+|---|---|---|---|
+| user-service | 3000 | IdP. 가입·로그인·역할 | `npx dotenv -e apps/user-service/.env -- nest start user-service` |
+| membership | 3001 | 멤버십 트리거 | `npx dotenv -e apps/membership/.env -- nest start membership` |
+| channel-adapter | **3003** | 이벤트 인박스·외부채널 | `npm run start:channel-adapter:dev` |
+| file-service | **3010** | **상품 이미지 업로드** | `npx dotenv -e apps/file-service/.env -- nest start file-service` |
+| **core** | **3100** | 🔴 **어드민 주문조회·출고·매칭이 전부 여기** | `npx dotenv -e apps/core/.env -- nest start core` |
+| **wallet-web** | **3200** | 🔴 **결제 화면. 체크아웃이 이리로 넘어간다** | `npm run start:wallet-web:dev` |
+| wallet | 5001 | 결제·포인트 백엔드 | `npx dotenv -e apps/wallet/.env -- nest start wallet` |
+| storefront | 8000 | 쇼핑몰 | `(cd web/almondyoung-storefront && npm run dev)` |
+| auth-web | 8001 | 로그인/가입 UI | `(cd web/auth-web && npm run dev)` |
+| admin-web | 8002 | 관리자 | `(cd apps/admin-web && npm run dev)` |
+| Medusa | 9000 (+**19000** 메트릭) | 커머스 코어 | `(cd apps/medusa && npx medusa develop)` |
+
+**2차 지침서에 없어서 3차가 결제에서 막힌 원인이 `wallet-web` 이다.** 체크아웃 「결제하기」는
+`localhost:3200/auth/handoff?...` 로 넘어간다. 그 앱이 없으면 브라우저가 그냥 에러 페이지를 띄운다.
+
+**`core` 는 이번에 안 띄웠다** — 그래서 admin-web 콘솔에 `/proxy/api/sales-orders/stats` 재시도가 무한히 찍혔다.
+다음 세션의 「주문조회·매칭」은 core 없이는 성립하지 않는다.
+
+---
+
+## 2. 준비 순서 — 이 순서를 지켜야 한다
+
+```bash
+# ① 컨테이너. 🔴 kafka 를 recreate 하면 zookeeper 에 옛 broker znode 가 남아 즉사한다.
+docker compose up -d postgres redis
+docker compose stop kafka && docker compose restart zookeeper && docker compose up -d kafka
+until (echo > /dev/tcp/127.0.0.1/9092) 2>/dev/null; do sleep 2; done   # 9092 가 열릴 때까지 기다린다
+
+# ② 마이그레이션 — drizzle 과 Medusa 는 별개다. 둘 다 해야 한다.
+npm run db:migrate:local          # 🔴 search 에서 멈춘다. Ctrl+C 해도 된다 — 아래 줄이 진짜다.
+DBU=$(grep -m1 '^DATABASE_URL=' apps/user-service/.env | cut -d= -f2- | tr -d '"'"'"' ')
+DATABASE_URL="$DBU" npx drizzle-kit migrate --config apps/user-service/database/drizzle/drizzle.config.ts
+(cd apps/medusa && npx medusa db:migrate --execute-safe-links)
+
+# ③ 시드 3종
+npm run db:seed:user-service:local                    # 역할·admin 계정·OAuth 클라이언트 3개
+npx tsx scripts/local/seed-wallet-local.ts            # 🔴 결제수단·지역. 없으면 결제 불가
+(cd apps/medusa && npx medusa exec ./src/scripts/seed.ts && npx medusa exec ./src/scripts/seed-shipping.ts)
+
+# ④ SMS 스텁 (회원가입 폰 인증)
+nohup node scripts/local/sms-stub.js > logs/sms-stub.log 2>&1 &
+
+# ⑤ 앱 기동 — kafka 가 «열린 뒤» 여야 한다 (§3 참조)
+```
+
+🔴 **`npm run db:migrate:local` 은 `search` 에서 멈춘다.** `SERVICES` 목록에서 `user_service` 가 `search`
+**뒤**에 있어, 스크립트를 그냥 돌리면 **user-service 는 영영 마이그레이션되지 않는다.** 그 결과는 §4 참조.
+
+---
+
+## 3. 🔴 포트 충돌 — 손봐야 한다
+
+`apps/channel-adapter/.env` 와 `apps/file-service/.env` 가 **둘 다 `PORT=3010`** 이다.
+`scripts/local/start-all.sh` 는 channel-adapter 를 **3003** 으로 본다.
+
+현재 상태로는 **먼저 뜬 쪽이 이기고 다른 쪽은 죽는다.** 그리고 admin-web 의 `FILE_SERVICE_URL=http://localhost:3010`
+이므로, channel-adapter 가 3010 을 쥐면 **파일 업로드가 channel-adapter 로 간다.**
+
+```bash
+# channel-adapter 를 start-all.sh 와 맞춘다
+sed -i 's/^PORT=3010/PORT=3003/' apps/channel-adapter/.env
+# 메트릭 포트도 따라간다 (PORT+10000): 13010 → 13003
+```
+
+**앱 3개(channel-adapter·wallet·membership)는 kafka 없이 부팅 중 «죽는다».** 경고가 아니라
+`KafkaJSNonRetriableError` 로 프로세스가 종료된다. 재시도 5회를 태우고 죽으므로 kafka 와 동시에 띄우면 진다.
+
+---
+
+## 4. env 파일 — **없어서 조용히 죽는 것들**
+
+`.env` 는 전부 gitignore 다. 아래는 **템플릿에 없어서 직접 넣어야 하는** 것만 모았다.
+
+| 파일 | 넣을 것 | 없으면 |
+|---|---|---|
+| `apps/medusa/.env` | `PORT=9000` | `:19000/metrics` 가 **아예 안 열린다**. 앱은 멀쩡히 뜨고 메트릭만 조용히 없다 |
+| `apps/medusa/.env` | `COUPON_AUTO_ISSUE_ENABLED=true` | 쿠폰 자동발급 API 가 빈 배열만 반환 |
+| `apps/admin-web/.env.local` | `WALLET_SERVICE_URL=http://localhost:5001` | 적립금 화면이 조용히 죽는다(통계가 전부 `0` 으로 보인다) |
+| `apps/user-service/.env` | `NOTIFICATION_SERVICE_URL=http://127.0.0.1:3099`<br>`NOTIFICATION_INTERNAL_KEY=local-rehearsal-stub-key` | 회원가입 폰 인증이 **503** → 가입 UI 를 못 지난다 |
+| **`apps/wallet-web/.env.local`** | **파일 자체가 없다.** 아래 전문 | 결제 페이지가 `Missing required env var: OIDC_ISSUER_URL` 로 죽는다 |
+
+### `apps/wallet-web/.env.local` (전문 — 그대로 만들 것)
+
+```bash
+# OIDC — wallet-web 자체가 RP다 (lib/auth/env.ts 가 6개를 전부 required 로 요구)
+OIDC_ISSUER_URL=http://localhost:3000
+OIDC_AUTHORIZATION_URL=http://localhost:8001/oauth/authorize
+OIDC_CLIENT_ID=wallet-web
+OIDC_CLIENT_SECRET=local-rehearsal-medusa-storefront-secret
+OIDC_REDIRECT_URI=http://localhost:3200/auth/callback
+OIDC_POST_LOGOUT_REDIRECT_URI=http://localhost:3200
+OAUTH_JWKS_URL=http://localhost:3000/.well-known/jwks.json
+
+# wallet API
+WALLET_API_URL=http://localhost:5001
+NEXT_PUBLIC_WALLET_API_URL=http://localhost:5001
+WALLET_API_KEY=dev-secret
+
+# 결제 후 스토어프론트로 복귀 허용
+WALLET_ALLOWED_RETURN_ORIGINS=http://localhost:8000
+ALLOWED_RETURN_HOST_SUFFIXES=localhost
+```
+
+🟢 `wallet-web` 은 **이미 `oauth_clients` 에 시드돼 있다**(redirect `http://localhost:3200/auth/callback`).
+클라이언트 등록은 필요 없고 `.env.local` 만 만들면 된다. `OIDC_CLIENT_SECRET` 은 로컬 RP 3개가 공유하는
+`seed-user-service-local.ts` 의 `LOCAL_CLIENT_SECRET` 기본값이다.
+
+### 값이 어긋나면 조용히 401/400 이 되는 3쌍
+
+`OAUTH_INTERNAL_SECRET`(user-service↔auth-web) · `OIDC_CLIENT_SECRET`(RP 3개↔`oauth_clients` 시드) ·
+`WALLET_API_KEY`(medusa↔wallet↔wallet-web).
+
+---
+
+## 5. 계정과 로그인
+
+| 용도 | 아이디 | 비밀번호 |
+|---|---|---|
+| 관리자 | **`admin`** | `Rehearsal1234!` |
+| 구매자(기존) | `buyer01` · `s2buyer01` · `s2buyer02` · `test01` | 각자 다름 |
+
+🔴 **로그인 식별자는 이메일이 아니라 `users.login_id` 다.** `admin@almondyoung.com` 을 넣으면
+입력칸 글자수 제한에 걸린다. 비밀번호 기본값은 `scripts/local/seed-user-service-local.ts` 의 `LOCAL_ADMIN_PASSWORD`.
+
+🔴 **스토어프론트 로그인 URL 은 `/kr/login`** 이다. `(account)` 는 괄호 route group 이라 URL 에 안 들어간다 —
+`/kr/account/login` 은 404.
+
+### 회원가입 (폰 인증)
+
+`user-service` 는 인증문자를 notification 의 `POST /internal/sms/send` 에 위임한다. **notification 을 실제로
+띄우면 안 된다** — 프로바이더가 NHN SMS 라 실 번호로 발송된다. 대신 스텁을 쓴다:
+
+```bash
+node scripts/local/sms-stub.js &      # :3099, 외부로 아무것도 안 보낸다
+```
+
+번호는 아무 값이나 되고, **인증번호는 두 곳에서 읽는다**:
+
+```bash
+tail -3 logs/sms-stub.log                                  # [SMS-STUB] … 인증번호: 515266
+psql "$USER_SERVICE_DB" -c "SELECT phone_number, code, expires_at FROM phone_verifications ORDER BY created_at DESC LIMIT 1;"
+```
+
+코드는 **평문 6자리, 유효 3분**. 저장이 발송과 같은 트랜잭션이라 스텁이 성공을 줘야 행이 남는다.
+
+---
+
+## 6. 🔴 크롬으로 사람처럼 조작할 때의 함정
+
+### ① 어드민과 고객을 «동시에» 유지할 수 없다
+
+**`localhost` 쿠키는 포트를 구분하지 않는다.** 스토어프론트(:8000)에서 고객으로 로그인하면
+admin-web(:8002)의 어드민 세션까지 그 고객으로 **교체된다.** 라이브는 도메인이 달라 안 겹치지만 로컬은 겹친다.
+
+증상: 어드민 화면이 멀쩡히 보이는데 백엔드 호출만 **403**. 우상단 아바타 글자가 바뀌어 있는 게 유일한 단서다.
+
+**대책 — 셋 중 하나를 반드시 정하고 시작할 것:**
+- **(권장) 브라우저 프로필/시크릿 창을 분리한다** — 어드민용 창과 고객용 창을 따로 연다
+- 또는 작업을 **어드민 구간 / 고객 구간으로 묶어** 순서대로 하고, 구간이 바뀔 때마다 재로그인한다
+- 매번 재로그인은 사람이 해야 한다 (아래 ③)
+
+### ② `BYPASS_AUTH=true` 가 그 함정을 숨긴다
+
+`apps/admin-web/.env.local` 의 `BYPASS_AUTH=true` 는 admin-web **자기 미들웨어·라우트 가드만** 건너뛴다.
+프록시가 백엔드로 보내는 토큰은 그대로다. 그래서 세션이 일반 사용자로 강등돼도 **로그인 화면으로 안 내쫓고**,
+화면은 다 보이는데 모든 API 가 403 이 된다.
+
+### ③ 에이전트가 못 하는 두 가지
+
+**비밀번호 입력과 계정 생성은 에이전트가 하지 않는다.** 사람이 해야 하는 지점은 정확히 둘이다 —
+**어드민 최초 로그인**과 **신규 가입 + 스토어프론트 첫 로그인**. 세션 시작 시 미리 알리고,
+그 차례가 오기 전에 다시 알릴 것. 그때 가서 막히면 흐름이 끊긴다.
+
+### ④ 화면과 로그를 성공 증거로 쓰지 말 것
+
+- **스토어프론트 OIDC 콜백은 실패해도 HTTP 200 이다** (`callback/oidc/route.ts` 의 `renderError`).
+  로그의 `GET /kr/callback/oidc … 200` 은 성공을 뜻하지 않는다. 실제로 Medusa 는 **401** 이었다.
+  → 로그인 성공 판정은 **`SELECT … FROM customer`** 로 한다.
+- **화면이 API 실패를 `0` 으로 그린다** (적립금 통계 4칸). 「데이터가 없다」와 「권한이 없다」가 같아 보인다.
+- Medusa customer 는 **스토어프론트 첫 로그인 때** 생긴다. 가입만으로는 안 생긴다.
+
+---
+
+## 7. 검증 판정은 DB 로
+
+화면·로그가 못 미더우므로 각 단계의 근거를 DB 에서 읽는다. DB URL 은 각 앱 `.env` 의 `DATABASE_URL`.
+
+| 단계 | 판정 |
+|---|---|
+| 가입 | `user_service.users` 에 `login_id` 행 |
+| 스토어프론트 로그인 | `medusa.customer` 에 `has_account=t` 행 (**이게 생겨야 로그인된 것**) |
+| 장바구니 | `medusa.cart` |
+| 쿠폰 적용 | 체크아웃 합계 변화 + `medusa.promotion` |
+| 결제 | `wallet.payment_intents` · `wallet.point_events` |
+| 주문 | `medusa.order` + `medusa.order_cart` 링크 |
+| 주문조회·매칭 | core DB (앱 `apps/core/.env`) |
+
+---
+
+## 8. ⛔ 미해결 — 다음 세션의 첫 관문
+
+**포인트 전액(0원) 결제가 승인되지 않는다.**
+
+```
+결제 화면(:3200)에서 포인트 전액 사용 → 결제금액 0원 → 「0원 결제하기」
+→ Medusa: Error was thrown trying to authorize payment session - payses_… was not authorized with the provider
+```
+
+- 직전에 `POST /hooks/payment-events ← 200` 이 있으므로 **wallet → Medusa 웹훅은 도달했다**
+- 결제수단 시드(§2 ③)를 넣은 **뒤에도** 재현된다
+- 원인 미규명. **0원 승인 경로**가 의심되나 확인 안 됨
+
+**이게 풀려야 「결제 → 주문 → 주문조회」가 이어진다.** 다음 세션은 여기서 시작하는 게 맞다.
+우회하고 싶으면 포인트를 일부만 쓰고 나머지를 다른 수단으로 태우는 조합을 먼저 시도해 볼 것
+(결제수단은 「카드 간편결제」·「무통장입금」 두 종이 시드된다).
+
+---
+
+## 9. 이번에 신설한 것
+
+| 파일 | 무엇 |
+|---|---|
+| `scripts/local/preflight-e2e.sh` | 사전 점검. 세션 시작마다 돌린다 |
+| `scripts/local/seed-wallet-local.ts` | 로컬 wallet reference 시드(결제수단·지역). 이게 없어 결제가 막혔다 |
+| `scripts/local/sms-stub.js` | 폰 인증용 로컬 SMS 스텁. 외부 발송 없음 |
+| `docs/local-e2e-environment.md` | 이 문서 |
+
+---
+
+## 10. 다음 세션 시작 프롬프트 (복붙용)
+
+```
+로컬 전 과정(E2E) 검증 환경을 세우고, 크롬으로 사람이 하듯 전 과정을 확인한다.
+검증 범위: 관리자 액션 · 회원가입 · 장바구니 · 쿠폰 적용 · 결제 · 어드민 주문조회 · 매칭.
+
+환경 문서: docs/local-e2e-environment.md — 먼저 전문을 읽어라. 정본은 docs/local-dev.md 이고
+이 문서는 거기에 없던 것만 모은 것이다. 앱은 8개가 아니라 «11개» 다(core·file-service·wallet-web 포함).
+
+시작 절차:
+  1. bash scripts/local/preflight-e2e.sh  → ✗ 를 전부 해결하고 시작한다
+  2. ⛔ 미해결 블로커는 §8 의 «0원 결제 승인 실패» 다. 여기서 시작하는 게 맞다.
+
+규칙:
+  - 「떠 있다」를 「최신이다」로 읽지 마라. 프로세스 기동 시각과 스키마를 먼저 재라(§0).
+  - 성공 판정은 화면·로그가 아니라 DB 로 한다(§7). 콜백은 실패해도 200 을 준다.
+  - 🔴 비밀번호 입력과 계정 생성은 네가 하지 않는다. 사람이 해야 하는 지점 둘(§6-③)을
+    «시작할 때» 미리 알리고, 그 차례가 오기 전에 다시 알려라.
+  - 🔴 어드민과 고객을 한 브라우저에서 동시에 유지할 수 없다(§6-①). 시작 전에 창 분리 여부를 정하라.
+  - 막히면 2~3회 만에 멈추고 물어라. 환경 결함이 계속 나오는 영역이다.
+  - 새로 발견한 환경 결함은 그때그때 이 문서에 추가하고 커밋해라.
+```

--- a/docs/superpowers/plans/2026-09-05-coupon-rehearsal-3.md
+++ b/docs/superpowers/plans/2026-09-05-coupon-rehearsal-3.md
@@ -140,15 +140,39 @@ echo 'COUPON_STUCK_MIN_AGE_MINUTES=1' >> apps/medusa/.env
   🔴 **C4 가 끝나면 이 줄을 지우거나 60 으로 되돌린다.** 1분짜리로 남겨두면 C1~C3 을 하는 중
   스위퍼 크론(`23 * * * *`)이 돌아 **정상 소모를 되돌려** 원인 모를 ❌ 를 만든다.
 
-### 2-2. Medusa 메트릭 포트가 실제로 뜨는지 — 시작하자마자 본다
+### 2-2. 🔴 Medusa 메트릭 포트 — **로컬에선 `PORT` 를 손으로 넣어야 뜬다** (2026-09-05 실측)
 
 ```bash
-curl -s localhost:19000/metrics | head -5
+grep -E '^PORT=|^METRICS_PORT=' apps/medusa/.env || echo '없음 → 아래를 추가한다'
+echo 'PORT=9000' >> apps/medusa/.env
+curl -s localhost:19000/metrics | head -5     # coupon_auto_issue_total 의 HELP/TYPE 가 보여야 한다
 ```
 
-포트는 `METRICS_PORT` 가 없으면 `PORT + 10000` 이다. 로컬 `PORT=9000` 이면 19000.
-**빈 문자열 `METRICS_PORT=` 는 위험하다** — 코드가 `> 0` 으로 걸러 폴백하지만, 값을 넣을 거면 정수여야 한다.
-바인딩 실패는 **프로세스를 죽이지 않고** `medusa-metrics-server` JSON 로그만 남긴다. 조용하다.
+`resolveMetricsPort` 는 `METRICS_PORT` 가 없으면 `PORT + 10000` 을 쓰고, **`PORT` 도 없으면 `undefined` 를 돌려
+메트릭 서버를 아예 안 띄운다.** 프로덕션은 Dockerfile 이 `PORT=9000` 을 박아서 19000 이 저절로 열리지만,
+**`env-templates/.env.medusa.local.example` 에는 `PORT` 가 없다** — Medusa 는 자기 기본값 9000 으로 잘 뜨므로
+앱은 정상이고 **메트릭만 조용히 없다.**
+
+🔴 **이걸 모르면 R12 의 `customer_registered` 축이 통째로 ⛔ 가 되고, 원인이 「코드가 안 들어왔나」로 오진된다.**
+바인딩 실패도 **프로세스를 죽이지 않고** `medusa-metrics-server` JSON 로그만 남긴다. 양쪽 다 조용하다.
+빈 문자열 `METRICS_PORT=` 는 코드가 `> 0` 으로 걸러 폴백하지만, 값을 넣을 거면 정수여야 한다.
+
+### 2-2b. 🔴 kafka 는 앱보다 «먼저» 그리고 «건강하게» 떠 있어야 한다 (2026-09-05 실측)
+
+**channel-adapter · wallet · membership 셋은 kafka 없이는 부팅 중 죽는다**(경고가 아니라 `KafkaJSNonRetriableError`
+로 프로세스 종료). 재시도 5회를 태우고 죽으므로 **앱을 kafka 와 동시에 띄우면 경주에서 진다.**
+
+**그리고 `docker compose up -d kafka` 만으로는 부족하다** — 컨테이너를 recreate 하면 zookeeper 에 옛 broker
+ephemeral znode 가 남아 `NodeExistsException` 으로 **kafka 가 뜨자마자 죽는다**(로그를 안 보면 「떴다」로 보인다).
+
+```bash
+docker compose stop kafka
+docker compose restart zookeeper        # 옛 broker znode 를 날린다
+docker compose up -d kafka
+# 9092 가 실제로 열릴 때까지 기다린 뒤에 앱을 띄운다
+until (echo > /dev/tcp/127.0.0.1/9092) 2>/dev/null; do sleep 2; done
+docker compose ps -a | grep kafka        # State 가 exited 면 로그부터 본다
+```
 
 ### 2-3. 2차에서 실제로 막혔던 지점 — 같은 데서 또 막히지 말 것
 

--- a/docs/superpowers/plans/2026-09-05-coupon-rehearsal-3.md
+++ b/docs/superpowers/plans/2026-09-05-coupon-rehearsal-3.md
@@ -74,7 +74,9 @@ ls apps/medusa/src/jobs/restore-stuck-coupon-consumptions.ts
 4. 🔴 **소모가 곧 검사다.** 옛 구조는 훅이 장을 «읽어 검사» 하고 열 스텝 뒤에 «썼다». 이제
    `consumeOneUsableGrantForCart` 의 결과가 판정이다 — `none` 이고 장이 사용을 지배하면 **주문이 거절된다.**
 5. 🔴 **소모의 키는 주문이 아니라 카트다.** 소모는 `completeCartWorkflow.validate` 훅에서 일어나고 그 시점엔 주문이 없다.
-   **`coupon_grant.order_id` 는 아무도 읽지도 쓰지도 않는다** — 소모돼도 계속 `NULL` 인 게 정상이다.
+   **`coupon_grant.order_id` 컬럼은 존재하지 않는다** — PR-3 이 읽기·쓰기를 끊고 **#785 contract 가 컬럼을 지웠다**
+   (`promotion_meta.issued_count` 도 함께). 2026-09-05 로컬 DB 실측으로 확인.
+   주문 ↔ 카트는 Medusa 의 **`order_cart` 링크**가 잇는다. 옛 문서·플랜에서 `order_id` 를 보면 그건 **지워지기 전 상태**다.
 6. 🔴 **`customer_registered` 는 이제 Kafka·channel-adapter 를 지나지 않는다.** Medusa 안에서 시작해 Medusa 안에서 끝난다.
    `membership_activated` 만 여전히 channel-adapter 를 지난다. **두 트리거의 경로가 다르다.**
 
@@ -91,6 +93,39 @@ ls apps/medusa/src/jobs/restore-stuck-coupon-consumptions.ts
 | ② | 메트릭 측정점 | channel-adapter `:13010/metrics` | **+ Medusa `:19000/metrics`** (신규) |
 | ③ | channel-adapter | R11·R11b 둘 다 여기를 지남 | **R11b·R13 만.** 그래도 **띄워야 한다**(회귀 검증 대상) |
 | ④ | 스위퍼 | 없었음 | `COUPON_STUCK_MIN_AGE_MINUTES` 조정 필요 (C4) |
+
+### 2-0. 🔴 **먼저 «떠 있는 것»을 믿지 마라** — 2026-09-05 실측으로 추가된 절
+
+2차 환경이 **그대로 살아 있을 수 있다.** 포트 8개가 다 열려 있고 `.env` 가 다 있어도 그것은
+**「2차 당시 코드가 4일째 돌고 있다」는 뜻일 수 있다.** 실제로 3차 착수 시 그랬다:
+프로세스 8개가 전부 `2026-09-01 06:47` 기동이었고, **Medusa DB 의 마지막 마이그레이션은 `Migration20260831110000`**,
+**`coupon_grant` 테이블 자체가 없었다.** 그 상태로 R11 을 돌렸으면 판정 SQL 이 죽고 C1~C5 는 전부 성립하지 않는다.
+
+**기동 전에 이 셋을 잰다:**
+
+```bash
+# ① 프로세스가 언제 떴나 — 오늘이 아니면 옛 코드다
+ps -eo pid,lstart,args | grep -E 'nest start|next dev|medusa develop' | grep -v grep
+
+# ② Medusa 메트릭 포트 — 닫혀 있으면 #775 이전 코드다
+curl -s localhost:19000/metrics | head -3
+
+# ③ 🔴 가장 중요 — 스키마가 최신인가
+psql "$DATABASE_URL" -tAc "SELECT to_regclass('public.coupon_grant');"          # NULL 이면 마이그 밀림
+psql "$DATABASE_URL" -tAc "SELECT name FROM mikro_orm_migrations ORDER BY id DESC LIMIT 3;"
+```
+
+**하나라도 어긋나면 전면 재기동이다:**
+```bash
+# 포트 점유 프로세스까지 정리한다 — 부모 npm 만 죽이면 자식이 포트를 쥐고 남는다
+for p in 3000 3001 3010 5001 8000 8001 8002 9000; do
+  kill -TERM $(ss -ltnpH "sport = :$p" | grep -oP 'pid=\K[0-9]+' | sort -u) 2>/dev/null
+done
+(cd apps/medusa && npx medusa db:migrate --execute-safe-links)
+# 그 뒤 2차 §2-5 기동 순서
+```
+⚠️ **`pkill -f` 패턴에 레포 이름(`almondyoung-server`)을 넣지 말 것** — 자기 셸의 명령줄에도 그 문자열이 있어 **자신을 죽인다**.
+⚠️ **`sst tunnel --stage live` 프로세스가 함께 떠 있을 수 있다. 죽이지 말 것** — 리허설과 무관하다.
 
 ### 2-1. `apps/medusa/.env` 에 추가 — 템플릿에 없다
 
@@ -182,9 +217,10 @@ API 로 만들면 **폼이 실제로 그 조합을 낼 수 있는지**를 검증
 
 ```sql
 -- ① 장이 생겼는가 / ② issued_via / ③ expires_at 이 validity_days 대로인가
-SELECT id, promotion_id, issued_via, issued_at, expires_at, used_at, cart_id, order_id
+SELECT id, promotion_id, issued_via, issued_at, expires_at, used_at, cart_id
   FROM coupon_grant
  WHERE customer_id = '<cus_...>' AND deleted_at IS NULL;
+-- 🔴 order_id 를 넣지 말 것 — #785 가 그 컬럼을 지웠다. 넣으면 쿼리가 죽는다.
 ```
 - ① 행이 **1건** 생겼다
 - ② `issued_via = 'customer_registered'`
@@ -287,14 +323,19 @@ C2 를 C3 앞에 놓으면 장이 이미 소모된 상태라 **거절이 옳게 
 1. R11 계정으로 `AY-WELCOME` 을 카트에 적용 → **포인트 전액결제**로 주문 완료
    (`POINTS` 는 외부 PG 를 안 탄다 — `docs/local-dev.md` §5)
 2. ```sql
-   SELECT id, used_at, cart_id, order_id, expires_at FROM coupon_grant WHERE customer_id='<cus_...>';
+   SELECT id, used_at, cart_id, expires_at FROM coupon_grant WHERE customer_id='<cus_...>';
    ```
 
 | 컬럼 | 기대 | 🔴 |
 |---|---|---|
 | `used_at` | 주문 완료 시각 | |
 | `cart_id` | **그 카트 id** | 소모의 키는 주문이 아니라 카트 |
-| `order_id` | **`NULL` 그대로** | 아무도 읽지도 쓰지도 않는다. 값이 차면 **옛 경로가 살아있다는 뜻** |
+
+🔴 **`order_id` 컬럼은 없다**(#785 가 지웠다). 주문과의 연결은 **`order_cart` 링크**로 확인한다:
+```sql
+SELECT order_id, cart_id FROM order_cart WHERE cart_id = '<위에서 본 cart_id>';
+```
+이 링크가 있어야 C4 의 스위퍼가 그 장을 「주문 있음」으로 보고 놓지 않는다.
 
 3. 마이페이지 **「사용완료」 탭**으로 옮겨갔는지 (📸 — B-03 과 겸함)
 

--- a/docs/superpowers/plans/2026-09-05-coupon-rehearsal-3.md
+++ b/docs/superpowers/plans/2026-09-05-coupon-rehearsal-3.md
@@ -1,0 +1,573 @@
+# 쿠폰 개통 리허설 3차 — 실행 지침
+
+> **이 문서는 별도 세션에서 돌리는 절차다.** 대화 맥락 없이 이것만 읽고 실행할 수 있게 썼다.
+> 자동 테스트가 아니다 — 여기 있는 항목은 **전부 자동 테스트가 못 덮는 것들**만 골랐다.
+>
+> **3차는 목적이 둘이다.** ① `A5` 개통 관문(검증) ② **리테일팀 가이드용 스크린샷 촬영**(자료).
+> 둘은 요구가 다르다 — §5 가 그 경계를 정한다. 섞으면 둘 다 못 쓴다.
+>
+> **▶ 세션을 시작할 프롬프트는 §9 에 복붙용으로 있다.**
+
+**SoT:** 이슈 [#488](https://github.com/LCNINE/almondyoung-server/issues/488) · [#775](https://github.com/LCNINE/almondyoung-server/issues/775) · 로드맵 `docs/superpowers/plans/2026-08-29-coupon-domain-master-plan.md`
+**2차 기록:** #488 「리허설 2차 실행 기록」 절 (2026-09-01) — **R11 만 ❌**, 나머지 전부 ✅ (R4 는 이벤트 0건이라 5곳 중 4곳만)
+**환경 절차 정본:** `docs/local-dev.md` 「전체 스택 로컬 구동」 + **`docs/superpowers/plans/2026-09-01-coupon-rehearsal-2.md` §2**
+ — 🔴 **이 문서는 2차 §2 를 복제하지 않는다.** 환경은 거기서 읽고, 여기 §2 는 **차이만** 적는다.
+
+---
+
+## 0. 왜 3차인가 — 재실행 범위는 diff 가 정했다
+
+2차(2026-09-01) 이후 두 덩어리가 들어왔고 **둘 다 라이브 실행 0회**다.
+
+1. **#775 / PR #787** (`6e315d1aa`, 배포 완료) — `customer_registered` 트리거를 도달 불가한
+   user-service `UserEmailVerified` 에서 **Medusa `customer.created` subscriber** 로 옮겼다.
+   2차의 **유일한 ❌ 였던 R11** 이 이것 때문이었다.
+2. **PR-2 · PR-3** (#781 · #784) — 쿠폰 «소모» 를 미문서 훅 `orderCreated` 에서 `validate` 훅으로
+   옮기고, **소모가 곧 검사**가 되게 하고, 소모의 키를 주문이 아니라 **카트**로 바꿨다.
+   취소 복원 구독자와 스위퍼가 함께 생겼다. **런타임 검증 0.**
+
+**「R11 하나만 다시 돌리면 된다」가 아니다.** #787 의 diff 가 channel-adapter 를 넓게 건드렸다:
+
+| 파일 | 변경 | 3차에 미치는 영향 |
+|---|---|---|
+| `channel-adapter/.../coupon-issue-reconciliation.service.ts` | **94줄** | **R13(빠른 레인) 회귀 위험** |
+| `channel-adapter/.../inbox-worker.service.ts` | 21줄 | R11b 경로 |
+| `channel-adapter/.../internal-membership.controller.ts` | 7줄 | R11b 경로 |
+| `channel-adapter/.../user-event.consumer.ts` | −57줄 | Cafe24 두 핸들러 생존 확인 필요 |
+| `medusa/.../metrics-server.ts` · `instrumentation.ts` | 신규 | **R12 의 측정점이 2곳으로** |
+
+그래서 3차 = **재실행 4(R11·R11b·R12·R13) + 신규 #775 3(N1~N3) + 신규 소모 5(C1~C5) = 12항목.**
+
+2차가 이미 닫은 R1~R10 · R14 는 **반복하지 않는다.** 단 그 쿠폰들은 §3 대본이 다시 만든다 —
+검증 때문이 아니라 **스크린샷 때문**이다.
+
+---
+
+## 1. 시작 전 — 어느 코드로 도는가
+
+```bash
+cd <레포>
+git fetch origin
+git checkout develop && git pull
+git log --oneline -1     # 여기서 본 해시를 결과 기록에 적는다
+```
+
+**#787 은 이미 라이브에 배포됐다.** 즉 로컬 `develop` 은 라이브와 같은 코드다.
+그래도 **리허설은 로컬에서 돈다** — 라이브에서 신규 가입·주문·취소를 만들 수 없기 때문이다.
+
+**확인:** 아래 파일이 전부 있어야 한다. 하나라도 없으면 develop 이 아니거나 pull 이 덜 된 것이다.
+```bash
+ls apps/medusa/src/subscribers/coupon-auto-issue-on-customer-created.ts
+ls apps/medusa/src/observability/metrics-server.ts
+ls apps/medusa/src/workflows/hooks/cart/consume-coupon-grants.ts
+ls apps/medusa/src/subscribers/coupon-grant-restore.ts
+ls apps/medusa/src/jobs/restore-stuck-coupon-consumptions.ts
+```
+
+### 사전 지식 6줄 — 이걸 모르면 결과를 오독한다
+
+1. **쿠폰 유효기간은 두 축이다.** 정책 축 = `promotion_meta.starts_at`/`ends_at`/`validity_days`(**발급 가능** 기간) ·
+   인스턴스 축 = **`coupon_grant.expires_at`**(**사용 가능** 기간, 발급 시점에 계산해 박는다). **캠페인 날짜는 안 쓴다.**
+2. **발급 시점 룰 평가는 fail-closed 다.** 분류표(`issuance-rules.ts`) 밖의 룰을 가진 쿠폰은 발급되지 않는다.
+   어드민 `force` 발급만 그 게이트를 넘는다.
+3. **`promotion_meta` 행이 없는 프로모션은 아무도 못 쓴다**(P10-A 닫힌 기본값). 네이티브 `/app/promotions` 로 만든 쿠폰이 여기 해당한다.
+4. 🔴 **소모가 곧 검사다.** 옛 구조는 훅이 장을 «읽어 검사» 하고 열 스텝 뒤에 «썼다». 이제
+   `consumeOneUsableGrantForCart` 의 결과가 판정이다 — `none` 이고 장이 사용을 지배하면 **주문이 거절된다.**
+5. 🔴 **소모의 키는 주문이 아니라 카트다.** 소모는 `completeCartWorkflow.validate` 훅에서 일어나고 그 시점엔 주문이 없다.
+   **`coupon_grant.order_id` 는 아무도 읽지도 쓰지도 않는다** — 소모돼도 계속 `NULL` 인 게 정상이다.
+6. 🔴 **`customer_registered` 는 이제 Kafka·channel-adapter 를 지나지 않는다.** Medusa 안에서 시작해 Medusa 안에서 끝난다.
+   `membership_activated` 만 여전히 channel-adapter 를 지난다. **두 트리거의 경로가 다르다.**
+
+---
+
+## 2. 환경 — 2차와 무엇이 다른가
+
+**기본 구축은 `2026-09-01-coupon-rehearsal-2.md` §2 를 그대로 따른다** (앱 8개, 포트, env 템플릿, 기동 순서,
+일치해야 하는 값 셋). 아래는 **3차에서만 다른 것**이다.
+
+| # | 항목 | 2차 | 3차 |
+|---|---|---|---|
+| ① | `customer_registered` 경로 | user-service → Kafka → channel-adapter → Medusa 라우트 | **Medusa 내부만** (`customer.created` subscriber) |
+| ② | 메트릭 측정점 | channel-adapter `:13010/metrics` | **+ Medusa `:19000/metrics`** (신규) |
+| ③ | channel-adapter | R11·R11b 둘 다 여기를 지남 | **R11b·R13 만.** 그래도 **띄워야 한다**(회귀 검증 대상) |
+| ④ | 스위퍼 | 없었음 | `COUPON_STUCK_MIN_AGE_MINUTES` 조정 필요 (C4) |
+
+### 2-1. `apps/medusa/.env` 에 추가 — 템플릿에 없다
+
+```bash
+echo 'COUPON_AUTO_ISSUE_ENABLED=true' >> apps/medusa/.env
+echo 'COUPON_STUCK_MIN_AGE_MINUTES=1' >> apps/medusa/.env
+```
+
+- 첫 줄이 없으면 **subscriber 도 라우트도 첫 줄에서 되돌아간다.** 2차가 이걸로 한 번 막혔다.
+- 둘째 줄은 C4 전용이다. **기본값은 60분**이고 `0` 은 안 먹는다 —
+  `Number.isFinite(raw) && raw > 0` 이라 `0` 은 기본값 60 으로 폴백한다. **`1` 이 최소다.**
+  🔴 **C4 가 끝나면 이 줄을 지우거나 60 으로 되돌린다.** 1분짜리로 남겨두면 C1~C3 을 하는 중
+  스위퍼 크론(`23 * * * *`)이 돌아 **정상 소모를 되돌려** 원인 모를 ❌ 를 만든다.
+
+### 2-2. Medusa 메트릭 포트가 실제로 뜨는지 — 시작하자마자 본다
+
+```bash
+curl -s localhost:19000/metrics | head -5
+```
+
+포트는 `METRICS_PORT` 가 없으면 `PORT + 10000` 이다. 로컬 `PORT=9000` 이면 19000.
+**빈 문자열 `METRICS_PORT=` 는 위험하다** — 코드가 `> 0` 으로 걸러 폴백하지만, 값을 넣을 거면 정수여야 한다.
+바인딩 실패는 **프로세스를 죽이지 않고** `medusa-metrics-server` JSON 로그만 남긴다. 조용하다.
+
+### 2-3. 2차에서 실제로 막혔던 지점 — 같은 데서 또 막히지 말 것
+
+1. **`COUPON_AUTO_ISSUE_ENABLED` 누락** → 발급 API 가 `{issued:[],skipped:[]}` 만 반환
+2. **`MEDUSA_MEMBERSHIP_GROUP_ID` 누락**(channel-adapter) → inbox 는 `published` 인데 쿠폰이 안 나감. R11b 전용
+3. **스토어프론트 회원가입 UI 를 로컬에서 못 지난다** — auth-web 3/3 단계의 휴대폰 인증이
+   notification 서비스로 위임되는데 로컬에 그 앱이 없어 503 이고, **코드 생성이 SMS 발송과 같은 트랜잭션**이라
+   (`send-verification-code.service.ts:76-86`) DB 에 행을 심어도 UI 게이트가 안 열린다.
+   → **가입은 `POST /auth/signup` 로 직접 한다.**
+   🔴 **하지만 로그인은 반드시 스토어프론트 UI 로 지나야 한다** — Medusa customer 는 **첫 로그인 때** 생기고,
+   그 생성이 곧 R11 의 트리거(`customer.created`)다. 2차처럼 가입만 API 로 우회하고 로그인을 건너뛰면 **R11 이 성립하지 않는다.**
+4. **kafka 컨테이너가 내려가 있는 경우** — 2차에서 재기동이 필요했다. R11b·R13 이 여기 걸린다.
+
+---
+
+## 3. 데이터 대본 — 실물 이름으로 한 번에 만든다
+
+🔴 **이번 리허설의 쿠폰은 처음부터 리테일팀이 봐도 되는 이름으로 만든다.** 스크린샷을 나중에 다시 찍지 않기 위해서다.
+대가는 **이름에서 축이 안 읽힌다**는 것 — 그래서 이 표를 실행 내내 옆에 둔다.
+
+| 코드 | 화면에 뜨는 이름 | 축 (검증용) | 쓰는 항목 | 스크린샷 절 |
+|---|---|---|---|---|
+| `AY-WELCOME` | 신규 가입 축하 쿠폰 | `assigned_only` · 정률 10% · 주문 · `validity_days=30` · **trigger=`customer_registered`** | **R11** · N1 · N2 · C1~C3 | A · C |
+| `AY-MEMBER` | 멤버십 시작 감사 쿠폰 | `assigned_only` · 정액 3,000원 · 주문 · `validity_days=30` · **trigger=`membership_activated`** | **R11b** · R13 | C |
+| `AY-FALL10` | 가을맞이 10% 할인 | `claimable` · 정률 10% · 주문 | 스크린샷 전용 | A · B |
+| `AY-FIRST3000` | 첫 구매 3,000원 할인 | `claimable` · 정액 3,000 · 주문 | 스크린샷 전용 | A · B |
+| `AY-SHIPFREE` | 배송비 무료 쿠폰 | `claimable` · 정액 · **배송비** | 스크린샷 전용 | A |
+| `AY-SHIPHALF` | 배송비 반값 (최대 2,000원) | `claimable` · **정률 50% + 캡 2,000** · 배송비 | 스크린샷 전용(**캡 필드 노출**) | A · B |
+
+**만드는 법:** 전부 **admin-web 실 폼**(`/mall/marketing/coupons` → 쿠폰 생성)으로 만든다.
+API 로 만들면 **폼이 실제로 그 조합을 낼 수 있는지**를 검증하지 못하고, 스크린샷도 못 얻는다.
+
+**폼 함정 둘 (2차 실측):**
+- 할인 유형을 **「정액」으로 바꾸면 「최대 할인금액」 필드가 사라진다** — 캡은 정률 전용(의도된 동작).
+  `AY-SHIPHALF` 의 캡 필드 컷(📷 A-05)은 **정률을 고른 상태에서만** 찍힌다.
+- 「할인 율」 칸의 `10` 은 **placeholder 이지 기본값이 아니다.** 안 채우면 생성 버튼이 계속 disabled 다.
+
+**계정 대본:**
+
+| 용도 | 계정 | 만드는 법 |
+|---|---|---|
+| R11 · C1~C3 주 계정 | `retail-demo01@local.test` | `POST /auth/signup` → **스토어프론트 UI 로 첫 로그인** |
+| N1 대조군 (어드민 생성) | 이름만 있는 고객 | **Medusa 어드민** `POST /admin/customers` (has_account=false) |
+| C2 이중사용 | R11 계정 그대로 | 카트 둘을 번갈아 |
+
+---
+
+## 4. 체크리스트 — 12항목
+
+> **⛔ 를 ✅ 로 반올림하지 않는다.** 1차·2차가 「전 항목 실행, ⛔ 0건」을 지킨 것이 그 기록을 믿을 수 있게 만든 이유다.
+> **📸 = 판정 증거 컷**(§5 규칙 참조). ❌ 는 증상 + 요청/응답 + 파일·줄까지 남긴다.
+
+### 4-A. 재실행 (회귀) — 근거는 §0 의 diff 표
+
+#### ★ R11. `customer_registered` 자동발급 e2e — **이 리허설의 본체이자 #775 의 종결 조건** 📸
+
+**2차의 유일한 ❌ 였고, 그것을 고치려고 #775 를 했다.**
+
+1. `AY-WELCOME` 이 `trigger=customer_registered` 로 존재하는지 확인 (§3)
+2. `POST /auth/signup` 으로 `retail-demo01@local.test` 가입
+3. **스토어프론트(`localhost:8000`) UI 로 로그인** — 여기서 Medusa customer 가 생긴다
+4. 🔴 **손으로 이벤트를 강제하지 않는다.** `medusa exec` 도, 발급 라우트 직접 호출도 안 된다.
+   그걸 하면 2차가 이미 검증한 뒷단만 다시 보는 것이고, **끊겼던 「입구」는 그대로 미검증**이다.
+
+**판정 5개 — 전부 봐야 ✅:**
+
+```sql
+-- ① 장이 생겼는가 / ② issued_via / ③ expires_at 이 validity_days 대로인가
+SELECT id, promotion_id, issued_via, issued_at, expires_at, used_at, cart_id, order_id
+  FROM coupon_grant
+ WHERE customer_id = '<cus_...>' AND deleted_at IS NULL;
+```
+- ① 행이 **1건** 생겼다
+- ② `issued_via = 'customer_registered'`
+- ③ `expires_at ≈ issued_at + 30일`
+- ④ 스토어프론트 **마이페이지 쿠폰 탭**에 그 쿠폰이 보인다 (📸)
+- ⑤ 카운터가 올랐다:
+  ```bash
+  curl -s localhost:19000/metrics | grep coupon_auto_issue_total
+  # coupon_auto_issue_total{trigger="customer_registered",outcome="issued"} 1
+  ```
+  🔴 **`:19000` 이다.** channel-adapter `:13010` 이 아니다 — 이 트리거는 이제 거길 안 지난다.
+
+**Medusa 로그에 이 줄이 있어야 한다:** `[coupon] 회원가입 자동발급 1장 (customer_id=..., codes=AY-WELCOME)`
+
+#### R11b. `membership_activated` 자동발급 e2e (회귀) 📸
+
+**왜 다시 도나:** #787 이 `inbox-worker.service.ts`(21줄)와 `internal-membership.controller.ts`(7줄)를 건드렸다.
+같은 파일에서 옆 소비자를 지웠으므로 **모듈 등록이 조용히 깨졌을 수 있다**
+(`@app/events` 의 가장 조용한 실수는 `controllers: []` 미등록이다).
+
+2차 §4 R11b 절차 그대로. 멤버십 활성화 → Kafka → channel-adapter inbox → Medusa 발급 라우트 → 장 생성.
+**측정점 주의:** 이 트리거는 **channel-adapter `:13010`** 이 센다.
+
+**부수 확인:** channel-adapter 로그에 `Cafe24Linked`/`Cafe24Unlinked` 핸들러가 등록돼 있는지
+(`user-event.consumer.ts` 는 `UserEmailVerified` 만 잘려나가고 살아 있어야 한다).
+
+#### R12. 메트릭 — 이제 **두 곳**이다 📸
+
+```bash
+curl -s localhost:13010/metrics | grep -E 'coupon_auto_issue|coupon_issue_inbox'   # channel-adapter
+curl -s localhost:19000/metrics | grep -E 'coupon_auto_issue'                       # Medusa (신규)
+```
+
+| 시리즈 | 어디서 | 기대 |
+|---|---|---|
+| `coupon_auto_issue_total{trigger="customer_registered",...}` | **Medusa :19000** | R11 후 `outcome="issued"` 1 |
+| `coupon_auto_issue_total{trigger="membership_activated",...}` | **channel-adapter :13010** | R11b 후 증가 |
+| `coupon_auto_issue_failures_total{...,kind="permanent"}` | 양쪽 | 정상 경로에선 **없다** |
+| `coupon_issue_inbox_failed_rows{event_type=...}` | channel-adapter | `UserEmailVerified` 라벨은 **더 이상 안 나온다** |
+
+🔴 **이름이 같고 라벨이 같다.** Grafana 는 job 구분 없이 합산하도록 의도됐다 — 두 job 에서 **같은 라벨 조합이
+동시에 나오면 안 된다**(이중 계수). `trigger` 로 갈리는지 확인한다.
+
+#### R13. 빠른 레인이 «1회만» 되살리는가 (회귀) 📸
+
+**왜 다시 도나:** `coupon-issue-reconciliation.service.ts` 가 **94줄** 바뀌었다. 3차 재실행 항목 중 회귀 위험이 가장 크다.
+
+2차 §4 R13 절차 그대로: 실패 유도 → 15분 빠른 레인이 1회차에 되살림 + `inbox_events.metadata` 에
+`coupon_fast_reset` 마커 → **2회차는 무시**(03:00 크론에 넘김).
+
+```sql
+SELECT id, event_type, status, attempts, next_attempt_at, metadata
+  FROM inbox_events WHERE event_type = 'MembershipStatusChanged' ORDER BY created_at DESC LIMIT 5;
+```
+
+### 4-B. 신규 — #775 (subscriber)
+
+#### N1. `has_account` 게이트 — 어드민이 만든 고객에겐 발급되지 않는다 📸
+
+`customer.created` 는 **어드민이 만든 고객에도 뜬다**(코어 `POST /admin/customers`, `has_account=false`).
+「회원가입」은 인증 계정이 붙은 고객뿐이다.
+
+1. Medusa 어드민에서 고객을 **손으로** 하나 만든다
+2. `SELECT * FROM coupon_grant WHERE customer_id='<그 고객>'` → **0행이어야 한다**
+3. 카운터도 **안 올라야 한다** (게이트는 세지 않고 그냥 `return` 한다)
+
+**이게 ❌ 면**(장이 생기면) 개통 시 어드민의 고객 등록이 곧 쿠폰 살포가 된다.
+
+#### N2. 같은 사건은 몇 번 와도 한 장 📸
+
+발급 키는 `trigger:<trigger>` 이고 `idx_coupon_grant_issue_key` 파셜 유니크가 강제한다.
+
+1. R11 의 고객에게 복구 명령을 **두 번** 부른다:
+   `POST /admin/customers/<id>/issue-coupons {"trigger":"customer_registered"}`
+2. `coupon_grant` 행 수가 **1 그대로**여야 한다
+3. 응답의 `skipped[].reason` 이 `already_issued` 여야 한다
+
+#### N3. 실패는 재시도되지 않고 «보인다»
+
+subscriber 에는 **재시도가 없다**(Redis 이벤트버스 기본 `attempts=1`, 스펙 결정 2).
+실패는 삼키되 카운터 + 로그로 남긴다.
+
+- 유도: `AY-WELCOME` 을 일시적으로 깨뜨리거나(예: 프로모션을 `inactive`) 새 계정 가입
+- 기대: `coupon_auto_issue_failures_total{trigger="customer_registered",kind="permanent"}` 증가
+- 기대: Medusa 로그에 **복구 명령이 문자 그대로** 찍힌다 —
+  `재시도 없음 — 수동 복구: POST /admin/customers/<id>/issue-coupons {"trigger":"customer_registered"}`
+- 그 명령을 실제로 불러 **복구되는지**까지 본다
+
+⛔ 유도 방법을 못 찾으면 ⛔ 로 남긴다. **✅ 로 반올림하지 않는다.**
+
+### 4-C. 신규 — 소모 경로 (PR-2 · PR-3)
+
+🔴 **순서대로 돈다: C1 → C3 → C2 → C4 → C5.** 문서의 번호 순이 아니다.
+`AY-WELCOME` 은 R11 이 발급한 **한 장**이고 C1~C3 이 그 한 장을 돌려쓴다 —
+C1(소모) → C3(취소로 복원) 을 먼저 해야 C2 가 「쓸 수 있는 장 1개」라는 전제를 갖는다.
+C2 를 C3 앞에 놓으면 장이 이미 소모된 상태라 **거절이 옳게 나와도 그게 C2 가 보려는 이유인지 알 수 없다.**
+
+#### C1. 소모 = 검사 — 주문 완료가 장을 잡는다 📸
+
+1. R11 계정으로 `AY-WELCOME` 을 카트에 적용 → **포인트 전액결제**로 주문 완료
+   (`POINTS` 는 외부 PG 를 안 탄다 — `docs/local-dev.md` §5)
+2. ```sql
+   SELECT id, used_at, cart_id, order_id, expires_at FROM coupon_grant WHERE customer_id='<cus_...>';
+   ```
+
+| 컬럼 | 기대 | 🔴 |
+|---|---|---|
+| `used_at` | 주문 완료 시각 | |
+| `cart_id` | **그 카트 id** | 소모의 키는 주문이 아니라 카트 |
+| `order_id` | **`NULL` 그대로** | 아무도 읽지도 쓰지도 않는다. 값이 차면 **옛 경로가 살아있다는 뜻** |
+
+3. 마이페이지 **「사용완료」 탭**으로 옮겨갔는지 (📸 — B-03 과 겸함)
+
+#### C2. 이중사용 창이 닫혔는가 — **PR-3 의 존재 이유** 📸
+
+옛 구조는 «읽어서 검사» 와 «써서 소모» 사이가 열려 있어 같은 고객의 두 카트가 장 하나로 **둘 다 통과**했다.
+
+1. **C3 이 되살린 그 한 장**으로 시작한다 (쓸 수 있는 장이 정확히 1개인 상태)
+2. 카트 A 에 적용 → 주문 완료 (장이 잡힌다)
+3. **카트 B** 에 같은 쿠폰 적용 → 주문 완료 시도
+4. **기대: 거절된다.** `consumeOneUsableGrantForCart` 가 `used_at IS NULL` 술어라 못 잡고 → `none` →
+   장이 사용을 지배하므로 훅이 던진다
+5. 같은 **카트 A** 를 다시 완료 시도하면 `already` 로 **통과**해야 한다(재시도는 스스로 낫는다)
+
+🔴 **4와 5를 헷갈리지 말 것.** 다른 카트 = 거절, 같은 카트 = 통과. 술어가 다르다.
+
+#### C3. 주문 취소가 장을 되살린다 (A2 의 쿠폰 축) 📸
+
+`order.canceled` → 구독자가 **`order_cart` 링크로** 카트를 찾아 `restoreGrantsByCart`.
+
+1. C1 의 주문을 **취소**한다
+2. ```sql
+   SELECT used_at, cart_id FROM coupon_grant WHERE id='<그 장>';
+   ```
+   **기대: `used_at IS NULL` AND `cart_id IS NULL`** (복원은 둘 다 비운다)
+3. 마이페이지에서 **다시 「내 쿠폰」** 탭으로 돌아왔는가 (📸)
+4. 실제로 **다시 쓸 수 있는가** — 새 카트에 적용해 주문까지
+
+**되살리지 않는 두 경우도 본다(있으면):** 이미 **만료된** 장 · 어드민이 **회수한**(`revoked_at`) 장.
+
+⚠️ **R14(2차)의 `campaign_budget_usage` 미반환은 별개 문제이고 여전히 미해결이다.** 여기서 보는 것은
+**장(`coupon_grant`)의 복원**이다. 둘을 같은 항목으로 적지 말 것.
+
+#### C4. 스위퍼 — 「주문 없는 소모」만 되돌리고 정상 주문은 놓지 않는다
+
+프로세스가 훅 커밋 직후에 죽으면 장이 «카트가 잡았는데 주문은 없는» 채로 남는다. 보상은 살아있는 프로세스만 돈다.
+
+1. `COUPON_STUCK_MIN_AGE_MINUTES=1` 확인 (§2-1)
+2. **고아 소모를 만든다.** 카트에 쿠폰을 적용한 뒤 주문 완료 **직전에 멈추는** 방법이 없으므로,
+   가장 싼 재현은 **버릴 장 하나**를 골라 손으로 상태를 만드는 것이다.
+   🔴 **C1~C3 이 쓰는 장을 쓰지 말 것** — 별도 계정에 손으로 한 장 발급해 그걸 쓴다.
+   ```sql
+   -- 주문 없는 카트 id 하나: SELECT id FROM cart WHERE completed_at IS NULL ORDER BY created_at DESC LIMIT 1;
+   UPDATE coupon_grant SET cart_id = '<주문 없는 카트 id>', used_at = now() - interval '5 minutes'
+    WHERE id = '<버릴 장 id>';
+   ```
+   `used_at` 을 5분 전으로 **백데이트하므로 기다릴 필요가 없다**(`minAge` 1분 > 5분 전). 
+   스위퍼의 **판정 로직**을 보는 것이 목적이지 프로세스 사망을 재현하는 것이 목적이 아니다.
+3. 손으로 돌린다:
+   ```bash
+   (cd apps/medusa && npx medusa exec ./src/scripts/restore-stuck-coupon-consumptions.ts)
+   ```
+4. **기대 로그:** `[coupon] 스위퍼 {"scanned":N,"restored":1,"kept":N-1}` +
+   `[coupon] 주문 없는 소모 1장 되돌림 (cart_id=...)`
+5. 🔴 **가장 중요한 판정: 정상 주문의 장은 `kept` 에 들어가야 한다.** `order_cart` 링크가 있거나
+   카트가 `completed_at` 을 가지면 놓지 않는다. **정상 주문이 restored 에 들어가면 ❌ — 개통하면 안 된다.**
+6. **끝나면 `COUPON_STUCK_MIN_AGE_MINUTES` 를 되돌린다**(§2-1 경고)
+
+#### C5. 훅 보상 — 뒤 스텝이 실패하면 장이 돌아온다 ⛔ 허용
+
+`validate` 훅이 잡은 장은 **뒤 스텝(주문 생성·재고예약·결제 승인)이 실패할 때** 훅 보상이 되돌린다.
+
+**시도해 볼 방법:** 재고를 0으로 만들어 예약 스텝을 실패시킨다 (카트 적용 뒤, 주문 완료 직전에 재고를 뺀다).
+
+**성공하면:** `used_at IS NULL` · `cart_id IS NULL` 로 돌아와야 한다.
+**안정적으로 유도하지 못하면 ⛔ 로 남긴다.** 자동 통합 스펙이 이 경로를 덮고 있으므로
+(`coupon-consume.spec.ts`) ⛔ 하나로 개통을 막지는 않는다 — 다만 **기록에 그렇게 적는다.**
+
+---
+
+## 5. 스크린샷 대본 — 📸 와 📷 는 다른 물건이다
+
+🔴 **요구가 정반대다. 한 컷으로 겸하려 들면 둘 다 못 쓴다.**
+
+| | 📸 증거 컷 | 📷 가이드 컷 |
+|---|---|---|
+| 목적 | 리허설 판정의 **반증 가능한 근거** | 리테일팀이 보는 **설명 그림** |
+| URL·시각·콘솔 | **보여야 한다** | **없어야 한다** (크롭) |
+| 데이터 | 있는 그대로 (`cus_01J...` 그대로 OK) | 실물 이름만. id·이메일은 크롭하거나 가린다 |
+| 붙는 곳 | #488 코멘트 | 스크래치패드 → 나중에 가이드 문서 |
+| 실패 화면 | 필요하면 찍는다 | **B절만** 의도적으로 찍는다 (거절 메시지) |
+
+**같은 화면을 두 번 찍는 비용이 붙는다. 그게 정직한 가격이다.**
+
+### 5-1. 저장 규칙
+
+```
+<스크래치패드>/screenshots/
+  ├── manifest.md          ← 🔴 컷과 한 몸. 이게 없으면 한 달 뒤 쓰레기다
+  ├── A-01-쿠폰목록.png
+  ├── A-02-쿠폰생성-기본정보.png
+  └── ...
+```
+
+**파일명:** `<절>-<번호>-<슬러그>.png` — 절은 `A`/`B`/`C`, 증거 컷은 `E-<항목>-<슬러그>.png` (예: `E-R11-마이페이지.png`)
+
+**`manifest.md` 한 줄 형식:**
+```
+| 파일 | 절 | 무엇을 보여주는가 | 캡션 초안 |
+```
+캡션 초안까지 **찍은 그 자리에서** 적는다. 나중에 40장을 놓고 기억해내려 하지 말 것.
+
+### 5-2. A절 — 쿠폰 만들기 (어드민 매뉴얼)
+
+**대상 화면:** admin-web `localhost:8002` → `/mall/marketing/coupons`
+
+| 컷 | 화면 | 무엇을 보여주려고 |
+|---|---|---|
+| A-01 | 쿠폰 목록 | 어디서 시작하는가 |
+| A-02 | 생성 다이얼로그 — 기본 정보 | 이름·코드(자동 생성 버튼) |
+| A-03 | 할인 설정 — **정률** | 할인율 칸이 placeholder 라는 것 |
+| A-04 | 할인 설정 — **정액** | 「최대 할인금액」이 **사라진** 상태 |
+| A-05 | **최대 할인금액(캡) 필드** | 정률에서만 뜬다. `AY-SHIPHALF` |
+| A-06 | 적용 대상 3종 | 주문 전체 / 특정 상품 / 배송비 |
+| A-07 | **유효기간 두 축** | 발급 가능 기간 ↔ `validity_days`(발급받은 날부터 N일) |
+| A-08 | 공개 범위 | `claimable` ↔ `assigned_only` 의 의미 |
+| A-09 | 생성 완료 후 목록 | 6장이 나열된 상태 |
+| A-10 | 쿠폰 상세 다이얼로그 | 만든 뒤 확인하는 자리 |
+| A-11 | 고객 목록 다이얼로그 | 누가 받았나 (`issued_via` 가 보이는 자리) |
+| A-12 | 발급 다이얼로그 | 손으로 발급하는 법 |
+
+🔴 **A-07 이 이 가이드의 핵심 컷이다.** 「두 축」은 리테일팀이 가장 틀리기 쉬운 개념이고,
+틀리면 «캠페인 끝났는데 왜 고객 쿠폰이 살아있냐» 는 문의로 돌아온다.
+
+### 5-3. B절 — 고객 화면 / CS 응대
+
+**대상 화면:** 스토어프론트 `localhost:8000`
+
+| 컷 | 화면 | 무엇을 보여주려고 |
+|---|---|---|
+| B-01 | 마이페이지 → **「내 쿠폰」** 탭 | 고객이 보는 기본 화면 |
+| B-02 | **「쿠폰 받기」** 탭 | `claimable` 쿠폰이 여기 뜬다 |
+| B-03 | **「사용완료」** 탭 | 「12/31까지 · 사용완료」 배지 (날짜는 미래일 수 있다) |
+| B-04 | **「만료 쿠폰」** 탭 | 만료일이 지난 것만 |
+| B-05 | 체크아웃 — 쿠폰 적용 성공 | 할인액이 붙은 모습 |
+| B-06 | 체크아웃 — **「적용 조건 미충족」** | 🔴 CS 문의 1순위 |
+| B-07 | 체크아웃 — **캡이 물린 정률 쿠폰** | 50%인데 2,000원만 깎인 이유 |
+| B-08 | 쿠폰 클레임 페이지 (`/coupons/claim`) | 링크로 받는 경로 |
+
+🔴 **B-03 은 함정 설명이 필요한 컷이다.** 카드에 뜨는 날짜는 «그 쿠폰의 만료일» 이라 **사용완료인데 미래 날짜**가 보인다.
+캡션에 그걸 적어두지 않으면 CS 가 버그로 오해한다.
+
+### 5-4. C절 — 자동발급 브리핑
+
+| 컷 | 화면 | 무엇을 보여주려고 |
+|---|---|---|
+| C-01 | 생성 폼의 **자동발급 트리거** 선택 | 「회원가입 완료」/「멤버십 시작」이 어디 있나 |
+| C-02 | 고객 목록 다이얼로그 — `issued_via` | 자동발급된 장이 어떻게 보이나 |
+| C-03 | 마이페이지 — 가입 직후 받은 쿠폰 | 고객이 실제로 보는 결과 (R11 의 ④와 겸함) |
+
+**C절에는 회원가입 화면을 넣지 않는다.** 관리자용 «쿠폰 기능» 가이드에 가입 절차는 필요 없다.
+(로컬에서 가입 UI 를 못 지나는 §2-3 ③ 제약은 **실행상의 문제일 뿐** 가이드 범위와 무관하다.)
+
+---
+
+## 6. 결과를 어디에 남기나
+
+🔴 **한 항목이 끝날 때마다 즉시 적는다.** 앱 8개 · 12항목 · 스크린샷 30여 장짜리 긴 작업이라,
+마지막에 몰아쓰려다 중간에 끊기면 앞이 통째로 사라진다. **스크래치패드에 누적하고 끝에 옮긴다.**
+
+1. **#488 에 「리허설 3차 실행 기록」 코멘트** — 1·2차와 같은 표(항목 / 결과 / 비고), 맨 위에 **브랜치·커밋 해시·실행일**
+2. **#775 에 R11 결과 코멘트** — ✅ 면 **거기서 이슈를 닫는다**(종결 조건이 R11 재실행이다)
+3. **마스터플랜** 진행 상황 갱신
+4. ❌ 는 이슈로 뽑거나 #488 항목으로 편입. **❌ 를 남긴 채 개통하지 않는다**
+5. ⛔ 를 ✅ 로 반올림하지 않는다
+6. **📷 가이드 컷은 #488 에 붙이지 않는다** — 스크래치패드 + `manifest.md` 로 두고,
+   가이드 문서를 쓸 때 옮긴다. 증거 컷(📸)만 코멘트에 붙는다
+
+---
+
+## 7. 통과 뒤 — A5 개통
+
+**#787 은 이미 배포됐다.** 남은 것은 **플래그 한 줄**이다.
+
+1. **라이브 재실측** — 플래그를 켜는 순간 발화하므로 규칙 수를 먼저 본다:
+   ```sql
+   SELECT auto_issue_trigger, count(*) FROM promotion_meta
+    WHERE auto_issue_trigger IS NOT NULL AND deleted_at IS NULL GROUP BY 1;
+   ```
+   **의도한 것 외에 있으면 멈춘다.**
+2. **플립** — `deployments/lcnine/services/infra/services.ts` 의 Medusa `environment` 에:
+   ```ts
+   COUPON_AUTO_ISSUE_ENABLED: 'true',
+   ```
+3. `sst deploy --stage live`
+4. **개통 확인** — 발급이 아니라 시리즈의 «존재» 로 본다:
+   ```promql
+   sum by (trigger, outcome) (increase(coupon_auto_issue_total[1h]))
+   ```
+5. **되돌리기** — 그 한 줄을 지우고 재배포. 이미 발급된 장은 남는다(회수는 어드민에서 건별)
+
+### 7-1. 리허설과 독립적으로 «지금» 확인할 것 — 배포가 끝났으므로
+
+- **Alloy 스크레이프 실효:** `up{job="medusa"} == 1` — #787 이 신설한 배관이 실제로 붙었는가.
+  **0 이면 R12 가 로컬에서 초록이어도 라이브 관측은 없다.**
+- **Grafana 정리:** `coupon_issue_inbox_failed_rows{event_type="UserEmailVerified"}` 를 참조하는 패널·알림이
+  있으면 **영구 No Data** 가 된다(그 경로를 지웠다). 찾아서 정리한다.
+- ⚠️ 발급 시리즈 자체는 **플래그가 꺼져 있는 동안 없는 게 정상**이다. `No Data → Alerting` 매핑 금지.
+
+---
+
+## 8. 이 리허설이 다루지 않는 것
+
+- **R1~R10 · R14 재실행** — 2차가 닫았다. §3 이 그 쿠폰을 다시 만드는 것은 **스크린샷 때문**이지 재검증이 아니다
+- **`campaign_budget_usage` 미반환 (A2 의 예산 축)** — 여전히 미해결. C3 은 **장의 복원**만 본다
+- **Firebase 경로(`Cafe24Linked`/`Cafe24Unlinked`)** — 외부 자격증명 필요. R11b 가 뒷단을 덮는다
+- **실 PG 결제** — 포인트 전액결제로 우회
+- **다중 인스턴스 동시성** — 로컬 단일 프로세스라 스위퍼 중복 실행·리더 선출 부재를 재현 못 한다
+- **`user.updated`·`user.deleted` subscriber 사망 (#786)** — 탈퇴 익명화 미전파(PII). **쿠폰보다 급하지만 별개 이슈다**
+- **CS 조회 화면(P8)** — 백엔드만 있고 admin-web 호출부 0건
+- **가이드 문서 작성 자체** — 3차는 **컷과 manifest 까지**. 문서는 별도 작업
+
+---
+
+## 9. 새 세션 시작 지침 (복붙용)
+
+리허설은 컨텍스트를 많이 먹으므로 **전용 세션**에서 돌린다. 아래를 그대로 붙여 시작한다.
+
+```
+쿠폰 개통 리허설 3차를 진행한다. 사람이 손으로 돌리는 절차고, 나는 그 절차를 안내·구동·기록한다.
+
+지침서: docs/superpowers/plans/2026-09-05-coupon-rehearsal-3.md
+  — 이 문서 하나로 실행 가능하게 썼다. 먼저 전문을 읽어라.
+  — 환경 «구축» 절차는 여기 없다. docs/local-dev.md 「전체 스택 로컬 구동」 +
+    docs/superpowers/plans/2026-09-01-coupon-rehearsal-2.md §2 가 정본이고,
+    3차 지침서 §2 는 그 둘과의 «차이»만 적는다. 셋을 다 봐야 한다.
+
+브랜치: develop. #787(#775)은 이미 라이브에 배포됐다 — 로컬 develop 이 라이브와 같은 코드다.
+  그래도 리허설은 로컬에서 돈다(라이브에서 신규 가입·주문·취소를 만들 수 없다).
+
+목적이 둘이다:
+  ① 검증 — 12항목(R11·R11b·R12·R13 / N1~N3 / C1~C5). A5 개통의 마지막 관문이다.
+  ② 촬영 — 리테일팀 «쿠폰 기능» 가이드에 넣을 스크린샷. 지침서 §5 가 대본이다.
+  🔴 §5 의 «📸 증거 컷 ≠ 📷 가이드 컷» 구분을 먼저 읽어라. 한 컷으로 겸하면 둘 다 못 쓴다.
+
+규칙:
+  - 12항목 전부 실행한다. 못 돌린 항목은 ⛔ 로 남기고 ✅ 로 반올림하지 않는다.
+    1·2차가 「전 항목 실행, ⛔ 0건」을 지킨 것이 그 기록을 믿을 수 있게 만든 이유다.
+  - 📸 항목은 스크린샷 없이는 ✅ 의 근거가 없다.
+  - ❌ 는 증상 + 요청/응답 + 파일·줄까지 남긴다. 그 자리에서 조용히 고치지 말고 먼저 기록해라.
+  - 🔴 한 항목을 끝낼 때마다 결과를 스크래치패드에 «즉시» 적어라. 스크린샷은 찍은 자리에서
+    manifest.md 에 캡션 초안까지 적어라. 마지막에 몰아서 쓰지 마라.
+  - 결과는 #488 「리허설 3차 실행 기록」 코멘트 + #775 (R11 이 ✅ 면 거기서 닫는다) + 마스터플랜.
+  - 로컬 .env 는 커밋하지 않는다.
+
+크롬 자동화를 쓴다:
+  - claude-in-chrome 스킬을 먼저 부르고, tabs_context_mcp 로 컨텍스트를 잡은 뒤 새 탭을 만든다.
+    기존 탭을 재사용하지 않는다.
+  - localhost:8000(스토어프론트)·localhost:8002(admin-web) 사이트 권한이 확장에 있어야 한다.
+  - 네이티브 alert/confirm 을 띄우지 마라 — 뜨면 확장이 먹통이 되고 사람이 직접 닫아야 한다.
+  - 2~3회 실패하면 같은 동작을 반복하지 말고 멈춰서 나에게 물어라.
+  - 🔴 자동화는 «구동기»지 «심판»이 아니다. 판정이 애매하면 ✅ 로 넘기지 말고 스크린샷과 함께
+    나에게 확인을 요청해라.
+
+가장 조용히 실패하는 지점 넷 — 막히면 여기부터 의심해라 (지침서에 상세히 있다):
+  1. apps/medusa/.env 의 COUPON_AUTO_ISSUE_ENABLED=true 누락 → 발급이 빈 배열만 반환
+  2. R11 에서 스토어프론트 «UI 로그인»을 건너뜀 → Medusa customer 가 안 생겨 트리거 자체가 없음
+  3. COUPON_STUCK_MIN_AGE_MINUTES=1 을 C4 뒤에 안 되돌림 → 스위퍼 크론이 정상 소모를 되돌림
+  4. 메트릭을 엉뚱한 포트에서 찾음 → customer_registered 는 Medusa :19000,
+     membership_activated 는 channel-adapter :13010. 트리거마다 측정점이 다르다
+
+리허설이 통과하면 A5 개통(플래그 한 줄 + sst deploy)은 그 뒤 별도 작업이다.
+```
+
+### 🔴 자동화가 늘리는 위험 — 이것만은 읽고 시작한다
+
+브라우저 자동화는 **처리량을 올리는 만큼 «거짓 초록» 도 올린다.** 에이전트가 페이지를 잘못 읽고 ✅ 를 적으면
+1차보다 **나쁜** 기록이 된다 — 1차는 적어도 사람 눈이 봤다.
+
+그래서 📸 규칙이 있다. 스크린샷이 붙은 ✅ 는 나중에 반증 가능하고, 안 붙은 ✅ 는 아니다.
+**자동화의 값어치는 속도가 아니라 그 증거에 있다.**
+
+**3차는 그 위험이 2차보다 크다** — 촬영 때문에 자동화 부하가 늘고, 「컷을 얻었다」가 「검증했다」로
+미끄러지기 쉽다. **📷 를 찍은 것은 아무것도 검증하지 않는다.** 판정은 📸 와 SQL·메트릭이 한다.
+
+환경 구축(§2)은 자동화 대상이 아니다 — 앱 8개·env·시드는 터미널 작업이다.

--- a/docs/superpowers/plans/2026-09-05-coupon-rehearsal-3.md
+++ b/docs/superpowers/plans/2026-09-05-coupon-rehearsal-3.md
@@ -110,9 +110,22 @@ ps -eo pid,lstart,args | grep -E 'nest start|next dev|medusa develop' | grep -v 
 # ② Medusa 메트릭 포트 — 닫혀 있으면 #775 이전 코드다
 curl -s localhost:19000/metrics | head -3
 
-# ③ 🔴 가장 중요 — 스키마가 최신인가
-psql "$DATABASE_URL" -tAc "SELECT to_regclass('public.coupon_grant');"          # NULL 이면 마이그 밀림
-psql "$DATABASE_URL" -tAc "SELECT name FROM mikro_orm_migrations ORDER BY id DESC LIMIT 3;"
+# ③ 🔴 Medusa 스키마가 최신인가
+psql "$MEDUSA_DATABASE_URL" -tAc "SELECT to_regclass('public.coupon_grant');"   # NULL 이면 마이그 밀림
+
+# ④ 🔴 **Medusa 만 보지 마라** — drizzle 서비스도 같이 밀린다
+psql "$USER_SERVICE_DATABASE_URL" -tAc \
+  "SELECT count(*) FROM information_schema.columns WHERE table_name='users' AND column_name='dormant_at';"
+  # 0 이면 user-service 마이그가 밀렸다 → **admin-web 로그인이 500 으로 죽는다**
+```
+
+🔴 **`db:migrate:local` 은 `search` 에서 멈춘다** (2026-09-05 실측). `SERVICES` 목록에서 `user_service` 가
+`search` **뒤**에 있어, 스크립트를 그냥 돌리면 **user-service 는 영영 마이그레이션되지 않는다.**
+필요한 것만 직접 붙이는 편이 빠르다:
+
+```bash
+DBU=$(grep -m1 '^DATABASE_URL=' apps/user-service/.env | cut -d= -f2- | tr -d '"'"'"' ')
+DATABASE_URL="$DBU" npx drizzle-kit migrate --config apps/user-service/database/drizzle/drizzle.config.ts
 ```
 
 **하나라도 어긋나면 전면 재기동이다:**
@@ -606,6 +619,12 @@ SELECT order_id, cart_id FROM order_cart WHERE cart_id = '<위에서 본 cart_id
   - 로컬 .env 는 커밋하지 않는다.
 
 크롬 자동화를 쓴다:
+  🔴 **로그인과 계정 생성은 에이전트가 못 한다 — 사람이 한다.** 비밀번호 입력·계정 생성은 수행하지 않는다.
+     리허설에서 해당 지점은 둘이다: ① admin-web 최초 로그인 ② R11 의 신규 가입 + 스토어프론트 첫 로그인.
+     **시작할 때 미리 알리고, R11 차례가 오기 전에 다시 알린다** — 그때 가서 막히면 흐름이 끊긴다.
+     로컬 계정 식별자는 **이메일이 아니라 `users.login_id`** 다(어드민 = `admin`, 비번은
+     `scripts/local/seed-user-service-local.ts` 의 `LOCAL_ADMIN_PASSWORD` 기본값). 이메일을 넣으면
+     입력칸 글자수 제한에 걸린다.
   - claude-in-chrome 스킬을 먼저 부르고, tabs_context_mcp 로 컨텍스트를 잡은 뒤 새 탭을 만든다.
     기존 탭을 재사용하지 않는다.
   - localhost:8000(스토어프론트)·localhost:8002(admin-web) 사이트 권한이 확장에 있어야 한다.
@@ -614,7 +633,10 @@ SELECT order_id, cart_id FROM order_cart WHERE cart_id = '<위에서 본 cart_id
   - 🔴 자동화는 «구동기»지 «심판»이 아니다. 판정이 애매하면 ✅ 로 넘기지 말고 스크린샷과 함께
     나에게 확인을 요청해라.
 
-가장 조용히 실패하는 지점 넷 — 막히면 여기부터 의심해라 (지침서에 상세히 있다):
+가장 조용히 실패하는 지점 다섯 — 막히면 여기부터 의심해라 (지침서에 상세히 있다):
+  0. user-service 마이그 밀림 → admin-web 로그인이 500. 화면 문구는 「로그인하지 못했어요」뿐이라
+     비밀번호 문제로 오해하기 쉽다. 원인은 코드의 users.dormant_at 이 DB 에 없어 select 가 죽는 것이고,
+     findUserByLoginId 의 catch 가 원 에러를 삼켜 「로그인 ID로 사용자 조회 중 오류」 500 만 남는다.
   1. apps/medusa/.env 의 COUPON_AUTO_ISSUE_ENABLED=true 누락 → 발급이 빈 배열만 반환
   2. R11 에서 스토어프론트 «UI 로그인»을 건너뜀 → Medusa customer 가 안 생겨 트리거 자체가 없음
   3. COUPON_STUCK_MIN_AGE_MINUTES=1 을 C4 뒤에 안 되돌림 → 스위퍼 크론이 정상 소모를 되돌림

--- a/scripts/local/preflight-e2e.sh
+++ b/scripts/local/preflight-e2e.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# 로컬 전 과정(E2E) 환경 사전 점검.
+#
+# 🔴 「떠 있다」와 「최신이다」는 다르다. 2026-09-05 리허설에서 포트 8개가 전부 열려 있었지만
+# 프로세스는 4일 묵은 코드였고 스키마는 3주 밀려 있었다. 이 스크립트는 그걸 잡는다.
+#
+# 사용: bash scripts/local/preflight-e2e.sh
+set -uo pipefail
+cd "$(dirname "$0")/../.."
+FAIL=0
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+bad()  { printf '  \033[31m✗\033[0m %s\n' "$1"; FAIL=1; }
+warn() { printf '  \033[33m!\033[0m %s\n' "$1"; }
+
+url_of() { grep -m1 '^DATABASE_URL=' "$1" 2>/dev/null | cut -d= -f2- | tr -d '"'\'' '; }
+
+echo "── 1. 컨테이너"
+for svc in postgres redis kafka; do
+  state=$(docker compose ps -a --format '{{.Service}} {{.State}}' 2>/dev/null | awk -v s="$svc" '$1==s{print $2}')
+  [ "$state" = "running" ] && ok "$svc running" || bad "$svc = ${state:-없음}  (kafka 가 exited 면 zookeeper 부터 재기동)"
+done
+
+echo "── 2. 포트"
+check_port() { (echo >/dev/tcp/127.0.0.1/"$1") >/dev/null 2>&1; }
+while read -r port name; do
+  [ -z "$port" ] && continue
+  check_port "$port" && ok "$port $name" || bad "$port $name — 안 떠 있음"
+done <<'PORTS'
+3000 user-service
+3001 membership
+3003 channel-adapter
+3010 file-service
+3100 core
+3200 wallet-web
+5001 wallet
+8000 storefront
+8001 auth-web
+8002 admin-web
+9000 medusa
+19000 medusa-metrics
+PORTS
+
+echo "── 3. 프로세스 신선도 (오늘 뜬 것인가)"
+STALE=$(ps -eo lstart,args | grep -E 'nest start|next dev|medusa develop' | grep -v grep \
+        | grep -vc "$(date '+%b %e')" || true)
+[ "${STALE:-0}" -eq 0 ] && ok "전부 오늘 기동" || warn "${STALE}개가 오늘 이전 기동 — 옛 코드일 수 있다"
+
+echo "── 4. 스키마 최신 여부"
+MED=$(url_of apps/medusa/.env)
+[ -n "$MED" ] && {
+  [ "$(psql "$MED" -tAc "SELECT to_regclass('public.coupon_grant');" 2>/dev/null)" = "coupon_grant" ] \
+    && ok "medusa: coupon_grant 존재" || bad "medusa 마이그 밀림 → (cd apps/medusa && npx medusa db:migrate --execute-safe-links)"
+}
+USR=$(url_of apps/user-service/.env)
+[ -n "$USR" ] && {
+  [ "$(psql "$USR" -tAc "SELECT count(*) FROM information_schema.columns WHERE table_name='users' AND column_name='dormant_at';" 2>/dev/null)" = "1" ] \
+    && ok "user-service: users.dormant_at 존재" || bad "user-service 마이그 밀림 → 로그인이 500 으로 죽는다 (핸드오프 §4)"
+}
+
+echo "── 5. 시드"
+[ -n "$USR" ] && {
+  [ "$(psql "$USR" -tAc "SELECT count(*) FROM oauth_clients;" 2>/dev/null)" -ge 3 ] \
+    && ok "oauth_clients ≥3 (medusa-storefront·admin-web·wallet-web)" || bad "user-service 시드 미실행 → npm run db:seed:user-service:local"
+}
+WAL=$(url_of apps/wallet/.env)
+[ -n "$WAL" ] && {
+  [ "$(psql "$WAL" -tAc "SELECT count(*) FROM region_payment_methods;" 2>/dev/null)" -ge 1 ] \
+    && ok "wallet: 결제수단 매핑 존재" || bad "wallet 시드 미실행 → 결제화면이 「사용 가능한 결제수단이 없습니다」 → npx tsx scripts/local/seed-wallet-local.ts"
+}
+
+echo "── 6. 조용히 죽는 env 키"
+grep -q '^PORT=' apps/medusa/.env 2>/dev/null && ok "medusa PORT (=:19000 메트릭)" || bad "apps/medusa/.env 에 PORT=9000 없음 → :19000 이 안 열린다"
+grep -q '^WALLET_SERVICE_URL=' apps/admin-web/.env.local 2>/dev/null && ok "admin-web WALLET_SERVICE_URL" || bad "admin-web 적립금 화면이 조용히 죽는다"
+[ -f apps/wallet-web/.env.local ] && ok "wallet-web .env.local 존재" || bad "wallet-web .env.local 없음 → 결제 페이지가 Missing required env var 로 죽는다 (핸드오프 §5)"
+grep -q '^NOTIFICATION_SERVICE_URL=' apps/user-service/.env 2>/dev/null && ok "user-service → SMS 스텁" || warn "폰 인증이 503 → 회원가입 UI 를 못 지난다 (scripts/local/sms-stub.js)"
+
+echo "── 7. 포트 충돌"
+CA=$(grep -m1 '^PORT=' apps/channel-adapter/.env 2>/dev/null | cut -d= -f2)
+FS=$(grep -m1 '^PORT=' apps/file-service/.env 2>/dev/null | cut -d= -f2)
+[ -n "$CA" ] && [ "$CA" = "$FS" ] && bad "channel-adapter 와 file-service 가 둘 다 PORT=$CA — 하나만 뜬다 (핸드오프 §3)" || ok "channel-adapter($CA) ≠ file-service($FS)"
+
+echo
+[ "$FAIL" -eq 0 ] && echo "✅ 사전 점검 통과" || { echo "❌ 위 ✗ 를 먼저 해결할 것"; exit 1; }

--- a/scripts/local/seed-wallet-local.ts
+++ b/scripts/local/seed-wallet-local.ts
@@ -1,0 +1,35 @@
+/**
+ * 로컬 wallet DB 에 reference 시드(결제수단 카탈로그·지역·지역별 매핑)를 적용한다.
+ *
+ * `npm run db:seed:ref` 는 SST/AWS 에서 배포 설정을 읽어 DB URL 을 해석하므로 로컬에서는 못 쓴다.
+ * `seed-user-service-local.ts` 와 같은 방식으로, 같은 `WalletSeedStep` 을 로컬 DATABASE_URL 로 직접 돌린다.
+ *
+ * 🔴 이게 없으면 결제 화면(wallet-web :3200)이 «대한민국(KR) 지역에서 사용 가능한 결제수단이 없습니다»
+ * 로 막혀 주문을 완결할 수 없다. 리허설 3차에서 실제로 여기서 막혔다.
+ *
+ * 사용: npx tsx scripts/local/seed-wallet-local.ts
+ */
+import { WalletSeedStep } from '../seeding/steps/wallet.seed-step';
+
+const LOCAL_PG = process.env.LOCAL_PG ?? 'postgresql://postgres:postgres@localhost:5432';
+const DATABASE_URL = process.env.WALLET_DATABASE_URL ?? `${LOCAL_PG}/wallet`;
+
+if (!/localhost|127\.0\.0\.1/.test(DATABASE_URL)) {
+  throw new Error(`로컬 전용 스크립트다. DATABASE_URL 이 localhost 가 아니다: ${DATABASE_URL}`);
+}
+
+async function main(): Promise<void> {
+  const step = new WalletSeedStep(DATABASE_URL);
+  console.log('[check-before]', JSON.stringify(await step.check(), null, 2));
+  const result = await step.apply();
+  console.log('[apply]', JSON.stringify(result, null, 2));
+  console.log('[check-after]', JSON.stringify(await step.check(), null, 2));
+}
+
+main().then(
+  () => process.exit(0),
+  (e) => {
+    console.error(e);
+    process.exit(1);
+  },
+);

--- a/scripts/local/sms-stub.js
+++ b/scripts/local/sms-stub.js
@@ -1,0 +1,19 @@
+// 리허설 전용 로컬 SMS 스텁 — notification 서비스의 /internal/sms/send 만 흉내낸다.
+// 외부로 아무것도 보내지 않는다. 받은 내용(=인증번호)을 stdout 에 찍는다.
+const http = require('http');
+const PORT = Number(process.env.SMS_STUB_PORT || 3099);
+http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/internal/sms/send') {
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => {
+      let to = '?', content = '?';
+      try { const j = JSON.parse(body); to = j.to; content = j.content; } catch {}
+      console.log(`[SMS-STUB] ${new Date().toISOString()} to=${to} content=${content}`);
+      res.writeHead(201, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ success: true, provider: 'local-stub' }));
+    });
+    return;
+  }
+  res.writeHead(404).end();
+}).listen(PORT, '127.0.0.1', () => console.log(`[SMS-STUB] listening on :${PORT}`));


### PR DESCRIPTION
## 무엇

문서·스크립트만이다. 코드 변경 0.

1. **쿠폰 개통 리허설 3차 지침서** (`docs/superpowers/plans/2026-09-05-coupon-rehearsal-3.md`)
2. **로컬 전 과정(E2E) 환경 핸드오프** (`docs/local-e2e-environment.md`) + 사전점검·시드·스텁 스크립트 3개

## 왜 3차의 범위가 「R11 하나」가 아니었나

#787 의 diff 가 정했다. `coupon-issue-reconciliation.service.ts` 가 **94줄** 바뀌어 R13(빠른 레인)이
회귀 위험이고, `inbox-worker`·`internal-membership.controller` 가 R11b 경로를 건드렸으며, Medusa 에
`metrics-server` 가 생겨 R12 의 측정점이 2곳이 됐다. → 재실행 4 + 신규 #775 3 + 신규 소모 5 = 12항목.

## 실행 결과 — **R11 통과, #775 종결 조건 충족**

가입 → 스토어프론트 UI 로그인 → **손대지 않고** 판정 5개 전부 ✅.
발급 시각이 customer 생성과 **같은 초**라, #775 가 안 3(Medusa `customer.created`)을 고른 근거
(「고객 미존재 → 최대 1시간 백오프」 함정이 원인부터 사라진다)가 실측으로 확인됐다.
새로 추출한 선별기(`auto-issue-selection.ts`)가 런타임에서 처음 돌았고 발급·fail-closed skip·
카트문맥 무시 세 갈래가 한 번에 지났다. 상세는 #775 코멘트.

**C1~C5(소모 경로)는 결제 승인 실패로 미착수.** 그 블로커는 핸드오프 §8.

## 환경 결함 13건 — 이게 이번 작업량의 대부분이었다

「떠 있다」를 「최신이다」로 읽으면 안 된다는 게 핵심이다. 착수 시 포트 8개가 전부 열려 있었지만
프로세스는 4일 묵은 코드였고 Medusa 스키마는 3주 밀려 `coupon_grant` 테이블 자체가 없었다.

특히 다음 세션에 직접 영향을 주는 것들:

- **앱은 8개가 아니라 11개다** — `wallet-web`(:3200, 결제가 이리로 넘어간다) · `core`(:3100, 어드민 주문조회) ·
  `file-service`(:3010) 가 2차 목록에 없었다. 그리고 `channel-adapter` 와 `file-service` 가 **둘 다 `PORT=3010`** 이다.
- **`localhost` 쿠키는 포트를 구분하지 않는다** — 스토어프론트 고객 로그인이 admin-web 어드민 세션을 덮는다.
  `BYPASS_AUTH=true` 가 강등된 세션을 안 내쫓아 「화면 정상 + API 403」으로만 나타난다.
- **`db:migrate:local` 이 `search` 에서 멈춰** `user_service` 가 영영 미적용 → `users.dormant_at` 누락 →
  **로그인이 500**(`findUserByLoginId` 의 catch 가 원인을 삼킨다).
- **wallet reference 시드 미실행** → 결제수단 0행 → 「사용 가능한 결제수단이 없습니다」.
- **스토어프론트 OIDC 콜백은 실패해도 HTTP 200** — 로그로 성공을 판정할 수 없다. 판정은 DB 로.

## 신설

`scripts/local/preflight-e2e.sh`(세션 시작마다 실행) · `scripts/local/seed-wallet-local.ts` ·
`scripts/local/sms-stub.js`(폰 인증, 외부 발송 없음).

## 검토 포인트

- 3차 지침서의 **C1 → C3 → C2** 실행 순서(장 한 장을 돌려쓴다)
- 기존 트리거 쿠폰 4개를 **지우지 않고 기대값을 조정**한 판단 — 덕분에 선별기 세 갈래가 한 번에 검증됐다
- 핸드오프 §3 의 **포트 충돌**은 문서만 고쳤다. `channel-adapter/.env` 실수정은 다음 세션 몫

https://claude.ai/code/session_01At51cGdxxwpnGrqk7YmeSv
