### PR TITLE
fix(test): 통합 스펙이 자기 .env 를 읽지 않게 — npx jest 가 로컬에서도 초록 (#793)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,7 @@ npx jest             # 전체 유닛 테스트. 실패 0 이 기준선이다
 npm run test:admin-web            # admin-web 전용
 npm run test:user-service         # user-service 전용 config
 npm run test:membership           # itdoc (전용 config)
+npm run test:membership:integration  # 실 membership DB (--runInBand 고정)
 npm run test:coupang:integration  # 실 DB + adapter-mock 필요
 npm run test:core:integration:local
 scripts/local/run-medusa-integration.sh            # medusa HTTP 통합 (실 DB+redis)
@@ -184,6 +185,20 @@ scripts/local/run-medusa-integration.sh --modules  # medusa 모듈 통합
 DB 를 요구하는 통합 스펙은 `describeIfDb` / `REQUIRE_*_DB=1` 가드로 기본 실행에서
 자동 skip 된다. 새 통합 스펙도 이 컨벤션을 따를 것 — 가드 없이 두면 기본 게이트가
 빨개진다.
+
+**스펙 안에서 `dotenv.config()` 를 부르지 말 것.** 가드는 `process.env.DATABASE_URL` 을
+읽는데, 스펙이 자기 `.env` 를 스스로 채우면 그 가드가 무력화되고 **파일이 스스로 기본
+게이트에 들어온다.** `.env` 는 바깥에서 주입한다 (`dotenv -e apps/<svc>/.env -- jest …`).
+#793 이 정확히 이거였다: membership 통합 스펙 2개가 `dotenv.config()` 로 자기를 켜서,
+`apps/membership/.env` 가 있는 사람(= 로컬 개발 세팅을 한 사람 전원)에게만 `npx jest` 가
+**항상** 21건 빨갰다 — 두 스펙이 같은 물리 DB 를 병렬 워커에서 두고 다퉜기 때문이다.
+CI 는 `.env` 가 없어 조용했으니 게이트가 못 잡았다. `scripts/jest/no-self-loaded-env-in-specs.spec.ts`
+가 이걸 지킨다.
+
+**같은 물리 DB 를 쓰는 통합 스펙끼리는 병렬이 안전하지 않다.** 이 저장소의 통합 스펙은
+`delete(schema.x)` 를 WHERE 없이 부르고 `tiers.code` 같은 전역 unique 값을 쓴다 — 스위트
+고유 값을 쓰는 것만으로는 부족하다(WHERE 없는 DELETE 가 그대로 남는다). 그래서 전용
+실행 명령은 **`--runInBand` 를 고정한다.**
 
 **`apps/medusa` 통합 스펙은 `npm run test:integration:*` 를 직접 부르면 안 된다.**
 `@medusajs/test-utils` 는 `DATABASE_URL` 이 아니라 `DB_HOST`/`DB_PORT`/`DB_USERNAME`/`DB_PASSWORD`

--- a/apps/membership/test/integration/recurring-billing-pause.integration.spec.ts
+++ b/apps/membership/test/integration/recurring-billing-pause.integration.spec.ts
@@ -24,12 +24,9 @@ import { membershipSchema, type MembershipSchema } from '../../src/shared/schema
 import * as schema from '../../src/shared/schemas/entities/schema';
 import { eq, and } from 'drizzle-orm';
 import { addDays, format } from 'date-fns';
-import * as dotenv from 'dotenv';
-import * as path from 'path';
-
-// .env 파일 로드
-dotenv.config({ path: path.resolve(__dirname, '../../.env') });
-
+// 실행: `npm run test:membership:integration` (전용 명령이 .env 를 주입하고 --runInBand 로 돈다).
+// 이 스펙은 **바깥 환경**의 DATABASE_URL 만 읽는다 — 스스로 .env 를 읽으면 맨 `npx jest` 에
+// 딸려 들어와, 같은 물리 DB 를 쓰는 다른 통합 스펙과 병렬 워커에서 경쟁한다 (#793).
 // DB 가 없으면 스위트를 건너뛴다 (core·channel-adapter 의 REQUIRE_*_DB 컨벤션과 동일).
 // CI 등 DB 가 반드시 있어야 하는 경로에서는 REQUIRE_MEMBERSHIP_DB=1 로 누락을 실패시킨다.
 const DATABASE_URL = process.env.DATABASE_URL ?? '';

--- a/apps/membership/test/integration/subscription-cancellation.integration.spec.ts
+++ b/apps/membership/test/integration/subscription-cancellation.integration.spec.ts
@@ -33,12 +33,9 @@ import { membershipSchema, type MembershipSchema } from '../../src/shared/schema
 import * as schema from '../../src/shared/schemas/entities/schema';
 import { eq } from 'drizzle-orm';
 import { addDays } from 'date-fns';
-import * as dotenv from 'dotenv';
-import * as path from 'path';
-
-// .env 파일 로드
-dotenv.config({ path: path.resolve(__dirname, '../../.env') });
-
+// 실행: `npm run test:membership:integration` (전용 명령이 .env 를 주입하고 --runInBand 로 돈다).
+// 이 스펙은 **바깥 환경**의 DATABASE_URL 만 읽는다 — 스스로 .env 를 읽으면 맨 `npx jest` 에
+// 딸려 들어와, 같은 물리 DB 를 쓰는 다른 통합 스펙과 병렬 워커에서 경쟁한다 (#793).
 // DB 가 없으면 스위트를 건너뛴다 (core·channel-adapter 의 REQUIRE_*_DB 컨벤션과 동일).
 // CI 등 DB 가 반드시 있어야 하는 경로에서는 REQUIRE_MEMBERSHIP_DB=1 로 누락을 실패시킨다.
 const DATABASE_URL = process.env.DATABASE_URL ?? '';

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "test:membership": "jest --config ./apps/membership/jest-e2e.json --testPathPattern=membership-api.itdoc.spec.ts --verbose",
     "test:membership:cancellation-e2e": "./scripts/test/membership-cancellation-e2e.sh",
     "test:membership:coverage": "jest --config ./apps/membership/test/jest-e2e.json --coverage",
+    "test:membership:integration": "REQUIRE_MEMBERSHIP_DB=1 dotenv -e apps/membership/.env -- jest --runInBand --testPathPattern='apps/membership/.*\\.integration\\.spec\\.ts$'",
     "test:membership:e2e:coverage": "npm run test:membership:coverage",
     "test:membership:e2e:verbose": "npm run test:membership:verbose",
     "test:membership:e2e:watch": "npm run test:membership:watch",

--- a/scripts/jest/no-self-loaded-env-in-specs.spec.ts
+++ b/scripts/jest/no-self-loaded-env-in-specs.spec.ts
@@ -1,0 +1,70 @@
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+/**
+ * 스펙 파일은 자기 `.env` 를 스스로 읽으면 안 된다 (#793).
+ *
+ * 이 레포의 통합 스펙은 `const DATABASE_URL = process.env.DATABASE_URL` 로 **바깥 환경**을
+ * 읽고, 없으면 `describeIfDb` 로 스스로 건너뛴다. 그래서 맨 `npx jest` 는 초록이고, 실제
+ * 실행은 `REQUIRE_*_DB=1 dotenv -e apps/<svc>/.env -- jest --runInBand …` 같은 전용
+ * 명령이 담당한다 (CLAUDE.md 「검증 게이트」).
+ *
+ * 스펙 안에서 `dotenv.config()` 를 부르면 그 규약이 뒤집힌다 — **파일이 스스로 게이트에
+ * 들어온다.** 그 결과가 #793 이었다: `apps/membership/.env` 를 가진 사람(= 로컬 개발
+ * 세팅을 한 사람 전원)에게만 통합 스펙 2개가 켜지고, 둘이 같은 물리 DB 의 `tiers` 를 두고
+ * 병렬 워커에서 경쟁해 `npx jest` 가 **항상** 21건 빨갰다. CI 는 `.env` 가 없어 조용했으니
+ * 게이트가 이걸 못 잡았고, 개발자는 「원래 빨간 것들」로 학습했다.
+ *
+ * ⚠️ 이 성질은 **아무 테스트도 실패하지 않는 방식으로** 깨진다 — 새로 넣은 `dotenv.config()`
+ * 는 그 자체로는 초록이고, 부작용은 「남의 스펙이 가끔 빨개진다」로만 나타난다. 그래서
+ * 감시자가 따로 필요하다 (`scripts/jest/tz-is-utc.spec.ts` 와 같은 이유).
+ *
+ * 정말 예외가 필요하면 여기에 이유와 함께 허용 항목을 만들 것. 지금은 없다 —
+ * 「.env 가 필요한 스펙」의 정답은 예외가 아니라 **전용 npm 스크립트**다.
+ */
+const REPO = join(__dirname, '..', '..');
+
+/**
+ * `dotenv.config(` 호출과 부작용 import (`import 'dotenv/config'`) 를 함께 잡는다.
+ * 맨 `dotenv` 문자열로 잡으면 **주석에 dotenv 를 언급한 스펙**까지 걸린다 — 실제로
+ * `bulk-session-draft.integration.spec.ts` 의 주석이 실행 방법으로 `dotenv -e` 를 안내한다.
+ * 그 안내는 옳은 형태(바깥에서 주입)이므로 걸리면 안 된다.
+ */
+const PATTERN = String.raw`(dotenv\.config\(|['"]dotenv/config['"])`;
+
+/**
+ * 이 파일 자신은 스캔에서 뺀다 — 아래 정밀도 테스트가 금지 패턴을 **문자열로** 들고 있어서
+ * 빼지 않으면 가드가 스스로에게 걸린다. 구멍은 이 한 파일뿐이고, 그 이유가 여기 적혀 있다.
+ */
+const SELF = ':(exclude)scripts/jest/no-self-loaded-env-in-specs.spec.ts';
+
+/** `git grep` 은 매치가 없으면 exit code 1 로 끝난다 — 그건 "위반 0" 이지 오류가 아니다. */
+function grepSpecs(pattern: string): string[] {
+  try {
+    const out = execFileSync('git', ['grep', '-nE', pattern, '--', '*.spec.ts', SELF], {
+      cwd: REPO,
+      encoding: 'utf8',
+    });
+    return out.split('\n').filter(Boolean);
+  } catch (error) {
+    const status = (error as { status?: number }).status;
+    if (status === 1) return [];
+    throw error;
+  }
+}
+
+describe('스펙은 자기 .env 를 스스로 읽지 않는다 (#793)', () => {
+  it('`dotenv.config()` 를 부르는 스펙 파일이 없다', () => {
+    const hits = grepSpecs(PATTERN);
+
+    expect(hits).toEqual([]);
+  });
+
+  it('정규식이 주석 속 `dotenv -e` 안내는 잡지 않는다 (이 가드가 지키려는 정밀도)', () => {
+    const comment = ' * 고정하지 않고 `dotenv -e apps/core/.env` 를 태우는데, 메인 체크아웃의 그 파일은';
+
+    expect(new RegExp(PATTERN).test(comment)).toBe(false);
+    expect(new RegExp(PATTERN).test("dotenv.config({ path: '../../.env' });")).toBe(true);
+    expect(new RegExp(PATTERN).test("import 'dotenv/config';")).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #793

## 무엇이 문제였나

`apps/membership` 통합 스펙 2개가 모듈 스코프에서 `dotenv.config()` 로 자기 `.env` 를 읽어,
`describeIfDb` 가드를 **스스로 무력화하고** 기본 `npx jest` 게이트에 들어왔다.
그래서 `apps/membership/.env` 가 있는 사람(= 로컬 개발 세팅을 한 사람 전원)에게만 게이트가 항상 21건 빨갰다.
CI 는 `.env` 가 없어 두 스펙이 skip 되므로 조용했고, 그래서 여태 안 걸렸다.

## 근본 원인은 두 겹이다

**① 왜 켜지는가** — 스펙이 스스로 `.env` 를 채운다.
저장소 전체를 훑으면 `dotenv.config()` 를 부르는 스펙은 정확히 이 2개뿐이고,
나머지 통합 스펙(core 30여 개·ugc·channel-adapter)은 전부 바깥 환경의 `DATABASE_URL` 만 읽는다.

**② 왜 깨지는가** — 두 스위트가 같은 물리 `membership` DB 를 병렬 워커에서 쓴다.

> ⚠️ **이슈에서 권한 「스위트별 고유 tier code」(옵션 1)만으로는 안 고쳐진다.**
> 재현 로그의 실패 21건 중 duplicate key 는 첫 충돌일 뿐이고, 실제로 관측된 것은
> `subscription_contracts_plan_id_plan_id_fk` **FK 위반**이다 —
> 두 스펙 모두 `cleanupAllData()`/`cleanupTestSpecificData()` 에서 **WHERE 없는**
> `delete(schema.plan)` · `delete(schema.subscriptionContracts)` 를 부르기 때문에,
> tier code 를 갈라도 상대 스위트의 행을 그대로 지운다.
> 병렬 안전성을 얻으려면 650줄짜리 스펙 2개의 정리 로직을 전부 스코프화해야 하는데,
> 그건 이 스펙들이 애초에 「전용 명령으로 직렬 실행」을 전제로 쓰였다는 사실과 어긋난다.
> 그래서 **실행을 직렬로 고정**하는 옵션 3 계열을 택했다.

## 변경

- 두 스펙에서 `dotenv.config()` + 미사용 `dotenv`/`path` import 제거 → 맨 `npx jest` 에서 skip.
- **`npm run test:membership:integration` 신설** — `REQUIRE_MEMBERSHIP_DB=1` + `dotenv -e apps/membership/.env --` + **`--runInBand` 고정**.
  membership 통합 스펙 전체(`apps/membership/**/*.integration.spec.ts`)를 잡으므로,
  같은 DB 를 쓰는 `benefit-tracking`·`admin-members.reader.count` 도 함께 직렬로 돈다.
- **`scripts/jest/no-self-loaded-env-in-specs.spec.ts` 가드 신설.**
  이 성질은 *아무 테스트도 실패하지 않는 방식으로* 깨진다 — 새로 넣은 `dotenv.config()` 는 그 자체로 초록이고
  부작용은 「남의 스펙이 가끔 빨개진다」로만 나타난다. `tz-is-utc.spec.ts` 와 같은 이유로 감시자를 둔다.
  주석 속 `dotenv -e` 안내(`bulk-session-draft.integration.spec.ts` 에 실재)는 잡지 않도록 정밀도 테스트를 함께 넣었다.
- CLAUDE.md 「검증 게이트」에 두 컨벤션 명문화 (자가 `.env` 로딩 금지 · 같은 DB 스펙은 `--runInBand`).

## 검증 (로컬, `apps/membership/.env` 있는 머신)

| 명령 | 이전 | 이후 |
|---|---|---|
| `npx jest --maxWorkers=2` | 2 suites / **21 tests 실패** | 539 passed · 110 skipped · **0 failed** |
| `npm run type-check` | — | exit 0 |
| `npm run test:membership:integration` | (없음) | 5 passed · 2 skipped, 39 tests passed |
| eslint (두 스펙) | 12 problems | 12 problems (신규 0건) |

재현도 먼저 확인했다 — 수정 전 `npx jest --maxWorkers=2 subscription-cancellation.integration recurring-billing-pause.integration` 은 23건 실패, `--runInBand` 는 통과.

## 리뷰어가 봐줬으면 하는 곳

- 두 스펙이 기본 게이트에서 **skip 되는 것**이 의도대로인가. CI 에서는 이전에도 skip 이었으므로 CI 커버리지 변화는 없고, 저장소의 다른 통합 스펙 전부와 같은 취급이 된다.
- 가드가 자기 자신을 `:(exclude)` 로 빼는 부분 (정밀도 테스트가 금지 패턴을 문자열로 들고 있어서 불가피). 구멍은 그 한 파일뿐.

https://claude.ai/code/session_01CcpjodNjV21HHWVxUTVomr
